### PR TITLE
Trim ShortDescription and Description manifest fields

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestYamlPopulator.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestYamlPopulator.cpp
@@ -287,7 +287,7 @@ namespace AppInstaller::Manifest
         // Common fields across versions
         std::vector<FieldProcessInfo> result =
         {
-            { "Description", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::Description>(value.as<std::string>()); return {}; } },
+            { "Description", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::Description>(Utility::Trim(value.as<std::string>())); return {}; } },
             { "LicenseUrl", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::LicenseUrl>(value.as<std::string>()); return {}; } },
         };
 
@@ -336,7 +336,7 @@ namespace AppInstaller::Manifest
                     { "License", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::License>(value.as<std::string>()); return {}; } },
                     { "Copyright", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::Copyright>(value.as<std::string>()); return {}; } },
                     { "CopyrightUrl", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::CopyrightUrl>(value.as<std::string>()); return {}; } },
-                    { "ShortDescription", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::ShortDescription>(value.as<std::string>()); return {}; } },
+                    { "ShortDescription", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::ShortDescription>(Utility::Trim(value.as<std::string>())); return {}; } },
                     { "Tags", [this](const YAML::Node& value)->ValidationErrors { m_p_localization->Add<Localization::Tags>(ProcessStringSequenceNode(value)); return {}; } },
                 };
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

This avoids the blank line after short and long descriptions in `winget show` when the manifest uses the
```yaml
Description: >
    REAPER is a complete...

    REAPER supports...
```
syntax for multi-line values. See e.g. https://github.com/microsoft/winget-pkgs/blob/master/manifests/c/Cockos/REAPER/6.28/Cockos.REAPER.locale.en-US.yaml and the output of `winget show reaper`:
```
Gefunden REAPER [Cockos.REAPER]
Version: 6.28
Publisher: Cockos Incorporated
Description: REAPER is a complete digital audio production application for computers, offering a full  multitrack audio and MIDI recording, editing, processing, mixing and mastering toolset.
REAPER supports a vast range of hardware, digital formats and plugins, and can be comprehensively extended, scripted and modified.

Homepage: https://www.reaper.fm/
License: Copyright © 2005-2021 Cockos Incorporated
Installer:
  Type: Nullsoft
  Download Url: https://www.reaper.fm/files/6.x/reaper628_x64-install.exe
  SHA256: 64560f45cec4ceca26b30d17d7f78c72503a89333ff8537864e5341b0948eb2d
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/927)