### PR TITLE
modified path for E2ETestLogs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,24 +251,10 @@ jobs:
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
     condition: succeededOrFailed()
 
-  - task: CmdLine@2	
-    displayName: Show files in localappdata directory	
-    inputs:	
-      script: dir /s	
-      workingDirectory: 'C:\Users\VssAdministrator\AppData\Local'
-    condition: succeededOrFailed()
-
-  - task: CmdLine@2	
-    displayName: Show files in localappdata directory	
-    inputs:	
-      script: dir /s	
-      workingDirectory: $(Agent.TempDirectory)
-    condition: succeededOrFailed()
-
   - task: PublishBuildArtifacts@1
     displayName: Publish E2E Tests Packaged x64 Log
     inputs:
-      PathtoPublish: '$(Agent.TempDirectory)\E2ETestLogs'
+      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
       ArtifactName: 'E2ETestPackagedx64Log'
       publishLocation: 'Container'
     condition: succeededOrFailed()  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,7 +254,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: Publish E2E Tests Packaged x64 Log
     inputs:
-      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\E2ETestLogs'
+      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
       ArtifactName: 'E2ETestPackagedx64Log'
       publishLocation: 'Container'
     condition: succeededOrFailed()  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,7 +255,7 @@ jobs:
     displayName: Show files in localappdata directory	
     inputs:	
       script: dir /s	
-      workingDirectory: %LOCALAPPDATA%	
+      workingDirectory: 'C:\Users\VssAdministrator\AppData\Local'
     condition: succeededOrFailed()
 
   - task: CmdLine@2	

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,10 +251,24 @@ jobs:
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
     condition: succeededOrFailed()
 
+  - task: CmdLine@2	
+    displayName: Show files in localappdata directory	
+    inputs:	
+      script: dir /s	
+      workingDirectory: %LOCALAPPDATA%	
+    condition: succeededOrFailed()
+
+  - task: CmdLine@2	
+    displayName: Show files in localappdata directory	
+    inputs:	
+      script: dir /s	
+      workingDirectory: $(Agent.TempDirectory)
+    condition: succeededOrFailed()
+
   - task: PublishBuildArtifacts@1
     displayName: Publish E2E Tests Packaged x64 Log
     inputs:
-      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
+      PathtoPublish: '$(Agent.TempDirectory)\E2ETestLogs'
       ArtifactName: 'E2ETestPackagedx64Log'
       publishLocation: 'Container'
     condition: succeededOrFailed()  

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -230,13 +230,13 @@ namespace AppInstallerCLIE2ETests
         }
 
         /// <summary>
-        /// Copies log files to the path %LOCALAPPDATA%\E2ETestLogs
+        /// Copies log files to the path %TEMP%\E2ETestLogs
         /// </summary>
         public static void PublishE2ETestLogs()
         {
-            string localAppDataPath = Environment.GetEnvironmentVariable("LocalAppData");
-            string testLogsSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
-            string testLogsDestPath = Path.Combine(localAppDataPath, "E2ETestLogs");
+            string tempPath = Environment.GetEnvironmentVariable("TEMP");
+            string testLogsSourcePath = Path.Combine(tempPath, Constants.E2ETestLogsPath);
+            string testLogsDestPath = Path.Combine(tempPath, "E2ETestLogs");
 
             if (Directory.Exists(testLogsDestPath))
             {

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -234,7 +234,7 @@ namespace AppInstallerCLIE2ETests
         /// </summary>
         public static void PublishE2ETestLogs()
         {
-            string tempPath = Environment.GetEnvironmentVariable("TEMP");
+            string tempPath = Path.GetTempPath();
             string testLogsSourcePath = Path.Combine(tempPath, Constants.E2ETestLogsPath);
             string testLogsDestPath = Path.Combine(tempPath, "E2ETestLogs");
 

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -235,7 +235,8 @@ namespace AppInstallerCLIE2ETests
         public static void PublishE2ETestLogs()
         {
             string tempPath = Path.GetTempPath();
-            string testLogsSourcePath = Path.Combine(tempPath, Constants.E2ETestLogsPath);
+            string localAppDataPath = Environment.GetEnvironmentVariable("LocalAppData");
+            string testLogsSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
             string testLogsDestPath = Path.Combine(tempPath, "E2ETestLogs");
 
             if (Directory.Exists(testLogsDestPath))


### PR DESCRIPTION
Minor Change:
Revised the path used to publish E2E Test Logs from %LOCALAPPDATA%/E2ETestLogs --> %TEMP%/E2ETestLogs

Validation:
- Passes all azp tests


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/614)