### PR TITLE
Improve upgrade output experience

### DIFF
--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -72,7 +72,7 @@ namespace AppInstaller::CLI
             Workflow::OpenSource <<
             Workflow::OpenCompositeSource(Repository::PredefinedSource::Installed) <<
             Workflow::SearchSourceForMany <<
-            Workflow::EnsureMatchesFromSearchResult <<
+            Workflow::EnsureMatchesFromSearchResult(true) <<
             Workflow::ReportListResult();
     }
 }

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -69,7 +69,7 @@ namespace AppInstaller::CLI
         context <<
             Workflow::OpenSource <<
             Workflow::SearchSourceForMany <<
-            Workflow::EnsureMatchesFromSearchResult <<
+            Workflow::EnsureMatchesFromSearchResult(false) <<
             Workflow::ReportSearchResult;
     }
 }

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -62,8 +62,8 @@ namespace AppInstaller::CLI
                 context <<
                     Workflow::OpenSource <<
                     Workflow::SearchSourceForSingle <<
-                    Workflow::EnsureOneMatchFromSearchResult <<
-                    Workflow::ReportSearchResultIdentity <<
+                    Workflow::EnsureOneMatchFromSearchResult(false) <<
+                    Workflow::ReportPackageIdentity <<
                     Workflow::ShowAppVersions;
             }
         }

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -14,6 +14,15 @@ using namespace AppInstaller::CLI::Workflow;
 
 namespace AppInstaller::CLI
 {
+    namespace
+    {
+        bool ShouldListUpgrade(Context& context)
+        {
+            return context.Args.Empty() ||
+                (context.Args.GetArgsCount() == 1 && context.Args.Contains(Execution::Args::Type::Source));
+        }
+    }
+
     std::vector<Argument> UpgradeCommand::GetArguments() const
     {
         return {
@@ -120,13 +129,12 @@ namespace AppInstaller::CLI
             OpenSource <<
             OpenCompositeSource(Repository::PredefinedSource::Installed);
 
-        if (context.Args.Empty() ||
-            (context.Args.GetArgsCount() == 1 && context.Args.Contains(Execution::Args::Type::Source)))
+        if (ShouldListUpgrade(context))
         {
             // Upgrade with no args list packages with updates available
             context <<
                 Workflow::SearchSourceForMany <<
-                Workflow::EnsureMatchesFromSearchResult <<
+                Workflow::EnsureMatchesFromSearchResult(true) <<
                 Workflow::ReportListResult(true);
         }
         else if (context.Args.Contains(Execution::Args::Type::All))
@@ -134,7 +142,7 @@ namespace AppInstaller::CLI
             // --all switch updates all packages found
             context <<
                 SearchSourceForMany <<
-                EnsureMatchesFromSearchResult <<
+                EnsureMatchesFromSearchResult(true) <<
                 UpdateAllApplicable;
         }
         else if (context.Args.Contains(Execution::Args::Type::Manifest))
@@ -144,7 +152,7 @@ namespace AppInstaller::CLI
                 GetManifestFromArg <<
                 ReportManifestIdentity <<
                 SearchSourceUsingManifest <<
-                EnsureOneMatchFromSearchResult <<
+                EnsureOneMatchFromSearchResult(true) <<
                 GetInstalledPackageVersion <<
                 EnsureUpdateVersionApplicable <<
                 EnsureMinOSVersion <<
@@ -163,20 +171,15 @@ namespace AppInstaller::CLI
             // The remaining case: search for single installed package to update
             context <<
                 SearchSourceForSingle <<
-                EnsureOneMatchFromSearchResult <<
-                ReportSearchResultIdentity <<
+                EnsureOneMatchFromSearchResult(true) <<
+                ReportPackageIdentity <<
                 GetInstalledPackageVersion;
-
-            if (context.IsTerminated())
-            {
-                return;
-            }
 
             if (context.Args.Contains(Execution::Args::Type::Version))
             {
                 // If version specified, use the version and verify applicability
                 context <<
-                    GetManifestFromSearchResult <<
+                    GetManifestFromPackage <<
                     EnsureUpdateVersionApplicable <<
                     EnsureMinOSVersion <<
                     SelectInstaller <<
@@ -186,13 +189,7 @@ namespace AppInstaller::CLI
             {
                 // iterate through available versions to find latest applicable update
                 // This step also populates Manifest and Installer in context data
-                context <<
-                    SelectLatestApplicableUpdate(*(context.Get<Execution::Data::SearchResult>().Matches.at(0).Package));
-
-                if (context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE)
-                {
-                    context.Reporter.Info() << Resource::String::UpdateNotApplicable << std::endl;
-                }
+                context << SelectLatestApplicableUpdate(true);
             }
 
             context <<

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -120,7 +120,8 @@ namespace AppInstaller::CLI
             OpenSource <<
             OpenCompositeSource(Repository::PredefinedSource::Installed);
 
-        if (context.Args.Empty())
+        if (context.Args.Empty() ||
+            (context.Args.GetArgsCount() == 1 && context.Args.Contains(Execution::Args::Type::Source)))
         {
             // Upgrade with no args list packages with updates available
             context <<
@@ -166,6 +167,11 @@ namespace AppInstaller::CLI
                 ReportSearchResultIdentity <<
                 GetInstalledPackageVersion;
 
+            if (context.IsTerminated())
+            {
+                return;
+            }
+
             if (context.Args.Contains(Execution::Args::Type::Version))
             {
                 // If version specified, use the version and verify applicability
@@ -182,6 +188,11 @@ namespace AppInstaller::CLI
                 // This step also populates Manifest and Installer in context data
                 context <<
                     SelectLatestApplicableUpdate(*(context.Get<Execution::Data::SearchResult>().Matches.at(0).Package));
+
+                if (context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE)
+                {
+                    context.Reporter.Info() << Resource::String::UpdateNotApplicable << std::endl;
+                }
             }
 
             context <<

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -116,6 +116,11 @@ namespace AppInstaller::CLI::Execution
             return m_parsedArgs.empty();
         }
 
+        size_t GetArgsCount()
+        {
+            return m_parsedArgs.size();
+        }
+
     private:
         std::map<Type, std::vector<std::string>> m_parsedArgs;
     };

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -116,14 +116,12 @@ namespace AppInstaller::CLI::Execution
             // Unless we want to spin a separate thread for all work, we have to just exit here.
             if (m_CtrlSignalCount >= 2)
             {
+                Logging::Telemetry().LogCommandTermination(hr, file, line);
                 std::exit(hr);
             }
         }
 
-        if (!file.empty() && line)
-        {
-            Logging::Telemetry().LogCommandTermination(hr, file, line);
-        }
+        Logging::Telemetry().LogCommandTermination(hr, file, line);
 
         m_isTerminated = true;
         m_terminationHR = hr;

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -66,6 +66,7 @@ namespace AppInstaller::CLI::Execution
         InstallerExecutionUseUpdate = 0x1,
         InstallerHashMatched = 0x2,
         InstallerTrusted = 0x4,
+        CompositeInstalledSource = 0x8,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ContextFlag);

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -46,6 +46,7 @@ namespace AppInstaller::CLI::Execution
         Source,
         SearchResult,
         SourceList,
