### PR TITLE
Fix nuget restore due to ADO build agents moving to VS 16.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,13 +50,21 @@ jobs:
   
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
-    displayName: Restore Packages
-    env: {
-    # Due to https://github.com/NuGet/Home/issues/7796, use older behavior
-        RestoreUseSkipNonexistentTargets: false
-    }
+    displayName: Restore Solution
     inputs:
       restoreSolution: '$(solution)'
+  
+  # Restore these UAP packages as https://github.com/NuGet/Home/issues/7796 leads to all UAP packages being skipped for restore.
+  # Even though they don't need any actual restore action, they need the project.assets.json file to be created and a direct restore does that.
+  - task: NuGetCommand@2
+    displayName: Restore AppInstallerCLIPackage
+    inputs:
+      restoreSolution: 'src\AppInstallerCLIPackage\AppInstallerCLIPackage.wapproj'
+  
+  - task: NuGetCommand@2
+    displayName: Restore AppInstallerTestMsixInstaller
+    inputs:
+      restoreSolution: 'src\AppInstallerTestMsixInstaller\AppInstallerTestMsixInstaller.wapproj'
   
   # Restores only .NET core projects, but is still necessary, as without this the IndexCreationTool and LocalhostWebServer projects fail to build
   - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,10 @@ jobs:
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Packages
+    env: {
+    # Due to https://github.com/NuGet/Home/issues/7796, use older behavior
+        RestoreUseSkipNonexistentTargets: false
+    }
     inputs:
       restoreSolution: '$(solution)'
   


### PR DESCRIPTION
## Change
Fix for build break caused by NuGet/Home#7796 now appearing in VS 16.10.  The only thing I found that worked was to manually restore each project that failed due to a missing project.assets.json in the pipeline after restoring the solution itself.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1082)