### PR TITLE
Move default log location to the approved directory for UIF collection

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -108,7 +108,7 @@ namespace AppInstaller::Logging
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
         }
 
-        AICLI_LOG(CLI, Info, << "AppInstallerCLI, version [" << version << "], activity [" << *GetActivityId() << ']');
+        AICLI_LOG(CLI, Info, << "WinGet, version [" << version << "], activity [" << *GetActivityId() << ']');
     }
  
     void TelemetryTraceLogger::LogCommand(std::string_view commandName) noexcept
@@ -195,7 +195,7 @@ namespace AppInstaller::Logging
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
         }
 
-        AICLI_LOG(CLI, Info, << "AppInstallerCLI, Name [" << name << "], Version [" << version << ']');
+        AICLI_LOG(CLI, Info, << "Manifest fields: Name [" << name << "], Version [" << version << ']');
     }
 
     void TelemetryTraceLogger::LogNoAppMatch() noexcept

--- a/src/AppInstallerCommonCore/FileLogger.cpp
+++ b/src/AppInstallerCommonCore/FileLogger.cpp
@@ -6,7 +6,7 @@
 #include "Public/AppInstallerRuntime.h"
 #include "Public/AppInstallerDateTime.h"
 
-#define AICLI_FILELOGGER_DEFAULT_FILE_PREFIX "AICLI-"
+#define AICLI_FILELOGGER_DEFAULT_FILE_PREFIX "WinGet-"
 #define AICLI_FILELOGGER_DEFAULT_FILE_EXT ".log"
 
 namespace AppInstaller::Logging
@@ -17,7 +17,7 @@ namespace AppInstaller::Logging
         if (filePath.empty())
         {
             m_name = "file";
-            m_filePath = Runtime::GetPathToTemp();
+            m_filePath = Runtime::GetPathToDefaultLogLocation();
             m_filePath /= AICLI_FILELOGGER_DEFAULT_FILE_PREFIX + Utility::GetCurrentTimeForFilename() + AICLI_FILELOGGER_DEFAULT_FILE_EXT;
         }
         else

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -22,6 +22,9 @@ namespace AppInstaller::Runtime
     // Gets the path to the local state location.
     std::filesystem::path GetPathToLocalState();
 
+    // Gets the path to the default log location.
+    std::filesystem::path GetPathToDefaultLogLocation();
+
     // Gets a stream containing the named setting's value, if present.
     // If the setting does not exist, returns an empty value.
     std::unique_ptr<std::istream> GetSettingStream(std::filesystem::path name);

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -5,7 +5,8 @@
 #include "Public/AppInstallerRuntime.h"
 #include "Public/AppInstallerStrings.h"
 
-#define AICLI_DEFAULT_TEMP_DIRECTORY "AICLI"
+#define AICLI_DEFAULT_TEMP_DIRECTORY "WinGet"
+#define WINGET_DEFAULT_LOG_DIRECTORY "DiagOutputDir"
 
 namespace AppInstaller::Runtime
 {
@@ -209,6 +210,23 @@ namespace AppInstaller::Runtime
         else
         {
             return GetPathToAppDataDir(s_AppDataDir_State);
+        }
+    }
+
+    std::filesystem::path GetPathToDefaultLogLocation()
+    {
+        if (IsRunningInPackagedContext())
+        {
+            // To enable UIF collection through Feedback hub, we must put our logs here.
+            auto result = GetPathToLocalState() / WINGET_DEFAULT_LOG_DIRECTORY;
+
+            std::filesystem::create_directories(result);
+
+            return result;
+        }
+        else
+        {
+            return GetPathToTemp();
         }
     }
 


### PR DESCRIPTION
## Change
Moves the default log location to the approved directory for UIF collection through Feedback Hub.  This only applies to our logs, and not to the logs produced by installers that we run.

## Testing
Manually verified logs were output to new location (%LOCALAPPDATA%\Packages\<PFN>\LocalState\DiagOutputDir).