### PR TITLE
Force connection serialization

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -106,6 +106,7 @@ foldc
 foldcase
 FOLDERID
 ftp
+FULLMUTEX
 FULLWIDTH
 fundraiser
 fuzzer

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
@@ -125,7 +125,7 @@ namespace AppInstaller::Repository::SQLite
     Connection::Connection(const std::string& target, OpenDisposition disposition, OpenFlags flags)
     {
         AICLI_LOG(SQL, Info, << "Opening SQLite connection: '" << target << "' [" << std::hex << static_cast<int>(disposition) << ", " << std::hex << static_cast<int>(flags) << "]");
-        // Always for connection serialization until we determine that there are situations where it is not needed
+        // Always force connection serialization until we determine that there are situations where it is not needed
         int resultingFlags = static_cast<int>(disposition) | static_cast<int>(flags) | SQLITE_OPEN_FULLMUTEX;
         THROW_IF_SQLITE_FAILED(sqlite3_open_v2(target.c_str(), &m_dbconn, resultingFlags, nullptr));
     }

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.cpp
@@ -125,7 +125,8 @@ namespace AppInstaller::Repository::SQLite
     Connection::Connection(const std::string& target, OpenDisposition disposition, OpenFlags flags)
     {
         AICLI_LOG(SQL, Info, << "Opening SQLite connection: '" << target << "' [" << std::hex << static_cast<int>(disposition) << ", " << std::hex << static_cast<int>(flags) << "]");
-        int resultingFlags = static_cast<int>(disposition) | static_cast<int>(flags);
+        // Always for connection serialization until we determine that there are situations where it is not needed
+        int resultingFlags = static_cast<int>(disposition) | static_cast<int>(flags) | SQLITE_OPEN_FULLMUTEX;
         THROW_IF_SQLITE_FAILED(sqlite3_open_v2(target.c_str(), &m_dbconn, resultingFlags, nullptr));
     }
 


### PR DESCRIPTION
## Change
Despite likely being the default, there is no documentation to prove that winsqlite3.dll was compiled this way.  So always pass the flag to force full serialization of calls to the connection.

## Validation
Existing tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1099)