### PR TITLE
Updating readme telemetry section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,5 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Data/Telemetry
 
-This project collects usage data and sends it to Microsoft to help improve our products and services. See the [privacy statement](privacy.md) for more details.
+This project collects usage data and sends it to Microsoft to help improve our products and services. Note however that no data collection is performed when using your private builds.
+See the [privacy statement](privacy.md) for more details.


### PR DESCRIPTION
Updating readme telemetry section to note that data is collected only when using release builds and not when using private builds. Please refer to privacy.md for the link to detailed privacy statement. The release build telemetry is covered by Windows 10 privacy -  https://support.microsoft.com/en-us/help/4468236/diagnostics-feedback-and-privacy-in-windows-10-microsoft-privacy