### PR TITLE
Added homepage command using the search command as a base

### DIFF
--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="Commands\ExperimentalCommand.h" />
     <ClInclude Include="Commands\FeaturesCommand.h" />
     <ClInclude Include="Commands\HashCommand.h" />
+    <ClInclude Include="Commands\HomepageCommand.h" />
     <ClInclude Include="Commands\SearchCommand.h" />
     <ClInclude Include="Commands\ShowCommand.h" />
     <ClInclude Include="Commands\InstallCommand.h" />
@@ -208,6 +209,7 @@
     <ClCompile Include="Commands\ExperimentalCommand.cpp" />
     <ClCompile Include="Commands\FeaturesCommand.cpp" />
     <ClCompile Include="Commands\HashCommand.cpp" />
+    <ClCompile Include="Commands\HomepageCommand.cpp" />
     <ClCompile Include="Commands\SearchCommand.cpp" />
     <ClCompile Include="Commands\ShowCommand.cpp" />
     <ClCompile Include="Commands\InstallCommand.cpp" />

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClInclude Include="Commands\FeaturesCommand.h">
       <Filter>Commands</Filter>
     </ClInclude>
+    <ClInclude Include="Commands\HomepageCommand.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -187,6 +190,9 @@
     </ClCompile>
     <ClCompile Include="Commands\FeaturesCommand.cpp">
       <Filter>Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="Commands\HomepageCommand.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
@@ -39,21 +39,36 @@ namespace AppInstaller::CLI
 		context <<
 			Workflow::OpenSource <<
 			Workflow::SearchSourceForSingleWithHomepage <<
-			Workflow::GetManifest <<
+			Workflow::GetManifestFromSearchResult <<
 			Workflow::EnsureOneMatchFromSearchResult <<
 			Workflow::ReportSearchResult;
-		if (context.Contains(Execution::Data::Manifest)) {
-			const auto& manifest = context.Get<Execution::Data::Manifest>();
-			Workflow::ManifestComparator manifestComparator(context.Args);
 
-			const auto selectedLocalization = manifestComparator.GetPreferredLocalization(manifest);
-
-			context.Reporter.Info() << "Homepage: " << selectedLocalization.Homepage << std::endl;
-			context << Workflow::OpenHomepage;
-		}
-		else
-		{
-			context.Reporter.Info() << "No Homepage found within manifest" << std::endl;
+		if (context.Contains(Execution::Data::SearchResult)) {
+			const auto& searchResult = context.Get<Execution::Data::SearchResult>();
+			if (searchResult.Matches.size() > 1)
+			{
+				context.Reporter.Warn() << "More than one result was found please refine your query." << std::endl;
+			}
+			else 
+			{
+				if (context.Contains(Execution::Data::Manifest)) {
+					const auto& manifest = context.Get<Execution::Data::Manifest>();
+					Workflow::ManifestComparator manifestComparator(context.Args);
+					const auto selectedLocalization = manifestComparator.GetPreferredLocalization(manifest);
+					if (selectedLocalization.Homepage.empty())
+					{
+						context.Reporter.Info() << "No Homepage found within manifest" << std::endl;
+					}
+					else {
+						context.Reporter.Info() << "Homepage: " << selectedLocalization.Homepage << std::endl;
+						context << Workflow::OpenHomepage;
+					}
+				}
+				else
+				{
+					context.Reporter.Info() << "No Homepage found within manifest" << std::endl;
+				}
+			}
 		}
 	}
 }

--- a/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
@@ -1,0 +1,59 @@
+#include "pch.h"
+#include "HomepageCommand.h"
+#include "Workflows/WorkflowBase.h"
+#include "Resources.h"
+#include "Workflows/ManifestComparator.h"
+
+namespace AppInstaller::CLI
+{
+	using namespace AppInstaller::CLI::Execution;
+	using namespace std::string_view_literals;
+
+	std::vector<Argument> HomepageCommand::GetArguments() const
+	{
+		return {
+			Argument::ForType(Execution::Args::Type::Query),
+			Argument::ForType(Execution::Args::Type::Id),
+			Argument::ForType(Execution::Args::Type::Name),
+			Argument::ForType(Execution::Args::Type::Moniker),
+			Argument::ForType(Execution::Args::Type::Tag),
+			Argument::ForType(Execution::Args::Type::Command),
+			Argument::ForType(Execution::Args::Type::Source),
+			Argument::ForType(Execution::Args::Type::Count),
+			Argument::ForType(Execution::Args::Type::Exact),
+		};
+	}
+
+	Resource::LocString HomepageCommand::ShortDescription() const
+	{
+		return { Resource::String::HomepageCommandShortDescription };
+	}
+
+	Resource::LocString HomepageCommand::LongDescription() const
+	{
+		return { Resource::String::HomepageCommandLongDescription };
+	}
+
+	void HomepageCommand::ExecuteInternal(Context& context) const
+	{
+		context <<
+			Workflow::OpenSource <<
+			Workflow::SearchSourceForSingleWithHomepage <<
+			Workflow::GetManifest <<
+			Workflow::EnsureOneMatchFromSearchResult <<
+			Workflow::ReportSearchResult;
+		if (context.Contains(Execution::Data::Manifest)) {
+			const auto& manifest = context.Get<Execution::Data::Manifest>();
+			Workflow::ManifestComparator manifestComparator(context.Args);
+
+			const auto selectedLocalization = manifestComparator.GetPreferredLocalization(manifest);
+
+			context.Reporter.Info() << "Homepage: " << selectedLocalization.Homepage << std::endl;
+			context << Workflow::OpenHomepage;
+		}
+		else
+		{
+			context.Reporter.Info() << "No Homepage found within manifest" << std::endl;
+		}
+	}
+}

--- a/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HomepageCommand.cpp
@@ -39,15 +39,15 @@ namespace AppInstaller::CLI
 		context <<
 			Workflow::OpenSource <<
 			Workflow::SearchSourceForSingleWithHomepage <<
-			Workflow::GetManifestFromSearchResult <<
 			Workflow::EnsureOneMatchFromSearchResult <<
