### PR TITLE
Ensure progress widgets respect UseVT

### DIFF
--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -133,11 +133,13 @@ namespace AppInstaller::CLI::Execution
     {
         void ProgressVisualizerBase::ApplyStyle(size_t i, size_t max, bool enabled)
         {
+            if (!UseVT())
+            {
+                // Either no style set or VT disabled
+                return;
+            }
             switch (m_style)
             {
-            case VisualStyle::NoVT:
-                // No VT means no style set
-                break;
             case VisualStyle::Retro:
                 if (enabled)
                 {


### PR DESCRIPTION
Otherwise the Spinner and Progress widgets merrily set the foreground colour but `TextFormat::Default` is never sent because the Reporter actually checks the VT setting!

Fixes #665

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/winget-cli/pull/667)