### PR TITLE
Update AAD App ID used for localization

### DIFF
--- a/azure-pipelines.loc.yml
+++ b/azure-pipelines.loc.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Send resources to Touchdown Build
     inputs:
       teamId: 8343
-      authId: d3dd8113-65b3-4526-bdca-a00a7d1c37ba
+      authId: 2796a411-f030-46c1-ae3e-ab56f60ea523
       authKey: $(LocServiceKey)
       isPreview: false
       relativePathRoot: src\AppInstallerCLIPackage\Shared\Strings\en-us


### PR DESCRIPTION
The pipeline task that submits files for localization requires an AAD app for auth. Updating the App Id to one owned by the team. Will update the secret key in the pipeline when merging.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/743)