+			Workflow::GetManifestFromSearchResult <<
 			Workflow::ReportSearchResult;
 
 		if (context.Contains(Execution::Data::SearchResult)) {
 			const auto& searchResult = context.Get<Execution::Data::SearchResult>();
 			if (searchResult.Matches.size() > 1)
 			{
-				context.Reporter.Warn() << "More than one result was found please refine your query." << std::endl;
+				context.Reporter.Warn() << "More than one result was found please refine your query. Use --Id, --Name --Tag" << std::endl;
 			}
 			else 
 			{

--- a/src/AppInstallerCLICore/Commands/HomepageCommand.h
+++ b/src/AppInstallerCLICore/Commands/HomepageCommand.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Command.h"
+
+namespace AppInstaller::CLI
+{
+    struct HomepageCommand final : public Command
+    {
+        HomepageCommand(std::string_view parent) : Command("homepage", parent) {}
+
+        virtual std::vector<Argument> GetArguments() const override;
+
+        virtual Resource::LocString ShortDescription() const override;
+        virtual Resource::LocString LongDescription() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+}

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -7,6 +7,7 @@
 #include "ShowCommand.h"
 #include "SourceCommand.h"
 #include "SearchCommand.h"
+#include "HomepageCommand.h"
 #include "HashCommand.h"
 #include "ValidateCommand.h"
 #include "SettingsCommand.h"
@@ -27,6 +28,7 @@ namespace AppInstaller::CLI
             std::make_unique<ShowCommand>(FullName()),
             std::make_unique<SourceCommand>(FullName()),
             std::make_unique<SearchCommand>(FullName()),
+            std::make_unique<HomepageCommand>(FullName()),
             std::make_unique<HashCommand>(FullName()),
             std::make_unique<ValidateCommand>(FullName()),
             std::make_unique<SettingsCommand>(FullName()),

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -120,6 +120,8 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(RetroArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(HomepageCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(HomepageCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchId);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchMatch);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchName);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -223,16 +223,35 @@ namespace AppInstaller::CLI::Workflow
 			matchType = MatchType::Exact;
 		}
 
+		////SearchRequest searchRequest;
+		////if (args.Contains(Execution::Args::Type::Query))
+		////{
+		////	std::string_view query = args.GetArg(Execution::Args::Type::Query);
+		////	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
+		////	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
+		////	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
+		////}
+
+		//SearchRequest searchRequest;
+		//if (args.Contains(Execution::Args::Type::Query))
+		//{
+		//	//searchRequest.Query.emplace(RequestMatch(matchType, args.GetArg(Execution::Args::Type::Query)));
+		//	std::string_view query = args.GetArg(Execution::Args::Type::Query);
+		//	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
+		//	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
+		//	searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
+		//}
+
+		//SearchSourceApplyFilters(context, searchRequest, matchType);
+
 		SearchRequest searchRequest;
 		if (args.Contains(Execution::Args::Type::Query))
 		{
-			std::string_view query = args.GetArg(Execution::Args::Type::Query);
-			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
-			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
-			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
+			searchRequest.Query.emplace(RequestMatch(matchType, args.GetArg(Execution::Args::Type::Query)));
 		}
 
 		SearchSourceApplyFilters(context, searchRequest, matchType);
+
 
 		Logging::Telemetry().LogSearchRequest(
 			"single",
@@ -244,10 +263,10 @@ namespace AppInstaller::CLI::Workflow
 			args.GetArg(Execution::Args::Type::Command),
 			searchRequest.MaximumResults,
 			searchRequest.ToString());
-
+		
 		context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
 	}
-	
+
 	void ReportSearchResult(Execution::Context& context)
 	{
 		auto& searchResult = context.Get<Execution::Data::SearchResult>();

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -6,392 +6,435 @@
 #include "ManifestComparator.h"
 #include "TableOutput.h"
 #include "Manifest/YamlParser.h"
+#include <windows.h>
+#include <shellapi.h>
 
 
 namespace AppInstaller::CLI::Workflow
 {
-    using namespace AppInstaller::Repository;
+	using namespace AppInstaller::Repository;
 
-    namespace
-    {
-        std::string GetMatchCriteriaDescriptor(const ResultMatch& match)
-        {
-            if (match.MatchCriteria.Field != ApplicationMatchField::Id && match.MatchCriteria.Field != ApplicationMatchField::Name)
-            {
-                std::string result{ ApplicationMatchFieldToString(match.MatchCriteria.Field) };
-                result += ": ";
-                result += match.MatchCriteria.Value;
-                return result;
-            }
-            else
-            {
-                return {};
-            }
-        }
+	namespace
+	{
+		std::string GetMatchCriteriaDescriptor(const ResultMatch& match)
+		{
+			if (match.MatchCriteria.Field != ApplicationMatchField::Id && match.MatchCriteria.Field != ApplicationMatchField::Name)
+			{
+				std::string result{ ApplicationMatchFieldToString(match.MatchCriteria.Field) };
+				result += ": ";
+				result += match.MatchCriteria.Value;
+				return result;
+			}
+			else
+			{
+				return {};
+			}
+		}
 
-        void ReportIdentity(Execution::Context& context, std::string_view name, std::string_view id)
-        {
-            context.Reporter.Info() << "Found " << Execution::NameEmphasis << name << " [" << Execution::IdEmphasis << id << ']' << std::endl;
-        }
+		void ReportIdentity(Execution::Context& context, std::string_view name, std::string_view id)
+		{
+			context.Reporter.Info() << "Found " << Execution::NameEmphasis << name << " [" << Execution::IdEmphasis << id << ']' << std::endl;
+		}
 
-        void SearchSourceApplyFilters(Execution::Context& context, SearchRequest& searchRequest, MatchType matchType)
-        {
-            const auto& args = context.Args;
+		void SearchSourceApplyFilters(Execution::Context& context, SearchRequest& searchRequest, MatchType matchType)
+		{
+			const auto& args = context.Args;
 
-            if (args.Contains(Execution::Args::Type::Id))
-            {
-                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, args.GetArg(Execution::Args::Type::Id)));
-            }
+			if (args.Contains(Execution::Args::Type::Id))
+			{
+				searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, args.GetArg(Execution::Args::Type::Id)));
+			}
 
-            if (args.Contains(Execution::Args::Type::Name))
-            {
-                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, args.GetArg(Execution::Args::Type::Name)));
-            }
+			if (args.Contains(Execution::Args::Type::Name))
+			{
+				searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, args.GetArg(Execution::Args::Type::Name)));
+			}
 
-            if (args.Contains(Execution::Args::Type::Moniker))
-            {
-                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, args.GetArg(Execution::Args::Type::Moniker)));
-            }
+			if (args.Contains(Execution::Args::Type::Moniker))
+			{
+				searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, args.GetArg(Execution::Args::Type::Moniker)));
+			}
 
-            if (args.Contains(Execution::Args::Type::Tag))
-            {
-                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Tag, matchType, args.GetArg(Execution::Args::Type::Tag)));
-            }
+			if (args.Contains(Execution::Args::Type::Tag))
+			{
+				searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Tag, matchType, args.GetArg(Execution::Args::Type::Tag)));
+			}
 
-            if (args.Contains(Execution::Args::Type::Command))
-            {
-                searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Command, matchType, args.GetArg(Execution::Args::Type::Command)));
-            }
+			if (args.Contains(Execution::Args::Type::Command))
+			{
+				searchRequest.Filters.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Command, matchType, args.GetArg(Execution::Args::Type::Command)));
+			}
 
