### PR TITLE
Refactor source and search functionality

### DIFF
--- a/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
@@ -57,7 +57,7 @@ namespace AppInstaller::CLI::Workflow
         {
             if (searchResult.Matches[i].MatchCriteria.Value.empty())
             {
-                OutputCompletionString(stream, searchResult.Matches[i].Application->GetId());
+                OutputCompletionString(stream, searchResult.Matches[i].Package->GetLatestAvailableVersion()->GetProperty(Repository::PackageVersionProperty::Id));
             }
             else
             {
@@ -71,12 +71,11 @@ namespace AppInstaller::CLI::Workflow
         const std::string& word = context.Get<Data::CompletionData>().Word();
         auto stream = context.Reporter.Completion();
 
-        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Application->GetVersions())
+        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
         {
-            std::string version = vc.GetVersion().ToString();
-            if (word.empty() || Utility::CaseInsensitiveStartsWith(version, word))
+            if (word.empty() || Utility::CaseInsensitiveStartsWith(vc.Version, word))
             {
-                OutputCompletionString(stream, version);
+                OutputCompletionString(stream, vc.Version);
             }
         }
     }
@@ -88,13 +87,12 @@ namespace AppInstaller::CLI::Workflow
 
         std::vector<std::string> channels;
 
-        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Application->GetVersions())
+        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
         {
-            std::string channel = vc.GetChannel().ToString();
-            if ((word.empty() || Utility::CaseInsensitiveStartsWith(channel, word)) &&
-                std::find(channels.begin(), channels.end(), channel) == channels.end())
+            if ((word.empty() || Utility::CaseInsensitiveStartsWith(vc.Channel, word)) &&
+                std::find(channels.begin(), channels.end(), vc.Channel) == channels.end())
             {
-                channels.emplace_back(std::move(channel));
+                channels.emplace_back(vc.Channel);
             }
         }
 
@@ -121,31 +119,31 @@ namespace AppInstaller::CLI::Workflow
         case Execution::Args::Type::Id:
             context <<
                 Workflow::OpenSource <<
-                Workflow::SearchSourceForCompletionField(Repository::ApplicationMatchField::Id) <<
+                Workflow::SearchSourceForCompletionField(Repository::PackageMatchField::Id) <<
                 Workflow::CompleteWithMatchedField;
             break;
         case Execution::Args::Type::Name:
             context <<
                 Workflow::OpenSource <<
-                Workflow::SearchSourceForCompletionField(Repository::ApplicationMatchField::Name) <<
+                Workflow::SearchSourceForCompletionField(Repository::PackageMatchField::Name) <<
                 Workflow::CompleteWithMatchedField;
             break;
         case Execution::Args::Type::Moniker:
             context <<
                 Workflow::OpenSource <<
-                Workflow::SearchSourceForCompletionField(Repository::ApplicationMatchField::Moniker) <<
+                Workflow::SearchSourceForCompletionField(Repository::PackageMatchField::Moniker) <<
                 Workflow::CompleteWithMatchedField;
             break;
         case Execution::Args::Type::Tag:
             context <<
                 Workflow::OpenSource <<
-                Workflow::SearchSourceForCompletionField(Repository::ApplicationMatchField::Tag) <<
+                Workflow::SearchSourceForCompletionField(Repository::PackageMatchField::Tag) <<
                 Workflow::CompleteWithMatchedField;
             break;
         case Execution::Args::Type::Command:
             context <<
                 Workflow::OpenSource <<
-                Workflow::SearchSourceForCompletionField(Repository::ApplicationMatchField::Command) <<
+                Workflow::SearchSourceForCompletionField(Repository::PackageMatchField::Command) <<
                 Workflow::CompleteWithMatchedField;
             break;
         case Execution::Args::Type::Version:

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -84,12 +84,12 @@ namespace AppInstaller::CLI::Workflow
 
     void ShowAppVersions(Execution::Context& context)
     {
-        auto app = context.Get<Execution::Data::SearchResult>().Matches.at(0).Application.get();
+        auto versions = context.Get<Execution::Data::SearchResult>().Matches.at(0).Package->GetAvailableVersionKeys();
 
         Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
-        for (auto& version : app->GetVersions())
+        for (const auto& version : versions)
         {
-            table.OutputLine({ version.GetVersion().ToString(), version.GetChannel().ToString() });
+            table.OutputLine({ version.Version, version.Channel });
         }
         table.Complete();
     }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -82,12 +82,12 @@ namespace AppInstaller::CLI::Workflow
     // Outputs: None
     struct SearchSourceForCompletionField : public WorkflowTask
     {
-        SearchSourceForCompletionField(Repository::ApplicationMatchField field) : WorkflowTask("SearchSourceForCompletionField"), m_field(field) {}
+        SearchSourceForCompletionField(Repository::PackageMatchField field) : WorkflowTask("SearchSourceForCompletionField"), m_field(field) {}
 
         void operator()(Execution::Context& context) const override;
 
     private:
-        Repository::ApplicationMatchField m_field;
+        Repository::PackageMatchField m_field;
     };
 
     // Outputs the search results.

--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -126,21 +126,27 @@ namespace
             return m_details;
         }
 
-        SearchResult Search(const SearchRequest& request) override
+        const std::string& GetIdentifier() const override
+        {
+            return m_identifier;
+        }
+
+        SearchResult Search(const SearchRequest& request) const override
         {
             UNREFERENCED_PARAMETER(request);
 
             SearchResult result;
-            ApplicationMatchFilter testMatchFilter1{ ApplicationMatchField::Id, MatchType::Exact, "test" };
-            ApplicationMatchFilter testMatchFilter2{ ApplicationMatchField::Name, MatchType::Exact, "test" };
-            ApplicationMatchFilter testMatchFilter3{ ApplicationMatchField::Id, MatchType::CaseInsensitive, "test" };
-            result.Matches.emplace_back(std::unique_ptr<IApplication>(), testMatchFilter1);
-            result.Matches.emplace_back(std::unique_ptr<IApplication>(), testMatchFilter2);
-            result.Matches.emplace_back(std::unique_ptr<IApplication>(), testMatchFilter3);
+            PackageMatchFilter testMatchFilter1{ PackageMatchField::Id, MatchType::Exact, "test" };
+            PackageMatchFilter testMatchFilter2{ PackageMatchField::Name, MatchType::Exact, "test" };
+            PackageMatchFilter testMatchFilter3{ PackageMatchField::Id, MatchType::CaseInsensitive, "test" };
+            result.Matches.emplace_back(std::unique_ptr<IPackage>(), testMatchFilter1);
+            result.Matches.emplace_back(std::unique_ptr<IPackage>(), testMatchFilter2);
+            result.Matches.emplace_back(std::unique_ptr<IPackage>(), testMatchFilter3);
             return result;
         }
 
         SourceDetails m_details;
+        std::string m_identifier = "*TestSource";
     };
 
     // Helper that allows some lambdas to be wrapped into a source factory.
@@ -591,12 +597,12 @@ TEST_CASE("RepoSources_SearchAcrossMultipleSources", "[sources]")
     REQUIRE(result.Matches.size() == 6);
     REQUIRE_FALSE(result.Truncated);
     // matches are sorted in expected order
-    REQUIRE((result.Matches[0].MatchCriteria.Type == MatchType::Exact && result.Matches[0].MatchCriteria.Field == ApplicationMatchField::Id));
-    REQUIRE((result.Matches[1].MatchCriteria.Type == MatchType::Exact && result.Matches[1].MatchCriteria.Field == ApplicationMatchField::Id));
-    REQUIRE((result.Matches[2].MatchCriteria.Type == MatchType::Exact && result.Matches[2].MatchCriteria.Field == ApplicationMatchField::Name));
-    REQUIRE((result.Matches[3].MatchCriteria.Type == MatchType::Exact && result.Matches[3].MatchCriteria.Field == ApplicationMatchField::Name));
-    REQUIRE((result.Matches[4].MatchCriteria.Type == MatchType::CaseInsensitive && result.Matches[4].MatchCriteria.Field == ApplicationMatchField::Id));
-    REQUIRE((result.Matches[5].MatchCriteria.Type == MatchType::CaseInsensitive && result.Matches[5].MatchCriteria.Field == ApplicationMatchField::Id));
+    REQUIRE((result.Matches[0].MatchCriteria.Type == MatchType::Exact && result.Matches[0].MatchCriteria.Field == PackageMatchField::Id));
+    REQUIRE((result.Matches[1].MatchCriteria.Type == MatchType::Exact && result.Matches[1].MatchCriteria.Field == PackageMatchField::Id));
+    REQUIRE((result.Matches[2].MatchCriteria.Type == MatchType::Exact && result.Matches[2].MatchCriteria.Field == PackageMatchField::Name));
+    REQUIRE((result.Matches[3].MatchCriteria.Type == MatchType::Exact && result.Matches[3].MatchCriteria.Field == PackageMatchField::Name));
+    REQUIRE((result.Matches[4].MatchCriteria.Type == MatchType::CaseInsensitive && result.Matches[4].MatchCriteria.Field == PackageMatchField::Id));
+    REQUIRE((result.Matches[5].MatchCriteria.Type == MatchType::CaseInsensitive && result.Matches[5].MatchCriteria.Field == PackageMatchField::Id));
 
     // when truncate required
     request.MaximumResults = 3;
@@ -604,7 +610,7 @@ TEST_CASE("RepoSources_SearchAcrossMultipleSources", "[sources]")
     REQUIRE(result.Matches.size() == 3);
     REQUIRE(result.Truncated);
     // matches are sorted in expected order
