### PR TITLE
Output sources from policy with --info

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -190,6 +190,8 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SourceCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceExportCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceExportCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(SourceListAdditionalSource);
+        WINGET_DEFINE_RESOURCE_STRINGID(SourceListAllowedSource);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListArg);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListCommandShortDescription);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -908,4 +908,12 @@ Configuration is disabled due to Group Policy.</value>
   <data name="SourceExportCommandShortDescription" xml:space="preserve">
     <value>Export current sources</value>
   </data>
+  <data name="SourceListAdditionalSource" xml:space="preserve">
+    <value>Additional source</value>
+    <comment>An additional source required by policy.</comment>
+  </data>
+  <data name="SourceListAllowedSource" xml:space="preserve">
+    <value>Allowed source</value>
+    <comment>A source that the user is allowed to add.</comment>
+  </data>
 </root>

--- a/src/AppInstallerCLITests/WorkflowGroupPolicy.cpp
+++ b/src/AppInstallerCLITests/WorkflowGroupPolicy.cpp
@@ -42,7 +42,6 @@ TEST_CASE("GroupPolicy_WinGet", "[groupPolicy]")
         rootCommand.Execute(context);
 
         REQUIRE_FALSE(context.IsTerminated());
-        REQUIRE(output.str().find("Enable Windows Package Manager") != std::string::npos);
     }
 }
 
@@ -88,5 +87,97 @@ TEST_CASE("GroupPolicy_LocalManifests", "[groupPolicy]")
         args.AddArg(Execution::Args::Type::ValidateManifest, TestDataFile("InstallFlowTest_Exe.yaml").GetPath().u8string());
         ValidateCommand validateCommand({});
         REQUIRE_NOTHROW(validateCommand.ValidateArguments(args));
+    }
+}
+
+TEST_CASE("GroupPolicy_Info", "[groupPolicy]")
+{
+    GroupPolicyTestOverride policies;
+
+    std::ostringstream output;
+    Execution::Context context{ output, std::cin };
+    context.Args.AddArg(Execution::Args::Type::Info);
+    RootCommand rootCommand({});
+
+    SECTION("Does not list not configured")
+    {
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") == std::string::npos);
+    }
+    SECTION("Shows enabled policies")
+    {
+        policies.SetState(TogglePolicy::Policy::HashOverride, PolicyState::Enabled);
+
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") != std::string::npos);
+        REQUIRE(output.str().find("Hash Override Enabled") != std::string::npos);
+    }
+    SECTION("Shows disabled policies")
+    {
+        policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::Disabled);
+
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") != std::string::npos);
+        REQUIRE(output.str().find("Local Manifest Files Disabled") != std::string::npos);
+    }
+    SECTION("Shows auto update interval")
+    {
+        policies.SetValue<ValuePolicy::SourceAutoUpdateIntervalInMinutes>(60);
+
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") != std::string::npos);
+        REQUIRE(output.str().find("Source Auto Update Interval In Minutes 60") != std::string::npos);
+    }
+    SECTION("Shows additional sources list")
+    {
+        SourceFromPolicy source;
+        source.Name = "policy-source";
+        source.Type = "Test.Type";
+        source.Arg = "test-arg";
+        policies.SetState(TogglePolicy::Policy::AdditionalSources, PolicyState::Enabled);
+        policies.SetValue<ValuePolicy::AdditionalSources>({ source });
+
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") != std::string::npos);
+        REQUIRE(output.str().find("Sources Enabled") != std::string::npos);
+        REQUIRE(output.str().find("Additional source") != std::string::npos);
+        REQUIRE(output.str().find(source.Name) != std::string::npos);
+        REQUIRE(output.str().find(source.Type) != std::string::npos);
+        REQUIRE(output.str().find(source.Arg) != std::string::npos);
+    }
+    SECTION("Shows allowed sources list")
+    {
+        SourceFromPolicy source;
+        source.Name = "allowed-source";
+        source.Type = "Test.Type";
+        source.Arg = "test-arg";
+        policies.SetState(TogglePolicy::Policy::AllowedSources, PolicyState::Enabled);
+        policies.SetValue<ValuePolicy::AllowedSources>({ source });
+
+        rootCommand.Execute(context);
+        INFO(output.str());
+
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("Group Policy") != std::string::npos);
+        REQUIRE(output.str().find("Allowed Sources Enabled") != std::string::npos);
+        REQUIRE(output.str().find("Allowed source") != std::string::npos);
+        REQUIRE(output.str().find(source.Name) != std::string::npos);
+        REQUIRE(output.str().find(source.Type) != std::string::npos);
+        REQUIRE(output.str().find(source.Arg) != std::string::npos);
     }
 }

--- a/src/AppInstallerCommonCore/Public/winget/GroupPolicy.h
+++ b/src/AppInstallerCommonCore/Public/winget/GroupPolicy.h
@@ -18,8 +18,8 @@ namespace AppInstaller::Settings
     enum class ValuePolicy
     {
         SourceAutoUpdateIntervalInMinutes,
-        AdditionalSources, // TODO
-        AllowedSources, // TODO
+        AdditionalSources,
+        AllowedSources,
         Max,
     };
 
@@ -37,8 +37,8 @@ namespace AppInstaller::Settings
             HashOverride,
             DefaultSource,
             MSStoreSource,
-            AdditionalSources, // TODO
-            AllowedSources, // TODO
+            AdditionalSources,
+            AllowedSources,
             Max,
         };
 


### PR DESCRIPTION
Adding the sources configured by Group Policy to the output of --info with the other policies. This is something I missed doing in #841 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/848)