+        Package,
         Manifest,
         PackageVersion,
         Installer,
@@ -66,7 +67,6 @@ namespace AppInstaller::CLI::Execution
         InstallerExecutionUseUpdate = 0x1,
         InstallerHashMatched = 0x2,
         InstallerTrusted = 0x4,
-        CompositeInstalledSource = 0x8,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ContextFlag);
@@ -95,6 +95,12 @@ namespace AppInstaller::CLI::Execution
         struct DataMapping<Data::SourceList>
         {
             using value_t = std::vector<Repository::SourceDetails>;
+        };
+
+        template <>
+        struct DataMapping<Data::Package>
+        {
+            using value_t = std::shared_ptr<Repository::IPackage>;
         };
 
         template <>

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -50,6 +50,8 @@ namespace AppInstaller::CLI::Execution
 
         void OutputLine(line_t&& line)
         {
+            m_empty = false;
+
             if (m_buffer.size() < m_sizingBuffer)
             {
                 m_buffer.emplace_back(std::move(line));
@@ -63,7 +65,15 @@ namespace AppInstaller::CLI::Execution
 
         void Complete()
         {
-            EvaluateAndFlushBuffer();
+            if (!m_empty)
+            {
+                EvaluateAndFlushBuffer();
+            }
+        }
+
+        bool IsEmpty()
+        {
+            return m_empty;
         }
 
     private:
@@ -81,6 +91,7 @@ namespace AppInstaller::CLI::Execution
         size_t m_sizingBuffer;
         std::vector<line_t> m_buffer;
         bool m_bufferEvaluated = false;
+        bool m_empty = true;
 
         void EvaluateAndFlushBuffer()
         {

--- a/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/CompletionFlow.cpp
@@ -71,7 +71,7 @@ namespace AppInstaller::CLI::Workflow
         const std::string& word = context.Get<Data::CompletionData>().Word();
         auto stream = context.Reporter.Completion();
 
-        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
+        for (const auto& vc : context.Get<Execution::Data::Package>()->GetAvailableVersionKeys())
         {
             if (word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Version, word))
             {
@@ -87,7 +87,7 @@ namespace AppInstaller::CLI::Workflow
 
         std::vector<std::string> channels;
 
-        for (const auto& vc : context.Get<Execution::Data::SearchResult>().Matches[0].Package->GetAvailableVersionKeys())
+        for (const auto& vc : context.Get<Execution::Data::Package>()->GetAvailableVersionKeys())
         {
             if ((word.empty() || Utility::ICUCaseInsensitiveStartsWith(vc.Channel, word)) &&
                 std::find(channels.begin(), channels.end(), vc.Channel) == channels.end())
@@ -164,14 +164,14 @@ namespace AppInstaller::CLI::Workflow
             // Here we require that the standard search finds a single entry, and we list those versions.
             context <<
                 Workflow::SearchSourceForSingle <<
-                Workflow::EnsureOneMatchFromSearchResult <<
+                Workflow::EnsureOneMatchFromSearchResult(false) <<
                 Workflow::CompleteWithSearchResultVersions;
             break;
         case Execution::Args::Type::Channel:
             // Here we require that the standard search finds a single entry, and we list those channels.
             context <<
                 Workflow::SearchSourceForSingle <<
-                Workflow::EnsureOneMatchFromSearchResult <<
+                Workflow::EnsureOneMatchFromSearchResult(false) <<
                 Workflow::CompleteWithSearchResultChannels;
             break;
         case Execution::Args::Type::Source:

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -84,7 +84,7 @@ namespace AppInstaller::CLI::Workflow
 
     void ShowAppVersions(Execution::Context& context)
     {
-        auto versions = context.Get<Execution::Data::SearchResult>().Matches.at(0).Package->GetAvailableVersionKeys();
+        auto versions = context.Get<Execution::Data::Package>()->GetAvailableVersionKeys();
 
         Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
         for (const auto& version : versions)

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -122,7 +122,9 @@ namespace AppInstaller::CLI::Workflow
 
             updateContext.Reporter.Info() << std::endl;
 
-            if (updateContext.GetTerminationHR() != S_OK)
+            // msstore update might still terminate with APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE
+            if (updateContext.GetTerminationHR() != S_OK &&
+                updateContext.GetTerminationHR() != APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE)
             {
                 updateAllHasFailure = true;
             }

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -102,9 +102,10 @@ namespace AppInstaller::CLI::Workflow
             auto updateContextPtr = context.Clone();
             Execution::Context& updateContext = *updateContextPtr;
 
-            updateContext.Add<Execution::Data::InstalledPackageVersion>(match.Package->GetInstalledVersion());
+            updateContext.Add<Execution::Data::Package>(match.Package);
 
             updateContext <<
+                Workflow::GetInstalledPackageVersion <<
                 Workflow::ReportExecutionStage(ExecutionStage::Discovery) <<
                 SelectLatestApplicableUpdate(false);
 

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.h
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.h
@@ -7,18 +7,18 @@
 namespace AppInstaller::CLI::Workflow
 {
     // Iterates through all available versions from a package and find latest applicable update
-    // Required Args: the package
-    // Inputs: InstalledPackageVersion
+    // Required Args: bool indicating whether to report update not found
+    // Inputs: InstalledPackageVersion, Package
     // Outputs: Manifest?, Installer?
     struct SelectLatestApplicableUpdate : public WorkflowTask
     {
-        SelectLatestApplicableUpdate(const AppInstaller::Repository::IPackage& package) :
-            WorkflowTask("SelectLatestApplicableUpdate"), m_package(package) {}
+        SelectLatestApplicableUpdate(bool reportUpdateNotFound) :
+            WorkflowTask("SelectLatestApplicableUpdate"), m_reportUpdateNotFound(reportUpdateNotFound) {}
 
         void operator()(Execution::Context& context) const override;
 
     private:
-        const AppInstaller::Repository::IPackage& m_package;
+        bool m_reportUpdateNotFound;
     };
 
     // Ensures the update package has higher version than installed

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -458,7 +458,7 @@ namespace AppInstaller::CLI::Workflow
                 AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND);
             }
 
-            auto package = searchResult.Matches.at(0).Package;
+            std::shared_ptr<IPackage> package = searchResult.Matches.at(0).Package;
             Logging::Telemetry().LogAppFound(package->GetProperty(PackageProperty::Name), package->GetProperty(PackageProperty::Id));
 
             context.Add<Execution::Data::Package>(std::move(package));

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -148,6 +148,12 @@ namespace AppInstaller::CLI::Workflow
         bool m_onlyShowUpgrades;
     };
 
+    // Outputs the search results when multiple packages found but only one expected.
+    // Required Args: None
+    // Inputs: SearchResult
+    // Outputs: None
+    void ReportMultiplePackageFoundResult(Execution::Context& context);
+
     // Ensures that there is at least one result in the search.
     // Required Args: bool indicating id the search result is from installed source
     // Inputs: SearchResult

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -149,22 +149,40 @@ namespace AppInstaller::CLI::Workflow
     };
 
     // Ensures that there is at least one result in the search.
-    // Required Args: None
+    // Required Args: bool indicating id the search result is from installed source
     // Inputs: SearchResult
     // Outputs: None
-    void EnsureMatchesFromSearchResult(Execution::Context& context);
+    struct EnsureMatchesFromSearchResult : public WorkflowTask
+    {
+        EnsureMatchesFromSearchResult(bool isFromInstalledSource) :
+            WorkflowTask("EnsureMatchesFromSearchResult"), m_isFromInstalledSource(isFromInstalledSource) {}
+
+        void operator()(Execution::Context& context) const override;
+
+    private:
+        bool m_isFromInstalledSource;
+    };
 
     // Ensures that there is only one result in the search.
-    // Required Args: None
+    // Required Args: bool indicating id the search result is from installed source
     // Inputs: SearchResult
     // Outputs: None
-    void EnsureOneMatchFromSearchResult(Execution::Context& context);
+    struct EnsureOneMatchFromSearchResult : public WorkflowTask
+    {
+        EnsureOneMatchFromSearchResult(bool isFromInstalledSource) :
+            WorkflowTask("EnsureOneMatchFromSearchResult"), m_isFromInstalledSource(isFromInstalledSource) {}
 
-    // Gets the manifest from a search result.
+        void operator()(Execution::Context& context) const override;
+
+    private:
+        bool m_isFromInstalledSource;
+    };
+
+    // Gets the manifest from package.
     // Required Args: None
-    // Inputs: SearchResult
-    // Outputs: Manifest
-    void GetManifestFromSearchResult(Execution::Context& context);
+    // Inputs: Package
+    // Outputs: Manifest, PackageVersion
+    void GetManifestFromPackage(Execution::Context& context);
 
     // Ensures the the file exists and is not a directory.
     // Required Args: the one given
@@ -186,11 +204,11 @@ namespace AppInstaller::CLI::Workflow
     // Outputs: Manifest
     void GetManifestFromArg(Execution::Context& context);
 
-    // Reports the search result's identity.
+    // Reports the search result's package identity.
     // Required Args: None
-    // Inputs: SearchResult (only 1)
+    // Inputs: Package
     // Outputs: None
-    void ReportSearchResultIdentity(Execution::Context& context);
+    void ReportPackageIdentity(Execution::Context& context);
 
     // Reports the manifest's identity.
     // Required Args: None
@@ -238,7 +256,7 @@ namespace AppInstaller::CLI::Workflow
 
     // Gets the installed package version
     // Required Args: None
-    // Inputs: SearchResult
+    // Inputs: Package
     // Outputs: InstalledPackageVersion
     void GetInstalledPackageVersion(Execution::Context& context);
 

--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -535,7 +535,7 @@ TEST_CASE("RepoSources_DropSourceByName", "[sources]")
     DropSource("testName");
 
     sources = GetSources();
-    REQUIRE(sources.size() == 3);
+    REQUIRE(sources.size() == 2);
 
     const char* suffix[2] = { "2", "3" };
 
@@ -549,8 +549,6 @@ TEST_CASE("RepoSources_DropSourceByName", "[sources]")
         REQUIRE(sources[i].LastUpdateTime == ConvertUnixEpochToSystemClock(i + 1));
         REQUIRE(sources[i].Origin == SourceOrigin::User);
     }
-
-    REQUIRE(sources[2].Origin == SourceOrigin::Default);
 }
 
 TEST_CASE("RepoSources_DropAllSources", "[sources]")

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -284,6 +284,7 @@ void OverrideForCompositeInstalledSource(TestContext& context)
     context.Override({ "OpenCompositeSource", [](TestContext& context)
     {
         context.Add<Execution::Data::Source>(std::make_shared<WorkflowTestCompositeSource>());
+        context.SetFlags(Execution::ContextFlag::CompositeInstalledSource);
     } });
 }
 

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -284,7 +284,6 @@ void OverrideForCompositeInstalledSource(TestContext& context)
     context.Override({ "OpenCompositeSource", [](TestContext& context)
     {
         context.Add<Execution::Data::Source>(std::make_shared<WorkflowTestCompositeSource>());
-        context.SetFlags(Execution::ContextFlag::CompositeInstalledSource);
     } });
 }
 

