### PR TITLE
Change "Spring" to "March-May" to be more explicit

### DIFF
--- a/doc/windows-package-manager-v1-roadmap.md
+++ b/doc/windows-package-manager-v1-roadmap.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document outlines our aspirational roadmap to delivering Windows Package Manager v1.0 by Spring 2021. We anticipate substantial feedback from the community, and as such, this plan is subject to change.
+This document outlines our aspirational roadmap to delivering Windows Package Manager v1.0 by March-May 2021. We anticipate substantial feedback from the community, and as such, this plan is subject to change.
 
 ## Milestones
 


### PR DESCRIPTION
First of all, apologies if this should be an issue first, but would rather open a pr to show what I mean. 

A lot of roadmaps and timelines use seasons as targets which I personally really dislike. Seasons aren't the same throughout the world and so it can be a bit confusing for people in the southern hemisphere (like myself) and we normally just have to assume northern. This change also aligns with some of the things highlighted in the code of conduct . https://opensource.microsoft.com/codeofconduct/

This may seem super minor and petty but I do think that it should honestly just be standard to go by either actual months, or even better quarters. (I prefer quarters but that is slightly different to seasons.) I also think we should be more exclusive in general of people throughout the world. 

Anyways, keen to make this sound better but I do really think this should be standard and am keen to here what everything thinks and hope people take it seriously. :)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/354)