### PR TITLE
Remove installer after a successful installation

### DIFF
--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -56,7 +56,8 @@ namespace AppInstaller::CLI
             Workflow::ShowInstallationDisclaimer <<
             Workflow::DownloadInstaller <<
             Workflow::VerifyInstallerHash <<
-            Workflow::ExecuteInstaller;
+            Workflow::ExecuteInstaller <<
+            Workflow::RemoveInstaller;
     }
 
     void InstallCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -223,4 +223,15 @@ namespace AppInstaller::CLI::Workflow
 
         context.Reporter.Info() << "Successfully installed." << std::endl;
     }
+
+    void RemoveInstaller(Execution::Context& context)
+    {
+        // Path may not be present if installed from a URL for MSIX
+        if (context.Contains(Execution::Data::InstallerPath))
+        {
+            const auto& path = context.Get<Execution::Data::InstallerPath>();
+            AICLI_LOG(CLI, Info, << "Removing installer: " << path);
+            std::filesystem::remove(path);
+        }
+    }
 }

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.h
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.h
@@ -70,4 +70,10 @@ namespace AppInstaller::CLI::Workflow
     // Inputs: Manifest?, Installer || InstallerPath
     // Outputs: None
     void MsixInstall(Execution::Context& context);
+
+    // Deletes the installer file.
+    // Required Args: None
+    // Inputs: InstallerPath
+    // Outputs: None
+    void RemoveInstaller(Execution::Context& context);
 }

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -116,7 +116,19 @@ struct WorkflowTaskOverride
 // Enables overriding the behavior of specific workflow tasks.
 struct TestContext : public Context
 {
-    TestContext(std::ostream& out, std::istream& in) : Context(out, in) {}
+    TestContext(std::ostream& out, std::istream& in) : Context(out, in)
+    {
+        WorkflowTaskOverride wto
+        { RemoveInstaller, [](TestContext&)
+            {
+                // Do nothing; we never want to remove the test files.
+        } };
+
+        // Mark this one as used so that it doesn't anger the destructor.
+        wto.Used = true;
+
+        Override(wto);
+    }
 
     ~TestContext()
     {


### PR DESCRIPTION
## Change
Nothing is currently cleaning up installers from the temp location.  This change causes successful installs to remove the installer file, which should reduce the amount of data we leave around significantly.  When we support local installers, we will need to ensure that we don't attempt to delete them here, but for now since anything that we download is temporary, this should be ok.

## Testing
Manual verification of file removal.