-    REQUIRE((result.Matches[0].MatchCriteria.Type == MatchType::Exact && result.Matches[0].MatchCriteria.Field == ApplicationMatchField::Id));
-    REQUIRE((result.Matches[1].MatchCriteria.Type == MatchType::Exact && result.Matches[1].MatchCriteria.Field == ApplicationMatchField::Id));
-    REQUIRE((result.Matches[2].MatchCriteria.Type == MatchType::Exact && result.Matches[2].MatchCriteria.Field == ApplicationMatchField::Name));
+    REQUIRE((result.Matches[0].MatchCriteria.Type == MatchType::Exact && result.Matches[0].MatchCriteria.Field == PackageMatchField::Id));
+    REQUIRE((result.Matches[1].MatchCriteria.Type == MatchType::Exact && result.Matches[1].MatchCriteria.Field == PackageMatchField::Id));
+    REQUIRE((result.Matches[2].MatchCriteria.Type == MatchType::Exact && result.Matches[2].MatchCriteria.Field == PackageMatchField::Name));
 }

--- a/src/AppInstallerRepositoryCore/AggregatedSource.cpp
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.cpp
@@ -5,23 +5,24 @@
 
 namespace AppInstaller::Repository
 {
-    AggregatedSource::AggregatedSource()
+    AggregatedSource::AggregatedSource(std::string identifier) :
+        m_identifier(identifier)
     {
         m_details.Name = "AggregatedSource";
         m_details.IsAggregated = true;
     }
 
-    const SourceDetails& AppInstaller::Repository::AggregatedSource::GetDetails() const
+    const SourceDetails& AggregatedSource::GetDetails() const
     {
         return m_details;
     }
 
-    void AggregatedSource::AddSource(std::shared_ptr<ISource> source)
+    const std::string& AggregatedSource::GetIdentifier() const
     {
-        m_sources.emplace_back(std::move(source));
+        return m_identifier;
     }
 
-    SearchResult AggregatedSource::Search(const SearchRequest& request)
+    SearchResult AggregatedSource::Search(const SearchRequest& request) const
     {
         SearchResult result;
 
@@ -45,6 +46,11 @@ namespace AppInstaller::Repository
         }
 
         return result;
+    }
+
+    void AggregatedSource::AddSource(std::shared_ptr<ISource> source)
+    {
+        m_sources.emplace_back(std::move(source));
     }
 
     void AggregatedSource::SortResultMatches(std::vector<ResultMatch>& matches)

--- a/src/AppInstallerRepositoryCore/AggregatedSource.h
+++ b/src/AppInstallerRepositoryCore/AggregatedSource.h
@@ -8,7 +8,7 @@ namespace AppInstaller::Repository
 {
     struct AggregatedSource : public ISource
     {
-        AggregatedSource();
+        explicit AggregatedSource(std::string identifier);
 
         AggregatedSource(const AggregatedSource&) = delete;
         AggregatedSource& operator=(const AggregatedSource&) = delete;
@@ -21,16 +21,24 @@ namespace AppInstaller::Repository
         // Get the source's details.
         const SourceDetails& GetDetails() const override;
 
-        // Execute a search on the source.
-        SearchResult Search(const SearchRequest & request) override;
+        // Gets the source's identifier; a unique identifier independent of the name
+        // that will not change between a remove/add or between additional adds.
+        // Must be suitable for filesystem names.
+        const std::string& GetIdentifier() const override;
 
+        // Execute a search on the source.
+        SearchResult Search(const SearchRequest & request) const override;
+
+        // Adds a source to be aggregated.
         void AddSource(std::shared_ptr<ISource> source);
 
     private:
         std::vector<std::shared_ptr<ISource>> m_sources;
         SourceDetails m_details;
+        std::string m_identifier;
 
-        void SortResultMatches(std::vector<ResultMatch>& matches);
+        // Sorts a vector of results.
+        static void SortResultMatches(std::vector<ResultMatch>& matches);
     };
 }
 

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -146,7 +146,7 @@ namespace AppInstaller::Repository::Microsoft
 
                 SQLiteIndex index = SQLiteIndex::Open(indexLocation.u8string(), SQLiteIndex::OpenDisposition::Immutable);
 
-                return std::make_shared<SQLiteIndexSource>(details, std::move(index), std::move(lock));
+                return std::make_shared<SQLiteIndexSource>(details, GetPackageFamilyNameFromDetails(details), std::move(index), std::move(lock));
             }
 
             void UpdateInternal(std::string packageLocation, const SourceDetails& details, IProgressCallback& progress) override
@@ -251,7 +251,7 @@ namespace AppInstaller::Repository::Microsoft
 
                 SQLiteIndex index = SQLiteIndex::Open(packageLocation.u8string(), SQLiteIndex::OpenDisposition::Read);
 
-                return std::make_shared<SQLiteIndexSource>(details, std::move(index), std::move(lock));
+                return std::make_shared<SQLiteIndexSource>(details, GetPackageFamilyNameFromDetails(details), std::move(index), std::move(lock));
             }
 
             void UpdateInternal(std::string packageLocation, const SourceDetails& details, IProgressCallback& progress) override

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -206,31 +206,26 @@ namespace AppInstaller::Repository::Microsoft
         m_interface->PrepareForPackaging(m_dbconn);
     }
 
-    Schema::ISQLiteIndex::SearchResult SQLiteIndex::Search(const SearchRequest& request)
+    Schema::ISQLiteIndex::SearchResult SQLiteIndex::Search(const SearchRequest& request) const
     {
         AICLI_LOG(Repo, Info, << "Performing search: " << request.ToString());
 
         return m_interface->Search(m_dbconn, request);
     }
 
-    std::optional<std::string> SQLiteIndex::GetIdStringById(IdType id)
+    std::optional<std::string> SQLiteIndex::GetPropertyByManifestId(IdType manifestId, PackageProperty property) const
     {
-        return m_interface->GetIdStringById(m_dbconn, id);
+        return m_interface->GetPropertyByManifestId(m_dbconn, manifestId, property);
     }
 
-    std::optional<std::string> SQLiteIndex::GetNameStringById(IdType id)
+    std::optional<SQLiteIndex::IdType> SQLiteIndex::GetManifestIdByKey(IdType id, std::string_view version, std::string_view channel) const
     {
-        return m_interface->GetNameStringById(m_dbconn, id);
+        return m_interface->GetManifestIdByKey(m_dbconn, id, version, channel);
     }
 
-    std::optional<std::string> SQLiteIndex::GetPathStringByKey(IdType id, std::string_view version, std::string_view channel)
+    std::vector<Utility::VersionAndChannel> SQLiteIndex::GetVersionKeysById(IdType id) const
     {
-        return m_interface->GetPathStringByKey(m_dbconn, id, version, channel);
-    }
-
-    std::vector<Utility::VersionAndChannel> SQLiteIndex::GetVersionsById(IdType id)
-    {
-        return m_interface->GetVersionsById(m_dbconn, id);
+        return m_interface->GetVersionKeysById(m_dbconn, id);
     }
 
     // Recording last write time based on MSDN documentation stating that time returns a POSIX epoch time and thus

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -213,7 +213,7 @@ namespace AppInstaller::Repository::Microsoft
         return m_interface->Search(m_dbconn, request);
     }
 
-    std::optional<std::string> SQLiteIndex::GetPropertyByManifestId(IdType manifestId, PackageProperty property) const
+    std::optional<std::string> SQLiteIndex::GetPropertyByManifestId(IdType manifestId, PackageVersionProperty property) const
     {
         return m_interface->GetPropertyByManifestId(m_dbconn, manifestId, property);
     }

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -88,20 +88,17 @@ namespace AppInstaller::Repository::Microsoft
         void PrepareForPackaging();
 
         // Performs a search based on the given criteria.
-        Schema::ISQLiteIndex::SearchResult Search(const SearchRequest& request);
+        Schema::ISQLiteIndex::SearchResult Search(const SearchRequest& request) const;
 
-        // Gets the Id string for the given id, if present.
-        std::optional<std::string> GetIdStringById(IdType id);
+        // Gets the string for the given property and manifest id, if present.
+        std::optional<std::string> GetPropertyByManifestId(IdType manifestId, PackageProperty property) const;
 
-        // Gets the Name string for the given id, if present.
-        std::optional<std::string> GetNameStringById(IdType id);
-
-        // Gets the relative path string for the given { id, version, channel }, if present.
+        // Gets the manifest id for the given { id, version, channel }, if present.
         // If version is empty, gets the value for the 'latest' version.
-        std::optional<std::string> GetPathStringByKey(IdType id, std::string_view version, std::string_view channel);
+        std::optional<IdType> GetManifestIdByKey(IdType id, std::string_view version, std::string_view channel) const;
 
         // Gets all versions and channels for the given id.
-        std::vector<Utility::VersionAndChannel> GetVersionsById(IdType id);
+        std::vector<Utility::VersionAndChannel> GetVersionKeysById(IdType id) const;
 
     private:
         // Constructor used to open an existing index.

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -91,7 +91,7 @@ namespace AppInstaller::Repository::Microsoft
         Schema::ISQLiteIndex::SearchResult Search(const SearchRequest& request) const;
 
         // Gets the string for the given property and manifest id, if present.
-        std::optional<std::string> GetPropertyByManifestId(IdType manifestId, PackageProperty property) const;
+        std::optional<std::string> GetPropertyByManifestId(IdType manifestId, PackageVersionProperty property) const;
 
         // Gets the manifest id for the given { id, version, channel }, if present.
         // If version is empty, gets the value for the 'latest' version.

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -37,11 +37,11 @@ namespace AppInstaller::Repository::Microsoft
                 SourceReference(source), m_manifestId(manifestId) {}
 
             // Inherited via IPackageVersion
