### PR TITLE
Disable binary version update for PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
 
 - job: 'Build'
   dependsOn: 'GetReleaseTag'
+  condition: always()
   variables:
     BuildVer: $[counter(dependencies.GetReleaseTag.outputs['GetTag.tag'], 1)]
   steps:


### PR DESCRIPTION
## Change
For PR builds, save the ~30 seconds it takes and make them more obvious by not setting the build version.