### PR TITLE
Create consistency check functionality

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -206,6 +206,17 @@ namespace AppInstaller::Repository::Microsoft
         m_interface->PrepareForPackaging(m_dbconn);
     }
 
+    bool SQLiteIndex::CheckConsistency(bool log) const
+    {
+        AICLI_LOG(Repo, Info, << "Checking index consistency...");
+
+        bool result = m_interface->CheckConsistency(m_dbconn, log);
+
+        AICLI_LOG(Repo, Info, << "...index *WAS" << (result ? "*" : " NOT*") << " consistent.");
+
+        return result;
+    }
+
     Schema::ISQLiteIndex::SearchResult SQLiteIndex::Search(const SearchRequest& request) const
     {
         AICLI_LOG(Repo, Info, << "Performing search: " << request.ToString());

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -87,6 +87,10 @@ namespace AppInstaller::Repository::Microsoft
         // Removes data that is no longer needed for an index that is to be published.
         void PrepareForPackaging();
 
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        bool CheckConsistency(bool log = false) const;
+
         // Performs a search based on the given criteria.
         Schema::ISQLiteIndex::SearchResult Search(const SearchRequest& request) const;
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
@@ -20,6 +20,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         std::pair<bool, SQLite::rowid_t> UpdateManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         SQLite::rowid_t RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         void PrepareForPackaging(SQLite::Connection& connection) override;
+        bool CheckConsistency(const SQLite::Connection& connection, bool log) const override;
         SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const override;
         std::optional<std::string> GetPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionProperty property) const override;
         std::optional<SQLite::rowid_t> GetManifestIdByKey(const SQLite::Connection& connection, SQLite::rowid_t id, std::string_view version, std::string_view channel) const override;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -348,6 +348,61 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         builder.Execute(connection);
     }
 