-            Utility::LocIndString GetProperty(PackageProperty property) const override
+            Utility::LocIndString GetProperty(PackageVersionProperty property) const override
             {
                 switch (property)
                 {
-                case PackageProperty::SourceId:
+                case PackageVersionProperty::SourceId:
                     return LocIndString{ GetSource()->GetIdentifier() };
                 default:
                     // Values coming from the index will always be localized/independent.
@@ -52,7 +52,7 @@ namespace AppInstaller::Repository::Microsoft
             std::optional<Manifest::Manifest> GetManifest() const override
             {
                 std::shared_ptr<const SQLiteIndexSource> source = GetSource();
-                std::optional<std::string> relativePathOpt = source->GetIndex().GetPropertyByManifestId(m_manifestId, PackageProperty::RelativePath);
+                std::optional<std::string> relativePathOpt = source->GetIndex().GetPropertyByManifestId(m_manifestId, PackageVersionProperty::RelativePath);
                 if (!relativePathOpt)
                 {
                     return {};

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -12,36 +12,52 @@ namespace AppInstaller::Repository::Microsoft
 
     namespace
     {
-        // The IApplication impl for SQLiteIndexSource.
-        struct Application : public IApplication
+        // The base for the package objects.
+        struct SourceReference
         {
-            Application(std::shared_ptr<SQLiteIndexSource>& source, SQLiteIndex::IdType id) :
-                m_id(id), m_source(source) {}
+            SourceReference(const std::shared_ptr<const SQLiteIndexSource>& source) :
+                m_source(source) {}
 
-            // Inherited via IApplication
-            LocIndString GetId() override
+        protected:
+            std::shared_ptr<const SQLiteIndexSource> GetSource() const
             {
-                // Values coming from the index will always be localized/independent.
-                return LocIndString{ GetSource()->GetIndex().GetIdStringById(m_id).value() };
+                std::shared_ptr<const SQLiteIndexSource> source = m_source.lock();
+                THROW_HR_IF(E_NOT_VALID_STATE, !source);
+                return source;
             }
 
-            LocIndString GetName() override
+        private:
+            std::weak_ptr<const SQLiteIndexSource> m_source;
+        };
+
+        // The IPackageVersion impl for SQLiteIndexSource.
+        struct PackageVersion : public SourceReference, public IPackageVersion
+        {
+            PackageVersion(const std::shared_ptr<const SQLiteIndexSource>& source, SQLiteIndex::IdType manifestId) :
+                SourceReference(source), m_manifestId(manifestId) {}
+
+            // Inherited via IPackageVersion
+            Utility::LocIndString GetProperty(PackageProperty property) const override
             {
                 // Values coming from the index will always be localized/independent.
-                return LocIndString{ GetSource()->GetIndex().GetNameStringById(m_id).value() };
+                return LocIndString{ GetSource()->GetIndex().GetPropertyByManifestId(m_manifestId, property).value() };
             }
 
-            std::optional<Manifest::Manifest> GetManifest(const Utility::NormalizedString& version, const Utility::NormalizedString& channel) override
+            std::optional<Manifest::Manifest> GetManifest() const override
             {
-                std::shared_ptr<SQLiteIndexSource> source = GetSource();
-                std::optional<std::string> relativePathOpt = source->GetIndex().GetPathStringByKey(m_id, version, channel);
+                std::shared_ptr<const SQLiteIndexSource> source = GetSource();
+                std::optional<std::string> relativePathOpt = source->GetIndex().GetPathStringByManifestId(m_manifestId);
                 if (!relativePathOpt)
                 {
                     return {};
                 }
-                std::string relativePath = relativePathOpt.value();
+                return GetManifestFromArgAndRelativePath(source->GetDetails().Arg, relativePathOpt.value());
+            }
 
-                std::string fullPath = source->GetDetails().Arg;
+        private:
+            static Manifest::Manifest GetManifestFromArgAndRelativePath(const std::string& arg, const std::string& relativePath)
+            {
+                std::string fullPath = arg;
                 if (fullPath.back() != '/')
                 {
                     fullPath += '/';
@@ -68,26 +84,70 @@ namespace AppInstaller::Repository::Microsoft
                 }
             }
 
-            std::vector<Utility::VersionAndChannel> GetVersions() override
+            SQLiteIndex::IdType m_manifestId;
+        };
+
+        // The IPackage impl for SQLiteIndexSource.
+        struct Package : public SourceReference, public IPackage
+        {
+            Package(const std::shared_ptr<const SQLiteIndexSource>& source, SQLiteIndex::IdType idId) :
+                SourceReference(source), m_idId(idId) {}
+
+            // Inherited via IPackage
+            std::shared_ptr<IPackageVersion> GetInstalledVersion() const override
             {
-                return GetSource()->GetIndex().GetVersionsById(m_id);
+                // Although an index might be the backing store for installed packages, the installed package version
+                // will be selected by external business logic.
+                return {};
+            }
+
+            std::vector<PackageVersionKey> GetAvailableVersionKeys() const override
+            {
+                std::shared_ptr<const SQLiteIndexSource> source = GetSource();
+                std::vector<Utility::VersionAndChannel> versions = source->GetIndex().GetVersionKeysById(m_idId);
+
+                std::vector<PackageVersionKey> result;
+                for (const auto& vac : versions)
+                {
+                    result.emplace_back(source->GetIdentifier(), vac.GetVersion(), vac.GetChannel());
+                }
+                return result;
+            }
+
+            std::shared_ptr<IPackageVersion> GetLatestAvailableVersion() const override
+            {
+                std::shared_ptr<const SQLiteIndexSource> source = GetSource();
+                std::vector<SQLiteIndex::IdType> manifestIds = source->GetIndex().GetVersionIdsById(m_idId);
+
+                if (!manifestIds.empty())
+                {
+                    return std::make_shared<PackageVersion>(source, manifestIds[0]);
+                }
+
+                return {};
+            }
+
+            std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey& versionKey) const override
+            {
+                std::shared_ptr<const SQLiteIndexSource> source = GetSource();
+                THROW_HR_IF(E_INVALIDARG, !versionKey.SourceId.empty() && versionKey.SourceId != source->GetIdentifier());
+                std::optional<SQLiteIndex::IdType> manifestId = source->GetIndex().GetVersionIdByKey(m_idId, versionKey.Version, versionKey.Channel);
+
+                if (manifestId)
+                {
+                    return std::make_shared<PackageVersion>(source, manifestId.value());
+                }
+
+                return {};
             }
 
         private:
-            std::shared_ptr<SQLiteIndexSource> GetSource()
-            {
-                std::shared_ptr<SQLiteIndexSource> source = m_source.lock();
-                THROW_HR_IF(E_NOT_VALID_STATE, !source);
-                return source;
-            }
-
-            std::weak_ptr<SQLiteIndexSource> m_source;
-            SQLiteIndex::IdType m_id;
+            SQLiteIndex::IdType m_idId;
         };
     }
 
-    SQLiteIndexSource::SQLiteIndexSource(const SourceDetails& details, SQLiteIndex&& index, Synchronization::CrossProcessReaderWriteLock&& lock) :
-        m_details(details), m_lock(std::move(lock)), m_index(std::move(index))
+    SQLiteIndexSource::SQLiteIndexSource(const SourceDetails& details, std::string identifier, SQLiteIndex&& index, Synchronization::CrossProcessReaderWriteLock&& lock) :
+        m_details(details), m_identifier(std::move(identifier)), m_lock(std::move(lock)), m_index(std::move(index))
     {
     }
 
@@ -96,12 +156,17 @@ namespace AppInstaller::Repository::Microsoft
         return m_details;
     }
 
-    SearchResult SQLiteIndexSource::Search(const SearchRequest& request)
+    const std::string& SQLiteIndexSource::GetIdentifier() const
+    {
+        return m_identifier;
+    }
+
+    SearchResult SQLiteIndexSource::Search(const SearchRequest& request) const
     {
         auto indexResults = m_index.Search(request);
 
         SearchResult result;
-        std::shared_ptr<SQLiteIndexSource> sharedThis = shared_from_this();
+        std::shared_ptr<const SQLiteIndexSource> sharedThis = shared_from_this();
         for (auto& indexResult : indexResults.Matches)
         {
             result.Matches.emplace_back(std::make_unique<Application>(sharedThis, indexResult.first), std::move(indexResult.second));

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -49,14 +49,11 @@ namespace AppInstaller::Repository::Microsoft
                 }
             }
 
-            std::optional<Manifest::Manifest> GetManifest() const override
+            Manifest::Manifest GetManifest() const override
             {
                 std::shared_ptr<const SQLiteIndexSource> source = GetSource();
                 std::optional<std::string> relativePathOpt = source->GetIndex().GetPropertyByManifestId(m_manifestId, PackageVersionProperty::RelativePath);
-                if (!relativePathOpt)
-                {
-                    return {};
-                }
+                THROW_HR_IF(E_NOT_SET, !relativePathOpt);
                 return GetManifestFromArgAndRelativePath(source->GetDetails().Arg, relativePathOpt.value());
             }
 

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.h
@@ -13,7 +13,7 @@ namespace AppInstaller::Repository::Microsoft
     // A source that holds a SQLiteIndex and lock.
     struct SQLiteIndexSource : public std::enable_shared_from_this<SQLiteIndexSource>, public ISource
     {
-        SQLiteIndexSource(const SourceDetails& details, SQLiteIndex&& index, Synchronization::CrossProcessReaderWriteLock&& lock = {});
+        SQLiteIndexSource(const SourceDetails& details, std::string identifier, SQLiteIndex&& index, Synchronization::CrossProcessReaderWriteLock&& lock = {});
 
         SQLiteIndexSource(const SQLiteIndexSource&) = delete;
         SQLiteIndexSource& operator=(const SQLiteIndexSource&) = delete;
@@ -26,14 +26,20 @@ namespace AppInstaller::Repository::Microsoft
         // Get the source's details.
         const SourceDetails& GetDetails() const override;
 
+        // Gets the source's identifier; a unique identifier independent of the name
+        // that will not change between a remove/add or between additional adds.
+        // Must be suitable for filesystem names.
+        const std::string& GetIdentifier() const override;
+
         // Execute a search on the source.
-        SearchResult Search(const SearchRequest& request) override;
+        SearchResult Search(const SearchRequest& request) const override;
 
         // Gets the index.
-        SQLiteIndex& GetIndex() { return m_index; }
+        const SQLiteIndex& GetIndex() const { return m_index; }
 
     private:
         SourceDetails m_details;
+        std::string m_identifier;
         Synchronization::CrossProcessReaderWriteLock m_lock;
         SQLiteIndex m_index;
     };

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
@@ -20,15 +20,14 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         std::pair<bool, SQLite::rowid_t> UpdateManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         SQLite::rowid_t RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         void PrepareForPackaging(SQLite::Connection& connection) override;
-        SearchResult Search(SQLite::Connection& connection, const SearchRequest& request) override;
-        std::optional<std::string> GetIdStringById(SQLite::Connection& connection, SQLite::rowid_t id) override;
-        std::optional<std::string> GetNameStringById(SQLite::Connection& connection, SQLite::rowid_t id) override;
-        std::optional<std::string> GetPathStringByKey(SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) override;
-        std::vector<Utility::VersionAndChannel> GetVersionsById(SQLite::Connection& connection, SQLite::rowid_t id) override;
+        SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const override;
+        std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const override;
+        std::optional<SQLite::rowid_t> GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const override;
+        std::vector<Utility::VersionAndChannel> GetVersionKeysById(const SQLite::Connection& connection, SQLite::rowid_t id) const override;
 
     protected:
         // Creates the search results table.
-        virtual std::unique_ptr<SearchResultsTable> CreateSearchResultsTable(SQLite::Connection& connection) const;
+        virtual std::unique_ptr<SearchResultsTable> CreateSearchResultsTable(const SQLite::Connection& connection) const;
 
         // Gets the ordering of matches to execute, with more specific matches coming first.
         virtual std::vector<MatchType> GetMatchTypeOrder(MatchType type) const;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
@@ -21,7 +21,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         SQLite::rowid_t RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         void PrepareForPackaging(SQLite::Connection& connection) override;
         SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const override;
-        std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const override;
+        std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionProperty property) const override;
         std::optional<SQLite::rowid_t> GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const override;
         std::vector<Utility::VersionAndChannel> GetVersionKeysById(const SQLite::Connection& connection, SQLite::rowid_t id) const override;
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -432,7 +432,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         return resultsTable->GetSearchResults(request.MaximumResults);
     }
 
