### PR TITLE
Add preindexed Microsoft Store source 

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -1,12 +1,12 @@
 # WinGet CLI Settings
 
-You can configure WinGet by editing the `settings.json` file. The file can be open with the default json editor by running `winget settings`. If no editor is configure, notepad.exe will be used.
+You can configure WinGet by editing the `settings.json` file. The file can be opened with the default json editor by running `winget settings`. If no editor is configured, notepad.exe will be used.
 
 ## File Location
 
 Settings file is located in %LOCALAPPDATA%\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json
 
-If you are using the non-packaged winget version by building it from source code the file will be located under %LOCALAPPDATA%\Microsoft\WinGet\Settings\settings.json
+If you are using the non-packaged winget version by building it from source code, the file will be located under %LOCALAPPDATA%\Microsoft\WinGet\Settings\settings.json
 
 ## Source
 
@@ -45,11 +45,13 @@ Color of the progress bar that WinGet displays when not specified by arguments.
 - retro
 - rainbow
 
-### experimentalFeatures
+## Experimental Features
 
 In order to allow work to be done in master, and distributed to early adopters for their feedback, settings have the ability to control "experimental" features.
 
-Currently there are no experimental features, just sample ones. Once they get implemented this file will be updated.
+### experimentalFeatures
+
+This is the root node representing experimental features. Individual feature can be enabled under this node. Below are the sample ones.
 
 ```
    "experimentalFeatures": {
@@ -57,3 +59,7 @@ Currently there are no experimental features, just sample ones. Once they get im
        "experimentalArg": false,
    },
 ```
+
+### experimentalMSStore
+
+The winget Microsoft Store App support is currently implemented as an experimental feature. It supports a curated list of utilitiy apps from Microsoft Store.

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -382,8 +382,8 @@ namespace AppInstaller::CLI::Workflow
 
                     Sleep(100);
                 }
-            });
 
-        context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+                context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+            });
     }
 }

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -339,6 +339,7 @@ namespace AppInstaller::CLI::Workflow
                 " PackageFamilyName: " << Utility::ConvertToUTF8(installItem.PackageFamilyName()));
         }
 
+        HRESULT errorCode = S_OK;
         context.Reporter.ExecuteWithProgress(
             [&](IProgressCallback& progress)
             {
@@ -356,12 +357,11 @@ namespace AppInstaller::CLI::Workflow
                         const auto& status = installItem.GetCurrentStatus();
                         currentProgress += static_cast<uint64_t>(status.PercentComplete());
 
-                        HRESULT errorCode = status.ErrorCode();
+                        errorCode = status.ErrorCode();
+
                         if (!SUCCEEDED(errorCode))
                         {
-                            context.Reporter.Info() << Resource::String::MSStoreInstallFailed << ' ' << WINGET_OSTREAM_FORMAT_HRESULT(errorCode) << std::endl;
-                            AICLI_LOG(CLI, Error, << "MSStore install failed. ProductId: " << Utility::ConvertToUTF8(productId) << " HResult: " << WINGET_OSTREAM_FORMAT_HRESULT(errorCode));
-                            AICLI_TERMINATE_CONTEXT(errorCode);
+                            return;
                         }
                     }
 
@@ -382,8 +382,17 @@ namespace AppInstaller::CLI::Workflow
 
                     Sleep(100);
                 }
-
-                context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
             });
+
+        if (SUCCEEDED(errorCode))
+        {
+            context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+        }
+        else
+        {
+            context.Reporter.Info() << Resource::String::MSStoreInstallFailed << ' ' << WINGET_OSTREAM_FORMAT_HRESULT(errorCode) << std::endl;
+            AICLI_LOG(CLI, Error, << "MSStore install failed. ProductId: " << Utility::ConvertToUTF8(productId) << " HResult: " << WINGET_OSTREAM_FORMAT_HRESULT(errorCode));
+            AICLI_TERMINATE_CONTEXT(errorCode);
+        }
     }
 }

--- a/src/AppInstallerCLICore/pch.h
+++ b/src/AppInstallerCLICore/pch.h
@@ -7,6 +7,19 @@
 #include <shellapi.h>
 #include <WinInet.h>
 
