### PR TITLE
Update spec template and spec to include link

### DIFF
--- a/doc/specs/#292 - winget should install an app if there is an exact match.md
+++ b/doc/specs/#292 - winget should install an app if there is an exact match.md
@@ -7,7 +7,7 @@ issue id: 292
 
 # Package matching bug fix
 
-For #292
+For [#292](https://github.com/microsoft/winget-cli/issues/292)
 
 ## Abstract
 

--- a/doc/specs/#292 - winget should install an app if there is an exact match.md
+++ b/doc/specs/#292 - winget should install an app if there is an exact match.md
@@ -2,10 +2,12 @@
 author: Demitrius Nelon @denelon
 created on: <2020-05-28>
 last updated: <2020-05-28>
-issue id: #292
+issue id: 292
 ---
 
 # Package matching bug fix
+
+For #292
 
 ## Abstract
 

--- a/doc/specs/#292 - winget should install an app if there is an exact match.md
+++ b/doc/specs/#292 - winget should install an app if there is an exact match.md
@@ -2,7 +2,7 @@
 author: Demitrius Nelon @denelon
 created on: <2020-05-28>
 last updated: <2020-05-28>
-issue id: 292
+issue id: #292
 ---
 
 # Package matching bug fix

--- a/doc/specs/spec-template.md
+++ b/doc/specs/spec-template.md
@@ -2,10 +2,12 @@
 author: <first-name> <last-name> <github-id>/<email>
 created on: <yyyy-mm-dd>
 last updated: <yyyy-mm-dd>
-issue id: <github issue id link>
+issue id: <github issue id>
 ---
 
 # Spec Title
+
+[comment]: # Link to issue: "For #1"
 
 ## Abstract
 

--- a/doc/specs/spec-template.md
+++ b/doc/specs/spec-template.md
@@ -7,7 +7,7 @@ issue id: <github issue id>
 
 # Spec Title
 
-[comment]: # Link to issue: "For #1"
+[comment]: # Link to issue: "For [#1](https://github.com/microsoft/winget-cli/issues/1)"
 
 ## Abstract
 

--- a/doc/specs/spec-template.md
+++ b/doc/specs/spec-template.md
@@ -2,7 +2,7 @@
 author: <first-name> <last-name> <github-id>/<email>
 created on: <yyyy-mm-dd>
 last updated: <yyyy-mm-dd>
-issue id: <github issue id>
+issue id: <github issue id link>
 ---
 
 # Spec Title


### PR DESCRIPTION
## Change
Add a place in the template to include a link to the issue, as it is somewhat onerous to have to find the issue oneself from the id alone.

Why wasn't my "# 292" (added a space because I don't actually want to reference it) turned into a link to the issue in this md file?  Does that only work in PRs and Issues themselves, but not in standalone markdown? ... Looked it up myself, and files don't get the short links:

https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls
```
Note: Autolinked references are not created in wikis or files in a repository.
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/368)