-    std::optional<std::string> Interface::GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const
+    std::optional<std::string> Interface::GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionProperty property) const
     {
         if (!ManifestTable::ExistsById(connection, manifestId))
         {
@@ -442,15 +442,15 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         switch (property)
         {
-        case AppInstaller::Repository::PackageProperty::Id:
+        case AppInstaller::Repository::PackageVersionProperty::Id:
             return std::get<0>(ManifestTable::GetValuesById<IdTable>(connection, manifestId));
-        case AppInstaller::Repository::PackageProperty::Name:
+        case AppInstaller::Repository::PackageVersionProperty::Name:
             return std::get<0>(ManifestTable::GetValuesById<NameTable>(connection, manifestId));
-        case AppInstaller::Repository::PackageProperty::Version:
+        case AppInstaller::Repository::PackageVersionProperty::Version:
             return std::get<0>(ManifestTable::GetValuesById<VersionTable>(connection, manifestId));
-        case AppInstaller::Repository::PackageProperty::Channel:
+        case AppInstaller::Repository::PackageVersionProperty::Channel:
             return std::get<0>(ManifestTable::GetValuesById<ChannelTable>(connection, manifestId));
-        case AppInstaller::Repository::PackageProperty::RelativePath:
+        case AppInstaller::Repository::PackageVersionProperty::RelativePath:
             return PathPartTable::GetPathById(connection, std::get<0>(ManifestTable::GetIdsById<PathPartTable>(connection, manifestId)));
         default:
             return {};

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -348,7 +348,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         builder.Execute(connection);
     }
 
-    ISQLiteIndex::SearchResult Interface::Search(SQLite::Connection& connection, const SearchRequest& request)
+    ISQLiteIndex::SearchResult Interface::Search(const SQLite::Connection& connection, const SearchRequest& request) const
     {
         // If an empty request, get everything
         if (!request.Query && request.Inclusions.empty() && request.Filters.empty())
@@ -358,7 +358,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             SearchResult result;
             for (SQLite::rowid_t id : ids)
             {
-                result.Matches.emplace_back(std::make_pair(id, ApplicationMatchFilter(ApplicationMatchField::Id, MatchType::Wildcard, {})));
+                result.Matches.emplace_back(std::make_pair(id, PackageMatchFilter(PackageMatchField::Id, MatchType::Wildcard, {})));
             }
 
             result.Truncated = (request.MaximumResults && IdTable::GetCount(connection) > request.MaximumResults);
@@ -400,7 +400,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             THROW_HR_IF(E_UNEXPECTED, request.Filters.empty());
 
             // Perform search for just the field matching the first filter
-            const ApplicationMatchFilter& filter = request.Filters[0];
+            const PackageMatchFilter& filter = request.Filters[0];
 
             for (MatchType match : GetMatchTypeOrder(filter.Type))
             {
@@ -417,7 +417,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         // Second phase, for remaining filters, flag matching search results, then remove unflagged values.
         for (size_t i = filterIndex; i < request.Filters.size(); ++i)
         {
-            const ApplicationMatchFilter& filter = request.Filters[i];
+            const PackageMatchFilter& filter = request.Filters[i];
 
             resultsTable->PrepareToFilter();
 
@@ -432,41 +432,37 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         return resultsTable->GetSearchResults(request.MaximumResults);
     }
 
-    std::optional<std::string> Interface::GetIdStringById(SQLite::Connection& connection, SQLite::rowid_t id)
+    std::optional<std::string> Interface::GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const
     {
-        return IdTable::SelectValueById(connection, id);
-    }
-
-    std::optional<std::string> Interface::GetNameStringById(SQLite::Connection& connection, SQLite::rowid_t id)
-    {
-        std::optional<SQLite::rowid_t> manifestIdOpt = GetManifestIdByKey(connection, id);
-
-        if (!manifestIdOpt)
+        if (!ManifestTable::ExistsById(connection, manifestId))
         {
-            AICLI_LOG(Repo, Info, << "Did not find manifest by Id id: " << id);
+            AICLI_LOG(Repo, Info, << "Did not find manifest by id: " << manifestId);
             return {};
         }
 
-        auto [name] = ManifestTable::GetValuesById<NameTable>(connection, manifestIdOpt.value());
-        return name;
-    }
-
-    std::optional<std::string> Interface::GetPathStringByKey(SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel)
-    {
-        std::optional<SQLite::rowid_t> manifestIdOpt = GetManifestIdByKey(connection, id, version, channel);
-
-        if (!manifestIdOpt)
+        switch (property)
         {
-            AICLI_LOG(Repo, Info, << "Did not find manifest for: " << id << ", " << version << ", " << channel);
+        case AppInstaller::Repository::PackageProperty::Id:
+            return std::get<0>(ManifestTable::GetValuesById<IdTable>(connection, manifestId));
+        case AppInstaller::Repository::PackageProperty::Name:
+            return std::get<0>(ManifestTable::GetValuesById<NameTable>(connection, manifestId));
+        case AppInstaller::Repository::PackageProperty::Version:
+            return std::get<0>(ManifestTable::GetValuesById<VersionTable>(connection, manifestId));
+        case AppInstaller::Repository::PackageProperty::Channel:
+            return std::get<0>(ManifestTable::GetValuesById<ChannelTable>(connection, manifestId));
+        case AppInstaller::Repository::PackageProperty::RelativePath:
+            return PathPartTable::GetPathById(connection, std::get<0>(ManifestTable::GetIdsById<PathPartTable>(connection, manifestId)));
+        default:
             return {};
         }
-
-        auto [pathPartId] = ManifestTable::GetIdsById<PathPartTable>(connection, manifestIdOpt.value());
-
-        return PathPartTable::GetPathById(connection, pathPartId);
     }
 
-    std::vector<Utility::VersionAndChannel> Interface::GetVersionsById(SQLite::Connection& connection, SQLite::rowid_t id)
+    std::optional<SQLite::rowid_t> Interface::GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const
+    {
+        return GetManifestIdByKey(connection, id, version, channel);
+    }
+
+    std::vector<Utility::VersionAndChannel> Interface::GetVersionKeysById(const SQLite::Connection& connection, SQLite::rowid_t id) const
     {
         auto versionsAndChannels = ManifestTable::GetAllValuesById<IdTable, VersionTable, ChannelTable>(connection, id);
 
@@ -482,7 +478,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         return result;
     }
 
-    std::unique_ptr<SearchResultsTable> Interface::CreateSearchResultsTable(SQLite::Connection& connection) const
+    std::unique_ptr<SearchResultsTable> Interface::CreateSearchResultsTable(const SQLite::Connection& connection) const
     {
         return std::make_unique<SearchResultsTable>(connection);
     }
@@ -514,11 +510,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     {
         for (MatchType match : GetMatchTypeOrder(query.Type))
         {
-            resultsTable.SearchOnField(ApplicationMatchField::Id, match, query.Value);
-            resultsTable.SearchOnField(ApplicationMatchField::Name, match, query.Value);
-            resultsTable.SearchOnField(ApplicationMatchField::Moniker, match, query.Value);
-            resultsTable.SearchOnField(ApplicationMatchField::Command, match, query.Value);
-            resultsTable.SearchOnField(ApplicationMatchField::Tag, match, query.Value);
+            resultsTable.SearchOnField(PackageMatchField::Id, match, query.Value);
+            resultsTable.SearchOnField(PackageMatchField::Name, match, query.Value);
+            resultsTable.SearchOnField(PackageMatchField::Moniker, match, query.Value);
+            resultsTable.SearchOnField(PackageMatchField::Command, match, query.Value);
+            resultsTable.SearchOnField(PackageMatchField::Tag, match, query.Value);
         }
     }
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -58,7 +58,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Gets a manifest id by the given key values.
-        std::optional<SQLite::rowid_t> GetManifestIdByKey(SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version = "", std::string_view channel = "")
+        std::optional<SQLite::rowid_t> StaticGetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version = "", std::string_view channel = "")
         {
             std::optional<SQLite::rowid_t> channelIdOpt = ChannelTable::SelectIdByValue(connection, channel, true);
             if (!channelIdOpt && !channel.empty())
@@ -459,7 +459,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
     std::optional<SQLite::rowid_t> Interface::GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const
     {
-        return GetManifestIdByKey(connection, id, version, channel);
+        return StaticGetManifestIdByKey(connection, id, version, channel);
     }
 
     std::vector<Utility::VersionAndChannel> Interface::GetVersionKeysById(const SQLite::Connection& connection, SQLite::rowid_t id) const

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     namespace details
     {
         std::optional<SQLite::rowid_t> ManifestTableSelectByValueIds(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<std::string_view> values,
             std::initializer_list<SQLite::rowid_t> ids)
         {
@@ -150,7 +150,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         std::vector<std::string> ManifestTableGetAllValuesByIds(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<SQLite::Builder::QualifiedColumn> valueColumns,
             std::initializer_list<std::string_view> idColumns,
             std::initializer_list<SQLite::rowid_t> ids)

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
@@ -61,7 +61,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         SQLite::Statement ManifestTableGetIdsById_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             SQLite::rowid_t id,
             std::initializer_list<std::string_view> values)
         {
@@ -81,7 +81,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         // JOIN [ids] ON [manifest].[id] = [ids].[rowid]
         // WHERE [manifest].[rowid] = 1
         SQLite::Statement ManifestTableGetValuesById_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             SQLite::rowid_t id,
             std::initializer_list<SQLite::Builder::QualifiedColumn> columns)
         {
@@ -106,7 +106,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         SQLite::Statement ManifestTableGetAllValuesByIds_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<SQLite::Builder::QualifiedColumn> valueColumns,
             std::initializer_list<std::string_view> idColumns,
             std::initializer_list<SQLite::rowid_t> ids)
@@ -350,6 +350,18 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         builder.Execute(connection);
 
         return connection.GetLastInsertRowID();
+    }
+
+    bool ManifestTable::ExistsById(const SQLite::Connection& connection, SQLite::rowid_t id)
+    {
+        SQLite::Builder::StatementBuilder builder;
+        builder.Select(SQLite::Builder::RowCount).From(s_ManifestTable_Table_Name).Where(SQLite::RowIDName).Equals(id);
+
+        SQLite::Statement countStatement = builder.Prepare(connection);
+
+        THROW_HR_IF(E_UNEXPECTED, !countStatement.Step());
+
+        return (countStatement.GetColumn<int>(0) != 0);
     }
 
     void ManifestTable::DeleteById(SQLite::Connection& connection, SQLite::rowid_t id)

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
@@ -21,19 +21,19 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets the requested ids for the manifest with the given rowid.
         SQLite::Statement ManifestTableGetIdsById_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             SQLite::rowid_t id,
             std::initializer_list<std::string_view> values);
 
         // Gets the requested values for the manifest with the given rowid.
         SQLite::Statement ManifestTableGetValuesById_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             SQLite::rowid_t id,
             std::initializer_list<SQLite::Builder::QualifiedColumn> columns);
 
         // Gets all values for rows that match the given ids.
         SQLite::Statement ManifestTableGetAllValuesByIds_Statement(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<SQLite::Builder::QualifiedColumn> valueColumns,
             std::initializer_list<std::string_view> idColumns,
             std::initializer_list<SQLite::rowid_t> ids);
@@ -88,6 +88,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         // Insert the given values into the table.
         static SQLite::rowid_t Insert(SQLite::Connection& connection, std::initializer_list<ManifestOneToOneValue> values);
 
+        // Gets a value indicating whether the manifest with rowid id exists.
+        static bool ExistsById(const SQLite::Connection& connection, SQLite::rowid_t id);
+
         // Select the first rowid of the manifest with the given value.
         template <typename... Tables>
         static std::optional<SQLite::rowid_t> SelectByValueIds(SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
@@ -98,14 +101,14 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets the ids requested for the manifest with the given rowid.
         template <typename... Tables>
-        static auto GetIdsById(SQLite::Connection& connection, SQLite::rowid_t id)
+        static auto GetIdsById(const SQLite::Connection& connection, SQLite::rowid_t id)
         {
             return details::ManifestTableGetIdsById_Statement(connection, id, { Tables::ValueName()... }).GetRow<Tables::id_t...>();
         }
 
         // Gets the values requested for the manifest with the given rowid.
         template <typename... Tables>
-        static auto GetValuesById(SQLite::Connection& connection, SQLite::rowid_t id)
+        static auto GetValuesById(const SQLite::Connection& connection, SQLite::rowid_t id)
         {
             return details::ManifestTableGetValuesById_Statement(connection, id, { SQLite::Builder::QualifiedColumn{ Tables::TableName(), Tables::ValueName() }... }).GetRow<Tables::value_t...>();
         }
@@ -119,7 +122,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets all values for rows that match the given id.
         template <typename IdTable, typename... ValueTables>
-        static std::vector<std::tuple<typename ValueTables::value_t...>> GetAllValuesById(SQLite::Connection& connection, SQLite::rowid_t id)
+        static std::vector<std::tuple<typename ValueTables::value_t...>> GetAllValuesById(const SQLite::Connection& connection, SQLite::rowid_t id)
         {
             auto stmt = details::ManifestTableGetAllValuesByIds_Statement(connection, { SQLite::Builder::QualifiedColumn{ ValueTables::TableName(), ValueTables::ValueName() }... }, { IdTable::ValueName() }, { id });
             std::vector<std::tuple<typename ValueTables::value_t...>> result;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
@@ -15,7 +15,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     {
         // Selects a manifest by the given value id.
         std::optional<SQLite::rowid_t> ManifestTableSelectByValueIds(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<std::string_view> values,
             std::initializer_list<SQLite::rowid_t> ids);
 
@@ -40,7 +40,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets all values for rows that match the given ids.
         std::vector<std::string> ManifestTableGetAllValuesByIds(
-            SQLite::Connection& connection,
+            const SQLite::Connection& connection,
             std::initializer_list<SQLite::Builder::QualifiedColumn> valueColumns,
             std::initializer_list<std::string_view> idColumns,
             std::initializer_list<SQLite::rowid_t> ids);
@@ -93,7 +93,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Select the first rowid of the manifest with the given value.
         template <typename... Tables>
-        static std::optional<SQLite::rowid_t> SelectByValueIds(SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
+        static std::optional<SQLite::rowid_t> SelectByValueIds(const SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
         {
             static_assert(sizeof...(Tables) >= 1);
             return details::ManifestTableSelectByValueIds(connection, { Tables::ValueName()... }, ids);
@@ -115,7 +115,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets the values for rows that match the given ids.
         template <typename ValueTable, typename... IdTables>
-        static std::vector<typename ValueTable::value_t> GetAllValuesByIds(SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
+        static std::vector<typename ValueTable::value_t> GetAllValuesByIds(const SQLite::Connection& connection, std::initializer_list<SQLite::rowid_t> ids)
         {
             return details::ManifestTableGetAllValuesByIds(connection, { SQLite::Builder::QualifiedColumn{ ValueTable::TableName(), ValueTable::ValueName() } }, { IdTables::ValueName()... }, ids);
         }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
@@ -92,7 +92,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             }
         }
 
-        std::vector<SQLite::rowid_t> OneToOneTableGetAllRowIds(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, size_t limit)
+        std::vector<SQLite::rowid_t> OneToOneTableGetAllRowIds(const SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, size_t limit)
         {
             SQLite::Builder::StatementBuilder selectBuilder;
             selectBuilder.Select(SQLite::RowIDName).From(tableName).OrderBy(valueName);
@@ -165,7 +165,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             }
         }
 
-        uint64_t OneToOneTableGetCount(SQLite::Connection& connection, std::string_view tableName)
+        uint64_t OneToOneTableGetCount(const SQLite::Connection& connection, std::string_view tableName)
         {
             SQLite::Builder::StatementBuilder builder;
             builder.Select(SQLite::Builder::RowCount).From(tableName);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
@@ -49,7 +49,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             }
         }
 
-        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike)
+        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(const SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike)
         {
             SQLite::Builder::StatementBuilder selectBuilder;
             selectBuilder.Select(SQLite::RowIDName).From(tableName).Where(valueName);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -16,7 +16,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         void CreateOneToOneTable(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, bool useNamedIndeces);
 
         // Selects the value from the table, returning the rowid if it exists.
-        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike = false);
+        std::optional<SQLite::rowid_t> OneToOneTableSelectIdByValue(const SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool useLike = false);
 
         // Selects the value from the table, returning the rowid if it exists.
         std::optional<std::string> OneToOneTableSelectValueById(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, SQLite::rowid_t id);
@@ -81,7 +81,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Selects the value from the table, returning the rowid if it exists.
-        static std::optional<SQLite::rowid_t> SelectIdByValue(SQLite::Connection& connection, std::string_view value, bool useLike = false)
+        static std::optional<SQLite::rowid_t> SelectIdByValue(const SQLite::Connection& connection, std::string_view value, bool useLike = false)
         {
             return details::OneToOneTableSelectIdByValue(connection, TableInfo::TableName(), TableInfo::ValueName(), value, useLike);
         }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -22,7 +22,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         std::optional<std::string> OneToOneTableSelectValueById(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, SQLite::rowid_t id);
 
         // Gets all row ids from the table.
-        std::vector<SQLite::rowid_t> OneToOneTableGetAllRowIds(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, size_t limit);
+        std::vector<SQLite::rowid_t> OneToOneTableGetAllRowIds(const SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, size_t limit);
 
         // Ensures that the values exists in the table.
         SQLite::rowid_t OneToOneTableEnsureExists(SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, std::string_view value, bool overwriteLikeMatch = false);
@@ -34,7 +34,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         void OneToOneTablePrepareForPackaging(SQLite::Connection& connection, std::string_view tableName, bool useNamedIndeces, bool preserveValuesIndex);
 
         // Gets the total number of rows in the table.
-        uint64_t OneToOneTableGetCount(SQLite::Connection& connection, std::string_view tableName);
+        uint64_t OneToOneTableGetCount(const SQLite::Connection& connection, std::string_view tableName);
 
         // Determines if the table is empty.
         bool OneToOneTableIsEmpty(SQLite::Connection& connection, std::string_view tableName);
@@ -93,7 +93,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Gets all row ids from the table.
-        static std::vector<SQLite::rowid_t> GetAllRowIds(SQLite::Connection& connection, size_t limit = 0)
+        static std::vector<SQLite::rowid_t> GetAllRowIds(const SQLite::Connection& connection, size_t limit = 0)
         {
             return details::OneToOneTableGetAllRowIds(connection, TableInfo::TableName(), TableInfo::ValueName(), limit);
         }
@@ -123,7 +123,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Gets the total number of rows in the table.
-        static uint64_t GetCount(SQLite::Connection& connection)
+        static uint64_t GetCount(const SQLite::Connection& connection)
         {
             return details::OneToOneTableGetCount(connection, TableInfo::TableName());
         }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
@@ -198,7 +198,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         return { (createIfNotFound ? partsAdded : true), parent.value() };
     }
 
-    std::optional<std::string> PathPartTable::GetPathById(SQLite::Connection& connection, SQLite::rowid_t id)
+    std::optional<std::string> PathPartTable::GetPathById(const SQLite::Connection& connection, SQLite::rowid_t id)
     {
         SQLite::Builder::StatementBuilder builder;
         builder.Select({ s_PathPartTable_ParentValue_Name, s_PathPartTable_PartValue_Name }).

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
@@ -37,7 +37,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         static std::tuple<bool, SQLite::rowid_t> EnsurePathExists(SQLite::Connection& connection, const std::filesystem::path& relativePath, bool createIfNotFound);
 
         // Gets the path string using the given id as the leaf.
-        static std::optional<std::string> GetPathById(SQLite::Connection& connection, SQLite::rowid_t id);
+        static std::optional<std::string> GetPathById(const SQLite::Connection& connection, SQLite::rowid_t id);
 
         // Removes the path that terminates at the given id.
         // Will not remove a path part if it is referenced.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable.h
@@ -16,7 +16,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
     // Table for holding temporary search results.
     struct SearchResultsTable : public SQLite::TempTable
     {
-        SearchResultsTable(SQLite::Connection& connection);
+        SearchResultsTable(const SQLite::Connection& connection);
 
         SearchResultsTable(const SearchResultsTable&) = delete;
         SearchResultsTable& operator=(const SearchResultsTable&) = delete;
@@ -25,7 +25,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         SearchResultsTable& operator=(SearchResultsTable&&) = default;
 
         // Performs the requested search type on the requested field.
-        void SearchOnField(ApplicationMatchField field, MatchType match, std::string_view value);
+        void SearchOnField(PackageMatchField field, MatchType match, std::string_view value);
 
         // Removes rows with manifest ids whose sort order is below the highest one.
         void RemoveDuplicateManifestRows();
@@ -34,7 +34,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         void PrepareToFilter();
 
         // Performs the requested filter type on the requested field.
-        void FilterOnField(ApplicationMatchField field, MatchType match, std::string_view value);
+        void FilterOnField(PackageMatchField field, MatchType match, std::string_view value);
 
         // Completes a filtering pass, removing filtered rows.
         void CompleteFilter();
@@ -44,17 +44,17 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
     protected:
         // Builds the search statement for the specified field and match type.
-        std::optional<int> BuildSearchStatement(SQLite::Builder::StatementBuilder& builder, ApplicationMatchField field, MatchType match) const;
+        std::optional<int> BuildSearchStatement(SQLite::Builder::StatementBuilder& builder, PackageMatchField field, MatchType match) const;
 
         virtual std::optional<int> BuildSearchStatement(
             SQLite::Builder::StatementBuilder& builder,
-            ApplicationMatchField field,
+            PackageMatchField field,
             std::string_view manifestAlias,
             std::string_view valueAlias,
             bool useLike) const;
 
     private:
-        SQLite::Connection& m_connection;
+        const SQLite::Connection& m_connection;
         int m_sortOrdinalValue = 0;
     };
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/SearchResultsTable_1_0.cpp
@@ -77,7 +77,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
     }
 
-    SearchResultsTable::SearchResultsTable(SQLite::Connection& connection) :
+    SearchResultsTable::SearchResultsTable(const SQLite::Connection& connection) :
         m_connection(connection)
     {
         using namespace SQLite::Builder;
@@ -113,7 +113,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
     }
 
-    void SearchResultsTable::SearchOnField(ApplicationMatchField field, MatchType match, std::string_view value)
+    void SearchResultsTable::SearchOnField(PackageMatchField field, MatchType match, std::string_view value)
     {
         using namespace SQLite::Builder;
 
@@ -140,7 +140,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         if (!bindIndex)
         {
-            AICLI_LOG(Repo, Verbose, << "ApplicationMatchField not supported in this version: " << ApplicationMatchFieldToString(field));
+            AICLI_LOG(Repo, Verbose, << "PackageMatchField not supported in this version: " << PackageMatchFieldToString(field));
             return;
         }
 
@@ -183,7 +183,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         builder.Execute(m_connection);
     }
 
-    void SearchResultsTable::FilterOnField(ApplicationMatchField field, MatchType match, std::string_view value)
+    void SearchResultsTable::FilterOnField(PackageMatchField field, MatchType match, std::string_view value)
     {
         using namespace SQLite::Builder;
 
@@ -204,7 +204,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         if (!bindIndex)
         {
-            AICLI_LOG(Repo, Verbose, << "ApplicationMatchField not supported in this version: " << ApplicationMatchFieldToString(field));
+            AICLI_LOG(Repo, Verbose, << "PackageMatchField not supported in this version: " << PackageMatchFieldToString(field));
             return;
         }
 
@@ -259,7 +259,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             }
 
             result.Matches.emplace_back(select.GetColumn<SQLite::rowid_t>(0), 
-                ApplicationMatchFilter(select.GetColumn<ApplicationMatchField>(1), select.GetColumn<MatchType>(2), select.GetColumn<std::string>(3)));
+                PackageMatchFilter(select.GetColumn<PackageMatchField>(1), select.GetColumn<MatchType>(2), select.GetColumn<std::string>(3)));
         }
 
         result.Truncated = (select.GetState() != SQLite::Statement::State::Completed);
@@ -267,29 +267,29 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         return result;
     }
 
