### PR TITLE
Fix #137: Add SuccessExitCode to ManifestInstaller

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -138,6 +138,7 @@ namespace AppInstaller::CLI::Workflow
     {
         context.Reporter.Info() << "Installing ..." << std::endl;
 
+        const auto& installer = context.Get<Execution::Data::Installer>();
         const std::string& installerArgs = context.Get<Execution::Data::InstallerArgs>();
 
         auto installResult = context.Reporter.ExecuteWithProgress(
@@ -151,7 +152,7 @@ namespace AppInstaller::CLI::Workflow
             context.Reporter.Warn() << "Installation abandoned" << std::endl;
             AICLI_TERMINATE_CONTEXT(E_ABORT);
         }
-        else if (installResult.value() != 0)
+        else if (installResult.value() != installer->SuccessExitCode)
         {
             const auto& manifest = context.Get<Execution::Data::Manifest>();
             Logging::Telemetry().LogInstallerFailure(manifest.Id, manifest.Version, manifest.Channel, "ShellExecute", installResult.value());

--- a/src/AppInstallerRepositoryCore/Manifest/ManifestInstaller.cpp
+++ b/src/AppInstallerRepositoryCore/Manifest/ManifestInstaller.cpp
@@ -15,6 +15,7 @@ namespace AppInstaller::Manifest
         YAML::Node switchesNode;
         this->InstallerType = defaultInstaller.InstallerType;
         this->Scope = "user";
+        this->SuccessExitCode = 0;
 
         std::vector<ManifestFieldInfo> fieldInfos;
 
@@ -30,6 +31,7 @@ namespace AppInstaller::Manifest
                 { "Scope", [this](const YAML::Node& value) { Scope = value.as<std::string>(); } },
                 { "InstallerType", [this](const YAML::Node& value) { InstallerType = ConvertToInstallerTypeEnum(value.as<std::string>()); } },
                 { "Switches", [&](const YAML::Node& value) { switchesNode = value; } },
+                { "SuccessExitCode", [&](const YAML::Node& value) { SuccessExitCode = value.as<DWORD>(); } },
             };
 
             std::move(previewFieldInfos.begin(), previewFieldInfos.end(), std::inserter(fieldInfos, fieldInfos.end()));

--- a/src/AppInstallerRepositoryCore/Manifest/ManifestInstaller.h
+++ b/src/AppInstallerRepositoryCore/Manifest/ManifestInstaller.h
@@ -71,6 +71,9 @@ namespace AppInstaller::Manifest
         // If present, has more precedence than root
         std::map<InstallerSwitchType, string_t> Switches;
 
+        // Optional. Default is zero.
+        DWORD SuccessExitCode;
+
         static InstallerTypeEnum ConvertToInstallerTypeEnum(const std::string& in);
 
         static std::map<InstallerSwitchType, string_t> GetDefaultKnownSwitches(InstallerTypeEnum installerType);


### PR DESCRIPTION
This PR suggests a fix for #137 by adding an optional `SuccessExitCode` attribute to the Installers entries in the manifest. If present, it overrides the default value of zero.

For now, this only allows a single value to be defined as success status code. I am not sure if there are cases where we would want multiple exit codes to count as success.

Right now, SuccessExitCode is not printed by the "show" command but we could add it if desired.