### PR TITLE
Change show and install to use a narrower search

### DIFF
--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -44,7 +44,7 @@ namespace AppInstaller::CLI
     {
         context <<
             Workflow::OpenSource <<
-            Workflow::SearchSource <<
+            Workflow::SearchSourceForMany <<
             Workflow::EnsureMatchesFromSearchResult <<
             Workflow::ReportSearchResult;
     }

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -54,7 +54,7 @@ namespace AppInstaller::CLI
             {
                 context <<
                     Workflow::OpenSource <<
-                    Workflow::SearchSource <<
+                    Workflow::SearchSourceForSingle <<
                     Workflow::EnsureOneMatchFromSearchResult <<
                     Workflow::ReportSearchResultIdentity <<
                     Workflow::ShowAppVersions;

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -91,9 +91,11 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(MonikerArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(MsixArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(MsixSignatureHashFailed);
+        WINGET_DEFINE_RESOURCE_STRINGID(MultiplePackagesFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NameArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(NoApplicableInstallers);
         WINGET_DEFINE_RESOURCE_STRINGID(NoExperimentalFeaturesMessage);
+        WINGET_DEFINE_RESOURCE_STRINGID(NoPackageFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NoVTArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(Options);
         WINGET_DEFINE_RESOURCE_STRINGID(OverrideArgumentDescription);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -33,7 +33,7 @@ namespace AppInstaller::CLI::Workflow
             context.Reporter.Info() << "Found " << Execution::NameEmphasis << name << " [" << Execution::IdEmphasis << id << ']' << std::endl;
         }
 
-        void SearchSourceApplyFilters(Execution::Context& context, SearchRequest searchRequest, MatchType matchType)
+        void SearchSourceApplyFilters(Execution::Context& context, SearchRequest& searchRequest, MatchType matchType)
         {
             const auto& args = context.Args;
 

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -32,6 +32,41 @@ namespace AppInstaller::CLI::Workflow
         {
             context.Reporter.Info() << "Found " << Execution::NameEmphasis << name << " [" << Execution::IdEmphasis << id << ']' << std::endl;
         }
+
+        void SearchSourceApplyFilters(Execution::Context& context, SearchRequest searchRequest, MatchType matchType)
+        {
+            const auto& args = context.Args;
+
+            if (args.Contains(Execution::Args::Type::Id))
+            {
+                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, args.GetArg(Execution::Args::Type::Id)));
+            }
+
+            if (args.Contains(Execution::Args::Type::Name))
+            {
+                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, args.GetArg(Execution::Args::Type::Name)));
+            }
+
+            if (args.Contains(Execution::Args::Type::Moniker))
+            {
+                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, args.GetArg(Execution::Args::Type::Moniker)));
+            }
+
+            if (args.Contains(Execution::Args::Type::Tag))
+            {
+                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Tag, matchType, args.GetArg(Execution::Args::Type::Tag)));
+            }
+
+            if (args.Contains(Execution::Args::Type::Command))
+            {
+                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Command, matchType, args.GetArg(Execution::Args::Type::Command)));
+            }
+
+            if (args.Contains(Execution::Args::Type::Count))
+            {
+                searchRequest.MaximumResults = std::stoi(std::string(args.GetArg(Execution::Args::Type::Count)));
+            }
+        }
     }
 
     bool WorkflowTask::operator==(const WorkflowTask& other) const
@@ -118,37 +153,10 @@ namespace AppInstaller::CLI::Workflow
             searchRequest.Query.emplace(RequestMatch(matchType, args.GetArg(Execution::Args::Type::Query)));
         }
 
-        if (args.Contains(Execution::Args::Type::Id))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, args.GetArg(Execution::Args::Type::Id)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Name))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, args.GetArg(Execution::Args::Type::Name)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Moniker))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, args.GetArg(Execution::Args::Type::Moniker)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Tag))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Tag, matchType, args.GetArg(Execution::Args::Type::Tag)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Command))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Command, matchType, args.GetArg(Execution::Args::Type::Command)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Count))
-        {
-            searchRequest.MaximumResults = std::stoi(std::string(args.GetArg(Execution::Args::Type::Count)));
-        }
+        SearchSourceApplyFilters(context, searchRequest, matchType);
 
         Logging::Telemetry().LogSearchRequest(
+            "many",
             args.GetArg(Execution::Args::Type::Query),
             args.GetArg(Execution::Args::Type::Id),
             args.GetArg(Execution::Args::Type::Name),
@@ -180,32 +188,10 @@ namespace AppInstaller::CLI::Workflow
             searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
         }
 
