### PR TITLE
Interface changes for list/update/uninstall

### DIFF
--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -102,6 +102,11 @@ namespace
                 }
             }
 
+            bool IsUpdateAvailable() const override
+            {
+                return false;
+            }
+
             Manifest m_manifest;
         };
 

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -62,6 +62,11 @@ namespace
                 return m_manifest;
             }
 
+            std::map<std::string, std::string> GetInstallationMetadata() const override
+            {
+                return {};
+            }
+
             Manifest m_manifest;
         };
 

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -57,6 +57,11 @@ namespace AppInstaller::Repository::Microsoft
                 return GetManifestFromArgAndRelativePath(source->GetDetails().Arg, relativePathOpt.value());
             }
 
+            std::map<std::string, std::string> GetInstallationMetadata() const override
+            {
+                return {};
+            }
+
         private:
             static Manifest::Manifest GetManifestFromArgAndRelativePath(const std::string& arg, const std::string& relativePath)
             {

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -149,6 +149,11 @@ namespace AppInstaller::Repository::Microsoft
                 return {};
             }
 
+            bool IsUpdateAvailable() const override
+            {
+                return false;
+            }
+
         private:
             SQLiteIndex::IdType m_idId;
         };

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -6,6 +6,7 @@
 #include <winget/LocIndependent.h>
 #include <winget/Manifest.h>
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -105,6 +106,16 @@ namespace AppInstaller::Repository
 
         // Gets the manifest of this package version.
         virtual Manifest::Manifest GetManifest() const = 0;
+
+        // Gets any metadata associated with this version if it is installed.
+        virtual std::map<std::string, std::string> GetInstallationMetadata() const = 0;
+    };
+
+    // An installed package version.
+    struct IInstalledPackageVersion : public IPackageVersion
+    {
+        // Sets metadata on the installed version.
+        virtual void SetInstallationMetadata(std::string_view key, std::string_view value) = 0;
     };
 
     // A key to identify a package version within a package.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySearch.h
@@ -152,6 +152,9 @@ namespace AppInstaller::Repository
 
         // Gets a specific version of this package.
         virtual std::shared_ptr<IPackageVersion> GetAvailableVersion(const PackageVersionKey& versionKey) const = 0;
+
+        // Gets a value indicating whether an available version is newer than the installed version.
+        virtual bool IsUpdateAvailable() const = 0;
     };
 
     // A single result from the search.

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -88,6 +88,20 @@ namespace AppInstaller::Repository
     // Passing an empty string as the name of the source will return a source that aggregates all others.
     std::shared_ptr<ISource> OpenSource(std::string_view name, IProgressCallback& progress);
 
+    // A predefined source.
+    // These sources are not under the direct control of the user, such as packages installed on the system.
+    enum class PredefinedSource
+    {
+        Installed,
+        ARP_System,
+        ARP_User,
+        MSIX,
+    };
+
+    // Opens a predefined source.
+    // These sources are not under the direct control of the user, such as packages installed on the system.
+    std::shared_ptr<ISource> OpenPredefinedSource(PredefinedSource source, IProgressCallback& progress);
+
     // Updates an existing source.
     // Return value indicates whether the named source was found.
     bool UpdateSource(std::string_view name, IProgressCallback& progress);

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -66,6 +66,15 @@ namespace AppInstaller::Repository
         virtual SearchResult Search(const SearchRequest& request) const = 0;
     };
 
+    // Interface extension to ISource for locally installed packages.
+    struct IInstalledPackageSource : public ISource
+    {
+        virtual ~IInstalledPackageSource() = default;
+
+        // Adds an installed package version to the source.
+        virtual std::shared_ptr<IInstalledPackageVersion> AddInstalledPackageVersion(const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) = 0;
+    };
+
     // Gets the details for all sources.
     std::vector<SourceDetails> GetSources();
 

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -575,6 +575,35 @@ namespace AppInstaller::Repository
         }
     }
 
+    std::shared_ptr<ISource> OpenPredefinedSource(PredefinedSource source, IProgressCallback& progress)
+    {
+        SourceDetails details;
+
+        switch (source)
+        {
+        case PredefinedSource::Installed:
+            // TODO: Pull directly from factory
+            details.Type = "Microsoft.Predefined.Installed";
+            return CreateSourceFromDetails(details, progress);
+        case PredefinedSource::ARP_System:
+            // TODO: Pull directly from factory
+            details.Type = "Microsoft.Predefined.ARP";
+            details.Arg = "system";
+            return CreateSourceFromDetails(details, progress);
+        case PredefinedSource::ARP_User:
+            // TODO: Pull directly from factory
+            details.Type = "Microsoft.Predefined.ARP";
+            details.Arg = "user";
+            return CreateSourceFromDetails(details, progress);
+        case PredefinedSource::MSIX:
+            // TODO: Pull directly from factory
+            details.Type = "Microsoft.Predefined.MSIX";
+            return CreateSourceFromDetails(details, progress);
+        }
+
+        THROW_HR(E_UNEXPECTED);
+    }
+
     bool UpdateSource(std::string_view name, IProgressCallback& progress)
     {
         THROW_HR_IF(E_INVALIDARG, name.empty());

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -39,6 +39,8 @@
 #include <functional>
 #include <initializer_list>
 #include <iomanip>
+#include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -49,7 +51,3 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
-
-#ifndef AICLI_DISABLE_TEST_HOOKS
-#include <map>
-#endif


### PR DESCRIPTION
## Change
The expected interface definition for use by `list`, `update`, and `uninstall` commands.  This will allow others to make progress implementing these commands, but note that they are not themselves yet implemented.

The expected use is:
```
auto source = OpenPredefinedSource(PredefinedSource::Installed, progress);
auto results = source->Search(...);
if (results.Matches.empty()) { ... } // Found none
else if (results.Matches.size() == 1) { ... } // For targeting a single application
else
{
  for (const auto& match : results.Matches) // For targeting all
  {
    if (match.IsUpdateAvailable())
    { ... } // An update is available
  }
}
```

## Validation
No functional changes should be observed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/577)