### PR TITLE
Fix misalignment of table output for multi-byte chars (#268)

### DIFF
--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -192,7 +192,7 @@ namespace AppInstaller::CLI::Execution
                     if (valueLength > col.MaxLength)
                     {
                         size_t replaceChars = std::min(col.MaxLength, static_cast<size_t>(3));
-                        std::string replacement = line[i].substr(0, col.MaxLength - replaceChars);
+                        std::string replacement = Utility::UTF8Substring(0, col.MaxLength - replaceChars);
                         replacement.append(replaceChars, '.');
                         out << replacement;
 

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -40,7 +40,7 @@ namespace AppInstaller::CLI::Execution
             for (size_t i = 0; i < FieldCount; ++i)
             {
                 m_columns[i].Name = std::move(header[i]);
-                m_columns[i].MinLength = m_columns[i].Name.length();
+                m_columns[i].MinLength = Utility::UTF8Length(m_columns[i].Name);
                 m_columns[i].MaxLength = 0;
             }
         }
@@ -91,7 +91,7 @@ namespace AppInstaller::CLI::Execution
             {
                 for (size_t i = 0; i < FieldCount; ++i)
                 {
-                    m_columns[i].MaxLength = std::max(m_columns[i].MaxLength, line[i].length());
+                    m_columns[i].MaxLength = std::max(m_columns[i].MaxLength, Utility::UTF8Length(line[i]));
                 }
             }
 
@@ -187,7 +187,9 @@ namespace AppInstaller::CLI::Execution
 
                 if (col.MaxLength)
                 {
-                    if (line[i].length() > col.MaxLength)
+                    size_t valueLength = Utility::UTF8Length(line[i]);
+
+                    if (valueLength > col.MaxLength)
                     {
                         size_t replaceChars = std::min(col.MaxLength, static_cast<size_t>(3));
                         std::string replacement = line[i].substr(0, col.MaxLength - replaceChars);
@@ -205,7 +207,7 @@ namespace AppInstaller::CLI::Execution
 
                         if (col.SpaceAfter)
                         {
-                            out << std::string(col.MaxLength - line[i].length() + 1, ' ');
+                            out << std::string(col.MaxLength - valueLength + 1, ' ');
                         }
                     }
                 }

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -191,10 +191,8 @@ namespace AppInstaller::CLI::Execution
 
                     if (valueLength > col.MaxLength)
                     {
-                        size_t replaceChars = std::min(col.MaxLength, static_cast<size_t>(3));
-                        std::string replacement = Utility::UTF8Substring(0, col.MaxLength - replaceChars);
-                        replacement.append(replaceChars, '.');
-                        out << replacement;
+                        out << Utility::UTF8Substring(line[i], 0, col.MaxLength - 1);
+                        out << "\xE2\x80\xA6"; // UTF8 encoding of ellipsis (…) character
 
                         if (col.SpaceAfter)
                         {

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -7,6 +7,35 @@
 using namespace AppInstaller::Utility;
 
 
+TEST_CASE("UTF8Length", "[strings]")
+{
+    REQUIRE(UTF8Length("") == 0);
+    REQUIRE(UTF8Length("a") == 1);
+    REQUIRE(UTF8Length(" a b c ") == 7);
+    REQUIRE(UTF8Length("K\xC3\xA4se") == 4); // "Käse"
+    REQUIRE(UTF8Length("bye\xE2\x80\xA6") == 4); // "bye…"
+    REQUIRE(UTF8Length("\xf0\x9f\xa6\x86") == 1); // [duck emoji]
+    REQUIRE(UTF8Length("\xf0\x9d\x85\xa0\xf0\x9d\x85\xa0") == 2); // [8th note][8th note]
+}
+
+TEST_CASE("UTF8Substring", "[strings]")
+{    
+    REQUIRE(UTF8Substring("", 0, 0) == "");
+    REQUIRE(UTF8Substring("abcd", 0, 4) == "abcd");
+    REQUIRE(UTF8Substring("abcd", 0, 2) == "ab");
+    REQUIRE(UTF8Substring("abcd", 1, 0) == "");
+    REQUIRE(UTF8Substring("abcd", 1, 1) == "b");
+    REQUIRE(UTF8Substring("abcd", 1, 3) == "bcd");
+    REQUIRE(UTF8Substring("abcd", 4, 0) == "");
+
+    const char* s = "\xf0\x9f\xa6\x86s like \xf0\x9f\x8c\x8a"; // [duck emoji]s like [wave emoji]
+    REQUIRE(UTF8Substring(s, 0, 9) == "\xf0\x9f\xa6\x86s like \xf0\x9f\x8c\x8a");
+    REQUIRE(UTF8Substring(s, 0, 1) == "\xf0\x9f\xa6\x86");
+    REQUIRE(UTF8Substring(s, 0, 2) == "\xf0\x9f\xa6\x86s");
+    REQUIRE(UTF8Substring(s, 1, 7) == "s like ");
+    REQUIRE(UTF8Substring(s, 1, 8) == "s like \xf0\x9f\x8c\x8a");
+}
+
 TEST_CASE("Normalize", "[strings]")
 {
     REQUIRE(Normalize("test") == "test");

--- a/src/AppInstallerCommonCore/AppInstallerStrings.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerStrings.cpp
@@ -58,6 +58,19 @@ namespace AppInstaller::Utility
         return result;
     }
 
+    size_t UTF8Length(std::string_view input)
+    {
+        if (input.empty())
+        {
+            return 0;
+        }
+
+        int utf16CharCount = MultiByteToWideChar(CP_UTF8, 0, input.data(), wil::safe_cast<int>(input.length()), nullptr, 0);
+        THROW_LAST_ERROR_IF(utf16CharCount == 0);
+
+        return wil::safe_cast<size_t>(utf16CharCount);
+    }
+
     std::string Normalize(std::string_view input, NORM_FORM form)
     {
         if (input.empty())

--- a/src/AppInstallerCommonCore/AppInstallerStrings.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerStrings.cpp
@@ -47,7 +47,7 @@ namespace AppInstaller::Utility
                 int32_t i = ubrk_first(m_brk.get());
                 if (i != 0)
                 {
-                    AICLI_LOG(Core, Error, << "ubrk_first returned 0");
+                    AICLI_LOG(Core, Error, << "ubrk_first returned " << i);
                     THROW_HR(E_UNEXPECTED);
                 }
             }

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -17,8 +17,11 @@ namespace AppInstaller::Utility
     // Converts the given UTF8 string to UTF16
     std::wstring ConvertToUTF16(std::string_view input);
 
-    // Returns the number of characters (not bytes) in an UTF8-encoded string.
+    // Returns the number of grapheme clusters (characters) in an UTF8-encoded string.
     size_t UTF8Length(std::string_view input);
+
+    // Returns a substring view in an UTF8-encoded string. Offset and count are measured in grapheme clusters (characters).
+    std::string_view UTF8Substring(std::string_view input, size_t offset, size_t count);
 
     // Normalizes a UTF8 string to the given form.
     std::string Normalize(std::string_view input, NORM_FORM form = NORM_FORM::NormalizationKC);

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -17,6 +17,9 @@ namespace AppInstaller::Utility
     // Converts the given UTF8 string to UTF16
     std::wstring ConvertToUTF16(std::string_view input);
 
+    // Returns the number of characters (not bytes) in an UTF8-encoded string.
+    size_t UTF8Length(std::string_view input);
+
     // Normalizes a UTF8 string to the given form.
     std::string Normalize(std::string_view input, NORM_FORM form = NORM_FORM::NormalizationKC);
 


### PR DESCRIPTION
This PR suggests a fix for #268. The problem is that `std::string::length()` is used in `TableOutput` to determine the length of table cell values. Since `std::string` is not UTF8-aware, it returns the number of bytes, not characters. The two are different if the string contains special characters.

This fix adds a `Utility::UTF8Length` method to obtain the number of characters of a UTF8 string, and uses it in `TableOutput` to compute the display length of cell values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/313)