### PR TITLE
Better error message for manifest input validation errors

### DIFF
--- a/schemas/JSON/manifests/preview/manifest.0.1.0.json
+++ b/schemas/JSON/manifests/preview/manifest.0.1.0.json
@@ -33,8 +33,7 @@
     },
     "Url": {
       "type": [ "string", "null" ],
-      "format": "uri",
-      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2000
     },
     "Homepage": {
@@ -108,8 +107,7 @@
         },
         "Url": {
           "type": "string",
-          "format": "uri",
-          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
           "maxLength": 2000,
           "description": "Url is required. The path to the installer."
         },

--- a/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
@@ -5,8 +5,7 @@
   "definitions": {
     "Url": {
       "type": [ "string", "null" ],
-      "format": "uri",
-      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2000,
       "description": "Optional Url type"
     },

--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -304,8 +304,7 @@
         },
         "InstallerUrl": {
           "type": "string",
-          "format": "uri",
-          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
           "description": "The installer Url"
         },
         "InstallerSha256": {

--- a/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
@@ -5,8 +5,7 @@
   "definitions": {
     "Url": {
       "type": [ "string", "null" ],
-      "format": "uri",
-      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2000,
       "description": "Optional Url type"
     },

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -23,8 +23,7 @@
     },
     "Url": {
       "type": [ "string", "null" ],
-      "format": "uri",
-      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2000,
       "description": "Optional Url type"
     },
@@ -316,8 +315,7 @@
         },
         "InstallerUrl": {
           "type": "string",
-          "format": "uri",
-          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://",
+          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
           "description": "The installer Url"
         },
         "InstallerSha256": {

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_NonZeroExitCode.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_NonZeroExitCode.yaml
@@ -1,5 +1,6 @@
 PackageIdentifier: AppInstallerCliTest.TestInstaller
 PackageVersion: 1.0.0.0
+PackageLocale: en-US
 PackageName: AppInstaller Test Installer
 Publisher: Microsoft Corporation
 Moniker: AICLITestExe

--- a/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
@@ -31,7 +31,7 @@ namespace AppInstaller::Manifest
         const char* const DuplicateInstallerEntry = "Duplicate installer entry found.";
         const char* const InstallerTypeDoesNotSupportPackageFamilyName = "The specified installer type does not support PackageFamilyName.";
         const char* const InstallerTypeDoesNotSupportProductCode = "The specified installer type does not support ProductCode.";
-        const char* const IncompleteMultiFileManifest = "The multi file manifest is incomplete.";
+        const char* const IncompleteMultiFileManifest = "The multi file manifest is incomplete. A multi file manifest must contain at least version, installer and defaultLocale manifest.";
         const char* const InconsistentMultiFileManifestFieldValue = "The multi file manifest has inconsistent field values.";
         const char* const DuplicateMultiFileManifestType = "The multi file manifest should contain only one file with the particular ManifestType.";
         const char* const DuplicateMultiFileManifestLocale = "The multi file manifest contains duplicate PackageLocale.";
@@ -85,6 +85,13 @@ namespace AppInstaller::Manifest
             return error;
         }
 
+        static ValidationError MessageFieldWithFile(std::string message, std::string field, std::string file)
+        {
+            ValidationError error{ message, field };
+            error.FileName = file;
+            return error;
+        }
+
         static ValidationError MessageFieldValueWithFile(std::string message, std::string field, std::string value, std::string file)
         {
             ValidationError error{ message, field, value };
@@ -115,7 +122,10 @@ namespace AppInstaller::Manifest
                 if (m_errors.empty())
                 {
                     // Syntax error, yaml parser error is stored in FailureInfo
-                    m_manifestErrorMessage = Utility::ConvertToUTF8(GetFailureInfo().pszMessage);
+                    if (GetFailureInfo().pszMessage)
+                    {
+                        m_manifestErrorMessage = Utility::ConvertToUTF8(GetFailureInfo().pszMessage);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Previously the manifest input validation code does not check required fields existence before using them to determine manifest consistency. This will result in unhelpful error message saying "Expected node type does not match". This change checks those fields before using them to give a better error message for winget validate commands.

Also removed the format uri restriction per Union's ask.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/812)