-    std::optional<int> SearchResultsTable::BuildSearchStatement(SQLite::Builder::StatementBuilder& builder, ApplicationMatchField field, MatchType match) const
+    std::optional<int> SearchResultsTable::BuildSearchStatement(SQLite::Builder::StatementBuilder& builder, PackageMatchField field, MatchType match) const
     {
         return BuildSearchStatement(builder, field, s_SearchResultsTable_SubSelect_ManifestAlias, s_SearchResultsTable_SubSelect_ValueAlias, MatchUsesLike(match));
     }
 
     std::optional<int> SearchResultsTable::BuildSearchStatement(
         SQLite::Builder::StatementBuilder& builder,
-        ApplicationMatchField field,
+        PackageMatchField field,
         std::string_view manifestAlias,
         std::string_view valueAlias,
         bool useLike) const
     {
         switch (field)
         {
-        case ApplicationMatchField::Id:
+        case PackageMatchField::Id:
             return ManifestTable::BuildSearchStatement<IdTable>(builder, manifestAlias, valueAlias, useLike);
-        case ApplicationMatchField::Name:
+        case PackageMatchField::Name:
             return ManifestTable::BuildSearchStatement<NameTable>(builder, manifestAlias, valueAlias, useLike);
-        case ApplicationMatchField::Moniker:
+        case PackageMatchField::Moniker:
             return ManifestTable::BuildSearchStatement<MonikerTable>(builder, manifestAlias, valueAlias, useLike);
-        case ApplicationMatchField::Tag:
+        case PackageMatchField::Tag:
             return ManifestTable::BuildSearchStatement<TagsTable>(builder, manifestAlias, valueAlias, useLike);
-        case ApplicationMatchField::Command:
+        case PackageMatchField::Command:
             return ManifestTable::BuildSearchStatement<CommandsTable>(builder, manifestAlias, valueAlias, useLike);
         default:
             return {};

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
@@ -17,10 +17,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         std::pair<bool, SQLite::rowid_t> UpdateManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         SQLite::rowid_t RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         void PrepareForPackaging(SQLite::Connection& connection) override;
-        SearchResult Search(SQLite::Connection& connection, const SearchRequest& request) override;
+        SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const override;
 
     protected:
-        std::unique_ptr<V1_0::SearchResultsTable> CreateSearchResultsTable(SQLite::Connection& connection) const override;
+        std::unique_ptr<V1_0::SearchResultsTable> CreateSearchResultsTable(const SQLite::Connection& connection) const override;
         void PerformQuerySearch(V1_0::SearchResultsTable& resultsTable, const RequestMatch& query) const override;
     };
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
@@ -173,14 +173,14 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         builder.Execute(connection);
     }
 