+#include <array>
+#include <iostream>
+#include <fstream>
+#include <future>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <vector>
+
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Management.Deployment.h>
@@ -17,18 +30,6 @@
 
 #include <wil/result_macros.h>
 #include <wil/safecast.h>
-
-#include <array>
-#include <iostream>
-#include <fstream>
-#include <future>
-#include <functional>
-#include <memory>
-#include <numeric>
-#include <optional>
-#include <sstream>
-#include <string_view>
-#include <vector>
 
 #include <wrl/client.h>
 #include <AppxPackaging.h>

--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -15,6 +15,25 @@
 #define YAML_DECLARE_STATIC
 #include <yaml.h>
 
+#include <algorithm>
+#include <chrono>
+#include <cwctype>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <iomanip>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <sstream>
+#include <stack>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
 // wil/cppwinrt.h should always be included before any C++/WinRT or WIL header file when both are in use
 #include <wil/cppwinrt.h>
 #include <wil/result_macros.h>
@@ -41,21 +60,3 @@
 #include <shcore.h>
 
 #include <AppxPackaging.h>
-
-#include <algorithm>
-#include <chrono>
-#include <cwctype>
-#include <filesystem>
-#include <fstream>
-#include <functional>
-#include <future>
-#include <iomanip>
-#include <limits>
-#include <memory>
-#include <ostream>
-#include <string>
-#include <sstream>
-#include <stack>
-#include <string_view>
-#include <type_traits>
-#include <vector>

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -196,12 +196,12 @@ namespace AppInstaller::Repository
 
                 if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::ExperimentalMSStore))
                 {
-                    SourceDetailsInternal details;
-                    details.Name = s_Source_WingetMSStoreDefault_Name;
-                    details.Type = Microsoft::PreIndexedPackageSourceFactory::Type();
-                    details.Arg = s_Source_WingetMSStoreDefault_Arg;
-                    details.Data = s_Source_WingetMSStoreDefault_Data;
-                    result.emplace_back(std::move(details));
+                    SourceDetailsInternal storeDetails;
+                    storeDetails.Name = s_Source_WingetMSStoreDefault_Name;
+                    storeDetails.Type = Microsoft::PreIndexedPackageSourceFactory::Type();
+                    storeDetails.Arg = s_Source_WingetMSStoreDefault_Arg;
+                    storeDetails.Data = s_Source_WingetMSStoreDefault_Data;
+                    result.emplace_back(std::move(storeDetails));
                 }
             }
                 break;

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -29,6 +29,10 @@ namespace AppInstaller::Repository
     constexpr std::string_view s_Source_WingetCommunityDefault_Arg = "https://winget.azureedge.net/cache"sv;
     constexpr std::string_view s_Source_WingetCommunityDefault_Data = "Microsoft.Winget.Source_8wekyb3d8bbwe"sv;
 
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Name = "msstore"sv;
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Arg = "https://winget.azureedge.net/msstore"sv;
+    constexpr std::string_view s_Source_WingetMSStoreDefault_Data = "Microsoft.Winget.MSStore.Source_8wekyb3d8bbwe"sv;
+
     namespace
     {
         // SourceDetails with additional data used by this file.
@@ -189,6 +193,16 @@ namespace AppInstaller::Repository
                 details.Arg = s_Source_WingetCommunityDefault_Arg;
                 details.Data = s_Source_WingetCommunityDefault_Data;
                 result.emplace_back(std::move(details));
+
+                if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::ExperimentalMSStore))
+                {
+                    SourceDetailsInternal details;
+                    details.Name = s_Source_WingetMSStoreDefault_Name;
+                    details.Type = Microsoft::PreIndexedPackageSourceFactory::Type();
+                    details.Arg = s_Source_WingetMSStoreDefault_Arg;
+                    details.Data = s_Source_WingetMSStoreDefault_Data;
+                    result.emplace_back(std::move(details));
+                }
             }
                 break;
             case SourceOrigin::User:


### PR DESCRIPTION
This is part 3 of #117

## Change
- Added a preindexed Microsoft Store source as default source is feature is enabled
- A minor fix to make Store app install failure message align correctly
- Updates settings doc with Experimental Store feature
- Fixed compilation failure after upgraded to VS ver 16.7.2

## Validation
- Existing tests(including Store flow) passed
- Manually searching and installing a Store app succeeded

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/544)