### PR TITLE
Add Hyperlink function to ViritualTerminal TextFormat namespace

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -140,6 +140,7 @@ hstring
 html
 http
 https
+Hyperlink
 IApplication
 IAppx
 IAsync

--- a/src/AppInstallerCLICore/VTSupport.cpp
+++ b/src/AppInstallerCLICore/VTSupport.cpp
@@ -149,6 +149,13 @@ namespace AppInstaller::CLI::VirtualTerminal
         {
 
         }
+
+        ConstructedSequence Hyperlink(const std::string& ref, const std::string& text)
+        {
+            std::ostringstream result;
+            result << AICLI_VT_OSC "8;;" << ref << AICLI_VT_ESCAPE << "\\" << text << AICLI_VT_OSC << "8;;" << AICLI_VT_ESCAPE << "\\";
+            return ConstructedSequence{ result.str() };
+        }
     }
 
     namespace TextModification

--- a/src/AppInstallerCLICore/VTSupport.cpp
+++ b/src/AppInstallerCLICore/VTSupport.cpp
@@ -150,7 +150,7 @@ namespace AppInstaller::CLI::VirtualTerminal
 
         }
 
-        ConstructedSequence Hyperlink(const std::string& text, const std::string& ref)
+        ConstructedSequence Hyperlink(const std::string& ref, const std::string& text)
         {
             std::ostringstream result;
             result << AICLI_VT_OSC "8;;" << ref << AICLI_VT_ESCAPE << "\\" << text << AICLI_VT_OSC << "8;;" << AICLI_VT_ESCAPE << "\\";

--- a/src/AppInstallerCLICore/VTSupport.cpp
+++ b/src/AppInstallerCLICore/VTSupport.cpp
@@ -150,7 +150,7 @@ namespace AppInstaller::CLI::VirtualTerminal
 
         }
 
-        ConstructedSequence Hyperlink(const std::string& ref, const std::string& text)
+        ConstructedSequence Hyperlink(const std::string& text, const std::string& ref)
         {
             std::ostringstream result;
             result << AICLI_VT_OSC "8;;" << ref << AICLI_VT_ESCAPE << "\\" << text << AICLI_VT_OSC << "8;;" << AICLI_VT_ESCAPE << "\\";

--- a/src/AppInstallerCLICore/VTSupport.h
+++ b/src/AppInstallerCLICore/VTSupport.h
@@ -123,6 +123,8 @@ namespace AppInstaller::CLI::VirtualTerminal
         {
 
         }
+
+        ConstructedSequence Hyperlink(const std::string& link, const std::string& text);
     }
 
     namespace TextModification

--- a/src/AppInstallerCLICore/VTSupport.h
+++ b/src/AppInstallerCLICore/VTSupport.h
@@ -124,7 +124,7 @@ namespace AppInstaller::CLI::VirtualTerminal
 
         }
 
-        ConstructedSequence Hyperlink(const std::string& link, const std::string& text);
+        ConstructedSequence Hyperlink(const std::string& text, const std::string& ref);
     }
 
     namespace TextModification

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -5,10 +5,8 @@
 #include "ShowFlow.h"
 #include "ManifestComparator.h"
 #include "TableOutput.h"
-#include "VTSupport.h"
 
 using namespace AppInstaller::Repository;
-using namespace AppInstaller::CLI::VirtualTerminal;
 
 namespace AppInstaller::CLI::Workflow
 {
@@ -22,7 +20,7 @@ namespace AppInstaller::CLI::Workflow
 
         // TODO: Come up with a prettier format
         context.Reporter.Info() << "Version: " << manifest.Version << std::endl;
-        context.Reporter.Info() << "Publisher: " << manifest.Publisher << " " << TextFormat::Hyperlink("(marstr blog)", "https://marstr.dev") << std::endl;
+        context.Reporter.Info() << "Publisher: " << manifest.Publisher << std::endl;
         if (!manifest.Author.empty())
         {
             context.Reporter.Info() << "Author: " << manifest.Author << std::endl;

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -5,8 +5,10 @@
 #include "ShowFlow.h"
 #include "ManifestComparator.h"
 #include "TableOutput.h"
+#include "VTSupport.h"
 
 using namespace AppInstaller::Repository;
+using namespace AppInstaller::CLI::VirtualTerminal;
 
 namespace AppInstaller::CLI::Workflow
 {
@@ -20,7 +22,7 @@ namespace AppInstaller::CLI::Workflow
 
         // TODO: Come up with a prettier format
         context.Reporter.Info() << "Version: " << manifest.Version << std::endl;
-        context.Reporter.Info() << "Publisher: " << manifest.Publisher << std::endl;
+        context.Reporter.Info() << "Publisher: " << manifest.Publisher << " " << TextFormat::Hyperlink("(marstr blog)", "https://marstr.dev") << std::endl;
         if (!manifest.Author.empty())
         {
             context.Reporter.Info() << "Author: " << manifest.Author << std::endl;


### PR DESCRIPTION
Adding VirtualTerminal TextFormat helper for making text a clickable link.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/758)