### PR TITLE
Automatically supply default silent args when possible

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -65,7 +65,20 @@ namespace AppInstaller::CLI::Workflow
             const std::map<ManifestInstaller::InstallerSwitchType, Utility::NormalizedString>& installerSwitches = context.Get<Execution::Data::Installer>()->Switches;
 
             // Construct install experience arg.
-            if (context.Args.Contains(Execution::Args::Type::Silent) && installerSwitches.find(ManifestInstaller::InstallerSwitchType::Silent) != installerSwitches.end())
+            auto installerType = context.Get<Execution::Data::Installer>()->InstallerType;
+            if (context.Args.Contains(Execution::Args::Type::Silent) && installerType == ManifestInstaller::InstallerTypeEnum::Nullsoft)
+            {
+                installerArgs += "/S";
+            }
+            else if (context.Args.Contains(Execution::Args::Type::Silent) && installerType == ManifestInstaller::InstallerTypeEnum::Inno)
+            {
+                installerArgs += "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-";
+            }
+            else if (context.Args.Contains(Execution::Args::Type::Silent) && installerType == ManifestInstaller::InstallerTypeEnum::Burn)
+            {
+                installerArgs += "/install /quiet";
+            }
+            else if (context.Args.Contains(Execution::Args::Type::Silent) && installerSwitches.find(ManifestInstaller::InstallerSwitchType::Silent) != installerSwitches.end())
             {
                 installerArgs += installerSwitches.at(ManifestInstaller::InstallerSwitchType::Silent);
             }


### PR DESCRIPTION
This is a rough first draft. Silent args for NSIS and InnoSetup were copied from Chocolatey scripts that call installers written using those technologies. Silent args for Burn were copied from the help text of a Burn-based installer for one of my projects; I understand all Burn-based bootstrappers use the same syntax. Feedback is welcome. Thanks!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/341)