### PR TITLE
Fixed incorrect capitalization for en-us

### DIFF
--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -372,7 +372,7 @@
     <value>Third Party Notices</value>
   </data>
   <data name="ToolDescription" xml:space="preserve">
-    <value>WinGet command line utility enables installing applications from the command line.</value>
+    <value>The winget command line utility enables installing applications from the command line.</value>
   </data>
   <data name="ToolInfoArgumentDescription" xml:space="preserve">
     <value>Display general info of the tool</value>


### PR DESCRIPTION
#139 Fixed the issue where winget has incorrect capitalization in --help.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/444)