### PR TITLE
Fix failure in indexing for duplicate PackageName or Publisher values

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_2/Interface_1_2.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_2/Interface_1_2.cpp
@@ -17,7 +17,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_2
         {
             if (localization.Contains(Manifest::Localization::PackageName))
             {
-                out.emplace_back(normalizer.NormalizeName(Utility::FoldCase(localization.Get<Manifest::Localization::PackageName>())).Name());
+                Utility::NormalizedString value = normalizer.NormalizeName(Utility::FoldCase(localization.Get<Manifest::Localization::PackageName>())).Name();
+                if (std::find(out.begin(), out.end(), value) == out.end())
+                {
+                    out.emplace_back(std::move(value));
+                }
             }
         }
 
@@ -25,7 +29,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_2
         {
             if (localization.Contains(Manifest::Localization::Publisher))
             {
-                out.emplace_back(normalizer.NormalizePublisher(Utility::FoldCase(localization.Get<Manifest::Localization::Publisher>())));
+                Utility::NormalizedString value = normalizer.NormalizePublisher(Utility::FoldCase(localization.Get<Manifest::Localization::Publisher>()));
+                if (std::find(out.begin(), out.end(), value) == out.end())
+                {
+                    out.emplace_back(std::move(value));
+                }
             }
         }
 


### PR DESCRIPTION
If a manifest has multiple localizations defined, and if the PackageName or Publisher values are duplicated across different localizations, the wingetutil indexing will fail with SQLITE_CONSTRAINT_UNIQUE.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/798)