### PR TITLE
Remove incorrect msi upgrade parameter

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -357,8 +357,7 @@ namespace AppInstaller::Manifest
                 {InstallerSwitchType::Silent, ManifestInstaller::string_t("/quiet")},
                 {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/passive")},
                 {InstallerSwitchType::Log, ManifestInstaller::string_t("/log \"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
-                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("TARGETDIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")},
-                {InstallerSwitchType::Update, ManifestInstaller::string_t("REINSTALL=ALL REINSTALLMODE=vamus")}
+                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("TARGETDIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
             };
         case InstallerTypeEnum::Nullsoft:
             return


### PR DESCRIPTION
Fixes part of #752

The default msi upgrade parameter we have works only on very specific minor version upgrade, and these parameter s are mostly for advanced user to control file over file installation. In common scenario msi upgrade/installation, direct invocation on the msi should be enough.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/907)