-            if (args.Contains(Execution::Args::Type::Count))
-            {
-                searchRequest.MaximumResults = std::stoi(std::string(args.GetArg(Execution::Args::Type::Count)));
-            }
-        }
-    }
+			if (args.Contains(Execution::Args::Type::Count))
+			{
+				searchRequest.MaximumResults = std::stoi(std::string(args.GetArg(Execution::Args::Type::Count)));
+			}
+		}
+	}
 
-    bool WorkflowTask::operator==(const WorkflowTask& other) const
-    {
-        if (m_isFunc && other.m_isFunc)
-        {
-            return m_func == other.m_func;
-        }
-        else if (!m_isFunc && !other.m_isFunc)
-        {
-            return m_name == other.m_name;
-        }
-        else
-        {
-            return false;
-        }
-    }
+	bool WorkflowTask::operator==(const WorkflowTask& other) const
+	{
+		if (m_isFunc && other.m_isFunc)
+		{
+			return m_func == other.m_func;
+		}
+		else if (!m_isFunc && !other.m_isFunc)
+		{
+			return m_name == other.m_name;
+		}
+		else
+		{
+			return false;
+		}
+	}
 
-    void WorkflowTask::operator()(Execution::Context& context) const
-    {
-        THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_isFunc);
-        m_func(context);
-    }
+	void WorkflowTask::operator()(Execution::Context& context) const
+	{
+		THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_isFunc);
+		m_func(context);
+	}
 
-    void OpenSource(Execution::Context& context)
-    {
-        std::string_view sourceName;
-        if (context.Args.Contains(Execution::Args::Type::Source))
-        {
-            sourceName = context.Args.GetArg(Execution::Args::Type::Source);
-        }
+	void OpenHomepage(Execution::Context& context)
+	{
+		std::string homepage = context.Get<Execution::Data::Manifest>().Homepage;
+		ShellExecuteA(NULL, 0, (LPCSTR)homepage.c_str(), NULL, NULL, SW_NORMAL);
+	}
 
-        std::shared_ptr<Repository::ISource> source;
-        try
-        {
-            source = context.Reporter.ExecuteWithProgress(std::bind(Repository::OpenSource, sourceName, std::placeholders::_1), true);
-        }
-        catch (...)
-        {
-            context.Reporter.Error() << "Failed to open the source; try removing and re-adding it" << std::endl;
-            throw;
-        }
+	void OpenSource(Execution::Context& context)
+	{
+		std::string_view sourceName;
+		if (context.Args.Contains(Execution::Args::Type::Source))
+		{
+			sourceName = context.Args.GetArg(Execution::Args::Type::Source);
+		}
 
-        if (!source)
-        {
-            std::vector<SourceDetails> sources = GetSources();
+		std::shared_ptr<Repository::ISource> source;
+		try
+		{
+			source = context.Reporter.ExecuteWithProgress(std::bind(Repository::OpenSource, sourceName, std::placeholders::_1), true);
+		}
+		catch (...)
+		{
+			context.Reporter.Error() << "Failed to open the source; try removing and re-adding it" << std::endl;
+			throw;
+		}
 
-            if (context.Args.Contains(Execution::Args::Type::Source) && !sources.empty())
-            {
-                // A bad name was given, try to help.
-                context.Reporter.Error() << "No sources match the given value: " << sourceName << std::endl;
-                context.Reporter.Info() << "The configured sources are:" << std::endl;
-                for (const auto& details : sources)
-                {
-                    context.Reporter.Info() << "  " << details.Name << std::endl;
-                }
+		if (!source)
+		{
+			std::vector<SourceDetails> sources = GetSources();
 
-                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST);
-            }
-            else
-            {
-                // Even if a name was given, there are no sources
-                context.Reporter.Error() << "No sources defined; add one with 'source add' or reset to defaults with 'source reset'" << std::endl;
-                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_SOURCES_DEFINED);
-            }
-        }
+			if (context.Args.Contains(Execution::Args::Type::Source) && !sources.empty())
+			{
+				// A bad name was given, try to help.
+				context.Reporter.Error() << "No sources match the given value: " << sourceName << std::endl;
+				context.Reporter.Info() << "The configured sources are:" << std::endl;
+				for (const auto& details : sources)
+				{
+					context.Reporter.Info() << "  " << details.Name << std::endl;
+				}
 
-        context.Add<Execution::Data::Source>(std::move(source));
-    }
+				AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST);
+			}
+			else
+			{
+				// Even if a name was given, there are no sources
+				context.Reporter.Error() << "No sources defined; add one with 'source add' or reset to defaults with 'source reset'" << std::endl;
+				AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_SOURCES_DEFINED);
+			}
+		}
 
-    void SearchSourceForMany(Execution::Context& context)
-    {
-        const auto& args = context.Args;
+		context.Add<Execution::Data::Source>(std::move(source));
+	}
 
-        MatchType matchType = MatchType::Substring;
-        if (args.Contains(Execution::Args::Type::Exact))
-        {
-            matchType = MatchType::Exact;
-        }
+	void SearchSourceForMany(Execution::Context& context)
+	{
+		const auto& args = context.Args;
 
-        SearchRequest searchRequest;
-        if (args.Contains(Execution::Args::Type::Query))
-        {
-            searchRequest.Query.emplace(RequestMatch(matchType, args.GetArg(Execution::Args::Type::Query)));
-        }
+		MatchType matchType = MatchType::Substring;
+		if (args.Contains(Execution::Args::Type::Exact))
+		{
+			matchType = MatchType::Exact;
+		}
 
-        SearchSourceApplyFilters(context, searchRequest, matchType);
+		SearchRequest searchRequest;
+		if (args.Contains(Execution::Args::Type::Query))
+		{
+			searchRequest.Query.emplace(RequestMatch(matchType, args.GetArg(Execution::Args::Type::Query)));
+		}
 
-        Logging::Telemetry().LogSearchRequest(
-            "many",
-            args.GetArg(Execution::Args::Type::Query),
-            args.GetArg(Execution::Args::Type::Id),
-            args.GetArg(Execution::Args::Type::Name),
-            args.GetArg(Execution::Args::Type::Moniker),
-            args.GetArg(Execution::Args::Type::Tag),
-            args.GetArg(Execution::Args::Type::Command),
-            searchRequest.MaximumResults,
-            searchRequest.ToString());
+		SearchSourceApplyFilters(context, searchRequest, matchType);
 
-        context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
-    }
+		Logging::Telemetry().LogSearchRequest(
+			"many",
+			args.GetArg(Execution::Args::Type::Query),
+			args.GetArg(Execution::Args::Type::Id),
+			args.GetArg(Execution::Args::Type::Name),
+			args.GetArg(Execution::Args::Type::Moniker),
+			args.GetArg(Execution::Args::Type::Tag),
+			args.GetArg(Execution::Args::Type::Command),
+			searchRequest.MaximumResults,
+			searchRequest.ToString());
 
