### PR TITLE
Update Smart Screen experience for msix

### DIFF
--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -113,7 +113,7 @@ namespace AppInstaller::CLI
 
     void UpgradeCommand::ExecuteInternal(Execution::Context& context) const
     {
-        WI_SetFlag(context.GetFlags(), Execution::ContextFlag::InstallerExecutionUseUpdate);
+        context.SetFlags(Execution::ContextFlag::InstallerExecutionUseUpdate);
 
         context <<
             Workflow::ReportExecutionStage(ExecutionStage::Discovery) <<

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -73,7 +73,7 @@ namespace AppInstaller::CLI::Execution
     std::unique_ptr<Context> Context::Clone()
     {
         auto clone = std::make_unique<Context>(Reporter);
-        clone->GetFlags() = m_flags;
+        clone->m_flags = m_flags;
         return clone;
     }
 

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -230,7 +230,7 @@ namespace AppInstaller::CLI::Execution
         }
 
         // Gets context flags
-        ContextFlag GetFlags()
+        ContextFlag GetFlags() const
         {
             return m_flags;
         }

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -64,6 +64,8 @@ namespace AppInstaller::CLI::Execution
     {
         None = 0x0,
         InstallerExecutionUseUpdate = 0x1,
+        InstallerHashMatched = 0x2,
+        InstallerTrusted = 0x4,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ContextFlag);

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -229,10 +229,22 @@ namespace AppInstaller::CLI::Execution
             return std::get<details::DataIndex(D)>(itr->second);
         }
 
-        // Gets context flags; which can be modified in place.
-        ContextFlag& GetFlags()
+        // Gets context flags
+        ContextFlag GetFlags()
         {
             return m_flags;
+        }
+
+        // Set context flags
+        void SetFlags(ContextFlag flags)
+        {
+            WI_SetAllFlags(m_flags, flags);
+        }
+
+        // Clear context flags
+        void ClearFlags(ContextFlag flags)
+        {
+            WI_ClearAllFlags(m_flags, flags);
         }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -255,7 +255,7 @@ namespace
         std::unique_ptr<Context> Clone() override
         {
             auto clone = std::make_unique<TestContext>(m_out, m_in, m_overrides);
-            clone->GetFlags() = this->GetFlags();
+            clone->SetFlags(this->GetFlags());
             return clone;
         }
 
@@ -981,7 +981,7 @@ TEST_CASE("VerifyInstallerTrustLevelAndUpdateInstallerFileMotw", "[DownloadInsta
     VerifyMotw(testInstallerPath, 2);
 
     testSource->Details.TrustLevel = SourceTrustLevel::None;
-    context.GetFlags() = ContextFlag::None;
+    context.ClearFlags(ContextFlag::InstallerTrusted);
     context << VerifyInstallerHash << UpdateInstallerFileMotwIfApplicable;
     REQUIRE_FALSE(WI_IsFlagSet(context.GetFlags(), ContextFlag::InstallerTrusted));
     VerifyMotw(testInstallerPath, 3);

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -952,7 +952,7 @@ void VerifyMotw(const std::filesystem::path& testFile, DWORD zone)
     REQUIRE(motwContentStr.find("ZoneId=" + std::to_string(zone)) != std::string::npos);
 }
 
-TEST_CASE("UpdateInstallerFileMotw", "[DownloadInstaller][workflow]")
+TEST_CASE("VerifyInstallerTrustLevelAndUpdateInstallerFileMotw", "[DownloadInstaller][workflow]")
 {
     TestCommon::TempFile testInstallerPath("TestInstaller.txt");
 
@@ -976,11 +976,14 @@ TEST_CASE("UpdateInstallerFileMotw", "[DownloadInstaller][workflow]")
     installer.Url = "http://NotTrusted.com";
     context.Add<Data::Installer>(std::move(installer));
 
-    UpdateInstallerFileMotwIfApplicable(context);
+    context << VerifyInstallerHash << UpdateInstallerFileMotwIfApplicable;
+    REQUIRE(WI_IsFlagSet(context.GetFlags(), ContextFlag::InstallerTrusted));
     VerifyMotw(testInstallerPath, 2);
 
     testSource->Details.TrustLevel = SourceTrustLevel::None;
-    UpdateInstallerFileMotwIfApplicable(context);
+    context.GetFlags() = ContextFlag::None;
+    context << VerifyInstallerHash << UpdateInstallerFileMotwIfApplicable;
+    REQUIRE_FALSE(WI_IsFlagSet(context.GetFlags(), ContextFlag::InstallerTrusted));
     VerifyMotw(testInstallerPath, 3);
 
     INFO(updateMotwOutput.str());

--- a/src/AppInstallerCommonCore/Deployment.cpp
+++ b/src/AppInstallerCommonCore/Deployment.cpp
@@ -56,6 +56,25 @@ namespace AppInstaller::Deployment
         }
     }
 
