### PR TITLE
Fall back to WinINet if DO download fails

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -537,7 +537,7 @@ namespace AppInstaller::Logging
             AICLI_TraceLoggingWriteActivity(
                 "NonFatalDOError",
                 TraceLoggingUInt32(s_subExecutionId, "SubExecutionId"),
-                AICLI_TraceLoggingStringView(url, "URL"),
+                AICLI_TraceLoggingStringView(url, "Url"),
                 TraceLoggingHResult(hr, "HResult"),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -530,6 +530,19 @@ namespace AppInstaller::Logging
         }
     }
 
+    void TelemetryTraceLogger::LogNonFatalDOError(std::string_view url, HRESULT hr) const noexcept
+    {
+        if (IsTelemetryEnabled())
+        {
+            AICLI_TraceLoggingWriteActivity(
+                "NonFatalDOError",
+                TraceLoggingUInt32(s_subExecutionId, "SubExecutionId"),
+                AICLI_TraceLoggingStringView(url, "URL"),
+                TraceLoggingHResult(hr, "HResult"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+        }
+    }
+
     bool TelemetryTraceLogger::IsTelemetryEnabled() const noexcept
     {
         return g_IsTelemetryProviderEnabled && m_isSettingEnabled && m_isRuntimeEnabled;

--- a/src/AppInstallerCommonCore/DODownloader.cpp
+++ b/src/AppInstallerCommonCore/DODownloader.cpp
@@ -14,7 +14,13 @@ namespace AppInstaller::Utility
 {
     namespace DeliveryOptimization
     {
-#define DO_E_DOWNLOAD_NO_PROGRESS HRESULT(0x80D02002L) // Download of a file saw no progress within the defined period
+// TODO: Once the SDK headers are available, remove these defines
+#define DO_E_DOWNLOAD_NO_PROGRESS               HRESULT(0x80D02002L)    // Download of a file saw no progress within the defined period
+
+#define DO_E_BLOCKED_BY_COST_TRANSFER_POLICY    HRESULT(0x80D03801L)    // DO core paused the job due to cost policy restrictions
+#define DO_E_BLOCKED_BY_CELLULAR_POLICY         HRESULT(0x80D03803L)    // DO core paused the job due to detection of cellular network and policy restrictions
+#define DO_E_BLOCKED_BY_POWER_STATE             HRESULT(0x80D03804L)    // DO core paused the job due to detection of power state change into non-AC mode
+#define DO_E_BLOCKED_BY_NO_NETWORK              HRESULT(0x80D03805L)    // DO core paused the job due to loss of network connectivity
 
         // Represents a download work item for Delivery Optimization.
         struct Download
@@ -403,5 +409,16 @@ namespace AppInstaller::Utility
         }
 
         return {};
+    }
+
+    bool IsDOErrorFatal(HRESULT error)
+    {
+        // If this gets to be large, store in a sorted array and binary search on it.
+        // There will be more to update here, which we should be able to discover through telemetry.
+        return
+            error == DO_E_BLOCKED_BY_COST_TRANSFER_POLICY ||
+            error == DO_E_BLOCKED_BY_CELLULAR_POLICY ||
+            error == DO_E_BLOCKED_BY_POWER_STATE ||
+            error == DO_E_BLOCKED_BY_NO_NETWORK;
     }
 }

--- a/src/AppInstallerCommonCore/DODownloader.h
+++ b/src/AppInstallerCommonCore/DODownloader.h
@@ -21,4 +21,8 @@ namespace AppInstaller::Utility
         IProgressCallback& progress,
         bool computeHash,
         std::optional<DownloadInfo> info);
+
+    // Returns true if the error from DODownload should be treated as fatal;
+    // false if we should be able to fall back to other download methods.
+    bool IsDOErrorFatal(HRESULT error);
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -114,6 +114,8 @@ namespace AppInstaller::Logging
             std::string_view arpPublisher,
             std::string_view arpLanguage) const noexcept;
 
+        void LogNonFatalDOError(std::string_view url, HRESULT hr) const noexcept;
+
     protected:
         TelemetryTraceLogger();
 


### PR DESCRIPTION
Resolves #1060 and resolves #1076 (well, mitigates really but that isn't a verb that GitHub responds to).

## Change
There have been several issues caused by DO being disabled by policy, or failing to redirect properly.  Due to this, and to prevent other issues from impacting users, we will fall back to the WinINet download code path when DO fails.

Some error codes are intentionally excluded from falling back, largely those pertaining to metered networks.  We will add more cases as we find them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1138)