### PR TITLE
Move to using {Id,Version,Channel} as the key for update and remove

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -53,18 +53,20 @@ namespace AppInstaller::Repository::Microsoft
         // If the function succeeds, the manifest has been added.
         void AddManifest(const Manifest::Manifest& manifest, const std::filesystem::path& relativePath);
 
-        // Updates the manifest at the repository relative path in the index.
+        // Updates the manifest with matching { Id, Version, Channel } in the index.
         // The return value indicates whether the index was modified by the function.
         bool UpdateManifest(const std::filesystem::path& manifestPath, const std::filesystem::path& relativePath);
 
-        // Updates the manifest at the repository relative path in the index.
+        // Updates the manifest with matching { Id, Version, Channel } in the index.
         // The return value indicates whether the index was modified by the function.
         bool UpdateManifest(const Manifest::Manifest& manifest, const std::filesystem::path& relativePath);
 
-        // Removes the manifest at the repository relative path from the index.
+        // Removes the manifest with matching { Id, Version, Channel } from the index.
+        // Path is currently ignored.
         void RemoveManifest(const std::filesystem::path& manifestPath, const std::filesystem::path& relativePath);
 
-        // Removes the manifest at the repository relative path from the index.
+        // Removes the manifest with matching { Id, Version, Channel } from the index.
+        // Path is currently ignored.
         void RemoveManifest(const Manifest::Manifest& manifest, const std::filesystem::path& relativePath);
 
         // Removes data that is no longer needed for an index that is to be published.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
@@ -13,7 +13,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     namespace details
     {
         // Selects a manifest by the given value id.
-        std::optional<SQLite::rowid_t> ManifestTableSelectByValueId(SQLite::Connection& connection, std::string_view valueName, SQLite::rowid_t id);
+        std::optional<SQLite::rowid_t> ManifestTableSelectByValueIds(
+            SQLite::Connection& connection,
+            std::initializer_list<std::string_view> values,
+            std::initializer_list<SQLite::rowid_t> ids);
 
         // Gets the requested ids for the manifest with the given rowid.
         SQLite::Statement ManifestTableGetIdsById_Statement(
@@ -56,10 +59,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         static SQLite::rowid_t Insert(SQLite::Connection& connection, std::initializer_list<ManifestOneToOneValue> values);
 
         // Select the first rowid of the manifest with the given value.
-        template <typename Table>
-        static std::optional<SQLite::rowid_t> SelectByValueId(SQLite::Connection& connection, SQLite::rowid_t id)
+        template <typename... Tables>
+        static std::optional<SQLite::rowid_t> SelectByValueIds(SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
         {
-            return details::ManifestTableSelectByValueId(connection, Table::ValueName(), id);
+            static_assert(sizeof...(Tables) >= 1);
+            return details::ManifestTableSelectByValueIds(connection, { Tables::ValueName()... }, ids);
         }
 
         // Gets the ids requested for the manifest with the given rowid.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "SQLiteWrapper.h"
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -12,6 +13,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     {
         // Creates the table.
         void CreateOneToOneTable(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName);
+
+        // Selects the value from the table, returning the rowid if it exists.
+        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value);
 
         // Ensures that the values exists in the table.
         SQLite::rowid_t OneToOneTableEnsureExists(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value);
@@ -49,6 +53,12 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         static constexpr std::string_view ValueName()
         {
             return TableInfo::ValueName();
+        }
+
+        // Selects the value from the table, returning the rowid if it exists.
+        static std::optional<SQLite::rowid_t> SelectIdByValue(SQLite::Connection& connection, std::string_view value)
+        {
+            return details::OneToOneTableSelectIdByValue(connection, TableInfo::TableName(), TableInfo::ValueName(), value);
         }
 
         // Ensures that the given value exists in the table, returning the rowid.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
@@ -12,6 +12,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     // A table that represents a single manifest
     struct PathPartTable
     {
+        // The id type
+        using id_t = SQLite::rowid_t;
+
         // Creates the table.
         static void Create(SQLite::Connection& connection);
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -29,10 +29,12 @@ namespace AppInstaller::Repository::Microsoft::Schema
         // Adds the manifest at the repository relative path to the index.
         virtual void AddManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) = 0;
 
-        // Updates the manifest at the repository relative path in the index.
+        // Updates the manifest with matching { Id, Version, Channel } in the index.
+        // The return value indicates whether the index was modified by the function.
         virtual bool UpdateManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) = 0;
 
-        // Removes the manifest at the repository relative path from the index.
+        // Removes the manifest with matching { Id, Version, Channel } from the index.
+        // Path is currently ignored.
         virtual void RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) = 0;
 
         // Removes data that is no longer needed for an index that is to be published.

--- a/src/AppInstallerSQLiteIndexUtil/AppInstallerSQLiteIndexUtil.h
+++ b/src/AppInstallerSQLiteIndexUtil/AppInstallerSQLiteIndexUtil.h
@@ -46,15 +46,16 @@ extern "C"
         APPINSTALLER_SQLITE_INDEX_STRING manifestPath, 
         APPINSTALLER_SQLITE_INDEX_STRING relativePath);
 
-    // Updates the manifest at the repository relative path in the index.
-    // The out value indicates whether the index was modified by the function.
+    // Updates the manifest with matching { Id, Version, Channel } in the index.
+    // The return value indicates whether the index was modified by the function.
     APPINSTALLER_SQLITE_INDEX_API AppInstallerSQLiteIndexUpdateManifest(
         APPINSTALLER_SQLITE_INDEX_HANDLE index, 
         APPINSTALLER_SQLITE_INDEX_STRING manifestPath, 
         APPINSTALLER_SQLITE_INDEX_STRING relativePath,
         bool* indexModified);
 
-    // Removes the manifest at the repository relative path from the index.
+    // Removes the manifest with matching { Id, Version, Channel } from the index.
+    // Path is currently ignored.
     APPINSTALLER_SQLITE_INDEX_API AppInstallerSQLiteIndexRemoveManifest(
         APPINSTALLER_SQLITE_INDEX_HANDLE index, 
         APPINSTALLER_SQLITE_INDEX_STRING manifestPath, 


### PR DESCRIPTION
## Change
The current mechanism for index update and remove uses path as the primary key, then ensures that the { Id, Version, Channel } match the given manifest.  To enable more dynamic construction of the cache, this change moves to using the triple as the primary key (which it already is within the manifest table).  Thus the given manifest for update or remove must still match an existing manifest row, but the path can be changed on an update, and is completely ignored on remove.

## Testing
A new test is added that explicitly changes only the path of an existing manifest.