### PR TITLE
Fix a bug in AddManifest

### DIFF
--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -141,9 +141,24 @@ TEST_CASE("SQLiteIndexCreateAndAddManifestFile", "[sqliteindex]")
     std::filesystem::path manifestPath{ "microsoft/msixsdk/microsoft.msixsdk-1.7.32.yml" };
 
     index.AddManifest(manifestFile, manifestPath);
+}
 
-    // Attempting to add again should fail
-    REQUIRE_THROWS_HR(index.AddManifest(manifestFile, manifestPath), HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+TEST_CASE("SQLiteIndexCreateAndAddManifestDuplicate", "[sqliteindex]")
+{
+    TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
+    INFO("Using temporary file named: " << tempFile.GetPath());
+
+    Manifest manifest;
+    std::string relativePath;
+
+    SQLiteIndex index = SimpleTestSetup(tempFile, manifest, relativePath);
+
+    // Attempting to add the same manifest at a different path should fail.
+    REQUIRE_THROWS_HR(index.AddManifest(manifest, "differentpath.yml"), HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
+
+    // Attempting to add a different manifest at the same path should fail.
+    manifest.Id += "-new";
+    REQUIRE_THROWS_HR(index.AddManifest(manifest, relativePath), HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS));
 }
 
 TEST_CASE("SQLiteIndex_RemoveManifestFile_NotPresent", "[sqliteindex]")


### PR DESCRIPTION
## Change
There was a bug in AddManifest after the change to use { Id, Version, Channel } as the primary key.  It still used the path to determine uniqueness, and would get a constraint violation.  This change fixes it to use the same method to ensure that the manifest does not exist, and also ensures that the path is unique.

## Testing
A new test is added to ensure that both errors occur as expected.