### PR TITLE
Add links to MSDN documentation in help output

### DIFF
--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -27,7 +27,7 @@ namespace AppInstaller::CLI
     void Command::OutputIntroHeader(Execution::Reporter& reporter) const
     {
         reporter.Info() <<
-            "Windows Package Manager v" << Runtime::GetClientVersion() << " " << Resources::GetInstance().ResolveWingetString(L"PreviewVersion").c_str() << std::endl <<
+            "Windows Package Manager v" << Runtime::GetClientVersion() << " " << Resources::GetInstance().ResolveWingetString(L"PreviewVersion") << std::endl <<
             "Copyright (c) Microsoft Corporation. All rights reserved." << std::endl;
     }
 
@@ -145,11 +145,11 @@ namespace AppInstaller::CLI
         {
             if (Name() == FullName())
             {
-                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableCommands").c_str() << std::endl;
+                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableCommands") << std::endl;
             }
             else
             {
-                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableSubcommands").c_str() << std::endl;
+                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableSubcommands") << std::endl;
             }
 
             size_t maxCommandNameLength = 0;
@@ -166,7 +166,7 @@ namespace AppInstaller::CLI
 
             infoOut <<
                 std::endl <<
-                Resources::GetInstance().ResolveWingetString(L"HelpForDetails").c_str()
+                Resources::GetInstance().ResolveWingetString(L"HelpForDetails")
                 << " [" << APPINSTALLER_CLI_HELP_ARGUMENT << ']' << std::endl;
         }
 
@@ -197,7 +197,7 @@ namespace AppInstaller::CLI
 
             if (hasArguments)
             {
-                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableArguements").c_str() << std::endl;
+                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableArguements") << std::endl;
 
                 size_t i = 0;
                 for (const auto& arg : GetArguments())
@@ -221,7 +221,7 @@ namespace AppInstaller::CLI
                     infoOut << std::endl;
                 }
 
-                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableOptions").c_str() << std::endl;
+                infoOut << Resources::GetInstance().ResolveWingetString(L"AvailableOptions") << std::endl;
 
                 size_t i = 0;
                 for (const auto& arg : GetArguments())
@@ -237,6 +237,13 @@ namespace AppInstaller::CLI
                     }
                 }
             }
+        }
+
+        // Finally, the link to the documentation pages
+        std::string helpLink = HelpLink();
+        if (!helpLink.empty())
+        {
+            infoOut << std::endl << Resources::GetInstance().ResolveWingetString(L"HelpLinkPreamble") << ' ' << helpLink << std::endl;
         }
     }
 
@@ -477,7 +484,7 @@ namespace AppInstaller::CLI
 
     void Command::ExecuteInternal(Execution::Context& context) const
     {
-        context.Reporter.Error() << Resources::GetInstance().ResolveWingetString(L"PendingWorkError").c_str() << std::endl;
+        context.Reporter.Error() << Resources::GetInstance().ResolveWingetString(L"PendingWorkError") << std::endl;
         THROW_HR(E_NOTIMPL);
     }
 }

--- a/src/AppInstallerCLICore/Command.h
+++ b/src/AppInstallerCLICore/Command.h
@@ -53,6 +53,7 @@ namespace AppInstaller::CLI
 
         virtual void OutputIntroHeader(Execution::Reporter& reporter) const;
         virtual void OutputHelp(Execution::Reporter& reporter, const CommandException* exception = nullptr) const;
+        virtual std::string HelpLink() const { return {}; }
 
         virtual std::unique_ptr<Command> FindSubCommand(Invocation& inv) const;
         virtual void ParseArguments(Invocation& inv, Execution::Args& execArgs) const;

--- a/src/AppInstallerCLICore/Commands/HashCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HashCommand.cpp
@@ -27,6 +27,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"HashHelperDescription");
     }
 
+    std::string HashCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-hash";
+    }
+
     void HashCommand::ExecuteInternal(Execution::Context& context) const
     {
         context <<

--- a/src/AppInstallerCLICore/Commands/HashCommand.h
+++ b/src/AppInstallerCLICore/Commands/HashCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };

--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -46,6 +46,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"InstallCommandDescription");
     }
 
+    std::string InstallCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-install";
+    }
+
     void InstallCommand::ExecuteInternal(Execution::Context& context) const
     {
         context <<

--- a/src/AppInstallerCLICore/Commands/InstallCommand.h
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         std::string ShortDescription() const override;
         std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -39,6 +39,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"ToolDescription");
     }
 
+    std::string RootCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-help";
+    }
+
     void RootCommand::ExecuteInternal(Execution::Context& context) const
     {
         if (context.Args.Contains(Execution::Args::Type::Info))

--- a/src/AppInstallerCLICore/Commands/RootCommand.h
+++ b/src/AppInstallerCLICore/Commands/RootCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
 
         std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const;
     };

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -35,6 +35,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"SearchCommandDescription").c_str();
     }
 