-    void SearchSourceForSingle(Execution::Context& context)
-    {
-        const auto& args = context.Args;
+		context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
+	}
 
-        MatchType matchType = MatchType::CaseInsensitive;
-        if (args.Contains(Execution::Args::Type::Exact))
-        {
-            matchType = MatchType::Exact;
-        }
+	void SearchSourceForSingle(Execution::Context& context)
+	{
+		const auto& args = context.Args;
 
-        SearchRequest searchRequest;
-        if (args.Contains(Execution::Args::Type::Query))
-        {
-            std::string_view query = args.GetArg(Execution::Args::Type::Query);
-            searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
-            searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
-            searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
-        }
+		MatchType matchType = MatchType::CaseInsensitive;
+		if (args.Contains(Execution::Args::Type::Exact))
+		{
+			matchType = MatchType::Exact;
+		}
 
-        SearchSourceApplyFilters(context, searchRequest, matchType);
+		SearchRequest searchRequest;
+		if (args.Contains(Execution::Args::Type::Query))
+		{
+			std::string_view query = args.GetArg(Execution::Args::Type::Query);
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
+		}
 
-        Logging::Telemetry().LogSearchRequest(
-            "single",
-            args.GetArg(Execution::Args::Type::Query),
-            args.GetArg(Execution::Args::Type::Id),
-            args.GetArg(Execution::Args::Type::Name),
-            args.GetArg(Execution::Args::Type::Moniker),
-            args.GetArg(Execution::Args::Type::Tag),
-            args.GetArg(Execution::Args::Type::Command),
-            searchRequest.MaximumResults,
-            searchRequest.ToString());
+		SearchSourceApplyFilters(context, searchRequest, matchType);
 
-        context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
-    }
+		Logging::Telemetry().LogSearchRequest(
+			"single",
+			args.GetArg(Execution::Args::Type::Query),
+			args.GetArg(Execution::Args::Type::Id),
+			args.GetArg(Execution::Args::Type::Name),
+			args.GetArg(Execution::Args::Type::Moniker),
+			args.GetArg(Execution::Args::Type::Tag),
+			args.GetArg(Execution::Args::Type::Command),
+			searchRequest.MaximumResults,
+			searchRequest.ToString());
 
-    void ReportSearchResult(Execution::Context& context)
-    {
-        auto& searchResult = context.Get<Execution::Data::SearchResult>();
-        Logging::Telemetry().LogSearchResultCount(searchResult.Matches.size());
+		context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
+	}
 
-        Execution::TableOutput<4> table(context.Reporter, { Resource::String::SearchName, Resource::String::SearchId, Resource::String::SearchVersion, Resource::String::SearchMatch });
+	void SearchSourceForSingleWithHomepage(Execution::Context& context)
+	{
+		const auto& args = context.Args;
 
-        for (size_t i = 0; i < searchResult.Matches.size(); ++i)
-        {
-            auto app = searchResult.Matches[i].Application.get();
-            auto allVersions = app->GetVersions();
+		MatchType matchType = MatchType::CaseInsensitive;
+		if (args.Contains(Execution::Args::Type::Exact))
+		{
+			matchType = MatchType::Exact;
+		}
 
-            table.OutputLine({ app->GetName(), app->GetId(), allVersions.at(0).GetVersion().ToString(), GetMatchCriteriaDescriptor(searchResult.Matches[i]) });
-        }
+		SearchRequest searchRequest;
+		if (args.Contains(Execution::Args::Type::Query))
+		{
+			std::string_view query = args.GetArg(Execution::Args::Type::Query);
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Id, matchType, query));
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Name, matchType, query));
+			searchRequest.Inclusions.emplace_back(ApplicationMatchFilter(ApplicationMatchField::Moniker, matchType, query));
+		}
 
-        table.Complete();
+		SearchSourceApplyFilters(context, searchRequest, matchType);
 
-        if (searchResult.Truncated)
-        {
-            context.Reporter.Info() << '<' << Resource::String::SearchTruncated << '>' << std::endl;
-        }
-    }
+		Logging::Telemetry().LogSearchRequest(
+			"single",
+			args.GetArg(Execution::Args::Type::Query),
+			args.GetArg(Execution::Args::Type::Id),
+			args.GetArg(Execution::Args::Type::Name),
+			args.GetArg(Execution::Args::Type::Moniker),
+			args.GetArg(Execution::Args::Type::Tag),
+			args.GetArg(Execution::Args::Type::Command),
+			searchRequest.MaximumResults,
+			searchRequest.ToString());
 
-    void EnsureMatchesFromSearchResult(Execution::Context& context)
-    {
-        auto& searchResult = context.Get<Execution::Data::SearchResult>();
+		context.Add<Execution::Data::SearchResult>(context.Get<Execution::Data::Source>()->Search(searchRequest));
+	}
+	
+	void ReportSearchResult(Execution::Context& context)
+	{
+		auto& searchResult = context.Get<Execution::Data::SearchResult>();
+		Logging::Telemetry().LogSearchResultCount(searchResult.Matches.size());
 
-        if (searchResult.Matches.size() == 0)
-        {
-            Logging::Telemetry().LogNoAppMatch();
-            context.Reporter.Info() << Resource::String::NoPackageFound << std::endl;
-            AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
-        }
-    }
+		Execution::TableOutput<4> table(context.Reporter, { Resource::String::SearchName, Resource::String::SearchId, Resource::String::SearchVersion, Resource::String::SearchMatch });
 
-    void EnsureOneMatchFromSearchResult(Execution::Context& context)
-    {
-        context <<
-            EnsureMatchesFromSearchResult <<
-            [](Execution::Context& context)
-        {
-            auto& searchResult = context.Get<Execution::Data::SearchResult>();
+		for (size_t i = 0; i < searchResult.Matches.size(); ++i)
+		{
+			auto app = searchResult.Matches[i].Application.get();
+			auto allVersions = app->GetVersions();
 
-            if (searchResult.Matches.size() > 1)
-            {
-                Logging::Telemetry().LogMultiAppMatch();
-                context.Reporter.Warn() << Resource::String::MultiplePackagesFound << std::endl;
-                context << ReportSearchResult;
-                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND);
-            }
+			table.OutputLine({ app->GetName(), app->GetId(), allVersions.at(0).GetVersion().ToString(), GetMatchCriteriaDescriptor(searchResult.Matches[i]) });
+		}
 
-            auto app = searchResult.Matches.at(0).Application.get();
-            Logging::Telemetry().LogAppFound(app->GetName(), app->GetId());
-        };
-    }
+		table.Complete();
 