-        if (args.Contains(Execution::Args::Type::Id))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, args.GetArg(Execution::Args::Type::Id)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Name))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, args.GetArg(Execution::Args::Type::Name)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Moniker))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, args.GetArg(Execution::Args::Type::Moniker)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Tag))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Tag, matchType, args.GetArg(Execution::Args::Type::Tag)));
-        }
-
-        if (args.Contains(Execution::Args::Type::Command))
-        {
-            searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Command, matchType, args.GetArg(Execution::Args::Type::Command)));
-        }
+        SearchSourceApplyFilters(context, searchRequest, matchType);
 
         Logging::Telemetry().LogSearchRequest(
+            "single",
             args.GetArg(Execution::Args::Type::Query),
             args.GetArg(Execution::Args::Type::Id),
             args.GetArg(Execution::Args::Type::Name),

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -52,7 +52,13 @@ namespace AppInstaller::CLI::Workflow
     // Required Args: None
     // Inputs: Source
     // Outputs: SearchResult
-    void SearchSource(Execution::Context& context);
+    void SearchSourceForMany(Execution::Context& context);
+
+    // Performs a search on the source with the semantics of targeting a single application.
+    // Required Args: None
+    // Inputs: Source
+    // Outputs: SearchResult
+    void SearchSourceForSingle(Execution::Context& context);
 
     // Outputs the search results.
     // Required Args: None

--- a/src/AppInstallerCLIE2ETests/SearchCommand.cs
+++ b/src/AppInstallerCLIE2ETests/SearchCommand.cs
@@ -48,7 +48,7 @@ namespace AppInstallerCLIE2ETests
             // Search through name. No app found because name is "Visual Studio Code"
             result = TestCommon.RunAICLICommand("search", "--name VisualStudioCode");
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("No app found matching input criteria."));
+            Assert.True(result.StdOut.Contains("No package found matching input criteria."));
 
             // Search Microsoft should return multiple
             result = TestCommon.RunAICLICommand("search", "Microsoft");
@@ -59,7 +59,7 @@ namespace AppInstallerCLIE2ETests
             // Search Microsoft with exact arg should return none
             result = TestCommon.RunAICLICommand("search", "Microsoft -e");
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("No app found matching input criteria."));
+            Assert.True(result.StdOut.Contains("No package found matching input criteria."));
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/ShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ShowCommand.cs
@@ -41,14 +41,19 @@ namespace AppInstallerCLIE2ETests
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
             Assert.True(result.StdOut.Contains("No package found matching input criteria."));
 
+            // Show with a substring match still returns 0 results
+            result = TestCommon.RunAICLICommand("show", $"Microsoft -s {ShowTestSourceName}");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
+            Assert.True(result.StdOut.Contains("No package found matching input criteria."));
+
             // Show with 1 search match shows detailed manifest info
