### PR TITLE
Only use ICU folding when needed

### DIFF
--- a/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
@@ -32,7 +32,7 @@ namespace AppInstaller::CLI::Workflow
 
         for (const auto& source : Repository::GetSources())
         {
-            if (word.empty() || Utility::CaseInsensitiveStartsWith(source.Name, word))
+            if (word.empty() || Utility::ICUCaseInsensitiveStartsWith(source.Name, word))
             {
                 OutputCompletionString(stream, source.Name);
             }
@@ -73,7 +73,7 @@ namespace AppInstaller::CLI::Workflow
 
         for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
         {
-            if (word.empty() || Utility::CaseInsensitiveStartsWith(vc.Version, word))
+            if (word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Version, word))
             {
                 OutputCompletionString(stream, vc.Version);
             }
@@ -89,7 +89,7 @@ namespace AppInstaller::CLI::Workflow
 
         for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
         {
-            if ((word.empty() || Utility::CaseInsensitiveStartsWith(vc.Channel, word)) &&
+            if ((word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Channel, word)) &&
                 std::find(channels.begin(), channels.end(), vc.Channel) == channels.end())
             {
                 channels.emplace_back(vc.Channel);

--- a/src/AppInstallerCommonCore/AppInstallerStrings.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerStrings.cpp
@@ -94,12 +94,22 @@ namespace AppInstaller::Utility
 
     bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
     {
-        return FoldCase(a) == FoldCase(b);
+        return ToLower(a) == ToLower(b);
     }
 
     bool CaseInsensitiveStartsWith(std::string_view a, std::string_view b)
     {
         return a.length() >= b.length() && CaseInsensitiveEquals(a.substr(0, b.length()), b);
+    }
+
+    bool ICUCaseInsensitiveEquals(std::string_view a, std::string_view b)
+    {
+        return FoldCase(a) == FoldCase(b);
+    }
+
+    bool ICUCaseInsensitiveStartsWith(std::string_view a, std::string_view b)
+    {
+        return a.length() >= b.length() && ICUCaseInsensitiveEquals(a.substr(0, b.length()), b);
     }
 
     std::string ConvertToUTF8(std::wstring_view input)

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -72,10 +72,18 @@ namespace AppInstaller::Utility
     using NormalizedString = NormalizedUTF8<>;
 
     // Compares the two UTF8 strings in a case insensitive manner.
+    // Use this if one of the values is a known value, and thus ToLower is sufficient.
     bool CaseInsensitiveEquals(std::string_view a, std::string_view b);
 
     // Determins if string a starts with string b.
+    // Use this if one of the values is a known value, and thus ToLower is sufficient.
     bool CaseInsensitiveStartsWith(std::string_view a, std::string_view b);
+
+    // Compares the two UTF8 strings in a case insensitive manner, using ICU for case folding.
+    bool ICUCaseInsensitiveEquals(std::string_view a, std::string_view b);
+
+    // Determins if string a starts with string b, using ICU for case folding.
+    bool ICUCaseInsensitiveStartsWith(std::string_view a, std::string_view b);
 
     // Returns the number of grapheme clusters (characters) in an UTF8-encoded string.
     size_t UTF8Length(std::string_view input);

--- a/src/AppInstallerCommonCore/Versions.cpp
+++ b/src/AppInstallerCommonCore/Versions.cpp
@@ -266,7 +266,7 @@ namespace AppInstaller::Utility
     bool VersionAndChannel::IsUpdatedBy(const VersionAndChannel& other) const
     {
         // Channel crossing should not happen here.
-        if (!Utility::CaseInsensitiveEquals(m_channel.ToString(), other.m_channel.ToString()))
+        if (!Utility::ICUCaseInsensitiveEquals(m_channel.ToString(), other.m_channel.ToString()))
         {
             return false;
         }

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -68,7 +68,7 @@ namespace AppInstaller::Repository
 
                     // Remove all elements whose channel does not match the installed package.
                     result.erase(
-                        std::remove_if(result.begin(), result.end(), [&](const PackageVersionKey& pvk) { return !Utility::CaseInsensitiveEquals(pvk.Channel, channel); }),
+                        std::remove_if(result.begin(), result.end(), [&](const PackageVersionKey& pvk) { return !Utility::ICUCaseInsensitiveEquals(pvk.Channel, channel); }),
                         result.end());
 
                     return result;
@@ -471,7 +471,7 @@ namespace AppInstaller::Repository
 
                             AICLI_LOG(Repo, Info, << "  Checking system reference match with package id: " << matchId);
 
-                            if (Utility::CaseInsensitiveEquals(id, matchId))
+                            if (Utility::ICUCaseInsensitiveEquals(id, matchId))
                             {
                                 availablePackage = std::move(availableMatch.Package);
                                 break;

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -46,7 +46,7 @@ namespace AppInstaller::Repository
         // Finds a source from the given vector by its name.
         auto FindSourceByName(std::vector<SourceDetailsInternal>& sources, std::string_view name)
         {
-            return std::find_if(sources.begin(), sources.end(), [&name](const SourceDetailsInternal& sd) { return Utility::CaseInsensitiveEquals(sd.Name, name); });
+            return std::find_if(sources.begin(), sources.end(), [&name](const SourceDetailsInternal& sd) { return Utility::ICUCaseInsensitiveEquals(sd.Name, name); });
         }
 
         // Attempts to read a single scalar value from the node.


### PR DESCRIPTION
## Change
Revert the change that I made previously to use ICU case folding for all case insensitive comparisons, and instead use it only when both sides are user defined.  If one side is a known value (given that these will be ASCII), then a simple ToLower will work to determine equality.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/624)