-    void GetManifestFromSearchResult(Execution::Context& context)
-    {
-        auto app = context.Get<Execution::Data::SearchResult>().Matches.at(0).Application.get();
+		if (searchResult.Truncated)
+		{
+			context.Reporter.Info() << '<' << Resource::String::SearchTruncated << '>' << std::endl;
+		}
+	}
 
-        std::string_view version = context.Args.GetArg(Execution::Args::Type::Version);
-        std::string_view channel = context.Args.GetArg(Execution::Args::Type::Channel);
+	void EnsureMatchesFromSearchResult(Execution::Context& context)
+	{
+		auto& searchResult = context.Get<Execution::Data::SearchResult>();
 
-        std::optional<Manifest::Manifest> manifest = app->GetManifest(version, channel);
+		if (searchResult.Matches.size() == 0)
+		{
+			Logging::Telemetry().LogNoAppMatch();
+			context.Reporter.Info() << Resource::String::NoPackageFound << std::endl;
+			AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
+		}
+	}
 
-        if (!manifest)
-        {
-            context.Reporter.Error() << "No version found matching: ";
-            if (!version.empty())
-            {
-                context.Reporter.Error() << version;
-            }
-            if (!channel.empty())
-            {
-                context.Reporter.Error() << '[' << channel << ']';
-            }
+	void EnsureOneMatchFromSearchResult(Execution::Context& context)
+	{
+		context <<
+			EnsureMatchesFromSearchResult <<
+			[](Execution::Context& context)
+		{
+			auto& searchResult = context.Get<Execution::Data::SearchResult>();
 
-            context.Reporter.Error() << std::endl;
-            AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_MANIFEST_FOUND);
-        }
+			if (searchResult.Matches.size() > 1)
+			{
+				Logging::Telemetry().LogMultiAppMatch();
+				context.Reporter.Warn() << Resource::String::MultiplePackagesFound << std::endl;
+				context << ReportSearchResult;
+				AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND);
+			}
 
-        Logging::Telemetry().LogManifestFields(manifest->Id, manifest->Name, manifest->Version, false);
-        context.Add<Execution::Data::Manifest>(std::move(manifest.value()));
-    }
+			auto app = searchResult.Matches.at(0).Application.get();
+			Logging::Telemetry().LogAppFound(app->GetName(), app->GetId());
+		};
+	}
 
-    void VerifyFile::operator()(Execution::Context& context) const
-    {
-        std::filesystem::path path = Utility::ConvertToUTF16(context.Args.GetArg(m_arg));
+	void GetManifestFromSearchResult(Execution::Context& context)
+	{
+		auto app = context.Get<Execution::Data::SearchResult>().Matches.at(0).Application.get();
 
-        if (!std::filesystem::exists(path))
-        {
-            context.Reporter.Error() << "File does not exist: " << path.u8string() << std::endl;
-            AICLI_TERMINATE_CONTEXT(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
-        }
+		std::string_view version = context.Args.GetArg(Execution::Args::Type::Version);
+		std::string_view channel = context.Args.GetArg(Execution::Args::Type::Channel);
 
-        if (std::filesystem::is_directory(path))
-        {
-            context.Reporter.Error() << "Path is a directory: " << path.u8string() << std::endl;
-            AICLI_TERMINATE_CONTEXT(HRESULT_FROM_WIN32(ERROR_DIRECTORY_NOT_SUPPORTED));
-        }
-    }
+		std::optional<Manifest::Manifest> manifest = app->GetManifest(version, channel);
 
-    void GetManifestFromArg(Execution::Context& context)
-    {
-        context <<
-            VerifyFile(Execution::Args::Type::Manifest) <<
-            [](Execution::Context& context)
-        {
-            Manifest::Manifest manifest = Manifest::YamlParser::CreateFromPath(Utility::ConvertToUTF16(context.Args.GetArg(Execution::Args::Type::Manifest)));
-            Logging::Telemetry().LogManifestFields(manifest.Id, manifest.Name, manifest.Version, true);
-            context.Add<Execution::Data::Manifest>(std::move(manifest));
-        };
-    }
+		if (!manifest)
+		{
+			context.Reporter.Error() << "No version found matching: ";
+			if (!version.empty())
+			{
+				context.Reporter.Error() << version;
+			}
+			if (!channel.empty())
+			{
+				context.Reporter.Error() << '[' << channel << ']';
+			}
 
-    void ReportSearchResultIdentity(Execution::Context& context)
-    {
-        auto app = context.Get<Execution::Data::SearchResult>().Matches.at(0).Application.get();
-        ReportIdentity(context, app->GetName(), app->GetId());
-    }
+			context.Reporter.Error() << std::endl;
+			AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_MANIFEST_FOUND);
+		}
 
-    void ReportManifestIdentity(Execution::Context& context)
-    {
-        const auto& manifest = context.Get<Execution::Data::Manifest>();
-        ReportIdentity(context, manifest.Name, manifest.Id);
-    }
+		Logging::Telemetry().LogManifestFields(manifest->Id, manifest->Name, manifest->Version, false);
+		context.Add<Execution::Data::Manifest>(std::move(manifest.value()));
+	}
 
-    void GetManifest(Execution::Context& context)
-    {
-        if (context.Args.Contains(Execution::Args::Type::Manifest))
-        {
-            context <<
-                GetManifestFromArg <<
-                ReportManifestIdentity;
-        }
-        else
-        {
-            context <<
-                OpenSource <<
-                SearchSourceForSingle <<
-                EnsureOneMatchFromSearchResult <<
-                ReportSearchResultIdentity <<
-                GetManifestFromSearchResult;
-        }
-    }
+	void VerifyFile::operator()(Execution::Context& context) const
+	{
+		std::filesystem::path path = Utility::ConvertToUTF16(context.Args.GetArg(m_arg));
 
-    void SelectInstaller(Execution::Context& context)
-    {
-        ManifestComparator manifestComparator(context.Args);
-        context.Add<Execution::Data::Installer>(manifestComparator.GetPreferredInstaller(context.Get<Execution::Data::Manifest>()));
-    }
+		if (!std::filesystem::exists(path))
+		{
+			context.Reporter.Error() << "File does not exist: " << path.u8string() << std::endl;
+			AICLI_TERMINATE_CONTEXT(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+		}
 
-    void EnsureRunningAsAdmin(Execution::Context& context)
-    {
-        if (!Runtime::IsRunningAsAdmin())
-        {
-            context.Reporter.Error() << Resource::String::CommandRequiresAdmin;
-            AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_COMMAND_REQUIRES_ADMIN);
-        }
-    }
+		if (std::filesystem::is_directory(path))
+		{
+			context.Reporter.Error() << "Path is a directory: " << path.u8string() << std::endl;
+			AICLI_TERMINATE_CONTEXT(HRESULT_FROM_WIN32(ERROR_DIRECTORY_NOT_SUPPORTED));
+		}
+	}
 