+    bool Interface::CheckConsistency(const SQLite::Connection& connection, bool log) const
+    {
+        bool result = true;
+
+        // Check the manifest table references to it's 1:1 tables
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<IdTable>(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<NameTable>(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<MonikerTable>(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<VersionTable>(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<ChannelTable>(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ManifestTable::CheckConsistency<PathPartTable>(connection, log) && result;
+        }
+
+        // Check the pathpaths table for consistency
+        if (result || log)
+        {
+            result = PathPartTable::CheckConsistency(connection, log) && result;
+        }
+
+        // Check the 1:N map tables for consistency
+        if (result || log)
+        {
+            result = TagsTable::CheckConsistency(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = CommandsTable::CheckConsistency(connection, log) && result;
+        }
+
+        return result;
+    }
+
     ISQLiteIndex::SearchResult Interface::Search(const SQLite::Connection& connection, const SearchRequest& request) const
     {
         // If an empty request, get everything

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
@@ -222,6 +222,38 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
             builder.Execute(connection);
         }
+
+        bool ManifestTableCheckConsistency(const SQLite::Connection& connection, const SQLite::Builder::QualifiedColumn& target, bool log)
+        {
+            using QCol = SQLite::Builder::QualifiedColumn;
+
+            // Build a select statement to find manifest rows containing references to 1:1 tables with non-existent rowids
+            // Such as:
+            // Select manifest.rowid, manifest.id, ids.id from manifest left outer join ids on manifest.id = ids.rowid where ids.id is NULL
+            SQLite::Builder::StatementBuilder builder;
+            builder.
+                Select({ QCol(s_ManifestTable_Table_Name, SQLite::RowIDName), QCol(s_ManifestTable_Table_Name, target.Column) }).
+                From(s_ManifestTable_Table_Name).
+                LeftOuterJoin(target.Table).On(QCol(s_ManifestTable_Table_Name, target.Column), QCol(target.Table, SQLite::RowIDName)).
+                Where(target).IsNull();
+
+            SQLite::Statement select = builder.Prepare(connection);
+            bool result = true;
+
+            while (select.Step())
+            {
+                result = false;
+
+                if (!log)
+                {
+                    break;
+                }
+
+                AICLI_LOG(Repo, Info, << "  [INVALID] manifest [" << select.GetColumn<SQLite::rowid_t>(0) << "] refers to " << target.Table << " [" << select.GetColumn<SQLite::rowid_t>(1) << "]");
+            }
+
+            return result;
+        }
     }
 
     std::string_view ManifestTable::TableName()

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
@@ -56,6 +56,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Update the value of a single column for the manifest with the given rowid.
         void ManifestTableUpdateValueIdById(SQLite::Connection& connection, std::string_view valueName, SQLite::rowid_t value, SQLite::rowid_t id);
+
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        bool ManifestTableCheckConsistency(const SQLite::Connection& connection, const SQLite::Builder::QualifiedColumn& target, bool log);
     }
 
     // Info on the manifest columns.
@@ -155,6 +159,14 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Removes data that is no longer needed for an index that is to be published.
         static void PrepareForPackaging_deprecated(SQLite::Connection& connection, std::initializer_list<std::string_view> values);
+
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        template <typename Table>
+        static bool CheckConsistency(const SQLite::Connection& connection, bool log)
+        {
+            return details::ManifestTableCheckConsistency(connection, SQLite::Builder::QualifiedColumn{ Table::TableName(), Table::ValueName() }, log);
+        }
 
         // Determines if the table is empty.
         static bool IsEmpty(SQLite::Connection& connection);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToManyTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToManyTable.h
@@ -36,6 +36,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         // Removes data that is no longer needed for an index that is to be published.
         void OneToManyTablePrepareForPackaging(SQLite::Connection& connection, std::string_view tableName, bool useNamedIndeces, bool preserveValuesIndex);
 
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+         bool OneToManyTableCheckConsistency(const SQLite::Connection& connection, std::string_view tableName, std::string_view valueName, bool log);
+
         // Determines if the table is empty.
         bool OneToManyTableIsEmpty(SQLite::Connection& connection, std::string_view tableName);
     }
@@ -102,6 +106,13 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         static void PrepareForPackaging_deprecated(SQLite::Connection& connection)
         {
             details::OneToManyTablePrepareForPackaging(connection, TableInfo::TableName(), false, false);
+        }
+
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        static bool CheckConsistency(const SQLite::Connection& connection, bool log)
+        {
+            return details::OneToManyTableCheckConsistency(connection, TableInfo::TableName(), TableInfo::ValueName(), log);
         }
 
         // Determines if the table is empty.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.cpp
@@ -145,6 +145,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         savepoint.Commit();
     }
 
+    std::string_view PathPartTable::TableName()
+    {
+        return s_PathPartTable_Table_Name;
+    }
+
     std::string_view PathPartTable::ValueName()
     {
         return s_PathPartTable_PartValue_Name;
@@ -294,6 +299,41 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         SQLite::Builder::StatementBuilder dropIndexBuilder;
         dropIndexBuilder.DropIndex(s_PathPartTable_ParentIndex_Name);
         dropIndexBuilder.Execute(connection);
+    }
+
+    bool PathPartTable::CheckConsistency(const SQLite::Connection& connection, bool log)
+    {
+        using QCol = SQLite::Builder::QualifiedColumn;
+
+        // Build a select statement to find pathpart rows containing references to parents with non-existent rowids
+        // Such as:
+        // Select l.rowid, l.parent from pathparts as l left outer join pathparts as r on l.parent = r.rowid where l.parent is not null and r.pathpart is null
+        constexpr std::string_view s_left = "left"sv;
+        constexpr std::string_view s_right = "right"sv;
+
+        SQLite::Builder::StatementBuilder builder;
+        builder.
+            Select({ QCol(s_left, SQLite::RowIDName), QCol(s_left, s_PathPartTable_ParentValue_Name) }).
+            From(s_PathPartTable_Table_Name).As(s_left).
+            LeftOuterJoin(s_PathPartTable_Table_Name).As(s_right).On(QCol(s_left, s_PathPartTable_ParentValue_Name), QCol(s_right, SQLite::RowIDName)).
+            Where(QCol(s_left, s_PathPartTable_ParentValue_Name)).IsNotNull().And(QCol(s_right, s_PathPartTable_PartValue_Name)).IsNull();
+
+        SQLite::Statement select = builder.Prepare(connection);
+        bool result = true;
+
+        while (select.Step())
+        {
+            result = false;
+
+            if (!log)
+            {
+                break;
+            }
+
+            AICLI_LOG(Repo, Info, << "  [INVALID] pathparts [" << select.GetColumn<SQLite::rowid_t>(0) << "] refers to " << s_PathPartTable_ParentValue_Name << " [" << select.GetColumn<SQLite::rowid_t>(1) << "]");
+        }
+
+        return result;
     }
 
     bool PathPartTable::IsEmpty(SQLite::Connection& connection)

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/PathPartTable.h
@@ -23,6 +23,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         // Creates the table with standard primary keys.
         static void Create_deprecated(SQLite::Connection& connection);
 
+        // Gets the table name.
+        static std::string_view TableName();
+
         // Gets the value name.
         static std::string_view ValueName();
 
@@ -48,6 +51,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Removes data that is no longer needed for an index that is to be published.
         static void PrepareForPackaging_deprecated(SQLite::Connection& connection);
+
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        static bool CheckConsistency(const SQLite::Connection& connection, bool log);
 
         // Determines if the table is empty.
         static bool IsEmpty(SQLite::Connection& connection);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
@@ -17,6 +17,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         std::pair<bool, SQLite::rowid_t> UpdateManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         SQLite::rowid_t RemoveManifest(SQLite::Connection& connection, const Manifest::Manifest& manifest, const std::filesystem::path& relativePath) override;
         void PrepareForPackaging(SQLite::Connection& connection) override;
+        bool CheckConsistency(const SQLite::Connection& connection, bool log) const override;
         SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const override;
 
     protected:

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
@@ -173,6 +173,24 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         builder.Execute(connection);
     }
 
