### PR TITLE
Remove quotes from booleans

### DIFF
--- a/doc/settings.schema.json
+++ b/doc/settings.schema.json
@@ -36,27 +36,27 @@
         "experimentalCMD": {
           "description": "Reference implementation for an experimental command",
           "type": "boolean",
-          "default": "false"
+          "default": false
         },
         "experimentalARG": {
           "description": "Reference implementation for an experimental argument",
           "type": "boolean",
-          "default": "false"
+          "default": false
         },
         "experimentalMSStore": {
           "description": "Experimental support for Microsoft Store source",
           "type": "boolean",
-          "default": "false"
+          "default": false
         },
         "list": {
           "description": "Enable the list command while it is in development",
           "type": "boolean",
-          "default": "false"
+          "default": false
         },
         "upgrade": {
           "description": "Enable the upgrade command while it is in development",
           "type": "boolean",
-          "default": "false"
+          "default": false
         }
       }
     }


### PR DESCRIPTION
## Change
Booleans in JSON are not quoted; remove the quotes as such.  VS Code now properly autofills a boolean rather than a string on tab completion.

While it isn't actually true, we could also change the default value for the experimental features to `true` to cause the tab completion (in VS Code at least) to fill in with the value that one likely wants in that case.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/621)