### PR TITLE
Change to proper bool to skip Component Governance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
   variables:
     runCodesignValidationInjection: ${{ false }}
-    skipComponentGovernanceDetection: ${{ false }}
+    skipComponentGovernanceDetection: ${{ true }}
   steps:
   - task: PowerShell@2
     name: 'GetTag'


### PR DESCRIPTION
## Change
The last change did not use the proper bool value, as it is the opposite semantics from the location it was copied from and has no visible affect on the PR builds.