### PR TITLE
Fix date formatting

### DIFF
--- a/src/AppInstallerCommonCore/DateTime.cpp
+++ b/src/AppInstallerCommonCore/DateTime.cpp
@@ -16,8 +16,8 @@ namespace AppInstaller::Utility
 
         stream
             << std::setw(4) << (1900 + localTime.tm_year) << '-'
-            << std::setw(2) << (1 + localTime.tm_mon) << '-'
-            << std::setw(2) << localTime.tm_mday << (useRFC3339 ? 'T' : ' ')
+            << std::setw(2) << std::setfill('0') << (1 + localTime.tm_mon) << '-'
+            << std::setw(2) << std::setfill('0') << localTime.tm_mday << (useRFC3339 ? 'T' : ' ')
             << std::setw(2) << std::setfill('0') << localTime.tm_hour << ':' 
             << std::setw(2) << std::setfill('0') << localTime.tm_min << ':' 
             << std::setw(2) << std::setfill('0') << localTime.tm_sec << '.';


### PR DESCRIPTION
I noticed during a presentation that the date format for the exported JSON files wasn't formatted correctly (the space just before the `3` for March instead of a `0`):

![image](https://user-images.githubusercontent.com/1439341/113143891-94ed7500-9224-11eb-8c03-7af48bd2318b.png)

This pull request updates the formatting to ensure that the day and month are padded with zeroes like the time already is.

Generating an export JSON locally, I get something similar to the following before and after the change.

## Before

```json
{
    "CreationDate" : "2021- 3-31 13:18:58.648"
}
```

## After

```json
{
    "CreationDate" : "2021-03-31 13:17:55.408"
}
```

There's a test that the date is output below, but it doesn't validate anything beyond it being present. As the clock isn't injectable in some way, I wasn't sure on the best way to add a test for it that would verify the format was always correct, rather than just on days that should have a leading zero, so I haven't updated any test for this fix.

https://github.com/microsoft/winget-cli/blob/9e104ebe699617ef003676eb2ab9837136d799b9/src/AppInstallerCLITests/PackageCollection.cpp#L66

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/836)