### PR TITLE
Make upgrade command correctly select latest applicable version

### DIFF
--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -51,6 +51,7 @@ namespace AppInstaller::CLI::Workflow
                 context.Add<Execution::Data::Installer>(std::move(installer));
 
                 updateFound = true;
+                break;
             }
             else
             {

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -456,6 +456,9 @@
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe_2.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Msix.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -345,6 +345,9 @@
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Msix.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/UpdateFlowTest_Exe_2.yaml
+++ b/src/AppInstallerCLITests/TestData/UpdateFlowTest_Exe_2.yaml
@@ -1,0 +1,18 @@
+# Same content with UpdateFlowTest_Exe.yaml but with higher version
+Id: AppInstallerCliTest.TestExeInstaller
+Version: 3.0.0.0
+Name: AppInstaller Test Installer
+Publisher: Microsoft Corporation
+AppMoniker: AICLITestExe
+License: Test
+Switches:
+  Custom: /custom /ver3.0.0.0
+  SilentWithProgress: /silentwithprogress
+  Silent: /silence
+  Update: /update
+Installers: 
+    - Arch: x64
+      Url: https://ThisIsNotUsed
+      InstallerType: exe
+      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+ManifestVersion: 0.1.0

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -112,6 +112,7 @@ namespace
             {
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
                 auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
                 result.Matches.emplace_back(
                     ResultMatch(
                         TestPackage::Make(
@@ -122,7 +123,7 @@ namespace
                                 { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
                                 { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
                             },
-                            std::vector<Manifest>{ manifest2, manifest },
+                            std::vector<Manifest>{ manifest3, manifest2, manifest },
                             this->shared_from_this()
                         ),
                         PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
@@ -877,6 +878,7 @@ TEST_CASE("UpdateFlow_UpdateExe", "[UpdateFlow][workflow]")
     std::getline(updateResultFile, updateResultStr);
     REQUIRE(updateResultStr.find("/update") != std::string::npos);
     REQUIRE(updateResultStr.find("/silence") != std::string::npos);
+    REQUIRE(updateResultStr.find("/ver3.0.0.0") != std::string::npos);
 }
 
 TEST_CASE("UpdateFlow_UpdateMsix", "[UpdateFlow][workflow]")


### PR DESCRIPTION
Fixes part of #794 

## Change
The code to select latest applicable upgrade version did not stop after it found the latest applicable version. The fix is to add a break once it did.

## Validation
Tried out the scenario described in #794 and confirmed winget installs latest after the fix.
Added unit tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/796)