+    std::string SearchCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-search";
+    }
+
     void SearchCommand::ExecuteInternal(Context& context) const
     {
         context <<

--- a/src/AppInstallerCLICore/Commands/SearchCommand.h
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -34,6 +34,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"ShowCommandLongDescription");
     }
 
+    std::string ShowCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-show";
+    }
+
     void ShowCommand::ExecuteInternal(Execution::Context& context) const
     {
         if (context.Args.Contains(Execution::Args::Type::ListVersions))

--- a/src/AppInstallerCLICore/Commands/ShowCommand.h
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         void ExecuteInternal(AppInstaller::CLI::Execution::Context& context) const override;
     };

--- a/src/AppInstallerCLICore/Commands/SourceCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.cpp
@@ -9,6 +9,9 @@
 namespace AppInstaller::CLI
 {
     using namespace AppInstaller::CLI::Execution;
+    using namespace std::string_view_literals;
+
+    static constexpr std::string_view s_SourceCommand_HelpLink = "https://aka.ms/winget-command-source"sv;
 
     std::vector<std::unique_ptr<Command>> SourceCommand::GetCommands() const
     {
@@ -29,6 +32,11 @@ namespace AppInstaller::CLI
     std::string SourceCommand::GetLongDescription() const
     {
         return Resources::GetInstance().ResolveWingetString(L"SourceCommandLongDescription");
+    }
+
+    std::string SourceCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
     }
 
     void SourceCommand::ExecuteInternal(Context& context) const
@@ -53,6 +61,11 @@ namespace AppInstaller::CLI
     std::string SourceAddCommand::GetLongDescription() const
     {
         return Resources::GetInstance().ResolveWingetString(L"SourceAddCommandLongDescription");
+    }
+
+    std::string SourceAddCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
     }
 
     void SourceAddCommand::ExecuteInternal(Context& context) const
@@ -80,6 +93,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"SourceListCommandLongDescription");
     }
 
+    std::string SourceListCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
+    }
+
     void SourceListCommand::ExecuteInternal(Context& context) const
     {
         context <<
@@ -102,6 +120,11 @@ namespace AppInstaller::CLI
     std::string SourceUpdateCommand::GetLongDescription() const
     {
         return Resources::GetInstance().ResolveWingetString(L"SourceUpdateCommandLongDescription");
+    }
+
+    std::string SourceUpdateCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
     }
 
     void SourceUpdateCommand::ExecuteInternal(Context& context) const
@@ -128,6 +151,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"SourceRemoveCommandLongDescription");
     }
 
+    std::string SourceRemoveCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
+    }
+
     void SourceRemoveCommand::ExecuteInternal(Context& context) const
     {
         context <<
@@ -151,6 +179,11 @@ namespace AppInstaller::CLI
     std::string SourceResetCommand::GetLongDescription() const
     {
         return Resources::GetInstance().ResolveWingetString(L"SourceResetCommandLongDescription");
+    }
+
+    std::string SourceResetCommand::HelpLink() const
+    {
+        return std::string{ s_SourceCommand_HelpLink };
     }
 
     void SourceResetCommand::ExecuteInternal(Context& context) const

--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const;
     };
@@ -26,6 +28,8 @@ namespace AppInstaller::CLI
 
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
+
+        std::string HelpLink() const override;
 
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const override;
@@ -40,6 +44,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const override;
     };
@@ -52,6 +58,8 @@ namespace AppInstaller::CLI
 
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
+
+        std::string HelpLink() const override;
 
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const override;
@@ -66,6 +74,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const override;
     };
@@ -78,6 +88,8 @@ namespace AppInstaller::CLI
 
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
+
+        std::string HelpLink() const override;
 
     protected:
         virtual void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
@@ -26,6 +26,11 @@ namespace AppInstaller::CLI
         return Resources::GetInstance().ResolveWingetString(L"ValidateCommandLongDescription");
     }
 
+    std::string ValidateCommand::HelpLink() const
+    {
+        return "https://aka.ms/winget-command-validate";
+    }
+
     void ValidateCommand::ExecuteInternal(Execution::Context& context) const
     {
         context <<

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.h
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.h
@@ -14,6 +14,8 @@ namespace AppInstaller::CLI
         virtual std::string ShortDescription() const override;
         virtual std::string GetLongDescription() const override;
 
+        std::string HelpLink() const override;
+
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -170,6 +170,9 @@
   <data name="HelpForDetails" xml:space="preserve">
     <value>For more details on a specific command, pass it the help argument.</value>
   </data>
+  <data name="HelpLinkPreamble" xml:space="preserve">
+    <value>More help can be found at:</value>
+  </data>
   <data name="IdArgumentDescription" xml:space="preserve">
     <value>Filter results by id</value>
   </data>


### PR DESCRIPTION
## Change
We have MSDN documentation for the various commands, this change adds links at the bottom of the help output to aka.ms redirectors.

## Validation
Manually verified the links for each command.