### PR TITLE
Disable verbose logging by default

### DIFF
--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -76,6 +76,8 @@ namespace AppInstaller::CLI
             return Argument{ "plain", None, Args::Type::PlainStyle, Resources::GetInstance().ResolveWingetString(L"PlainArgumentDescription").c_str(), ArgumentType::Flag, Visibility::Hidden };
         case Args::Type::Force:
             return Argument{ "force", None, Args::Type::Force, Resources::GetInstance().ResolveWingetString(L"ForceArgumentDescription").c_str(), ArgumentType::Flag };
+        case Args::Type::VerboseLogs:
+            return Argument{ "verbose-logs", None, Args::Type::VerboseLogs, Resources::GetInstance().ResolveWingetString(L"VerboseLogsArgumentDescription").c_str(), ArgumentType::Flag };
         default:
             THROW_HR(E_UNEXPECTED);
         }
@@ -87,5 +89,6 @@ namespace AppInstaller::CLI
         args.push_back(ForType(Args::Type::NoVT));
         args.push_back(ForType(Args::Type::RainbowStyle));
         args.push_back(ForType(Args::Type::PlainStyle));
+        args.push_back(ForType(Args::Type::VerboseLogs));
     }
 }

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -45,7 +45,7 @@ namespace AppInstaller::CLI
         // Set output to UTF8
         ConsoleOuputCPRestore utf8CP(CP_UTF8);
 
-        // Enable logging (*all* for now, TODO: add common arguments to allow control of logging)
+        // Enable all logging for this phase; we will update once we have the arguments
         Logging::Log().EnableChannel(Logging::Channel::All);
         Logging::Log().SetLevel(Logging::Level::Verbose);
         Logging::AddFileLogger();
@@ -88,7 +88,15 @@ namespace AppInstaller::CLI
             Logging::Telemetry().LogCommand(command->FullName());
 
             command->ParseArguments(invocation, context.Args);
+
+            // Change logging level to Info if Verbose not requested
+            if (!context.Args.Contains(Execution::Args::Type::VerboseLogs))
+            {
+                Logging::Log().SetLevel(Logging::Level::Info);
+            }
+
             context.UpdateForArgs();
+
             command->ValidateArguments(context.Args);
         }
         // Exceptions specific to parsing the arguments of a command

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -58,6 +58,7 @@ namespace AppInstaller::CLI::Execution
             RainbowStyle, // Makes progress display as a rainbow
             Help, // Show command usage
             Info, // Show general info about WinGet
+            VerboseLogs, // Increases winget logging level to verbose
         };
 
         bool Contains(Type arg) const { return (m_parsedArgs.count(arg) != 0); }

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -330,6 +330,9 @@
   <data name="ValidateManifestArgumentDescription" xml:space="preserve">
     <value>The path to the manifest to be validated</value>
   </data>
+  <data name="VerboseLogsArgumentDescription" xml:space="preserve">
+    <value>Enables verbose logging for WinGet</value>
+  </data>
   <data name="VersionArgumentDescription" xml:space="preserve">
     <value>Use the specified version; default is the latest version</value>
   </data>

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
@@ -108,7 +108,7 @@ namespace AppInstaller::Repository::SQLite
 
     void Connection::EnableICU()
     {
-        AICLI_LOG(SQL, Info, << "Enabling ICU");
+        AICLI_LOG(SQL, Verbose, << "Enabling ICU");
         THROW_IF_SQLITE_FAILED(sqlite3IcuInit(m_dbconn.get()));
     }
 


### PR DESCRIPTION
## Change
Verbose logging is 95% SQLite statement information.  This change disables it by default, with the ability to enable it from the command line with '--verbose-logs'.  The file size difference for 'search' is currently over 120KB, as well as taking ~100 ms longer with verbose logging on.

## Testing
Manually confirmed verbose logs not produced by default.