### PR TITLE
Add missing export to def file

### DIFF
--- a/src/AppInstallerSQLiteIndexUtil/Source.def
+++ b/src/AppInstallerSQLiteIndexUtil/Source.def
@@ -1,5 +1,6 @@
 LIBRARY     AppInstallerSQLiteIndexUtil
 EXPORTS
+    AppInstallerLoggingInit
     AppInstallerSQLiteIndexCreate
     AppInstallerSQLiteIndexOpen
     AppInstallerSQLiteIndexClose


### PR DESCRIPTION
## Change
The logging init function was missed from the export file when it was added recently.  This change adds it.

## Testing
After build, I manually reviewed that the export was present via dumpbin /exports.