### PR TITLE
Fix #446: Save some file to UTF-8 (with BOM) encoding.

### DIFF
--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
 #include "ExecutionReporter.h"
@@ -192,7 +192,7 @@ namespace AppInstaller::CLI::Execution
                     if (valueLength > col.MaxLength)
                     {
                         out << Utility::UTF8Substring(line[i], 0, col.MaxLength - 1);
-                        out << "\xE2\x80\xA6"; // UTF8 encoding of ellipsis (�) character
+                        out << "\xE2\x80\xA6"; // UTF8 encoding of ellipsis (…) character
 
                         if (col.SpaceAfter)
                         {

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+ï»¿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
 #include "TestCommon.h"
@@ -12,8 +12,8 @@ TEST_CASE("UTF8Length", "[strings]")
     REQUIRE(UTF8Length("") == 0);
     REQUIRE(UTF8Length("a") == 1);
     REQUIRE(UTF8Length(" a b c ") == 7);
-    REQUIRE(UTF8Length("K\xC3\xA4se") == 4); // "Käse"
-    REQUIRE(UTF8Length("bye\xE2\x80\xA6") == 4); // "bye…"
+    REQUIRE(UTF8Length("K\xC3\xA4se") == 4); // "KÃ¤se"
+    REQUIRE(UTF8Length("bye\xE2\x80\xA6") == 4); // "byeâ€¦"
     REQUIRE(UTF8Length("\xf0\x9f\xa6\x86") == 1); // [duck emoji]
     REQUIRE(UTF8Length("\xf0\x9d\x85\xa0\xf0\x9d\x85\xa0") == 2); // [8th note][8th note]
 }


### PR DESCRIPTION
#446 Fixed the issue where change file encoding from Windows-1252 to UTF-8 (with BOM).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/447)