### PR TITLE
Continue pipeline if CG fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -310,6 +310,7 @@ jobs:
   
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance
+    continueOnError: true
     inputs:
       scanType: 'Register'
       verbosity: 'Verbose'


### PR DESCRIPTION
At least while we sort out the issue with Component Governance, allow us to continue making changes by making the failure of this task a warning in the overall build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/772)