### PR TITLE
Add user specific directory for secure settings

### DIFF
--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -6,6 +6,7 @@
 #include <Windows.h>
 #include <appmodel.h>
 #include <WinInet.h>
+#include <sddl.h>
 #include <Shlobj.h>
 #include <Shlwapi.h>
 


### PR DESCRIPTION
For #464 

## Change
Injects the current user SID into the secure settings path to enable multiple users to have independent settings streams.

## Validation
Existing tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/465)