-    ISQLiteIndex::SearchResult Interface::Search(SQLite::Connection& connection, const SearchRequest& request)
+    ISQLiteIndex::SearchResult Interface::Search(const SQLite::Connection& connection, const SearchRequest& request) const
     {
         // Update any system reference strings to be folded
         SearchRequest foldedRequest = request;
 
-        auto foldIfNeeded = [](ApplicationMatchFilter& filter)
+        auto foldIfNeeded = [](PackageMatchFilter& filter)
         {
-            if ((filter.Field == ApplicationMatchField::PackageFamilyName || filter.Field == ApplicationMatchField::ProductCode) &&
+            if ((filter.Field == PackageMatchField::PackageFamilyName || filter.Field == PackageMatchField::ProductCode) &&
                 filter.Type == MatchType::Exact)
             {
                 filter.Value = Utility::FoldCase(filter.Value);
@@ -200,7 +200,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         return V1_0::Interface::Search(connection, foldedRequest);
     }
 
-    std::unique_ptr<V1_0::SearchResultsTable> Interface::CreateSearchResultsTable(SQLite::Connection& connection) const
+    std::unique_ptr<V1_0::SearchResultsTable> Interface::CreateSearchResultsTable(const SQLite::Connection& connection) const
     {
         return std::make_unique<SearchResultsTable>(connection);
     }
@@ -210,8 +210,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         // First, do an exact match search for the folded system reference strings
         // We do this first because it is exact, and likely won't match anything else if it matches this.
         std::string foldedQuery = Utility::FoldCase(query.Value);
-        resultsTable.SearchOnField(ApplicationMatchField::PackageFamilyName, MatchType::Exact, foldedQuery);
-        resultsTable.SearchOnField(ApplicationMatchField::ProductCode, MatchType::Exact, foldedQuery);
+        resultsTable.SearchOnField(PackageMatchField::PackageFamilyName, MatchType::Exact, foldedQuery);
+        resultsTable.SearchOnField(PackageMatchField::ProductCode, MatchType::Exact, foldedQuery);
 
         // Then do the 1.0 search
         V1_0::Interface::PerformQuerySearch(resultsTable, query);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/SearchResultsTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/SearchResultsTable.h
@@ -9,7 +9,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
     // Table for holding temporary search results.
     struct SearchResultsTable : public V1_0::SearchResultsTable
     {
-        SearchResultsTable(SQLite::Connection& connection) : V1_0::SearchResultsTable(connection) {}
+        SearchResultsTable(const SQLite::Connection& connection) : V1_0::SearchResultsTable(connection) {}
 
         SearchResultsTable(const SearchResultsTable&) = delete;
         SearchResultsTable& operator=(const SearchResultsTable&) = delete;
@@ -20,7 +20,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
     protected:
         std::optional<int> BuildSearchStatement(
             SQLite::Builder::StatementBuilder& builder,
-            ApplicationMatchField field,
+            PackageMatchField field,
             std::string_view manifestAlias,
             std::string_view valueAlias,
             bool useLike) const override;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/SearchResultsTable_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/SearchResultsTable_1_1.cpp
@@ -13,16 +13,16 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
 {
     std::optional<int> SearchResultsTable::BuildSearchStatement(
         SQLite::Builder::StatementBuilder& builder,
-        ApplicationMatchField field,
+        PackageMatchField field,
         std::string_view manifestAlias,
         std::string_view valueAlias,
         bool useLike) const
     {
         switch (field)
         {
-        case ApplicationMatchField::PackageFamilyName:
+        case PackageMatchField::PackageFamilyName:
             return V1_0::ManifestTable::BuildSearchStatement<PackageFamilyNameTable>(builder, manifestAlias, valueAlias, useLike);
-        case ApplicationMatchField::ProductCode:
+        case PackageMatchField::ProductCode:
             return V1_0::ManifestTable::BuildSearchStatement<ProductCodeTable>(builder, manifestAlias, valueAlias, useLike);
         default:
             return V1_0::SearchResultsTable::BuildSearchStatement(builder, field, manifestAlias, valueAlias, useLike);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -54,7 +54,7 @@ namespace AppInstaller::Repository::Microsoft::Schema
         virtual SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const = 0;
 
         // Gets the string for the given property and manifest id, if present.
-        virtual std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const = 0;
+        virtual std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionProperty property) const = 0;
 
         // Gets the manifest id for the given { id, version, channel }, if present.
         // If version is empty, gets the value for the 'latest' version.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -24,7 +24,7 @@ namespace AppInstaller::Repository::Microsoft::Schema
         // New fields must have initializers to their down-schema defaults.
         struct SearchResult
         {
-            std::vector<std::pair<SQLite::rowid_t, ApplicationMatchFilter>> Matches;
+            std::vector<std::pair<SQLite::rowid_t, PackageMatchFilter>> Matches;
             bool Truncated = false;
         };
 
@@ -51,19 +51,16 @@ namespace AppInstaller::Repository::Microsoft::Schema
         virtual void PrepareForPackaging(SQLite::Connection& connection) = 0;
 
         // Performs a search based on the given criteria.
-        virtual SearchResult Search(SQLite::Connection& connection, const SearchRequest& request) = 0;
+        virtual SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const = 0;
 
-        // Gets the Id string for the given id, if present.
-        virtual std::optional<std::string> GetIdStringById(SQLite::Connection& connection, SQLite::rowid_t id) = 0;
+        // Gets the string for the given property and manifest id, if present.
+        virtual std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageProperty property) const = 0;
 
-        // Gets the Name string for the given id, if present.
-        virtual std::optional<std::string> GetNameStringById(SQLite::Connection& connection, SQLite::rowid_t id) = 0;
-
-        // Gets the relative path string for the given { id, version, channel }, if present.
+        // Gets the manifest id for the given { id, version, channel }, if present.
         // If version is empty, gets the value for the 'latest' version.
-        virtual std::optional<std::string> GetPathStringByKey(SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) = 0;
+        virtual std::optional<SQLite::rowid_t> GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const = 0;
 
         // Gets all versions and channels for the given id.
-        virtual std::vector<Utility::VersionAndChannel> GetVersionsById(SQLite::Connection& connection, SQLite::rowid_t id) = 0;
+        virtual std::vector<Utility::VersionAndChannel> GetVersionKeysById(const SQLite::Connection& connection, SQLite::rowid_t id) const = 0;
     };
 }

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -133,10 +133,10 @@ namespace AppInstaller::Repository
         virtual std::vector<PackageVersionKey> GetAvailableVersionKeys() const = 0;
 
         // Gets a specific version of this package.
-        virtual std::shared_ptr<IPackageVersion> GetLatestAvailableVersion() = 0;
+        virtual std::shared_ptr<IPackageVersion> GetLatestAvailableVersion() const = 0;
 
         // Gets a specific version of this package.
-        virtual std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey& versionKey) = 0;
+        virtual std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey& versionKey) const = 0;
     };
 
     // A single result from the search.
