### PR TITLE
Fix registry reading code to allow for a single null byte on a wide string value

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -135,6 +135,7 @@ IHost
 IID
 IInstalled
 incosistencies
+INET
 inl
 inor
 iosfwd
@@ -207,6 +208,7 @@ mysilentwithprogress
 mytool
 Newtonsoft
 nfinity
+NOEXPAND
 noreturn
 nuffing
 nullopt
@@ -240,6 +242,7 @@ REGSAM
 REINSTALLMODE
 rhs
 rosoft
+RRF
 rrr
 rzkzqaqjwj
 schematab
@@ -326,4 +329,3 @@ Wunused
 WZDNCRFJ
 xf
 xl
-INET

--- a/src/AppInstallerCLITests/PredefinedInstalledSource.cpp
+++ b/src/AppInstallerCLITests/PredefinedInstalledSource.cpp
@@ -385,15 +385,6 @@ TEST_CASE("ARPHelper_PopulateIndexFromKey_Two", "[arphelper][list]")
     VerifyEntryAgainstIndex(index, result.Matches[0].first, entry2);
 }
 
-TEST_CASE("ARPHelper_PopulateFromOddStringLength", "[arphelper][list]")
-{
-    Registry::Key key(HKEY_LOCAL_MACHINE, "LISTBUG");
-    ARPHelper helper;
-
-    auto index = SQLiteIndex::CreateNew(SQLITE_MEMORY_DB_CONNECTION_TARGET);
-    helper.PopulateIndexFromKey(index, key, s_TestScope, "TestArchitecture");
-}
-
 TEST_CASE("PredefinedInstalledSource_Create", "[installed][list]")
 {
     auto source = CreatePredefinedInstalledSource();

--- a/src/AppInstallerCLITests/PredefinedInstalledSource.cpp
+++ b/src/AppInstallerCLITests/PredefinedInstalledSource.cpp
@@ -385,6 +385,15 @@ TEST_CASE("ARPHelper_PopulateIndexFromKey_Two", "[arphelper][list]")
     VerifyEntryAgainstIndex(index, result.Matches[0].first, entry2);
 }
 
+TEST_CASE("ARPHelper_PopulateFromOddStringLength", "[arphelper][list]")
+{
+    Registry::Key key(HKEY_LOCAL_MACHINE, "LISTBUG");
+    ARPHelper helper;
+
+    auto index = SQLiteIndex::CreateNew(SQLITE_MEMORY_DB_CONNECTION_TARGET);
+    helper.PopulateIndexFromKey(index, key, s_TestScope, "TestArchitecture");
+}
+
 TEST_CASE("PredefinedInstalledSource_Create", "[installed][list]")
 {
     auto source = CreatePredefinedInstalledSource();

--- a/src/AppInstallerCLITests/TestCommon.cpp
+++ b/src/AppInstallerCLITests/TestCommon.cpp
@@ -179,9 +179,9 @@ namespace TestCommon
         THROW_IF_WIN32_ERROR(RegSetValueExW(key, name.c_str(), 0, type, reinterpret_cast<const BYTE*>(value.c_str()), static_cast<DWORD>(sizeof(wchar_t) * (value.size() + 1))));
     }
 
-    void SetRegistryValue(HKEY key, const std::wstring& name, const std::vector<BYTE>& value)
+    void SetRegistryValue(HKEY key, const std::wstring& name, const std::vector<BYTE>& value, DWORD type)
     {
-        THROW_IF_WIN32_ERROR(RegSetValueExW(key, name.c_str(), 0, REG_BINARY, reinterpret_cast<const BYTE*>(value.data()), static_cast<DWORD>(value.size())));
+        THROW_IF_WIN32_ERROR(RegSetValueExW(key, name.c_str(), 0, type, reinterpret_cast<const BYTE*>(value.data()), static_cast<DWORD>(value.size())));
     }
 
     void SetRegistryValue(HKEY key, const std::wstring& name, DWORD value)

--- a/src/AppInstallerCLITests/TestCommon.h
+++ b/src/AppInstallerCLITests/TestCommon.h
@@ -106,7 +106,7 @@ namespace TestCommon
 
     // Set registry values.
     void SetRegistryValue(HKEY key, const std::wstring& name, const std::wstring& value, DWORD type = REG_SZ);
-    void SetRegistryValue(HKEY key, const std::wstring& name, const std::vector<BYTE>& value);
+    void SetRegistryValue(HKEY key, const std::wstring& name, const std::vector<BYTE>& value, DWORD type = REG_BINARY);
     void SetRegistryValue(HKEY key, const std::wstring& name, DWORD value);
 
 }

--- a/src/AppInstallerCommonCore/Registry.cpp
+++ b/src/AppInstallerCommonCore/Registry.cpp
@@ -231,7 +231,7 @@ namespace AppInstaller::Registry
         while (data.size() < (64 << 20))
         {
             byteCount = wil::safe_cast<DWORD>(data.size());
-            status = RegQueryValueExW(m_key.get(), name.c_str(), nullptr, &type, data.data(), &byteCount);
+            status = RegGetValueW(m_key.get(), nullptr, name.c_str(), RRF_RT_ANY | RRF_NOEXPAND, &type, data.data(), &byteCount);
 
             if (status == ERROR_MORE_DATA && byteCount > data.size())
             {


### PR DESCRIPTION
Fixes #657 

## Change
The issue was due to a REG_SZ value containing a wide string with a narrow null terminator.  Move to using RegGetValue, as it ensures that a proper null character will always be at the end of a registry string value.

## Validation
The provided registry hive was readable by the underlying list code, and a new test is added to ensure that this specific case works.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/662)