### PR TITLE
Respect visual style settings on import

### DIFF
--- a/src/AppInstallerCLICore/ExecutionReporter.cpp
+++ b/src/AppInstallerCLICore/ExecutionReporter.cpp
@@ -32,6 +32,10 @@ namespace AppInstaller::CLI::Execution
     Reporter::Reporter(const Reporter& other, clone_t) :
         Reporter(other.m_out, other.m_in)
     {
+        if (other.m_style.has_value())
+        {
+            SetStyle(*other.m_style);
+        }
     }
 
     OutputStream Reporter::GetOutputStream(Level level)
@@ -78,6 +82,7 @@ namespace AppInstaller::CLI::Execution
 
     void Reporter::SetStyle(VisualStyle style)
     {
+        m_style = style;
         if (m_spinner)
         {
             m_spinner->SetStyle(style);

--- a/src/AppInstallerCLICore/ExecutionReporter.h
+++ b/src/AppInstallerCLICore/ExecutionReporter.h
@@ -131,6 +131,7 @@ namespace AppInstaller::CLI::Execution
         std::ostream& m_out;
         std::istream& m_in;
         bool m_isVTEnabled = true;
+        std::optional<AppInstaller::Settings::VisualStyle> m_style;
         std::optional<IndefiniteSpinner> m_spinner;
         std::optional<ProgressBar> m_progressBar;
         wil::srwlock m_progressCallbackLock;


### PR DESCRIPTION
Progress bar style is not being respected for import (and I assume upgrade all). This is because when creating the sub-ExecutionContexts where each install is made we clone the Reporter without preserving its style. Added the style to the Reporter to preserve it when set and pass it along to the clone.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/795)