### PR TITLE
Case insensitivity improvements

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -25,7 +25,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         std::vector<SQLite::rowid_t> OneToOneTableGetAllRowIds(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, size_t limit);
 
         // Ensures that the values exists in the table.
-        SQLite::rowid_t OneToOneTableEnsureExists(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value);
+        SQLite::rowid_t OneToOneTableEnsureExists(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool overwriteLikeMatch = false);
 
         // Removes the given row by its rowid if it is no longer referenced.
         void OneToOneTableDeleteIfNotNeededById(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, SQLite::rowid_t id);
@@ -90,9 +90,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Ensures that the given value exists in the table, returning the rowid.
-        static SQLite::rowid_t EnsureExists(SQLite::Connection& connection, std::string_view value)
+        static SQLite::rowid_t EnsureExists(SQLite::Connection& connection, std::string_view value, bool overwriteLikeMatch = false)
         {
-            return details::OneToOneTableEnsureExists(connection, TableInfo::TableName(), TableInfo::ValueName(), value);
+            return details::OneToOneTableEnsureExists(connection, TableInfo::TableName(), TableInfo::ValueName(), value, overwriteLikeMatch);
         }
 
         // Removes the given row by its rowid if it is no longer referenced.


### PR DESCRIPTION
Resolves #252 

## Change
Makes version and channel case insensitive for lookups from the user.  They already were required to be case insensitive unique, so this shouldn't have any effect other than making use easier.

Causes an index modification (add / update) to overwrite the existing Id value with the incoming one if the casing is different.  So last writer wins on Id casing.  Other fields can have distinct casing per manifest revision for now, but since Id needs to be the thing that ties them together, it needs to be a single value.

## Validation
Added unit tests that verify both behaviors.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/459)