+    bool Interface::CheckConsistency(const SQLite::Connection& connection, bool log) const
+    {
+        bool result = V1_0::Interface::CheckConsistency(connection, log);
+
+        // If the v1.0 index was consistent, or if full logging of inconsistency was requested, check the v1.1 data.
+        if (result || log)
+        {
+            result = PackageFamilyNameTable::CheckConsistency(connection, log) && result;
+        }
+
+        if (result || log)
+        {
+            result = ProductCodeTable::CheckConsistency(connection, log) && result;
+        }
+
+        return result;
+    }
+
     ISQLiteIndex::SearchResult Interface::Search(const SQLite::Connection& connection, const SearchRequest& request) const
     {
         // Update any system reference strings to be folded

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -50,6 +50,10 @@ namespace AppInstaller::Repository::Microsoft::Schema
         // Removes data that is no longer needed for an index that is to be published.
         virtual void PrepareForPackaging(SQLite::Connection& connection) = 0;
 
+        // Checks the consistency of the index to ensure that every referenced row exists.
+        // Returns true if index is consistent; false if it is not.
+        virtual bool CheckConsistency(const SQLite::Connection& connection, bool log) const = 0;
+
         // Performs a search based on the given criteria.
         virtual SearchResult Search(const SQLite::Connection& connection, const SearchRequest& request) const = 0;
 

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -350,9 +350,9 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
-    StatementBuilder& StatementBuilder::IsNull()
+    StatementBuilder& StatementBuilder::IsNull(bool isNull)
     {
-        m_stream << " IS NULL";
+        m_stream << " IS " << (isNull ? "" : "NOT ") << "NULL";
         return *this;
     }
 
@@ -383,6 +383,24 @@ namespace AppInstaller::Repository::SQLite::Builder
     StatementBuilder& StatementBuilder::Join(std::initializer_list<std::string_view> table)
     {
         OutputOperationAndTable(m_stream, " JOIN", table);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::LeftOuterJoin(std::string_view table)
+    {
+        OutputOperationAndTable(m_stream, " LEFT OUTER JOIN", table);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::LeftOuterJoin(QualifiedTable table)
+    {
+        OutputOperationAndTable(m_stream, " LEFT OUTER JOIN", table);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::LeftOuterJoin(std::initializer_list<std::string_view> table)
+    {
+        OutputOperationAndTable(m_stream, " LEFT OUTER JOIN", table);
         return *this;
     }
 

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -226,7 +226,9 @@ namespace AppInstaller::Repository::SQLite::Builder
         StatementBuilder& Not();
         StatementBuilder& In();
 
-        StatementBuilder& IsNull();
+        // IsNull(true) means the value is null; IsNull(false) means the value is not null.
+        StatementBuilder& IsNull(bool isNull = true);
+        StatementBuilder& IsNotNull() { return IsNull(false); }
 
         // Operators for combining filter clauses.
         StatementBuilder& And(std::string_view column);
@@ -237,6 +239,12 @@ namespace AppInstaller::Repository::SQLite::Builder
         StatementBuilder& Join(std::string_view table);
         StatementBuilder& Join(QualifiedTable table);
         StatementBuilder& Join(std::initializer_list<std::string_view> table);
+
+        // Begin a left outer join clause.
+        // The initializer_list form enables the table name to be constructed from multiple parts.
+        StatementBuilder& LeftOuterJoin(std::string_view table);
+        StatementBuilder& LeftOuterJoin(QualifiedTable table);
+        StatementBuilder& LeftOuterJoin(std::initializer_list<std::string_view> table);
 
         // Set the join constraint.
         StatementBuilder& On(const QualifiedColumn& column1, const QualifiedColumn& column2);

--- a/src/WinGetUtil/Exports.cpp
+++ b/src/WinGetUtil/Exports.cpp
@@ -157,6 +157,21 @@ extern "C"
     }
     CATCH_RETURN()
 
+    WINGET_UTIL_API WinGetSQLiteIndexCheckConsistency(
+        WINGET_SQLITE_INDEX_HANDLE index,
+        BOOL* succeeded) try
+    {
+        THROW_HR_IF(E_INVALIDARG, !index);
+        THROW_HR_IF(E_INVALIDARG, !succeeded);
+
+        bool result = reinterpret_cast<SQLiteIndex*>(index)->CheckConsistency(true);
+
+        *succeeded = (result ? TRUE : FALSE);
+
+        return S_OK;
+    }
+    CATCH_RETURN()
+
     WINGET_UTIL_API WinGetValidateManifest(
         WINGET_STRING manifestPath,
         BOOL* succeeded,

--- a/src/WinGetUtil/WinGetUtil.h
+++ b/src/WinGetUtil/WinGetUtil.h
@@ -68,6 +68,11 @@ extern "C"
     WINGET_UTIL_API WinGetSQLiteIndexPrepareForPackaging(
         WINGET_SQLITE_INDEX_HANDLE index);
 
+    // Checks the index for consistency, ensuring that at a minimum all referenced rows actually exist.
+    WINGET_UTIL_API WinGetSQLiteIndexCheckConsistency(
+        WINGET_SQLITE_INDEX_HANDLE index,
+        BOOL* succeeded);
+
     // Validates a given manifest. Returns a bool for validation result and
     // a string representing validation errors if validation failed.
     WINGET_UTIL_API WinGetValidateManifest(


### PR DESCRIPTION
## Change
To ensure at least a base level of consistency within the index, these functions ensure that all referenced rows actually exist.  Failures are logged out if requested.  More extensive checks can be added as needed, although some form of cycle detection in the pathparts is the only thing that I can foresee without additional data being added.  The function is also exported via WinGetUtil.

## Validation
A call is made in the recently added test for rowid migration, as well as adding a test that directly removes a row to ensure failure from the function.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/609)