### PR TITLE
Fix missed change for incoming search; use substring for now

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -27,7 +27,7 @@ namespace AppInstaller::Workflow
         OpenIndexSource();
 
         // Construct query
-        MatchType matchType = MatchType::Fuzzy;
+        MatchType matchType = MatchType::Substring;
         if (m_argsRef.Contains(ExecutionArgs::Type::Exact))
         {
             matchType = MatchType::Exact;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable.cpp
@@ -153,6 +153,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         SQLite::Statement statement = builder.Prepare(m_connection);
         ExecuteStatementForMatchType(statement, match, bindIndex, MatchUsesLike(match), value);
+        AICLI_LOG(Repo, Verbose, << "Search found " << m_connection.GetChanges() << " rows");
     }
 
     void SearchResultsTable::RemoveDuplicateManifestRows()
@@ -175,6 +176,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         EndParenthetical();
 
         builder.Execute(m_connection);
+        AICLI_LOG(Repo, Verbose, << "Removed " << m_connection.GetChanges() << " duplicate rows");
     }
 
     void SearchResultsTable::PrepareToFilter()
@@ -209,6 +211,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         SQLite::Statement statement = builder.Prepare(m_connection);
         ExecuteStatementForMatchType(statement, match, bindIndex, MatchUsesLike(match), value);
+        AICLI_LOG(Repo, Verbose, << "Filter kept " << m_connection.GetChanges() << " rows");
     }
 
     void SearchResultsTable::CompleteFilter()
@@ -218,6 +221,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         builder.DeleteFrom(GetQualifiedName()).Where(s_SearchResultsTable_Filter).Equals(false);
 
         builder.Execute(m_connection);
+        AICLI_LOG(Repo, Verbose, << "Filter deleted " << m_connection.GetChanges() << " rows");
     }
 
     std::vector<std::pair<SQLite::rowid_t, ApplicationMatchFilter>> SearchResultsTable::GetSearchResults(size_t limit)

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
@@ -105,9 +105,14 @@ namespace AppInstaller::Repository::SQLite
         return result;
     }
 
-    int64_t Connection::GetLastInsertRowID()
+    rowid_t Connection::GetLastInsertRowID()
     {
         return sqlite3_last_insert_rowid(m_dbconn.get());
+    }
+
+    int Connection::GetChanges()
+    {
+        return sqlite3_changes(m_dbconn.get());
     }
 
     Statement::Statement(Connection& connection, std::string_view sql, bool persistent)

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.h
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.h
@@ -135,7 +135,11 @@ namespace AppInstaller::Repository::SQLite
 
         ~Connection() = default;
 
-        int64_t GetLastInsertRowID();
+        // Gets the last inerted rowid to the database.
+        rowid_t GetLastInsertRowID();
+
+        // Gets the count of changed rows for the last executed statement.
+        int GetChanges();
 
         operator sqlite3* () const { return m_dbconn.get(); }
 


### PR DESCRIPTION
## Change
Change the base search functionality to use Substring for now, since it is the broadest search implemented.  Also includes a function to get the number of changes made by the last statement, and logging in search to see that.

## Testing
This is simply a change to the search being used by default, as I changed the semantics of Fuzzy.