--- a/src/AppInstallerCommonCore/Manifest/ManifestInstaller.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestInstaller.cpp
@@ -12,6 +12,7 @@ namespace AppInstaller::Manifest
             None,
             Exe,
             Msi,
+            Msix,
         };
 
         CompatibilitySet GetCompatibilitySet(ManifestInstaller::InstallerTypeEnum type)
@@ -26,6 +27,9 @@ namespace AppInstaller::Manifest
             case ManifestInstaller::InstallerTypeEnum::Wix:
             case ManifestInstaller::InstallerTypeEnum::Msi:
                 return CompatibilitySet::Msi;
+            case ManifestInstaller::InstallerTypeEnum::Msix:
+            case ManifestInstaller::InstallerTypeEnum::MSStore:
+                return CompatibilitySet::Msix;
             default:
                 return CompatibilitySet::None;
             }

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -705,20 +705,6 @@ namespace AppInstaller::Repository
                 THROW_HR(E_UNEXPECTED);
             }
 
-            // Add back tombstoned default sources, otherwise the info will be lost by SetSourcesByOrigin
-            auto defaultSources = GetSourcesByOrigin(SourceOrigin::Default);
-            for (const auto& defaultSource : defaultSources)
-            {
-                if (FindSourceByName(currentSources, defaultSource.Name) == currentSources.end())
-                {
-                    SourceDetailsInternal tombstone;
-                    tombstone.Name = defaultSource.Name;
-                    tombstone.IsTombstone = true;
-                    tombstone.Origin = SourceOrigin::User;
-                    currentSources.emplace_back(std::move(tombstone));
-                }
-            }
-
             SetSourcesByOrigin(SourceOrigin::User, currentSources);
 
             return true;


### PR DESCRIPTION
## Change
- Previously, upgrade flow assumes at least one available version is there for each search match from composite installed source. It's not the case. So in this change, all places calling GetLatestAvailableVersion() are examined and made sure there's proper null check.
- Fixed output spamming in upgrade --all case
- Fixed an issue where any user source operation will restore tombstoned default source
- Always log E_ABORT context termination to reduce noise

## Validation
- Updated tests
- Manual validation and fix


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/634)