@@ -205,9 +205,9 @@ namespace AppInstaller::Repository
             return "Name"sv;
         case PackageMatchField::Tag:
             return "Tag"sv;
-        case ApplicationMatchField::PackageFamilyName:
+        case PackageMatchField::PackageFamilyName:
             return "PackageFamilyName"sv;
-        case ApplicationMatchField::ProductCode:
+        case PackageMatchField::ProductCode:
             return "ProductCode"sv;
         }
 

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -92,6 +92,7 @@ namespace AppInstaller::Repository
         SourceId,
         Version,
         Channel,
+        RelativePath,
     };
 
     // A single package version.
@@ -109,6 +110,9 @@ namespace AppInstaller::Repository
     // A key to identify a package version within a package.
     struct PackageVersionKey
     {
+        PackageVersionKey(Utility::NormalizedString sourceId, Utility::NormalizedString version, Utility::NormalizedString channel) :
+            SourceId(std::move(sourceId)), Version(std::move(version)), Channel(std::move(channel)) {}
+
         // The source id that this version came from.
         Utility::NormalizedString SourceId;
 

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -104,7 +104,7 @@ namespace AppInstaller::Repository
         virtual Utility::LocIndString GetProperty(PackageVersionProperty property) const = 0;
 
         // Gets the manifest of this package version.
-        virtual std::optional<Manifest::Manifest> GetManifest() const = 0;
+        virtual Manifest::Manifest GetManifest() const = 0;
     };
 
     // A key to identify a package version within a package.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -85,7 +85,7 @@ namespace AppInstaller::Repository
     };
 
     // A property of a package.
