### PR TITLE
Switch to using sqlite3_prepare_v2

### DIFF
--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -689,9 +689,9 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
-    Statement StatementBuilder::Prepare(Connection& connection, bool persistent)
+    Statement StatementBuilder::Prepare(Connection& connection)
     {
-        Statement result = Statement::Create(connection, m_stream.str(), persistent);
+        Statement result = Statement::Create(connection, m_stream.str());
         for (const auto& f : m_binders)
         {
             f(result);

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -334,7 +334,7 @@ namespace AppInstaller::Repository::SQLite::Builder
         int GetLastBindIndex() const { return m_bindIndex - 1; }
 
         // Prepares and returns the statement, applying any bindings that were requested.
-        Statement Prepare(Connection& connection, bool persistent = false);
+        Statement Prepare(Connection& connection);
 
         // A convenience function that prepares, binds, and then executes a statement that does not return rows.
         void Execute(Connection& connection);

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.h
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.h
@@ -155,9 +155,9 @@ namespace AppInstaller::Repository::SQLite
     // A SQL statement.
     struct Statement
     {
-        static Statement Create(Connection& connection, const std::string& sql, bool persistent = false);
-        static Statement Create(Connection& connection, std::string_view sql, bool persistent = false);
-        static Statement Create(Connection& connection, char const* const sql, bool persistent = false);
+        static Statement Create(Connection& connection, const std::string& sql);
+        static Statement Create(Connection& connection, std::string_view sql);
+        static Statement Create(Connection& connection, char const* const sql);
 
         Statement() = default;
 
@@ -231,7 +231,7 @@ namespace AppInstaller::Repository::SQLite
         operator bool() const { return static_cast<bool>(m_stmt); }
 
     private:
-        Statement(Connection& connection, std::string_view sql, bool persistent);
+        Statement(Connection& connection, std::string_view sql);
 
         // Helper to receive the integer sequence from the public function.
         // This is equivalent to calling:


### PR DESCRIPTION
## Change
v3 is not available on Windows 10 (16299), and we don't really need or use the persistent statements in a meaningful way.  Fall back to v2 and remove the persistent statement support.

## Validation
Regression tests and manual use against production environment.