### PR TITLE
Add logging to user settings

### DIFF
--- a/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
@@ -56,6 +56,7 @@ namespace AppInstaller::CLI
         if (static_cast<int>(reinterpret_cast<uintptr_t>(res)) <= 32)
         {
             // User doesn't have file type association. Default to notepad
+            AICLI_LOG(CLI, Info, << "Json file type association not found, using notepad.exe");
             ShellExecuteW(nullptr, nullptr, L"notepad", filePathUTF16.c_str(), nullptr, SW_SHOW);
         }
     }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -219,7 +219,7 @@ namespace AppInstaller::Settings
         }
         else
         {
-            AICLI_LOG(Core, Info, << "Setting file not found. Using default values.");
+            AICLI_LOG(Core, Info, << "Valid settings file not found. Using default values.");
         }
     }
 

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include <AppInstallerRuntime.h>
 #include "AppInstallerLanguageUtilities.h"
+#include "AppInstallerLogging.h"
 #include "JsonUtil.h"
 #include "winget/Settings.h"
 #include "winget/UserSettings.h"
@@ -24,10 +25,11 @@ namespace AppInstaller::Settings
     // }
 })"sv;
 
-    namespace SettingsWarnings
+    namespace SettingsMessage
     {
         const char* const Field = " Field: ";
         const char* const Value = " Value: ";
+        const char* const ValidMessage = "Valid setting";
         const char* const InvalidFieldValue = "Invalid field value.";
         const char* const InvalidFieldFormat = "Invalid field format.";
         constexpr std::string_view LoadedBackupSettings = "Loaded settings from backup file."sv;
@@ -38,7 +40,7 @@ namespace AppInstaller::Settings
         // Jsoncpp doesn't provide line number and column for an individual Json::Value node.
         inline std::string GetSettingsMessage(const std::string& message, const std::string& path)
         {
-            return message + SettingsWarnings::Field + path;
+            return message + SettingsMessage::Field + path;
         }
 
         template<class T>
@@ -56,7 +58,7 @@ namespace AppInstaller::Settings
                 convertedValue = value;
             }
 
-            return GetSettingsMessage(message, path) + SettingsWarnings::Value + convertedValue;
+            return GetSettingsMessage(message, path) + SettingsMessage::Value + convertedValue;
         }
 
 
@@ -82,6 +84,7 @@ namespace AppInstaller::Settings
                     return root;
                 }
 
+                AICLI_LOG(Core, Error, << "Error parsing " << fileName.u8string() << ": " << error);
                 warnings.emplace_back(fileName.u8string());
                 warnings.emplace_back(error);
             }
@@ -113,16 +116,25 @@ namespace AppInstaller::Settings
                         // Finally add it to the map
                         settings[S].emplace<details::SettingIndex(S)>(
                             std::forward<typename details::SettingMapping<S>::value_t>(validatedValue.value()));
+                        AICLI_LOG(Core, Info, << GetSettingsMessage(SettingsMessage::ValidMessage, path, jsonValue.value()));
                     }
                     else
                     {
-                        warnings.push_back(GetSettingsMessage(SettingsWarnings::InvalidFieldValue, path, jsonValue.value()));
+                        auto invalidFieldMsg = GetSettingsMessage(SettingsMessage::InvalidFieldValue, path, jsonValue.value());
+                        AICLI_LOG(Core, Error, << invalidFieldMsg << " Using default");
+                        warnings.emplace_back(invalidFieldMsg);
                     }
                 }
                 else
                 {
-                    warnings.emplace_back(GetSettingsMessage(SettingsWarnings::InvalidFieldFormat, path));
+                    auto invalidFormatMsg = GetSettingsMessage(SettingsMessage::InvalidFieldFormat, path);
+                    AICLI_LOG(Core, Error, << invalidFormatMsg << " Using default");
+                    warnings.emplace_back(invalidFormatMsg);
                 }
+            }
+            else
+            {
+                AICLI_LOG(Core, Info, << "Setting " << path <<" not found. Using default");
             }
         }
 
@@ -183,6 +195,7 @@ namespace AppInstaller::Settings
         auto settingsJson = ParseFile(s_SettingFileName, m_warnings);
         if (settingsJson.has_value())
         {
+            AICLI_LOG(Core, Info, << "Settings loaded from " << s_SettingFileName);
             m_type = UserSettingsType::Standard;
             settingsRoot = settingsJson.value();
         }
@@ -193,7 +206,8 @@ namespace AppInstaller::Settings
             auto settingsBackupJson = ParseFile(s_SettingBackupFileName, m_warnings);
             if (settingsBackupJson.has_value())
             {
-                m_warnings.emplace_back(SettingsWarnings::LoadedBackupSettings);
+                AICLI_LOG(Core, Info, << "Settings loaded from " << s_SettingFileName);
+                m_warnings.emplace_back(SettingsMessage::LoadedBackupSettings);
                 m_type = UserSettingsType::Backup;
                 settingsRoot = settingsBackupJson.value();
             }
@@ -202,6 +216,10 @@ namespace AppInstaller::Settings
         if (!settingsRoot.isNull())
         {
             ValidateAll(settingsRoot, m_settings, m_warnings, std::make_index_sequence<static_cast<size_t>(Setting::Max)>());
+        }
+        else
+        {
+            AICLI_LOG(Core, Info, << "Setting file not found. Using default values.");
         }
     }
 
@@ -215,6 +233,7 @@ namespace AppInstaller::Settings
             if (!std::filesystem::exists(UserSettings::SettingsFilePath()))
             {
                 SetSetting(Type::UserFile, s_SettingFileName, s_SettingEmpty);
+                AICLI_LOG(Core, Info, << "Created new settings file");
             }
         }
         else if (userSettingType == UserSettingsType::Standard)
@@ -223,6 +242,7 @@ namespace AppInstaller::Settings
             auto from = SettingsFilePath();
             auto to = SettingsBackupFilePath();
             std::filesystem::copy_file(from, to, std::filesystem::copy_options::overwrite_existing);
+            AICLI_LOG(Core, Info, << "Copied settings to backup file");
         }
     }
 


### PR DESCRIPTION
Add logs to have more information about the settings such as from where it got loaded and the values to failures parsing the file or validating values.

Validated by running scenarios and looking at the logs.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/452)