### PR TITLE
Make Id,Version,Channel key for manifest operations case insensitive

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
@@ -22,10 +22,19 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             createTableBuilder.Execute(connection);
         }
 
-        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value)
+        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike)
         {
             SQLite::Builder::StatementBuilder selectBuilder;
-            selectBuilder.Select(SQLite::RowIDName).From(tableName).Where(valueName).Equals(value);
+            selectBuilder.Select(SQLite::RowIDName).From(tableName).Where(valueName);
+
+            if (useLike)
+            {
+                selectBuilder.LikeWithEscape(value);
+            }
+            else
+            {
+                selectBuilder.Equals(value);
+            }
 
             SQLite::Statement select = selectBuilder.Prepare(connection);
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -16,7 +16,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         void CreateOneToOneTable(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName);
 
         // Selects the value from the table, returning the rowid if it exists.
-        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value);
+        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike = false);
 
         // Selects the value from the table, returning the rowid if it exists.
         std::optional<std::string> OneToOneTableSelectValueById(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, SQLite::rowid_t id);
@@ -72,9 +72,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Selects the value from the table, returning the rowid if it exists.
-        static std::optional<SQLite::rowid_t> SelectIdByValue(SQLite::Connection& connection, std::string_view value)
+        static std::optional<SQLite::rowid_t> SelectIdByValue(SQLite::Connection& connection, std::string_view value, bool useLike = false)
         {
-            return details::OneToOneTableSelectIdByValue(connection, TableInfo::TableName(), TableInfo::ValueName(), value);
+            return details::OneToOneTableSelectIdByValue(connection, TableInfo::TableName(), TableInfo::ValueName(), value, useLike);
         }
 
         // Selects the value from the table, returning it if it exists.

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -297,6 +297,12 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
+    StatementBuilder& StatementBuilder::LikeWithEscape(std::string_view value)
+    {
+        AddBindFunctor(AppendOpAndBinder(Op::Like), EscapeStringForLike(value));
+        return Escape(EscapeCharForLike);
+    }
+
     StatementBuilder& StatementBuilder::Like(details::unbound_t)
     {
         AppendOpAndBinder(Op::Like);

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -202,7 +202,9 @@ namespace AppInstaller::Repository::SQLite::Builder
         StatementBuilder& Equals(details::unbound_t);
         StatementBuilder& Equals(std::nullptr_t);
 
+        StatementBuilder& LikeWithEscape(std::string_view value);
         StatementBuilder& Like(details::unbound_t);
+
         StatementBuilder& Escape(std::string_view escapeChar);
 
         StatementBuilder& Not();


### PR DESCRIPTION
## Change
To prevent confusion, and enable updates to the casing of these values, this change makes the Id, Version, and Channel fields case insensitive for manifest operations (add/update/remove).  Updates will also change the values to the new casings.

## Validation
Added/updated tests for this new case insensitive behavior.