### PR TITLE
Add forgotten export to def file

### DIFF
--- a/src/WinGetUtil/Source.def
+++ b/src/WinGetUtil/Source.def
@@ -9,5 +9,6 @@ EXPORTS
     WinGetSQLiteIndexUpdateManifest
     WinGetSQLiteIndexRemoveManifest
     WinGetSQLiteIndexPrepareForPackaging
+    WinGetSQLiteIndexCheckConsistency
     WinGetValidateManifest
     WinGetDownload


### PR DESCRIPTION
## Change
`WinGetSQLiteIndexCheckConsistency` was forgotten from the def file.

## Validation
dumpbin shows the export now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/631)