### PR TITLE
Update schema to remove additionalProperties

### DIFF
--- a/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
@@ -138,5 +138,6 @@
     "ShortDescription",
     "ManifestType",
     "ManifestVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -30,6 +30,7 @@
     "Platform": {
       "type": [ "array", "null" ],
       "items": {
+        "title": "Platform",
         "type": "string",
         "enum": [
           "Windows.Desktop",
@@ -72,6 +73,7 @@
     "InstallModes": {
       "type": [ "array", "null" ],
       "items": {
+        "title": "InstallModes",
         "type": "string",
         "enum": [
           "interactive",
@@ -128,7 +130,8 @@
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "InstallerSuccessCodes": {
       "type": [ "array", "null" ],
@@ -220,7 +223,8 @@
                 "$ref": "#/definitions/PackageVersion"
               }
             },
-            "required": [ "PackageIdentifier" ]
+            "required": [ "PackageIdentifier" ],
+            "additionalProperties": false
           },
           "maxItems": 16,
           "uniqueItems": true,
@@ -237,7 +241,8 @@
           "uniqueItems": true,
           "description": "List of external package dependencies"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PackageFamilyName": {
       "type": [ "string", "null" ],
@@ -358,7 +363,8 @@
         "Architecture",
         "InstallerUrl",
         "InstallerSha256"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -450,5 +456,6 @@
     "Installers",
     "ManifestType",
     "ManifestVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
@@ -134,5 +134,6 @@
     "PackageLocale",
     "ManifestType",
     "ManifestVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -42,6 +42,7 @@
     "Platform": {
       "type": [ "array", "null" ],
       "items": {
+        "title": "Platform",
         "type": "string",
         "enum": [
           "Windows.Desktop",
@@ -84,6 +85,7 @@
     "InstallModes": {
       "type": [ "array", "null" ],
       "items": {
+        "title": "InstallModes",
         "type": "string",
         "enum": [
           "interactive",
@@ -140,7 +142,8 @@
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "InstallerSuccessCodes": {
       "type": [ "array", "null" ],
@@ -232,7 +235,8 @@
                 "$ref": "#/definitions/PackageVersion"
               }
             },
-            "required": [ "PackageIdentifier" ]
+            "required": [ "PackageIdentifier" ],
+            "additionalProperties": false
           },
           "maxItems": 16,
           "description": "List of package dependencies from current source"
@@ -248,7 +252,8 @@
           "uniqueItems": true,
           "description": "List of external package dependencies"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PackageFamilyName": {
       "type": [ "string", "null" ],
@@ -369,7 +374,8 @@
         "Architecture",
         "InstallerUrl",
         "InstallerSha256"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -551,5 +557,6 @@
     "Installers",
     "ManifestType",
     "ManifestVersion"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/schemas/JSON/manifests/v1.0.0/manifest.version.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.version.1.0.0.json
@@ -41,5 +41,6 @@
     "DefaultLocale",
     "ManifestType",
     "ManifestVersion"
-  ]
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
- Sets additional properties to false to not allow fields that aren't defined in the schema
- Defines a title for InstallModes and Platform enums to help with Winget-Create autogenerated object model labeling those enums as "anonymous".

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/849)