### PR TITLE
Change to download the source file first

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -184,25 +184,39 @@ namespace AppInstaller::Repository::Microsoft
 
                 // Due to complications with deployment, download the file and deploy from
                 // a local source while we investigate further.
-                std::filesystem::path tempFile = Runtime::GetPathToTemp();
-                tempFile /= GetPackageFullNameFromDetails(details) + ".msix";
+                bool download = Utility::IsUrlRemote(packageLocation);
+                std::filesystem::path tempFile;
+                winrt::Windows::Foundation::Uri uri = nullptr;
 
-                Utility::Download(packageLocation, tempFile, progress);
+                if (download)
+                {
+                    tempFile = Runtime::GetPathToTemp();
+                    tempFile /= GetPackageFullNameFromDetails(details) + ".msix";
 
-                winrt::Windows::Foundation::Uri uri(tempFile.c_str());
+                    Utility::Download(packageLocation, tempFile, progress);
+
+                    uri = winrt::Windows::Foundation::Uri(tempFile.c_str());
+                }
+                else
+                {
+                    uri = winrt::Windows::Foundation::Uri(Utility::ConvertToUTF16(packageLocation));
+                }
+
                 Deployment::RequestAddPackage(
                     uri,
                     winrt::Windows::Management::Deployment::DeploymentOptions::None,
                     progress);
 
-                // If successful, delete the file
-                std::filesystem::remove(tempFile);
+                if (download)
+                {
+                    // If successful, delete the file
+                    std::filesystem::remove(tempFile);
+                }
             }
 
             void RemoveInternal(const SourceDetails& details, IProgressCallback& callback) override
             {
-                // Begin package removal, but let it run its course without waiting.
-                AICLI_LOG(Repo, Info, << "Removing package " << GetPackageFullNameFromDetails(details));
+                AICLI_LOG(Repo, Info, << "Removing package: " << GetPackageFullNameFromDetails(details));
                 Deployment::RemovePackage(GetPackageFullNameFromDetails(details), callback);
             }
         };


### PR DESCRIPTION
## Change
Due to issues we are seeing with deploying directly from the URL, this change moves the client to download the msix file first, and deploy it from a local file.  This is intended to be a temporary measure until we can investigate the direct deployment issue further, but it may need to become permanent depending on the result of the investigation.

## Testing
Manually validated that the change works against the production environment with source add and automatic update.