### PR TITLE
Added "doProgressTimeoutInSeconds" Setting

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -105,12 +105,12 @@ The `downloader` setting controls which code is used when downloading packages. 
 `wininet` uses the [WinINet](https://docs.microsoft.com/en-us/windows/win32/wininet/about-wininet) APIs, while `do` uses the
 [Delivery Optimization](https://support.microsoft.com/en-us/windows/delivery-optimization-in-windows-10-0656e53c-15f2-90de-a87a-a2172c94cf6d) service.
 
-The `doProgressTimeoutInSeconds` setting updates the number of seconds to wait without progress before fallback. The default number of seconds is 20, minimum is 1 and the maximum is 600. 
+The `doProgressTimeoutInSeconds` setting updates the number of seconds to wait without progress before fallback. The default number of seconds is 60, minimum is 1 and the maximum is 600. 
 
 ```json
    "network": {
        "downloader": "do",
-       "doProgressTimeoutInSeconds": 20
+       "doProgressTimeoutInSeconds": 60
    }
 ```
 

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -105,9 +105,12 @@ The `downloader` setting controls which code is used when downloading packages. 
 `wininet` uses the [WinINet](https://docs.microsoft.com/en-us/windows/win32/wininet/about-wininet) APIs, while `do` uses the
 [Delivery Optimization](https://support.microsoft.com/en-us/windows/delivery-optimization-in-windows-10-0656e53c-15f2-90de-a87a-a2172c94cf6d) service.
 
+The `doProgressTimeoutInSeconds` setting updates the number of seconds to wait without progress before fallback. The default number of seconds is 20, minimum is 1 and the maximum is 600. 
+
 ```json
    "network": {
-       "downloader": "do"
+       "downloader": "do",
+       "doProgressTimeoutInSeconds": 20
    }
 ```
 

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -94,7 +94,7 @@
         "doProgressTimeoutInSeconds": {
           "description": "Number of seconds to wait without progress before fallback",
           "type": "integer",
-          "default": 20,
+          "default": 60,
           "minimum": 1,
           "maximum": 600
         }


### PR DESCRIPTION
Added the "doProgressTimeoutInSeconds'' setting which is used to setup minimum, maximum timeout period for the progress bar.

- [x ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1174)