### PR TITLE
Fix format of CreationDate on export

### DIFF
--- a/src/AppInstallerCLICore/PackageCollection.cpp
+++ b/src/AppInstallerCLICore/PackageCollection.cpp
@@ -108,9 +108,8 @@ namespace AppInstaller::CLI
             root[ss.PackagesJson_WinGetVersion] = wingetVersion;
             root[ss.PackagesJson_Schema] = ss.PackagesJson_SchemaUri_v1_0;
 
-            // TODO: This uses localtime. Do we want to use UTC or add time zone?
             std::stringstream currentTimeStream;
-            Utility::OutputTimePoint(currentTimeStream, std::chrono::system_clock::now());
+            Utility::OutputTimePoint(currentTimeStream, std::chrono::system_clock::now(), true);
             root[ss.PackagesJson_CreationDate] = currentTimeStream.str();
 
             return root;

--- a/src/AppInstallerCommonCore/DateTime.cpp
+++ b/src/AppInstallerCommonCore/DateTime.cpp
@@ -18,8 +18,8 @@ namespace AppInstaller::Utility
             << std::setw(4) << (1900 + localTime.tm_year) << '-'
             << std::setw(2) << std::setfill('0') << (1 + localTime.tm_mon) << '-'
             << std::setw(2) << std::setfill('0') << localTime.tm_mday << (useRFC3339 ? 'T' : ' ')
-            << std::setw(2) << std::setfill('0') << localTime.tm_hour << ':' 
-            << std::setw(2) << std::setfill('0') << localTime.tm_min << ':' 
+            << std::setw(2) << std::setfill('0') << localTime.tm_hour << ':'
+            << std::setw(2) << std::setfill('0') << localTime.tm_min << ':'
             << std::setw(2) << std::setfill('0') << localTime.tm_sec << '.';
 
         // Get partial seconds
@@ -27,6 +27,14 @@ namespace AppInstaller::Utility
         auto leftoverMillis = duration_cast<milliseconds>(sinceEpoch) - duration_cast<seconds>(sinceEpoch);
 
         stream << std::setw(3) << std::setfill('0') << leftoverMillis.count();
+
+        if (useRFC3339)
+        {
+            // RFC 3339 requires adding time zone info.
+            // No need to bother getting the actual time zone as we don't need it.
+            // -00:00 represents an unspecified time zone, not UTC.
+            stream << "-00:00";
+        }
     }
 
     std::string GetCurrentTimeForFilename()


### PR DESCRIPTION
This is a follow up to #836 

CreationDate in the package collection JSON schema is declared as a date-time but the file we generated when exporting didn't follow the requirements for the format. This wasn't a problem because valijson does not validate this format, so we would not reject it, and we don't need to because we don't use the field. Ensuring we use the proper format probably only has the benefit of it not showing up as an error when editing or otherwise processing the file with a tool that validates the schema.

The date should follow the format specified by RFC 3339 according to the JSON schema. What I missed before was using T as a separator and adding the time zone offset at the end. I wasn't able to easily get the time zone offset in the right format, so instead I'm adding the -00:00 offset which represents an unknown time zone.

Updated the tests for exported files to check that the creation date has the right format (or at least something close) and added a test for reading a file with the old bad format to ensure we don't break with existing files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/843)