-            result = TestCommon.RunAICLICommand("show", $"VisualStudioCode -s {ShowTestSourceName}");
+            result = TestCommon.RunAICLICommand("show", $"Microsoft.VisualStudioCode -s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
             Assert.True(result.StdOut.Contains("Visual Studio Code"));
 
             // Show with --versions list the versions
-            result = TestCommon.RunAICLICommand("show", $"VisualStudioCode --versions -s {ShowTestSourceName}");
+            result = TestCommon.RunAICLICommand("show", $"Microsoft.VisualStudioCode --versions -s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
             Assert.True(result.StdOut.Contains("1.41.1"));

--- a/src/AppInstallerCLIE2ETests/ShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ShowCommand.cs
@@ -36,13 +36,6 @@ namespace AppInstallerCLIE2ETests
             Assert.True(result.StdOut.Contains("Microsoft.PowerToys"));
             Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
 
-            // Show with multiple search matches shows a "please refine input"
-            result = TestCommon.RunAICLICommand("show", $"Microsoft -s {ShowTestSourceName}");
-            Assert.AreEqual(Constants.ErrorCode.ERROR_MULTIPLE_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("Multiple packages found matching input criteria. Please refine the input."));
-            Assert.True(result.StdOut.Contains("Microsoft.PowerToys"));
-            Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
-
             // Show with 0 search match shows a "please refine input"
             result = TestCommon.RunAICLICommand("show", $"DoesNotExist -s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);

--- a/src/AppInstallerCLIE2ETests/ShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ShowCommand.cs
@@ -32,21 +32,21 @@ namespace AppInstallerCLIE2ETests
             // Show with no arg lists every app and a warning message
             var result = TestCommon.RunAICLICommand("show", $"-s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.ERROR_MULTIPLE_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("Multiple apps found matching input criteria. Please refine the input."));
+            Assert.True(result.StdOut.Contains("Multiple packages found matching input criteria. Please refine the input."));
             Assert.True(result.StdOut.Contains("Microsoft.PowerToys"));
             Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
 
             // Show with multiple search matches shows a "please refine input"
             result = TestCommon.RunAICLICommand("show", $"Microsoft -s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.ERROR_MULTIPLE_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("Multiple apps found matching input criteria. Please refine the input."));
+            Assert.True(result.StdOut.Contains("Multiple packages found matching input criteria. Please refine the input."));
             Assert.True(result.StdOut.Contains("Microsoft.PowerToys"));
             Assert.True(result.StdOut.Contains("Microsoft.VisualStudioCode"));
 
             // Show with 0 search match shows a "please refine input"
             result = TestCommon.RunAICLICommand("show", $"DoesNotExist -s {ShowTestSourceName}");
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
-            Assert.True(result.StdOut.Contains("No app found matching input criteria."));
+            Assert.True(result.StdOut.Contains("No package found matching input criteria."));
 
             // Show with 1 search match shows detailed manifest info
             result = TestCommon.RunAICLICommand("show", $"VisualStudioCode -s {ShowTestSourceName}");

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -157,7 +157,7 @@
     <value>Done</value>
   </data>
   <data name="ExactArgumentDescription" xml:space="preserve">
-    <value>Find app using exact match</value>
+    <value>Find package using exact match</value>
   </data>
   <data name="ExperimentalArgumentDescription" xml:space="preserve">
     <value>Experimental argument for demonstration purposes</value>
@@ -237,13 +237,14 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.</value>
   </data>
   <data name="InstallationRequiresHigherWindows" xml:space="preserve">
-    <value>Cannot install application, as it requires a higher version of Windows:</value>
+    <value>Cannot install package, as it requires a higher version of Windows:</value>
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
-    <value>Installs the selected application, either found by searching a configured source or directly from a manifest.</value>
+    <value>Installs the selected package, either found by searching a configured source or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
-    <value>Installs the given application</value>
+    <value>Installs the given package</value>
   </data>
   <data name="InstallerHashMismatchAdminBlock" xml:space="preserve">
     <value>Installer hash does not match; this cannot be overridden when running as admin</value>
@@ -298,7 +299,7 @@ They can be configured through the settings file 'winget settings'.</value>
     <comment>The primary webpage for the software</comment>
   </data>
   <data name="ManifestArgumentDescription" xml:space="preserve">
-    <value>The path to the manifest of the application</value>
+    <value>The path to the manifest of the package</value>
   </data>
   <data name="ManifestValidationFail" xml:space="preserve">
     <value>Manifest validation failed.</value>
@@ -313,13 +314,16 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Argument value required, but none found</value>
   </data>
   <data name="MonikerArgumentDescription" xml:space="preserve">
-    <value>Filter results by app moniker</value>
+    <value>Filter results by moniker</value>
   </data>
   <data name="MsixArgumentDescription" xml:space="preserve">
     <value>Input file will be treated as msix; signature hash will be provided if signed</value>
   </data>
   <data name="MsixSignatureHashFailed" xml:space="preserve">
     <value>Failed to calculate MSIX signature hash.</value>
+  </data>
+  <data name="MultiplePackagesFound" xml:space="preserve">
+    <value>Multiple packages found matching input criteria. Please refine the input.</value>
   </data>
   <data name="NameArgumentDescription" xml:space="preserve">
     <value>Filter results by name</value>
@@ -329,6 +333,9 @@ They can be configured through the settings file 'winget settings'.</value>
   </data>
   <data name="NoExperimentalFeaturesMessage" xml:space="preserve">
     <value>There are currently no exprimental features available. </value>
+  </data>
+  <data name="NoPackageFound" xml:space="preserve">
+    <value>No package found matching input criteria.</value>
   </data>
   <data name="NoVTArgumentDescription" xml:space="preserve">
     <value>Disables VirtualTerminal display</value>
@@ -355,7 +362,7 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Privacy Statement</value>
   </data>
   <data name="QueryArgumentDescription" xml:space="preserve">
-    <value>The query used to search for an app</value>
+    <value>The query used to search for a package</value>
   </data>
   <data name="RainbowArgumentDescription" xml:space="preserve">
     <value>Progress display a rainbow of colors</value>
@@ -367,10 +374,10 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Progress display as the default color</value>
   </data>
   <data name="SearchCommandLongDescription" xml:space="preserve">
-    <value>Searches for applications from configured sources.</value>
+    <value>Searches for pacakges from configured sources.</value>
   </data>
   <data name="SearchCommandShortDescription" xml:space="preserve">
-    <value>Find and show basic info of apps</value>
+    <value>Find and show basic info of packages</value>
   </data>
   <data name="SearchId" xml:space="preserve">
     <value>Id</value>
@@ -404,10 +411,10 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Channel</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
-    <value>Shows information on a specific application.</value>
+    <value>Shows information on a specific pacakge. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.</value>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
-    <value>Shows info about an application</value>
+    <value>Shows info about an package</value>
   </data>
   <data name="ShowVersion" xml:space="preserve">
     <value>Version</value>
@@ -431,7 +438,7 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Adding source:</value>
   </data>
   <data name="SourceAddCommandLongDescription" xml:space="preserve">
-    <value>Add a new source. A source provides the data for you to discover and install applications. Only add a new source if you trust it as a secure location.</value>
+    <value>Add a new source. A source provides the data for you to discover and install packages. Only add a new source if you trust it as a secure location.</value>
   </data>
   <data name="SourceAddCommandShortDescription" xml:space="preserve">
     <value>Add a new source</value>
@@ -440,13 +447,13 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Argument given to the source</value>
   </data>
   <data name="SourceArgumentDescription" xml:space="preserve">
-    <value>Find app using the specified source</value>
+    <value>Find package using the specified source</value>
   </data>
   <data name="SourceCommandLongDescription" xml:space="preserve">
-    <value>Manage sources with the sub-commands. A source provides the data for you to discover and install applications. Only add a new source if you trust it as a secure location.</value>
+    <value>Manage sources with the sub-commands. A source provides the data for you to discover and install packages. Only add a new source if you trust it as a secure location.</value>
   </data>
   <data name="SourceCommandShortDescription" xml:space="preserve">
-    <value>Manage sources of applications</value>
+    <value>Manage sources of packages</value>
   </data>
   <data name="SourceListArg" xml:space="preserve">
     <value>Argument</value>
@@ -551,7 +558,7 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Third Party Notices</value>
   </data>
   <data name="ToolDescription" xml:space="preserve">
-    <value>The winget command line utility enables installing applications from the command line.</value>
+    <value>The winget command line utility enables installing applications and other packages from the command line.</value>
   </data>
   <data name="ToolInfoArgumentDescription" xml:space="preserve">
     <value>Display general info of the tool</value>
@@ -594,6 +601,6 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Use the specified version; default is the latest version</value>
   </data>
   <data name="VersionsArgumentDescription" xml:space="preserve">
-    <value>Show available versions of the app</value>
+    <value>Show available versions of the package</value>
   </data>
 </root>

--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -1302,7 +1302,7 @@ TEST_CASE("SQLiteIndex_Search_InclusionAndFilter", "[sqliteindex]")
 
     auto result = index.GetIdStringById(results.Matches[0].first);
     REQUIRE(result.has_value());
-    REQUIRE(result.value() == "Id2");
+    REQUIRE(result.value() == "Nope");
 }
 
 TEST_CASE("SQLiteIndex_Search_QueryInclusionAndFilter", "[sqliteindex]")
@@ -1312,14 +1312,14 @@ TEST_CASE("SQLiteIndex_Search_QueryInclusionAndFilter", "[sqliteindex]")
 
     SQLiteIndex index = SearchTestSetup(tempFile, {
         { "Nope", "Name", "Moniker", "Version", "Channel", { "Tag" }, { "Command" }, "Path1" },
-        { "Id2", "Na", "Moniker", "Version", "Channel", { "Tag" }, { "Command" }, "Path2" },
-        { "Id3", "No", "Moniker", "Version", "Channel", { "Tag" }, { "Command" }, "Path3" },
+        { "Id2", "Na", "monicka", "Version", "Channel", { "Tag" }, { "Command" }, "Path2" },
+        { "Id3", "No", "moniker", "Version", "Channel", { "Tag" }, { "Command" }, "Path3" },
         });
 
     SearchRequest request;
     request.Query = RequestMatch(MatchType::Substring, "id3");
     request.Inclusions.emplace_back(ApplicationMatchField::Name, MatchType::Substring, "na");
-    request.Filters.emplace_back(ApplicationMatchField::Name, MatchType::CaseInsensitive, "name");
+    request.Filters.emplace_back(ApplicationMatchField::Moniker, MatchType::CaseInsensitive, "MONIKER");
 
     auto results = index.Search(request);
     REQUIRE(results.Matches.size() == 2);

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -284,6 +284,7 @@ namespace AppInstaller::Logging
     }
 
     void TelemetryTraceLogger::LogSearchRequest(
+        std::string_view type,
         std::string_view query,
         std::string_view id,
         std::string_view name,
@@ -299,6 +300,7 @@ namespace AppInstaller::Logging
                 "SearchRequest",
                 GetActivityId(),
                 nullptr,
+                AICLI_TraceLoggingStringView(type, "Type"),
                 AICLI_TraceLoggingStringView(query, "Query"),
                 AICLI_TraceLoggingStringView(id, "Id"),
                 AICLI_TraceLoggingStringView(name, "Name"),

--- a/src/AppInstallerCommonCore/Errors.cpp
+++ b/src/AppInstallerCommonCore/Errors.cpp
@@ -51,11 +51,11 @@ namespace AppInstaller
             case APPINSTALLER_CLI_ERROR_SOURCE_ARG_ALREADY_EXISTS:
                 return "The source location is already configured under another name";
             case APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND:
-                return "No applications found";
+                return "No packages found";
             case APPINSTALLER_CLI_ERROR_NO_SOURCES_DEFINED:
                 return "No sources are configured";
             case APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND:
-                return "Multiple applications found matching the criteria";
+                return "Multiple packages found matching the criteria";
             case APPINSTALLER_CLI_ERROR_NO_MANIFEST_FOUND:
                 return "No manifest found matching the criteria";
             case APPINSTALLER_CLI_ERROR_COMMAND_REQUIRES_ADMIN:

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -60,6 +60,7 @@ namespace AppInstaller::Logging
 
         // Logs details of a search request.
         void LogSearchRequest(
+            std::string_view type,
             std::string_view query,
             std::string_view id,
             std::string_view name,

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -19,6 +19,7 @@ namespace AppInstaller::Repository
     enum class MatchType
     {
         Exact,
+        CaseInsensitive,
         Substring,
         Wildcard,
         Fuzzy,
@@ -53,11 +54,16 @@ namespace AppInstaller::Repository
     };
 
     // Container for data used to filter the available manifests in a source.
+    // If Query and Inclusions are both empty, the starting data set will be the entire database.
     struct SearchRequest
     {
         // The generic query matches against a source defined set of fields.
-        // If not provided, the filters should be used against the entire dataset.
         std::optional<RequestMatch> Query;
+
+        // Specific fields used to include more data.
+        // If Query is defined, this can add more rows afterward.
+        // If Query is not defined, this is the only set of data included.
+        std::vector<ApplicationMatchFilter> Inclusions;
 
         // Specific fields used to filter the data further.
         std::vector<ApplicationMatchFilter> Filters;
@@ -122,6 +128,8 @@ namespace AppInstaller::Repository
         {
         case MatchType::Exact:
             return "Exact"sv;
+        case MatchType::CaseInsensitive:
+            return "CaseInsensitive"sv;
         case MatchType::Substring:
             return "Substring"sv;
         case MatchType::Wildcard:

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -54,7 +54,10 @@ namespace AppInstaller::Repository
     };
 
     // Container for data used to filter the available manifests in a source.
+    // It can be thought of as:
+    //  (Query || Inclusions...) && Filters...
     // If Query and Inclusions are both empty, the starting data set will be the entire database.
+    //  Everything && Filters...
     struct SearchRequest
     {
         // The generic query matches against a source defined set of fields.

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -652,6 +652,11 @@ namespace AppInstaller::Repository
             result << "[none]";
         }
 
+        for (const auto& include : Inclusions)
+        {
+            result << " Inclusions:" << ApplicationMatchFieldToString(include.Field) << "='" << include.Value << "'[" << MatchTypeToString(include.Type) << "]";
+        }
+
         for (const auto& filter : Filters)
         {
             result << " Filter:" << ApplicationMatchFieldToString(filter.Field) << "='" << filter.Value << "'[" << MatchTypeToString(filter.Type) << "]";


### PR DESCRIPTION
For #292 

## Change
This changes show and install to use case insensitive equality on id, name or moniker as the default query behavior.  So ```winget show git``` now returns ```Git.Git``` as it matches on both name and moniker.  The filters can still be used to target specific fields, but they too will require case insensitive equality rather than substring.  The best way to target a specific package will be to use ```--id```, as the command ```winget install --id foo.bar``` should now always find the package ```foo.bar```, or nothing. (For reference, show and install use the same algorithm to find the package to operate on.)

```
PS C:\git\pkgs\Tools> wingetdev search git
Name                                    Id                                       Version      Match
----------------------------------------------------------------------------------------------------------
Git                                     Git.Git                                  2.27.0       Moniker: git
TortoiseSVN                             TortoiseSVN.TortoiseSVN                  1.14.0       Tag: git
TortoiseGit                             TortoiseGit.TortoiseGit                  2.10.0.2     Tag: git
Sublime Merge                           SublimeHQ.SublimeMerge                   1119         Tag: git
Fork                                    Fork.Fork                                1.51.2       Tag: git
Snagit                                  TechSmith.Snagit                         6.10.34
GitHubReleaseNotes                      StefHeyenrath.GitHubReleaseNotes         1.0.5.3
MicrosoftGitCredentialManagerforWindows Microsoft.GitCredentialManagerforWindows 1.20.0
Logitech Gaming Software                Logitech.LGS                             9.02.65
Logitech Harmony Remote                 Logitech.Harmony                         1.0.1.308
Gitter IM                               Gitlab.Gitter.IM                         4.1.0
Git Large File Storage                  GitHub.GitLFS                            2.11.0
GitHub Desktop                          GitHub.GitHubDesktop                     2.5.3
GitHub CLI                              GitHub.cli                               0.10.1
Atom                                    GitHub.Atom                              1.48.0
Git Extensions                          GitExtensionsTeam.GitExtensions          3.4.1
MaxTo                                   DigitalCreations.MaxTo                   2.0.1
AdobeDigitalEditions                    Adobe.AdobeDigitalEditions               4.5.11
GitKraken                               Axosoft.GitKraken                        7.0.1
Logitech Gaming Hub                     Logitech.LGH                             latest
Camtasia                                TechSmith.Camtasia                       2020.0.2     Tag: snagit
Cacher                                  PenguinLabs.Cacher                       202.30.4     Tag: github
AppInstallerFileBuilder                 Microsoft.AppInstallerFileBuilder        1.2020.211.0 Tag: GitHub
PS C:\git\pkgs\Tools> wingetdev show git
Found Git [Git.Git]
Version: 2.27.0
Publisher: Git
Description: Git version control system.
Homepage: https://git-scm.com/
License: GNU General Public License, version 2
License Url: https://github.com/git-for-windows/git/blob/master/COPYING
Installer:
  SHA256: 5974db8c52b32f5e575ee021e8b47948892ce0e760095eef98c31e3bbd5167b6
  Download Url: https://github.com/git-for-windows/git/releases/download/v2.27.0.windows.1/Git-2.27.0-64-bit.exe
  Type: Inno
```

As part of implementing this change, a case insensitive match level was added to the search functionality.  This will sort case insensitive matches higher than substring matches in search results.  So in the above example, ```winget search git``` puts ```Git.Git``` at the top of the search results now.  This also means that if the search query is usable as an install query, the packages that would be found will also be at the top.

Finally, a few more strings were moved to localized resources and many instances of ```application``` were changed to ```package``` for consistency with the overall name and future considerations regarding non-application packages (such as fonts). 
 Thanks to @thlac for his proposal in #283 that spurred the discussion to change these.  If someone knows how to give him co-author credit I would be happy to.

## Validation
Added tests for case insensitive match level, as well as for the new search for single package functionality.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/492)