-    void EnsureFeatureEnabled::operator()(Execution::Context& context) const
-    {
-        if (!Settings::ExperimentalFeature::IsEnabled(m_feature))
-        {
-            context.Reporter.Error() << Resource::String::FeatureDisabledMessage << " : '" <<
-                Settings::ExperimentalFeature::GetFeature(m_feature).JsonName() << '\'' << std::endl;
-            AICLI_LOG(CLI, Error, << Settings::ExperimentalFeature::GetFeature(m_feature).Name() << " feature is disabled. Execution cancelled.");
-            AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_EXPERIMENTAL_FEATURE_DISABLED);
-        }
-    }
+	void GetManifestFromArg(Execution::Context& context)
+	{
+		context <<
+			VerifyFile(Execution::Args::Type::Manifest) <<
+			[](Execution::Context& context)
+		{
+			Manifest::Manifest manifest = Manifest::YamlParser::CreateFromPath(Utility::ConvertToUTF16(context.Args.GetArg(Execution::Args::Type::Manifest)));
+			Logging::Telemetry().LogManifestFields(manifest.Id, manifest.Name, manifest.Version, true);
+			context.Add<Execution::Data::Manifest>(std::move(manifest));
+		};
+	}
+
+	void ReportSearchResultIdentity(Execution::Context& context)
+	{
+		auto app = context.Get<Execution::Data::SearchResult>().Matches.at(0).Application.get();
+		ReportIdentity(context, app->GetName(), app->GetId());
+	}
+
+	void ReportManifestIdentity(Execution::Context& context)
+	{
+		const auto& manifest = context.Get<Execution::Data::Manifest>();
+		ReportIdentity(context, manifest.Name, manifest.Id);
+	}
+
+	void GetManifest(Execution::Context& context)
+	{
+		if (context.Args.Contains(Execution::Args::Type::Manifest))
+		{
+			context <<
+				GetManifestFromArg <<
+				ReportManifestIdentity;
+		}
+		else
+		{
+			context <<
+				OpenSource <<
+				SearchSourceForSingle <<
+				EnsureOneMatchFromSearchResult <<
+				ReportSearchResultIdentity <<
+				GetManifestFromSearchResult;
+		}
+	}
+
+	void SelectInstaller(Execution::Context& context)
+	{
+		ManifestComparator manifestComparator(context.Args);
+		context.Add<Execution::Data::Installer>(manifestComparator.GetPreferredInstaller(context.Get<Execution::Data::Manifest>()));
+	}
+
+	void EnsureRunningAsAdmin(Execution::Context& context)
+	{
+		if (!Runtime::IsRunningAsAdmin())
+		{
+			context.Reporter.Error() << Resource::String::CommandRequiresAdmin;
+			AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_COMMAND_REQUIRES_ADMIN);
+		}
+	}
+
+	void EnsureFeatureEnabled::operator()(Execution::Context& context) const
+	{
+		if (!Settings::ExperimentalFeature::IsEnabled(m_feature))
+		{
+			context.Reporter.Error() << Resource::String::FeatureDisabledMessage << " : '" <<
+				Settings::ExperimentalFeature::GetFeature(m_feature).JsonName() << '\'' << std::endl;
+			AICLI_LOG(CLI, Error, << Settings::ExperimentalFeature::GetFeature(m_feature).Name() << " feature is disabled. Execution cancelled.");
+			AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_EXPERIMENTAL_FEATURE_DISABLED);
+		}
+	}
 }
 
 AppInstaller::CLI::Execution::Context& operator<<(AppInstaller::CLI::Execution::Context& context, AppInstaller::CLI::Workflow::WorkflowTask::Func f)
 {
-    return (context << AppInstaller::CLI::Workflow::WorkflowTask(f));
+	return (context << AppInstaller::CLI::Workflow::WorkflowTask(f));
 }
 
 AppInstaller::CLI::Execution::Context& operator<<(AppInstaller::CLI::Execution::Context& context, const AppInstaller::CLI::Workflow::WorkflowTask& task)
 {
-    if (!context.IsTerminated())
-    {
+	if (!context.IsTerminated())
+	{
 #ifndef AICLI_DISABLE_TEST_HOOKS
-        if (context.ShouldExecuteWorkflowTask(task))
+		if (context.ShouldExecuteWorkflowTask(task))
 #endif
-        {
-            task(context);
-        }
-    }
-    return context;
+		{
+			task(context);
+		}
+	}
+	return context;
 }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -10,144 +10,150 @@
 
 namespace AppInstaller::CLI::Execution
 {
-    struct Context;
+	struct Context;
 }
 
 namespace AppInstaller::CLI::Workflow
 {
-    // A task in the workflow.
-    struct WorkflowTask
-    {
-        using Func = void (*)(Execution::Context&);
+	// A task in the workflow.
+	struct WorkflowTask
+	{
+		using Func = void (*)(Execution::Context&);
 
-        WorkflowTask(Func f) : m_isFunc(true), m_func(f) {}
-        WorkflowTask(std::string_view name) : m_name(name) {}
+		WorkflowTask(Func f) : m_isFunc(true), m_func(f) {}
+		WorkflowTask(std::string_view name) : m_name(name) {}
 
-        virtual ~WorkflowTask() = default;
+		virtual ~WorkflowTask() = default;
 
-        WorkflowTask(const WorkflowTask&) = default;
-        WorkflowTask& operator=(const WorkflowTask&) = default;
+		WorkflowTask(const WorkflowTask&) = default;
+		WorkflowTask& operator=(const WorkflowTask&) = default;
 
-        WorkflowTask(WorkflowTask&&) = default;
-        WorkflowTask& operator=(WorkflowTask&&) = default;
+		WorkflowTask(WorkflowTask&&) = default;
+		WorkflowTask& operator=(WorkflowTask&&) = default;
 
-        bool operator==(const WorkflowTask& other) const;
+		bool operator==(const WorkflowTask& other) const;
 
-        virtual void operator()(Execution::Context& context) const;
+		virtual void operator()(Execution::Context& context) const;
 
-        const std::string& GetName() const { return m_name; }
+		const std::string& GetName() const { return m_name; }
 
-    private:
-        bool m_isFunc = false;
-        Func m_func = nullptr;
-        std::string m_name;
-    };
+	private:
+		bool m_isFunc = false;
+		Func m_func = nullptr;
+		std::string m_name;
+	};
 
-    // Creates the source object.
-    // Required Args: None
-    // Inputs: None
-    // Outputs: Source
-    void OpenSource(Execution::Context& context);
+	// Creates the source object.
+	// Required Args: None
+	// Inputs: None
+	// Outputs: Source
+	void OpenSource(Execution::Context& context);
+	void OpenHomepage(Execution::Context& context);
+	// Performs a search on the source.
+	// Required Args: None
+	// Inputs: Source
+	// Outputs: SearchResult
+	void SearchSourceForMany(Execution::Context& context);
 
-    // Performs a search on the source.
-    // Required Args: None
-    // Inputs: Source
-    // Outputs: SearchResult
-    void SearchSourceForMany(Execution::Context& context);
+	// Performs a search on the source with the semantics of targeting a single application.
+	// Required Args: None
+	// Inputs: Source
+	// Outputs: SearchResult
+	void SearchSourceForSingle(Execution::Context& context);
 
-    // Performs a search on the source with the semantics of targeting a single application.
-    // Required Args: None
-    // Inputs: Source
-    // Outputs: SearchResult
-    void SearchSourceForSingle(Execution::Context& context);
+	// Performs a search on the source with the semantics of targeting a single application.
+	// Required Args: None
+	// Inputs: Source
+	// Outputs: SearchResult
+	void SearchSourceForSingleWithHomepage(Execution::Context& context);
 
-    // Outputs the search results.
-    // Required Args: None
-    // Inputs: SearchResult
-    // Outputs: None
-    void ReportSearchResult(Execution::Context& context);
+	// Outputs the search results.
+	// Required Args: None
+	// Inputs: SearchResult
+	// Outputs: None
+	void ReportSearchResult(Execution::Context& context);
 
-    // Ensures that there is at least one result in the search.
-    // Required Args: None
-    // Inputs: SearchResult
-    // Outputs: None
-    void EnsureMatchesFromSearchResult(Execution::Context& context);
+	// Ensures that there is at least one result in the search.
+	// Required Args: None
+	// Inputs: SearchResult
+	// Outputs: None
+	void EnsureMatchesFromSearchResult(Execution::Context& context);
 
-    // Ensures that there is only one result in the search.
-    // Required Args: None
-    // Inputs: SearchResult
-    // Outputs: None
-    void EnsureOneMatchFromSearchResult(Execution::Context& context);
+	// Ensures that there is only one result in the search.
+	// Required Args: None
+	// Inputs: SearchResult
+	// Outputs: None
+	void EnsureOneMatchFromSearchResult(Execution::Context& context);
 
-    // Gets the manifest from a search result.
-    // Required Args: None
-    // Inputs: SearchResult
-    // Outputs: Manifest
-    void GetManifestFromSearchResult(Execution::Context& context);
+	// Gets the manifest from a search result.
+	// Required Args: None
+	// Inputs: SearchResult
+	// Outputs: Manifest
+	void GetManifestFromSearchResult(Execution::Context& context);
 
-    // Ensures the the file exists and is not a directory.
-    // Required Args: the one given
-    // Inputs: None
-    // Outputs: None
-    struct VerifyFile : public WorkflowTask
-    {
-        VerifyFile(Execution::Args::Type arg) : WorkflowTask("VerifyFile"), m_arg(arg) {}
+	// Ensures the the file exists and is not a directory.
+	// Required Args: the one given
+	// Inputs: None
+	// Outputs: None
+	struct VerifyFile : public WorkflowTask
+	{
+		VerifyFile(Execution::Args::Type arg) : WorkflowTask("VerifyFile"), m_arg(arg) {}
 
-        void operator()(Execution::Context& context) const override;
+		void operator()(Execution::Context& context) const override;
 
-    private:
-        Execution::Args::Type m_arg;
-    };
+	private:
+		Execution::Args::Type m_arg;
+	};
 
-    // Opens the manifest file provided on the command line.
-    // Required Args: Manifest
-    // Inputs: None
-    // Outputs: Manifest
-    void GetManifestFromArg(Execution::Context& context);
+	// Opens the manifest file provided on the command line.
+	// Required Args: Manifest
+	// Inputs: None
+	// Outputs: Manifest
+	void GetManifestFromArg(Execution::Context& context);
 
-    // Reports the search result's identity.
-    // Required Args: None
-    // Inputs: SearchResult (only 1)
-    // Outputs: None
-    void ReportSearchResultIdentity(Execution::Context& context);
+	// Reports the search result's identity.
+	// Required Args: None
+	// Inputs: SearchResult (only 1)
+	// Outputs: None
+	void ReportSearchResultIdentity(Execution::Context& context);
 
-    // Reports the manifest's identity.
-    // Required Args: None
-    // Inputs: Manifest
-    // Outputs: None
-    void ReportManifestIdentity(Execution::Context& context);
+	// Reports the manifest's identity.
+	// Required Args: None
+	// Inputs: Manifest
+	// Outputs: None
+	void ReportManifestIdentity(Execution::Context& context);
 
-    // Composite flow that produces a manifest; either from one given on the command line or by searching.
-    // Required Args: None
-    // Inputs: None
-    // Outputs: Manifest
-    void GetManifest(Execution::Context& context);
+	// Composite flow that produces a manifest; either from one given on the command line or by searching.
+	// Required Args: None
+	// Inputs: None
+	// Outputs: Manifest
+	void GetManifest(Execution::Context& context);
 
-    // Selects the installer from the manifest, if one is applicable.
-    // Required Args: None
-    // Inputs: Manifest
-    // Outputs: Installer
-    void SelectInstaller(Execution::Context& context);
+	// Selects the installer from the manifest, if one is applicable.
+	// Required Args: None
+	// Inputs: Manifest
+	// Outputs: Installer
+	void SelectInstaller(Execution::Context& context);
 
-    // Ensures that the process is running as admin.
-    // Required Args: None
-    // Inputs: None
-    // Outputs: None
-    void EnsureRunningAsAdmin(Execution::Context& context);
+	// Ensures that the process is running as admin.
+	// Required Args: None
+	// Inputs: None
+	// Outputs: None
+	void EnsureRunningAsAdmin(Execution::Context& context);
 
-    // Ensures that the feature is enabled.
-    // Required Args: the desired feature
-    // Inputs: None
-    // Outputs: None
-    struct EnsureFeatureEnabled : public WorkflowTask
-    {
-        EnsureFeatureEnabled(Settings::ExperimentalFeature::Feature feature) : WorkflowTask("EnsureFeatureEnabled"), m_feature(feature) {}
+	// Ensures that the feature is enabled.
+	// Required Args: the desired feature
+	// Inputs: None
+	// Outputs: None
+	struct EnsureFeatureEnabled : public WorkflowTask
+	{
+		EnsureFeatureEnabled(Settings::ExperimentalFeature::Feature feature) : WorkflowTask("EnsureFeatureEnabled"), m_feature(feature) {}
 
-        void operator()(Execution::Context& context) const override;
+		void operator()(Execution::Context& context) const override;
 
-    private:
-        Settings::ExperimentalFeature::Feature m_feature;
-    };
+	private:
+		Settings::ExperimentalFeature::Feature m_feature;
+	};
 }
 
 // Passes the context to the function if it has not been terminated; returns the context.

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -227,6 +227,12 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="HelpLinkPreamble" xml:space="preserve">
     <value>More help can be found at:</value>
   </data>
