### PR TITLE
Skip ComponentGovernance on GetReleaseTag job as well

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
   variables:
     runCodesignValidationInjection: ${{ false }}
+    skipComponentGovernanceDetection: ${{ false }}
   steps:
   - task: PowerShell@2
     name: 'GetTag'


### PR DESCRIPTION
## Change
Sneaky ComponentGovernance only auto-injects when the build is CI.  Skip it in the first job as well.