+    void AddPackage(const winrt::Windows::Foundation::Uri& uri, winrt::Windows::Management::Deployment::DeploymentOptions options, IProgressCallback& callback)
+    {
+        size_t id = GetDeploymentOperationId();
+        AICLI_LOG(Core, Info, << "Starting AddPackage operation #" << id << ": " << Utility::ConvertToUTF8(uri.AbsoluteUri().c_str()));
+
+        PackageManager packageManager;
+
+        auto deployOperation = packageManager.AddPackageAsync(
+            uri,
+            nullptr, /*dependencyPackageUris*/
+            options,
+            nullptr, /*targetVolume*/
+            nullptr, /*optionalAndRelatedPackageFamilyNames*/
+            nullptr, /*optionalPackageUris*/
+            nullptr /*relatedPackageUris*/);
+
+        WaitForDeployment(deployOperation, id, callback);
+    }
+
     void RequestAddPackage(
         const winrt::Windows::Foundation::Uri& uri,
         winrt::Windows::Management::Deployment::DeploymentOptions options,

--- a/src/AppInstallerCommonCore/Deployment.cpp
+++ b/src/AppInstallerCommonCore/Deployment.cpp
@@ -82,7 +82,7 @@ namespace AppInstaller::Deployment
         }
         else
         {
-            packageManager.RequestAddPackageAsync(
+            deployOperation = packageManager.RequestAddPackageAsync(
                 uri,
                 nullptr, /*dependencyPackageUris*/
                 options,

--- a/src/AppInstallerCommonCore/Deployment.cpp
+++ b/src/AppInstallerCommonCore/Deployment.cpp
@@ -56,43 +56,40 @@ namespace AppInstaller::Deployment
         }
     }
 
-    void AddPackage(const winrt::Windows::Foundation::Uri& uri, winrt::Windows::Management::Deployment::DeploymentOptions options, IProgressCallback& callback)
-    {
-        size_t id = GetDeploymentOperationId();
-        AICLI_LOG(Core, Info, << "Starting AddPackage operation #" << id << ": " << Utility::ConvertToUTF8(uri.AbsoluteUri().c_str()));
-
-        PackageManager packageManager;
-
-        auto deployOperation = packageManager.AddPackageAsync(
-            uri,
-            nullptr, /*dependencyPackageUris*/
-            options,
-            nullptr, /*targetVolume*/
-            nullptr, /*optionalAndRelatedPackageFamilyNames*/
-            nullptr, /*optionalPackageUris*/
-            nullptr /*relatedPackageUris*/);
-
-        WaitForDeployment(deployOperation, id, callback);
-    }
-
-    void RequestAddPackage(
+    void AddPackage(
         const winrt::Windows::Foundation::Uri& uri,
         winrt::Windows::Management::Deployment::DeploymentOptions options,
+        bool skipSmartScreen,
         IProgressCallback& callback)
     {
         size_t id = GetDeploymentOperationId();
-        AICLI_LOG(Core, Info, << "Starting RequestAddPackage operation #" << id << ": " << Utility::ConvertToUTF8(uri.AbsoluteUri().c_str()));
+        AICLI_LOG(Core, Info, << "Starting AddPackage operation #" << id << ": " << Utility::ConvertToUTF8(uri.AbsoluteUri().c_str()) << "SkipSmartScreen: " << skipSmartScreen);
 
         PackageManager packageManager;
 
-        // RequestAddPackageAsync will invoke smart screen.
-        auto deployOperation = packageManager.RequestAddPackageAsync(
-            uri,
-            nullptr, /*dependencyPackageUris*/
-            options,
-            nullptr, /*targetVolume*/
-            nullptr, /*optionalAndRelatedPackageFamilyNames*/
-            nullptr /*relatedPackageUris*/);
+        IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress> deployOperation;
+
+        if (skipSmartScreen)
+        {
+            deployOperation = packageManager.AddPackageAsync(
+                uri,
+                nullptr, /*dependencyPackageUris*/
+                options,
+                nullptr, /*targetVolume*/
+                nullptr, /*optionalAndRelatedPackageFamilyNames*/
+                nullptr, /*optionalPackageUris*/
+                nullptr /*relatedPackageUris*/);
+        }
+        else
+        {
+            packageManager.RequestAddPackageAsync(
+                uri,
+                nullptr, /*dependencyPackageUris*/
+                options,
+                nullptr, /*targetVolume*/
+                nullptr, /*optionalAndRelatedPackageFamilyNames*/
+                nullptr /*relatedPackageUris*/);
+        }
 
         WaitForDeployment(deployOperation, id, callback);
     }

--- a/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
@@ -7,6 +7,13 @@
 
 namespace AppInstaller::Deployment
 {
+    // Calls winrt::Windows::Management::Deployment::PackageManager::AddPackageAsync
+    // which does not trigger smart screen scan
+    void AddPackage(
+        const winrt::Windows::Foundation::Uri& uri,
+        winrt::Windows::Management::Deployment::DeploymentOptions options,
+        IProgressCallback& callback);
+
     // Calls winrt::Windows::Management::Deployment::PackageManager::RequestAddPackageAsync
     void RequestAddPackage(
         const winrt::Windows::Foundation::Uri& uri, 

--- a/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
@@ -7,17 +7,12 @@
 
 namespace AppInstaller::Deployment
 {
-    // Calls winrt::Windows::Management::Deployment::PackageManager::AddPackageAsync
-    // which does not trigger smart screen scan
+    // Calls winrt::Windows::Management::Deployment::PackageManager::AddPackageAsync if skipSmartScreen is true,
+    // Otherwise, calls winrt::Windows::Management::Deployment::PackageManager::RequestAddPackageAsync
     void AddPackage(
         const winrt::Windows::Foundation::Uri& uri,
         winrt::Windows::Management::Deployment::DeploymentOptions options,
-        IProgressCallback& callback);
-
-    // Calls winrt::Windows::Management::Deployment::PackageManager::RequestAddPackageAsync
-    void RequestAddPackage(
-        const winrt::Windows::Foundation::Uri& uri, 
-        winrt::Windows::Management::Deployment::DeploymentOptions options,
+        bool skipSmartScreen,
         IProgressCallback& callback);
 
     // Calls winrt::Windows::Management::Deployment::PackageManager::RemovePackageAsync

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -198,20 +198,11 @@ namespace AppInstaller::Repository::Microsoft
                     uri = winrt::Windows::Foundation::Uri(Utility::ConvertToUTF16(packageLocation));
                 }
 
-                if (SourceTrustLevel::Trusted == details.TrustLevel)
-                {
-                    Deployment::AddPackage(
-                        uri,
-                        winrt::Windows::Management::Deployment::DeploymentOptions::None,
-                        progress);
-                }
-                else
-                {
-                    Deployment::RequestAddPackage(
-                        uri,
-                        winrt::Windows::Management::Deployment::DeploymentOptions::None,
-                        progress);
-                }
+                Deployment::AddPackage(
+                    uri,
+                    winrt::Windows::Management::Deployment::DeploymentOptions::None,
+                    SourceTrustLevel::Trusted == details.TrustLevel,
+                    progress);
 
                 if (download)
                 {

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -198,10 +198,20 @@ namespace AppInstaller::Repository::Microsoft
                     uri = winrt::Windows::Foundation::Uri(Utility::ConvertToUTF16(packageLocation));
                 }
 
-                Deployment::RequestAddPackage(
-                    uri,
-                    winrt::Windows::Management::Deployment::DeploymentOptions::None,
-                    progress);
+                if (SourceTrustLevel::Trusted == details.TrustLevel)
+                {
+                    Deployment::AddPackage(
+                        uri,
+                        winrt::Windows::Management::Deployment::DeploymentOptions::None,
+                        progress);
+                }
+                else
+                {
+                    Deployment::RequestAddPackage(
+                        uri,
+                        winrt::Windows::Management::Deployment::DeploymentOptions::None,
+                        progress);
+                }
 
                 if (download)
                 {


### PR DESCRIPTION
## Change
- Use AddPackageAsync to bypass smart screen when adding or updating trusted source
- Use AddPackageAsync to bypass smart screen when deploying msix from trusted source

## Validation
Modified unit test to also verify IsInstallerTrusted flag

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/627)