### PR TITLE
Using custom http stage for injecting tests responses

### DIFF
--- a/src/AppInstallerRepositoryCore/Rest/HttpClientHelper.h
+++ b/src/AppInstallerRepositoryCore/Rest/HttpClientHelper.h
@@ -9,25 +9,24 @@ namespace AppInstaller::Repository::Rest
 {
     struct HttpClientHelper
     {
-        HttpClientHelper(const utility::string_t& url);
+        HttpClientHelper(std::optional<std::shared_ptr<web::http::http_pipeline_stage>> = {});
 
-        pplx::task<web::http::http_response> Post(const web::json::value& body, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
+        pplx::task<web::http::http_response> Post(const utility::string_t& uri, const web::json::value& body, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
 
-        std::optional<web::json::value> HandlePost(const web::json::value& body, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
+        std::optional<web::json::value> HandlePost(const utility::string_t& uri, const web::json::value& body, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
 
-        pplx::task<web::http::http_response> Get(const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
+        pplx::task<web::http::http_response> Get(const utility::string_t& uri, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
 
-        std::optional<web::json::value> HandleGet(const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
+        std::optional<web::json::value> HandleGet(const utility::string_t& uri, const std::vector<std::pair<utility::string_t, utility::string_t>>& headers = {});
+        
+        web::http::client::http_client GetClient(const utility::string_t& uri);
 
     protected:
-        pplx::task<web::http::http_response> MakeRequest(web::http::http_request req);
-
         std::optional<web::json::value> ValidateAndExtractResponse(const web::http::http_response& response);
 
         std::optional<web::json::value> ExtractJsonResponse(const web::http::http_response& response);
 
     private:
-        web::http::client::http_client m_client;
-        utility::string_t m_url;
+        std::optional<std::shared_ptr<web::http::http_pipeline_stage>> m_requestHandlerStage;
     };
 }

--- a/src/AppInstallerRepositoryCore/Rest/RestClient.h
+++ b/src/AppInstallerRepositoryCore/Rest/RestClient.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <set>
 #include "Rest/Schema/IRestClient.h"
+#include "Rest/HttpClientHelper.h"
 #include "cpprest/json.h"
 
 namespace AppInstaller::Repository::Rest
@@ -29,11 +30,11 @@ namespace AppInstaller::Repository::Rest
 
         static utility::string_t GetInformationEndpoint(const utility::string_t& restApiUri);
         
-        static AppInstaller::Utility::Version GetSupportedVersion(const utility::string_t& restApi, const std::set<AppInstaller::Utility::Version>& wingetSupportedVersions);
+        static AppInstaller::Utility::Version GetSupportedVersion(const utility::string_t& restApi, const std::set<AppInstaller::Utility::Version>& wingetSupportedVersions, HttpClientHelper&& httpClientHelper);
 
         static std::unique_ptr<Schema::IRestClient> GetSupportedInterface(const std::string& restApi, const AppInstaller::Utility::Version& version);
 
-        static RestClient Create(const std::string& restApi);
+        static RestClient Create(const std::string& restApi, HttpClientHelper&& helper);
 
     private:
         std::unique_ptr<Schema::IRestClient> m_interface;

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -4,6 +4,7 @@
 #include "RestSourceFactory.h"
 #include "RestClient.h"
 #include "RestSource.h"
+#include <Rest/HttpClientHelper.h>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -19,7 +20,8 @@ namespace AppInstaller::Repository::Rest
             {
                 THROW_HR_IF(E_INVALIDARG, !Utility::CaseInsensitiveEquals(details.Type, RestSourceFactory::Type()));
 
-                RestClient restClient = RestClient::Create(details.Arg);
+                HttpClientHelper helper{};
+                RestClient restClient = RestClient::Create(details.Arg, std::move(helper));
 
                 // TODO: Change identifier if required.
                 return std::make_shared<RestSource>(details, details.Arg, std::move(restClient));

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Interface.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Interface.cpp
@@ -54,11 +54,12 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         }
     }
 
-    Interface::Interface(const std::string& restApi)
+    Interface::Interface(const std::string& restApi, HttpClientHelper&& httpClientHelper)
     {
         THROW_HR_IF(APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_URL, !RestHelper::IsValidUri(JsonHelper::GetUtilityString(restApi)));
 
         m_restApiUri = restApi;
+        m_httpClientHelper = std::move(httpClientHelper);
         m_searchEndpoint = GetSearchEndpoint(m_restApiUri);
         m_requiredRestApiHeaders.emplace_back(
             std::pair(JsonHelper::GetUtilityString(ContractVersion), JsonHelper::GetUtilityString(GetVersion().ToString())));
@@ -78,8 +79,8 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         }
 
         // TODO: Handle continuation token
-        HttpClientHelper clientHelper{ m_searchEndpoint };
-        std::optional<web::json::value> jsonObject = clientHelper.HandlePost(GetSearchBody(request), m_requiredRestApiHeaders);
+        std::optional<web::json::value> jsonObject = GetHttpClientHelper().HandlePost(
+            m_searchEndpoint, GetSearchBody(request), m_requiredRestApiHeaders);
 
         if (!jsonObject)
         {
@@ -159,8 +160,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
     std::vector<Manifest::Manifest> Interface::GetManifests(const std::string& packageId, const std::map<std::string_view, std::string>& params) const
     {
         std::vector<Manifest::Manifest> results;
-        HttpClientHelper clientHelper{ GetManifestByVersionEndpoint(m_restApiUri, packageId, params) };
-        std::optional<web::json::value> jsonObject = clientHelper.HandleGet(m_requiredRestApiHeaders);
+        std::optional<web::json::value> jsonObject = GetHttpClientHelper().HandleGet(GetManifestByVersionEndpoint(m_restApiUri, packageId, params), m_requiredRestApiHeaders);
 
         if (!jsonObject)
         {
@@ -194,5 +194,10 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         }
 
         return results;
+    }
+
+    HttpClientHelper Interface::GetHttpClientHelper() const
+    {
+        return m_httpClientHelper;
     }
 }

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Interface.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Interface.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "Rest/Schema/IRestClient.h"
 #include "cpprest/json.h"
+#include "Rest/HttpClientHelper.h"
 #include <vector>
 
 namespace AppInstaller::Repository::Rest::Schema::V1_0
@@ -10,7 +11,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
     // Interface to this schema version exposed through IRestClient.
     struct Interface : public IRestClient
     {
-        Interface(const std::string& restApi);
+        Interface(const std::string& restApi, HttpClientHelper&& httpClientHelper);
 
         Interface(const Interface&) = delete;
         Interface& operator=(const Interface&) = delete;
@@ -24,6 +25,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         std::vector<Manifest::Manifest> GetManifests(const std::string& packageId, const std::map<std::string_view, std::string>& params = {}) const override;
    
     protected:
+        HttpClientHelper GetHttpClientHelper() const;
         bool MeetsOptimizedSearchCriteria(const SearchRequest& request) const;
         IRestClient::SearchResult OptimizedSearch(const SearchRequest& request) const;
 
@@ -31,5 +33,6 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         std::string m_restApiUri;
         utility::string_t m_searchEndpoint;
         std::vector<std::pair<utility::string_t, utility::string_t>> m_requiredRestApiHeaders;
+        HttpClientHelper m_httpClientHelper;
     };
 }


### PR DESCRIPTION
- Added optional stage to httpclienthelper and injected httpclienthelper into Interface.
- The optional stage can be used to intercept request message and return test responses in tests.
- Added a sample test doing the above.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/853)