### PR TITLE
Search across multiple sources and add msstore source

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -127,6 +127,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SearchId);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchMatch);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchName);
+        WINGET_DEFINE_RESOURCE_STRINGID(SearchSource);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchTruncated);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchVersion);
         WINGET_DEFINE_RESOURCE_STRINGID(SettingLoadFailure);

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -11,29 +11,28 @@ namespace AppInstaller::CLI::Workflow
     bool InstallerComparator::operator() (const ManifestInstaller& installer1, const ManifestInstaller& installer2)
     {
         // Todo: Compare only architecture for now. Need more work and spec.
-        if (Utility::IsApplicableArchitecture(installer1.Arch) < Utility::IsApplicableArchitecture(installer2.Arch))
+        if (Utility::IsApplicableArchitecture(installer1.Arch) > Utility::IsApplicableArchitecture(installer2.Arch))
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     bool LocalizationComparator::operator() (const ManifestLocalization& loc1, const ManifestLocalization& loc2)
     {
-        UNREFERENCED_PARAMETER(loc2);
-
         // Todo: Compare simple language for now. Need more work and spec.
         std::string userPreferredLocale = std::locale("").name();
 
-        auto found = userPreferredLocale.find(loc1.Language);
+        auto foundLoc1 = userPreferredLocale.find(loc1.Language);
+        auto foundLoc2 = userPreferredLocale.find(loc2.Language);
 
-        if (found != std::string::npos)
+        if (foundLoc1 != std::string::npos && foundLoc2 == std::string::npos)
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     std::optional<Manifest::ManifestInstaller> ManifestComparator::GetPreferredInstaller(const Manifest::Manifest& manifest)

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -251,14 +251,14 @@ namespace AppInstaller::CLI::Workflow
         auto& searchResult = context.Get<Execution::Data::SearchResult>();
         Logging::Telemetry().LogSearchResultCount(searchResult.Matches.size());
 
-        Execution::TableOutput<4> table(context.Reporter, { Resource::String::SearchName, Resource::String::SearchId, Resource::String::SearchVersion, Resource::String::SearchMatch });
+        Execution::TableOutput<5> table(context.Reporter, { Resource::String::SearchName, Resource::String::SearchId, Resource::String::SearchVersion, Resource::String::SearchMatch, Resource::String::SearchSource });
 
         for (size_t i = 0; i < searchResult.Matches.size(); ++i)
         {
             auto app = searchResult.Matches[i].Application.get();
             auto allVersions = app->GetVersions();
 
-            table.OutputLine({ app->GetName(), app->GetId(), allVersions.at(0).GetVersion().ToString(), GetMatchCriteriaDescriptor(searchResult.Matches[i]) });
+            table.OutputLine({ app->GetName(), app->GetId(), allVersions.at(0).GetVersion().ToString(), GetMatchCriteriaDescriptor(searchResult.Matches[i]), searchResult.Matches[i].SourceName });
         }
 
         table.Complete();

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -435,6 +435,9 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="SearchName" xml:space="preserve">
     <value>Name</value>
   </data>
+  <data name="SearchSource" xml:space="preserve">
+    <value>Source</value>
+  </data>
   <data name="SearchTruncated" xml:space="preserve">
     <value>additional entries truncated due to result limit</value>
   </data>

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -32,151 +32,154 @@ using namespace AppInstaller::Utility;
     REQUIRE(_context_.IsTerminated()); \
     REQUIRE(_hr_ == _context_.GetTerminationHR())
 
-struct TestSource : public ISource
+namespace
 {
-    struct TestApplication : public IApplication
+    struct TestSource : public ISource
     {
-        TestApplication(const Manifest manifest) : m_manifest(manifest) {}
-
-        std::optional<Manifest> GetManifest(const NormalizedString&, const NormalizedString&) override
+        struct TestApplication : public IApplication
         {
-            return m_manifest;
-        }
+            TestApplication(const Manifest manifest) : m_manifest(manifest) {}
 
-        LocIndString GetId() override
-        {
-            return LocIndString{ m_manifest.Id };
-        }
+            std::optional<Manifest> GetManifest(const NormalizedString&, const NormalizedString&) override
+            {
+                return m_manifest;
+            }
 
-        LocIndString GetName() override
-        {
-            return LocIndString{ m_manifest.Name };
-        }
+            LocIndString GetId() override
+            {
+                return LocIndString{ m_manifest.Id };
+            }
 
-        std::vector<VersionAndChannel> GetVersions() override
+            LocIndString GetName() override
+            {
+                return LocIndString{ m_manifest.Name };
+            }
+
+            std::vector<VersionAndChannel> GetVersions() override
+            {
+                std::vector<VersionAndChannel> result;
+                result.emplace_back(Version(m_manifest.Version), Channel(m_manifest.Channel));
+                return result;
+            }
+
+            Manifest m_manifest;
+        };
+
+        SearchResult Search(const SearchRequest& request) override
         {
-            std::vector<VersionAndChannel> result;
-            result.emplace_back(Version(m_manifest.Version), Channel(m_manifest.Channel));
+            SearchResult result;
+
+            std::string input;
+
+            if (request.Query)
+            {
+                input = request.Query->Value;
+            }
+            else if (!request.Inclusions.empty())
+            {
+                input = request.Inclusions[0].Value;
+            }
+
+            if (input == "TestQueryReturnOne")
+            {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                result.Matches.emplace_back(
+                    ResultMatch(
+                        std::make_unique<TestApplication>(manifest),
+                        ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnOne")));
+            }
+            else if (input == "TestQueryReturnTwo")
+            {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                result.Matches.emplace_back(
+                    ResultMatch(
+                        std::make_unique<TestApplication>(manifest),
+                        ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
+
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("Manifest-Good.yaml"));
+                result.Matches.emplace_back(
+                    ResultMatch(
+                        std::make_unique<TestApplication>(manifest2),
+                        ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
+            }
+
             return result;
         }
 
-        Manifest m_manifest;
+        const SourceDetails& GetDetails() const override { THROW_HR(E_NOTIMPL); }
     };
 
-    SearchResult Search(const SearchRequest& request) override
+    struct TestContext;
+
+    struct WorkflowTaskOverride
     {
-        SearchResult result;
+        WorkflowTaskOverride(WorkflowTask::Func f, const std::function<void(TestContext&)>& o) :
+            Target(f), Override(o) {}
 
-        std::string input;
+        WorkflowTaskOverride(std::string_view n, const std::function<void(TestContext&)>& o) :
+            Target(n), Override(o) {}
 
-        if (request.Query)
-        {
-            input = request.Query->Value;
-        }
-        else if (!request.Inclusions.empty())
-        {
-            input = request.Inclusions[0].Value;
-        }
+        WorkflowTaskOverride(const WorkflowTask& t, const std::function<void(TestContext&)>& o) :
+            Target(t), Override(o) {}
 
-        if (input == "TestQueryReturnOne")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    std::make_unique<TestApplication>(manifest),
-                    ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnOne")));
-        }
-        else if (input == "TestQueryReturnTwo")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    std::make_unique<TestApplication>(manifest),
-                    ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
+        bool Used = false;
+        WorkflowTask Target;
+        std::function<void(TestContext&)> Override;
+    };
 
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("Manifest-Good.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    std::make_unique<TestApplication>(manifest2),
-                    ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
-        }
-
-        return result;
-    }
-
-    const SourceDetails& GetDetails() const override { THROW_HR(E_NOTIMPL); }
-};
-
-struct TestContext;
-
-struct WorkflowTaskOverride
-{
-    WorkflowTaskOverride(WorkflowTask::Func f, const std::function<void(TestContext&)>& o) :
-        Target(f), Override(o) {}
-
-    WorkflowTaskOverride(std::string_view n, const std::function<void(TestContext&)>& o) :
-        Target(n), Override(o) {}
-
-    WorkflowTaskOverride(const WorkflowTask& t, const std::function<void(TestContext&)>& o) :
-        Target(t), Override(o) {}
-
-    bool Used = false;
-    WorkflowTask Target;
-    std::function<void(TestContext&)> Override;
-};
-
-// Enables overriding the behavior of specific workflow tasks.
-struct TestContext : public Context
-{
-    TestContext(std::ostream& out, std::istream& in) : Context(out, in)
+    // Enables overriding the behavior of specific workflow tasks.
+    struct TestContext : public Context
     {
-        WorkflowTaskOverride wto
-        { RemoveInstaller, [](TestContext&)
+        TestContext(std::ostream& out, std::istream& in) : Context(out, in)
+        {
+            WorkflowTaskOverride wto
+            { RemoveInstaller, [](TestContext&)
+                {
+                    // Do nothing; we never want to remove the test files.
+            } };
+
+            // Mark this one as used so that it doesn't anger the destructor.
+            wto.Used = true;
+
+            Override(wto);
+        }
+
+        ~TestContext()
+        {
+            for (const auto& wto : m_overrides)
             {
-                // Do nothing; we never want to remove the test files.
-        } };
-
-        // Mark this one as used so that it doesn't anger the destructor.
-        wto.Used = true;
-
-        Override(wto);
-    }
-
-    ~TestContext()
-    {
-        for (const auto& wto : m_overrides)
-        {
-            if (!wto.Used)
-            {
-                FAIL("Unused override");
+                if (!wto.Used)
+                {
+                    FAIL("Unused override");
+                }
             }
         }
-    }
 
-    bool ShouldExecuteWorkflowTask(const Workflow::WorkflowTask& task) override
-    {
-        auto itr = std::find_if(m_overrides.begin(), m_overrides.end(), [&](const WorkflowTaskOverride& wto) { return wto.Target == task; });
-
-        if (itr == m_overrides.end())
+        bool ShouldExecuteWorkflowTask(const Workflow::WorkflowTask& task) override
         {
-            return true;
+            auto itr = std::find_if(m_overrides.begin(), m_overrides.end(), [&](const WorkflowTaskOverride& wto) { return wto.Target == task; });
+
+            if (itr == m_overrides.end())
+            {
+                return true;
+            }
+            else
+            {
+                itr->Used = true;
+                itr->Override(*this);
+                return false;
+            }
         }
-        else
+
+        void Override(const WorkflowTaskOverride& wto)
         {
-            itr->Used = true;
-            itr->Override(*this);
-            return false;
+            m_overrides.emplace_back(wto);
         }
-    }
 
-    void Override(const WorkflowTaskOverride& wto)
-    {
-        m_overrides.emplace_back(wto);
-    }
-
-private:
-    std::vector<WorkflowTaskOverride> m_overrides;
-};
+    private:
+        std::vector<WorkflowTaskOverride> m_overrides;
+    };
+}
 
 void OverrideForOpenSource(TestContext& context)
 {

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -201,7 +201,6 @@
     <ClInclude Include="Telemetry\MicrosoftTelemetry.h" />
     <ClInclude Include="Telemetry\TraceLogging.h" />
     <ClInclude Include="Telemetry\WinEventLogLevels.h" />
-    <ClInclude Include="winget\settings\Setting.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AppInstallerLogging.cpp" />

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj.filters
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj.filters
@@ -108,9 +108,6 @@
     <ClInclude Include="Public\winget\UserSettings.h">
       <Filter>Public\winget</Filter>
     </ClInclude>
-    <ClInclude Include="winget\settings\Setting.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="JsonUtil.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/AppInstallerRepositoryCore/AggregatedSource.cpp
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "AggregatedSource.h"
+
+namespace AppInstaller::Repository
+{
+    AggregatedSource::AggregatedSource()
+    {
+        m_details.Name = "AggregatedSource";
+        m_details.IsAggregated = true;
+    }
+
+    const SourceDetails& AppInstaller::Repository::AggregatedSource::GetDetails() const
+    {
+        return m_details;
+    }
+
+    void AggregatedSource::AddSource(std::shared_ptr<ISource> source)
+    {
+        m_sources.emplace_back(std::move(source));
+    }
+
+    SearchResult AggregatedSource::Search(const SearchRequest& request)
+    {
+        SearchResult result;
+
+        for (auto& source : m_sources)
+        {
+            auto oneSourceResult = source->Search(request);
+
+            for (auto& r : oneSourceResult.Matches)
+            {
+                r.SourceName = source->GetDetails().Name;
+                result.Matches.emplace_back(std::move(r));
+            }
+        }
+
+        SortResultMatches(result.Matches);
+
+        if (request.MaximumResults > 0 && result.Matches.size() > request.MaximumResults)
+        {
+            result.Truncated = true;
+            result.Matches.erase(result.Matches.begin() + request.MaximumResults, result.Matches.end());
+        }
+
+        return result;
+    }
+
+    void AggregatedSource::SortResultMatches(std::vector<ResultMatch>& matches)
+    {
+        // TODO: for now just simply prefer winget source.
+        struct ResultMatchComparator
+        {
+            bool operator() (
+                const ResultMatch& match1,
+                const ResultMatch& match2)
+            {
+                if (Utility::CaseInsensitiveEquals(match1.SourceName, s_Source_WingetCommunityDefault_Name) &&
+                    Utility::CaseInsensitiveEquals(match2.SourceName, s_Source_WingetCommunityDefault_Name))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        };
+
+        std::stable_sort(matches.begin(), matches.end(), ResultMatchComparator());
+    }
+}
+

--- a/src/AppInstallerRepositoryCore/AggregatedSource.cpp
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.cpp
@@ -58,12 +58,12 @@ namespace AppInstaller::Repository
             {
                 if (match1.MatchCriteria.Type != match2.MatchCriteria.Type)
                 {
-                    return (static_cast<int>(match2.MatchCriteria.Type) - static_cast<int>(match1.MatchCriteria.Type)) > 0;
+                    return match2.MatchCriteria.Type > match1.MatchCriteria.Type;
                 }
 
                 if (match1.MatchCriteria.Field != match2.MatchCriteria.Field)
                 {
-                    return (static_cast<int>(match2.MatchCriteria.Field) - static_cast<int>(match1.MatchCriteria.Field)) > 0;
+                    return match2.MatchCriteria.Field > match1.MatchCriteria.Field;
                 }
 
                 return false;

--- a/src/AppInstallerRepositoryCore/AggregatedSource.cpp
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.cpp
@@ -57,7 +57,7 @@ namespace AppInstaller::Repository
                 const ResultMatch& match2)
             {
                 if (Utility::CaseInsensitiveEquals(match1.SourceName, s_Source_WingetCommunityDefault_Name) &&
-                    Utility::CaseInsensitiveEquals(match2.SourceName, s_Source_WingetCommunityDefault_Name))
+                    !Utility::CaseInsensitiveEquals(match2.SourceName, s_Source_WingetCommunityDefault_Name))
                 {
                     return true;
                 }

--- a/src/AppInstallerRepositoryCore/AggregatedSource.cpp
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.cpp
@@ -56,30 +56,14 @@ namespace AppInstaller::Repository
                 const ResultMatch& match1,
                 const ResultMatch& match2)
             {
-                std::vector<MatchType> MatchTypeOrder =
-                { MatchType::Exact, MatchType::CaseInsensitive, MatchType::StartsWith, MatchType::Fuzzy,
-                  MatchType::Substring, MatchType::FuzzySubstring, MatchType::Wildcard };
-
-                auto matchTypeOrder1 = std::find(MatchTypeOrder.begin(), MatchTypeOrder.end(), match1.MatchCriteria.Type);
-                auto matchTypeOrder2 = std::find(MatchTypeOrder.begin(), MatchTypeOrder.end(), match2.MatchCriteria.Type);
-                auto matchTypeDistance = std::distance(matchTypeOrder1, matchTypeOrder2);
-
-                if (matchTypeDistance != 0)
+                if (match1.MatchCriteria.Type != match2.MatchCriteria.Type)
                 {
-                    return matchTypeDistance > 0;
+                    return (static_cast<int>(match2.MatchCriteria.Type) - static_cast<int>(match1.MatchCriteria.Type)) > 0;
                 }
 
-                std::vector<ApplicationMatchField> MatchFieldOrder =
-                { ApplicationMatchField::Id, ApplicationMatchField::Name, ApplicationMatchField::Moniker,
-                  ApplicationMatchField::Command, ApplicationMatchField::Tag };
-
-                auto matchFieldOrder1 = std::find(MatchFieldOrder.begin(), MatchFieldOrder.end(), match1.MatchCriteria.Field);
-                auto matchFieldOrder2 = std::find(MatchFieldOrder.begin(), MatchFieldOrder.end(), match2.MatchCriteria.Field);
-                auto matchFieldDistance = std::distance(matchFieldOrder1, matchFieldOrder2);
-
-                if (matchFieldDistance != 0)
+                if (match1.MatchCriteria.Field != match2.MatchCriteria.Field)
                 {
-                    return matchFieldDistance > 0;
+                    return (static_cast<int>(match2.MatchCriteria.Field) - static_cast<int>(match1.MatchCriteria.Field)) > 0;
                 }
 
                 return false;

--- a/src/AppInstallerRepositoryCore/AggregatedSource.h
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include "AppInstallerRepositorySource.h"
+
+namespace AppInstaller::Repository
+{
+    struct AggregatedSource : public ISource
+    {
+        AggregatedSource();
+
+        AggregatedSource(const AggregatedSource&) = delete;
+        AggregatedSource& operator=(const AggregatedSource&) = delete;
+
+        AggregatedSource(AggregatedSource&&) = default;
+        AggregatedSource& operator=(AggregatedSource&&) = default;
+
+        ~AggregatedSource() = default;
+
+        // Get the source's details.
+        const SourceDetails& GetDetails() const override;
+
+        // Execute a search on the source.
+        SearchResult Search(const SearchRequest & request) override;
+
+        void AddSource(std::shared_ptr<ISource> source);
+
+    private:
+        std::vector<std::shared_ptr<ISource>> m_sources;
+        SourceDetails m_details;
+
+        void SortResultMatches(std::vector<ResultMatch>& matches);
+    };
+}
+
+

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -172,6 +172,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="AggregatedSource.h" />
     <ClInclude Include="ICU\SQLiteICU.h" />
     <ClInclude Include="Manifest\Manifest.h" />
     <ClInclude Include="Manifest\ManifestInstaller.h" />
@@ -206,6 +207,7 @@
     <ClInclude Include="SQLiteWrapper.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AggregatedSource.cpp" />
     <ClCompile Include="ICU\SQLiteICU.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="Manifest\YamlParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="AggregatedSource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -192,6 +195,9 @@
       <Filter>Manifest</Filter>
     </ClCompile>
     <ClCompile Include="Manifest\YamlParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="AggregatedSource.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -112,10 +112,9 @@ namespace AppInstaller::Repository
         ApplicationMatchFilter MatchCriteria;
 
         // The name of the source where the result is from. Used in aggregated source scenario.
-        std::string SourceName;
+        std::string SourceName = {};
 
-        ResultMatch(std::unique_ptr<IApplication>&& a, ApplicationMatchFilter f, std::string source = {}) :
-            Application(std::move(a)), MatchCriteria(std::move(f)), SourceName(std::move(source)) {}
+        ResultMatch(std::unique_ptr<IApplication>&& a, ApplicationMatchFilter f) : Application(std::move(a)), MatchCriteria(std::move(f)) {}
     };
 
     // Search result data.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -16,25 +16,27 @@
 namespace AppInstaller::Repository
 {
     // The type of matching to perform during a search.
+    // The values must be declared in order of preference in search results.
     enum class MatchType
     {
-        Exact,
+        Exact = 0,
         CaseInsensitive,
         StartsWith,
-        Substring,
-        Wildcard,
         Fuzzy,
+        Substring,
         FuzzySubstring,
+        Wildcard,
     };
 
     // The field to match on.
+    // The values must be declared in order of preference in search results.
     enum class ApplicationMatchField
     {
-        Id,
+        Id = 0,
         Name,
         Moniker,
-        Tag,
         Command,
+        Tag,
     };
 
     // A single match to be performed during a search.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -111,7 +111,11 @@ namespace AppInstaller::Repository
         // The highest order field on which the application matched the search.
         ApplicationMatchFilter MatchCriteria;
 
-        ResultMatch(std::unique_ptr<IApplication>&& a, ApplicationMatchFilter f) : Application(std::move(a)), MatchCriteria(std::move(f)) {}
+        // The name of the source where the result is from. Used in aggregated source scenario.
+        std::string SourceName;
+
+        ResultMatch(std::unique_ptr<IApplication>&& a, ApplicationMatchFilter f, std::string source = {}) :
+            Application(std::move(a)), MatchCriteria(std::move(f)), SourceName(std::move(source)) {}
     };
 
     // Search result data.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -14,17 +14,6 @@
 
 namespace AppInstaller::Repository
 {
-    using namespace std::string_view_literals;
-
-    constexpr std::string_view s_Source_WingetCommunityDefault_Name = "winget"sv;
-    constexpr std::string_view s_Source_WingetCommunityDefault_Arg = "https://winget.azureedge.net/cache"sv;
-    constexpr std::string_view s_Source_WingetCommunityDefault_Data = "Microsoft.Winget.Source_8wekyb3d8bbwe"sv;
-
-    constexpr std::string_view s_Source_WingetMSStoreDefault_Name = "msstore"sv;
-    // TODO: update to use prod endpoint
-    constexpr std::string_view s_Source_WingetMSStoreDefault_Arg = "https://winget-test.azureedge.net/msstore"sv;
-    constexpr std::string_view s_Source_WingetMSStoreDefault_Data = "Microsoft.Winget.MSStore.Source_8wekyb3d8bbwe"sv;
-
     // Defines the origin of the source details.
     enum class SourceOrigin
     {

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -14,6 +14,17 @@
 
 namespace AppInstaller::Repository
 {
+    using namespace std::string_view_literals;
+
+    constexpr std::string_view s_Source_WingetCommunityDefault_Name = "winget"sv;
+    constexpr std::string_view s_Source_WingetCommunityDefault_Arg = "https://winget.azureedge.net/cache"sv;
+    constexpr std::string_view s_Source_WingetCommunityDefault_Data = "Microsoft.Winget.Source_8wekyb3d8bbwe"sv;
+
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Name = "msstore"sv;
+    // TODO: update to use prod endpoint
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Arg = "https://winget-test.azureedge.net/msstore"sv;
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Data = "Microsoft.Winget.MSStore.Source_8wekyb3d8bbwe"sv;
+
     // Defines the origin of the source details.
     enum class SourceOrigin
     {
@@ -43,6 +54,9 @@ namespace AppInstaller::Repository
 
         // The origin of the source.
         SourceOrigin Origin = SourceOrigin::Default;
+
+        // If the source is an aggregated source
+        bool IsAggregated = false;
     };
 
     // Interface for interacting with a source from outside of the repository lib.

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -25,6 +25,10 @@ namespace AppInstaller::Repository
     constexpr std::string_view s_MetadataYaml_Source_Name = "Name"sv;
     constexpr std::string_view s_MetadataYaml_Source_LastUpdate = "LastUpdate"sv;
 
+    constexpr std::string_view s_Source_WingetCommunityDefault_Name = "winget"sv;
+    constexpr std::string_view s_Source_WingetCommunityDefault_Arg = "https://winget.azureedge.net/cache"sv;
+    constexpr std::string_view s_Source_WingetCommunityDefault_Data = "Microsoft.Winget.Source_8wekyb3d8bbwe"sv;
+
     namespace
     {
         // SourceDetails with additional data used by this file.
@@ -184,16 +188,6 @@ namespace AppInstaller::Repository
                 details.Type = Microsoft::PreIndexedPackageSourceFactory::Type();
                 details.Arg = s_Source_WingetCommunityDefault_Arg;
                 details.Data = s_Source_WingetCommunityDefault_Data;
-                result.emplace_back(std::move(details));
-            }
-
-            if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::ExperimentalMSStore))
-            {
-                SourceDetailsInternal details;
-                details.Name = s_Source_WingetMSStoreDefault_Name;
-                details.Type = Microsoft::PreIndexedPackageSourceFactory::Type();
-                details.Arg = s_Source_WingetMSStoreDefault_Arg;
-                details.Data = s_Source_WingetMSStoreDefault_Data;
                 result.emplace_back(std::move(details));
             }
                 break;
@@ -535,10 +529,12 @@ namespace AppInstaller::Repository
 
                     if (ShouldUpdateBeforeOpen(source))
                     {
+                        // TODO: Consider adding a context callback to indicate we are doing the same action
+                        // to avoid the progress bar fill up multiple times.
                         UpdateSourceFromDetails(source, progress);
                         sourceUpdated = true;
                     }
-                    aggregatedSource->AddSource(std::move(CreateSourceFromDetails(source, progress)));
+                    aggregatedSource->AddSource(CreateSourceFromDetails(source, progress));
                 }
 
                 if (sourceUpdated)

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -628,6 +628,20 @@ namespace AppInstaller::Repository
                 THROW_HR(E_UNEXPECTED);
             }
 
+            // Add back tombstoned default sources, otherwise the info will be lost by SetSourcesByOrigin
+            auto defaultSources = GetSourcesByOrigin(SourceOrigin::Default);
+            for (const auto& defaultSource : defaultSources)
+            {
+                if (FindSourceByName(currentSources, defaultSource.Name) == currentSources.end())
+                {
+                    SourceDetailsInternal tombstone;
+                    tombstone.Name = defaultSource.Name;
+                    tombstone.IsTombstone = true;
+                    tombstone.Origin = SourceOrigin::User;
+                    currentSources.emplace_back(std::move(tombstone));
+                }
+            }
+
             SetSourcesByOrigin(SourceOrigin::User, currentSources);
 
             return true;

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -18,7 +18,9 @@
 #include <AppInstallerSynchronization.h>
 #include <AppInstallerVersions.h>
 #include <winget/ExtensionCatalog.h>
+#include <winget/ExperimentalFeature.h>
 #include <winget/Settings.h>
+#include <winget/UserSettings.h>
 #include <yaml-cpp/yaml.h>
 
 #include <wil/result_macros.h>


### PR DESCRIPTION
This is part 2 of #117

## Change
- Added support to search across multiple sources
- Added store source as one of the default sources if experimental feature is enabled
- Fixed a minor bug where removing a source will always restore default sources

## Validation
- Existing tests passed
- Added new tests to test multiple source search
- Manually tested the test msstore source and community source work together

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/527)