+  <data name="HomepageCommandLongDescription" xml:space="preserve">
+    <value>Opens the manifest's Homepage in default browser if the value exists in the manifest</value>
+  </data>
+  <data name="HomepageCommandShortDescription" xml:space="preserve">
+    <value>Opens the Home page in the default browser</value>
+  </data>
   <data name="IdArgumentDescription" xml:space="preserve">
     <value>Filter results by id</value>
   </data>

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -314,6 +314,38 @@ namespace AppInstaller::Logging
         }
     }
 
+    void TelemetryTraceLogger::LogSearchHomepageRequest(
+        std::string_view type,
+        std::string_view query,
+        std::string_view id,
+        std::string_view name,
+        std::string_view homepage,
+        std::string_view moniker,
+        std::string_view tag,
+        std::string_view command,
+        size_t maximum,
+        std::string_view request)
+    {
+        if (g_IsTelemetryProviderEnabled)
+        {
+            TraceLoggingWriteActivity(g_hTelemetryProvider,
+                "SearchRequest",
+                GetActivityId(),
+                nullptr,
+                AICLI_TraceLoggingStringView(type, "Type"),
+                AICLI_TraceLoggingStringView(query, "Query"),
+                AICLI_TraceLoggingStringView(id, "Id"),
+                AICLI_TraceLoggingStringView(name, "Name"),
+                AICLI_TraceLoggingStringView(homepage, "Homepage"),
+                AICLI_TraceLoggingStringView(moniker, "Moniker"),
+                AICLI_TraceLoggingStringView(tag, "Tag"),
+                AICLI_TraceLoggingStringView(command, "Command"),
+                TraceLoggingUInt64(static_cast<UINT64>(maximum), "Maximum"),
+                AICLI_TraceLoggingStringView(request, "Request"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance | PDT_ProductAndServiceUsage),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
+        }
+    }
     void TelemetryTraceLogger::LogSearchResultCount(uint64_t resultCount) noexcept
     {
         if (g_IsTelemetryProviderEnabled)

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -70,6 +70,18 @@ namespace AppInstaller::Logging
             size_t maximum,
             std::string_view request);
 
+        void LogSearchHomepageRequest(
+            std::string_view type,
+            std::string_view query,
+            std::string_view id,
+            std::string_view name,
+            std::string_view homepage,
+            std::string_view moniker,
+            std::string_view tag,
+            std::string_view command,
+            size_t maximum,
+            std::string_view request);
+    	
         // Logs the Search Result
         void LogSearchResultCount(uint64_t resultCount) noexcept;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds the "homepage" command that when referencing one manifest / app Id it will open the homepage that is within the manifest in the systems default browser.

* If there is no homepage within the manifest it will alert the user to that effect.
* If more than one manifest is found it will list the found manifests and not open a homepage.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

* [X] Closes #501 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed : No documentation on where tests were required/needed/should be preformed. All existing tests pass.
* [X] Requires documentation to be updated : adding new page to https://github.com/skyhoshi/windows-uwp/tree/docs/hub/package-manager/winget
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx  
NOTE, In Response to above: I haven't had a conversation with anyone about the work. and I understand if this is rejected but I do ask that someone explains clearly why. this is one of my first edits on a project where the language is one that i consider myself weak in. and would appreciate this learning opportunity from the community. thanks!

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added a new command that mimics the search function, added locallizable descriptions and added new telemetry call to monitor use of the homepage command and output.
the telemetry action would be to respond to bad actors attempting to include sites and webpages not intended to describe or provide information on the application included within the repository.
The command does a fuzzy lookup on the ID, Name, Monkier and tag fields to provide a list of possible matches, the output includes hints on how to refine or pick a certain manifest from the list. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Demonstration of a list of manifests returned when no query specified

```powershell
.\AppInstallerCLI.exe homepage
```

Results

```txt
Multiple packages found matching input criteria. Please refine the input.
Name                                  Id                                  Version
------------------------------------------------------------------------------------------
Robo3T                                3T.Robo3T                           1.3.1
~~~~~~~~~~~~~~~~~~~ Removed large portion of list for brevity ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Zerotier                              zerotier.zerotier                   1.4.6.0
More than one result was found please refine your query.
```

Demonstration of a list of manifests return from a query

```powershell
.\AppInstallerCLI.exe homepage Microsoft
```

Results

```txt
Multiple packages found matching input criteria. Please refine the input.
Name                      Id                               Version        Match
----------------------------------------------------------------------------------------
PowerBI Desktop           Microsoft.PowerBI                2.82.5858.1161 Tag: microsoft
Mouse and Keyboard Center Microsoft.MouseandKeyboardCenter 12.181.137.0   Tag: microsoft
Smallbasic                Microsoft.SmallBasic             1.2            Tag: microsoft
More than one result was found please refine your query.
```

Demonstration of a single manifest with a homepage.

```powershell
.\AppInstallerCLI.exe homepage Microsoft.VisualStudioCode
```

Results

```txt
Name               Id                         Version
---------------------------------------------------------------
Visual Studio Code Microsoft.VisualStudioCode 1.47.2.17299e413d
Homepage: https://code.visualstudio.com
<OPENS BROWSER TO HOMEPAGE>
```

Demonstration of a Manifest without a homepage.

```powershell
.\AppInstallerCLI.exe homepage PlayStation.PSNow
```

Results

```txt
Name            Id                Version
-----------------------------------------
PlayStation Now PlayStation.PSNow 11.1.2
No Homepage found within manifest
```

Demonstration of a Manifest found with quoted text

```powershell
.\AppInstallerCLI.exe homepage "Visual Studio Code"
```

Results

```txt
Name               Id                         Version
---------------------------------------------------------------
Visual Studio Code Microsoft.VisualStudioCode 1.47.2.17299e413d
Homepage: https://code.visualstudio.com
<OPENS BROWSER TO HOMEPAGE>
```
Demonstration of a Manifest found with quoted text

```powershell
.\AppInstallerCLI.exe homepage  --Name "Visual Studio Code"
```

Results

```txt
Name               Id                         Version
---------------------------------------------------------------
Visual Studio Code Microsoft.VisualStudioCode 1.47.2.17299e413d
Homepage: https://code.visualstudio.com
<OPENS BROWSER TO HOMEPAGE>
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/503)