### PR TITLE
Create integer primary keys in tables that need to be referenced

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
@@ -240,6 +240,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         StatementBuilder createTableBuilder;
         createTableBuilder.CreateTable(s_ManifestTable_Table_Name).BeginColumns();
 
+        // Add an integer primary key to keep the manifest rowid consistent
+        createTableBuilder.Column(IntegerPrimaryKey());
+
         for (const ManifestColumnInfo& value : values)
         {
             createTableBuilder.Column(ColumnBuilder(value.Name, Type::Int64).NotNull());

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.cpp
@@ -26,6 +26,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
                 StatementBuilder createTableBuilder;
 
                 createTableBuilder.CreateTable(tableName).Columns({
+                    IntegerPrimaryKey(),
                     ColumnBuilder(valueName, Type::Text).NotNull()
                     });
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
@@ -104,6 +104,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         StatementBuilder createTableBuilder;
         createTableBuilder.CreateTable(s_PathPartTable_Table_Name).Columns({
+            IntegerPrimaryKey(),
             ColumnBuilder(s_PathPartTable_ParentValue_Name, Type::Int64),
             ColumnBuilder(s_PathPartTable_PartValue_Name, Type::Text).NotNull()
             });

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -143,6 +143,20 @@ namespace AppInstaller::Repository::SQLite::Builder
         }
     }
 
+    IntegerPrimaryKey::IntegerPrimaryKey()
+    {
+        m_stream << SQLite::RowIDName << " INTEGER PRIMARY KEY";
+    }
+
+    IntegerPrimaryKey& IntegerPrimaryKey::AutoIncrement(bool isTrue)
+    {
+        if (isTrue)
+        {
+            m_stream << " AUTOINCREMENT";
+        }
+        return *this;
+    }
+
     ColumnBuilder::ColumnBuilder(std::string_view column, Type type)
     {
         OutputColumns(m_stream, "", column);

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -97,6 +97,22 @@ namespace AppInstaller::Repository::SQLite::Builder
         Min
     };
 
+    // Helper to mark create an integer primary key for rowid, making it stable across vacuum.
+    struct IntegerPrimaryKey : public details::SubBuilderBase
+    {
+        IntegerPrimaryKey();
+
+        IntegerPrimaryKey(const IntegerPrimaryKey&) = default;
+        IntegerPrimaryKey& operator=(const IntegerPrimaryKey&) = default;
+
+        IntegerPrimaryKey(IntegerPrimaryKey&&) noexcept = default;
+        IntegerPrimaryKey& operator=(IntegerPrimaryKey&&) noexcept = default;
+
+        // Set the column to autoincrement. SQLite recommends against using this value unless
+        // you need to ensure that rowids are not ever reused.
+        IntegerPrimaryKey& AutoIncrement(bool isTrue = true);
+    };
+
     // Helper used when creating a table.
     struct ColumnBuilder : public details::SubBuilderBase
     {


### PR DESCRIPTION
## Motivation
The previous change to create stand-alone indexes rather than primary keys, and subsequently drop more of them when packaging, exposed an issue with our database schema.  SQLite's implicit rowid is not guaranteed to be stable, especially across a `VACUUM`.  As the index was built around referencing other data by it's rowid, this lead to corrupted databases being created when manifests were removed or updated.

## Change
This change causes all relevant tables (every table except the map tables) to have an integer primary key column, which will prevent the rowid from changing, as it is now a data member.

## Validation
A new test is added to ensure that rowid's do not change after a manifest removal and `VACUUM`. It failed prior to the fix being in place, and succeeds afterward.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/604)