-    enum class PackageProperty
+    enum class PackageVersionProperty
     {
         Id,
         Name,
@@ -101,7 +101,7 @@ namespace AppInstaller::Repository
         virtual ~IPackageVersion() = default;
 
         // Gets a property of this package version.
-        virtual Utility::LocIndString GetProperty(PackageProperty property) const = 0;
+        virtual Utility::LocIndString GetProperty(PackageVersionProperty property) const = 0;
 
         // Gets the manifest of this package version.
         virtual std::optional<Manifest::Manifest> GetManifest() const = 0;

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -56,8 +56,13 @@ namespace AppInstaller::Repository
         // Get the source's details.
         virtual const SourceDetails& GetDetails() const = 0;
 
+        // Gets the source's identifier; a unique identifier independent of the name
+        // that will not change between a remove/add or between additional adds.
+        // Must be suitable for filesystem names.
+        virtual const std::string& GetIdentifier() const = 0;
+
         // Execute a search on the source.
-        virtual SearchResult Search(const SearchRequest& request) = 0;
+        virtual SearchResult Search(const SearchRequest& request) const = 0;
     };
 
     // Gets the details for all sources.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -58,7 +58,8 @@ namespace AppInstaller::Repository
 
         // Gets the source's identifier; a unique identifier independent of the name
         // that will not change between a remove/add or between additional adds.
-        // Must be suitable for filesystem names.
+        // Must be suitable for filesystem names unless the source is internal to winget,
+        // in which case the identifier should begin with a '*' character.
         virtual const std::string& GetIdentifier() const = 0;
 
         // Execute a search on the source.

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -528,7 +528,7 @@ namespace AppInstaller::Repository
             else
             {
                 AICLI_LOG(Repo, Info, << "Default source requested, multiple sources available, creating aggregated source.");
-                auto aggregatedSource = std::make_shared<AggregatedSource>();
+                auto aggregatedSource = std::make_shared<AggregatedSource>("*DefaultSource");
 
                 bool sourceUpdated = false;
                 for (auto& source : currentSources)
@@ -702,12 +702,12 @@ namespace AppInstaller::Repository
 
         for (const auto& include : Inclusions)
         {
-            result << " Inclusions:" << ApplicationMatchFieldToString(include.Field) << "='" << include.Value << "'[" << MatchTypeToString(include.Type) << "]";
+            result << " Inclusions:" << PackageMatchFieldToString(include.Field) << "='" << include.Value << "'[" << MatchTypeToString(include.Type) << "]";
         }
 
         for (const auto& filter : Filters)
         {
-            result << " Filter:" << ApplicationMatchFieldToString(filter.Field) << "='" << filter.Value << "'[" << MatchTypeToString(filter.Type) << "]";
+            result << " Filter:" << PackageMatchFieldToString(filter.Field) << "='" << filter.Value << "'[" << MatchTypeToString(filter.Type) << "]";
         }
 
         if (MaximumResults)

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -713,7 +713,7 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
-    Statement StatementBuilder::Prepare(Connection& connection)
+    Statement StatementBuilder::Prepare(const Connection& connection)
     {
         Statement result = Statement::Create(connection, m_stream.str());
         for (const auto& f : m_binders)
@@ -723,7 +723,7 @@ namespace AppInstaller::Repository::SQLite::Builder
         return result;
     }
 
-    void StatementBuilder::Execute(Connection& connection)
+    void StatementBuilder::Execute(const Connection& connection)
     {
         Prepare(connection).Execute();
     }

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -342,10 +342,10 @@ namespace AppInstaller::Repository::SQLite::Builder
         int GetLastBindIndex() const { return m_bindIndex - 1; }
 
         // Prepares and returns the statement, applying any bindings that were requested.
-        Statement Prepare(Connection& connection);
+        Statement Prepare(const Connection& connection);
 
         // A convenience function that prepares, binds, and then executes a statement that does not return rows.
-        void Execute(Connection& connection);
+        void Execute(const Connection& connection);
 
     private:
         enum class Op

--- a/src/AppInstallerRepositoryCore/SQLiteTempTable.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteTempTable.cpp
@@ -33,7 +33,7 @@ namespace AppInstaller::Repository::SQLite
         return Builder::QualifiedTable("temp"sv, m_name);
     }
 
-    void TempTable::InitDropStatement(Connection& connection)
+    void TempTable::InitDropStatement(const Connection& connection)
     {
         Builder::StatementBuilder builder;
         builder.DropTable(m_name);

--- a/src/AppInstallerRepositoryCore/SQLiteTempTable.h
+++ b/src/AppInstallerRepositoryCore/SQLiteTempTable.h
@@ -26,7 +26,7 @@ namespace AppInstaller::Repository::SQLite
 
         // Prepares the drop table statement for use in destructor.
         // It needs to be run by the derived class after the table is actually created.
-        void InitDropStatement(Connection& connection);
+        void InitDropStatement(const Connection& connection);
 
     private:
         std::string m_name;

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
@@ -123,12 +123,12 @@ namespace AppInstaller::Repository::SQLite
         return sqlite3_last_insert_rowid(m_dbconn.get());
     }
 
-    int Connection::GetChanges()
+    int Connection::GetChanges() const
     {
         return sqlite3_changes(m_dbconn.get());
     }
 
-    Statement::Statement(Connection& connection, std::string_view sql)
+    Statement::Statement(const Connection& connection, std::string_view sql)
     {
         m_id = GetNextStatementId();
         AICLI_LOG(SQL, Verbose, << "Preparing statement #" << m_id << ": " << sql);
@@ -176,20 +176,20 @@ namespace AppInstaller::Repository::SQLite
 #define WINGET_SQLITE_EXPLAIN_QUERY_PLAN(_connection_,_sql_)
 #endif
 
-    Statement Statement::Create(Connection& connection, const std::string& sql)
+    Statement Statement::Create(const Connection& connection, const std::string& sql)
     {
         WINGET_SQLITE_EXPLAIN_QUERY_PLAN(connection, sql);
         return { connection, { sql.c_str(), sql.size() } };
     }
 
-    Statement Statement::Create(Connection& connection, std::string_view sql)
+    Statement Statement::Create(const Connection& connection, std::string_view sql)
     {
         WINGET_SQLITE_EXPLAIN_QUERY_PLAN(connection, sql);
         // We need the statement to be null terminated, and the only way to guarantee that with a string_view is to construct a string copy.
         return Create(connection, std::string(sql));
     }
 
-    Statement Statement::Create(Connection& connection, char const* const sql)
+    Statement Statement::Create(const Connection& connection, char const* const sql)
     {
         WINGET_SQLITE_EXPLAIN_QUERY_PLAN(connection, sql);
         return { connection, sql };

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.h
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.h
@@ -142,7 +142,7 @@ namespace AppInstaller::Repository::SQLite
         rowid_t GetLastInsertRowID();
 
         // Gets the count of changed rows for the last executed statement.
-        int GetChanges();
+        int GetChanges() const;
 
         operator sqlite3* () const { return m_dbconn.get(); }
 
@@ -155,9 +155,9 @@ namespace AppInstaller::Repository::SQLite
     // A SQL statement.
     struct Statement
     {
-        static Statement Create(Connection& connection, const std::string& sql);
-        static Statement Create(Connection& connection, std::string_view sql);
-        static Statement Create(Connection& connection, char const* const sql);
+        static Statement Create(const Connection& connection, const std::string& sql);
+        static Statement Create(const Connection& connection, std::string_view sql);
+        static Statement Create(const Connection& connection, char const* const sql);
 
         Statement() = default;
 
@@ -231,7 +231,7 @@ namespace AppInstaller::Repository::SQLite
         operator bool() const { return static_cast<bool>(m_stmt); }
 
     private:
-        Statement(Connection& connection, std::string_view sql);
+        Statement(const Connection& connection, std::string_view sql);
 
         // Helper to receive the integer sequence from the public function.
         // This is equivalent to calling:


### PR DESCRIPTION
## Motivation
This change is being made to support future work for `list`, `update`, and `uninstall`.  It should have 0 functional impact at this time.  It also renames the existing classes to be more in line with the goals, changing from the work Application to Package.  Finally, more const'ness is imposed.

This change was made separate from any new use to create less churn when the actual functional changes are included.

## Change
Starting with `ISource`, a unique identifier is added to enable tying installs to them regardless of the name given to the source by the user.  `Search` is not changed at face value, but the result struct now returns a collection of `IPackage`s rather than the previous `IApplication`.  `IPackage` is a collection of `IPackageVersion`s in different states.  Currently that is [0, 1] possible installed versions, and [0, N] available versions.

`IPackageVersion` contains functionality to get individual properties of the specific version, as well as the manifest.

All other changes fall out of the above.

## Validation
Existing regression tests cover all affected code.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/575)