### PR TITLE
Sort the output of "winget search" and other commands by name

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -88,7 +88,7 @@ namespace AppInstaller::CLI::Workflow
     {
         auto versions = context.Get<Execution::Data::Package>()->GetAvailableVersionKeys();
 
-        Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
+        Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel }, 0, 0);
         for (const auto& version : versions)
         {
             table.OutputLine({ version.Version, version.Channel });

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -336,7 +336,7 @@ namespace AppInstaller::CLI::Workflow
                 Resource::String::SearchVersion,
                 Resource::String::SearchMatch,
                 Resource::String::SearchSource
-            });
+            }, 0, 0);
 
         for (size_t i = 0; i < searchResult.Matches.size(); ++i)
         {
@@ -367,7 +367,7 @@ namespace AppInstaller::CLI::Workflow
             {
                 Resource::String::SearchName,
                 Resource::String::SearchId
-            });
+            }, 0, 0);
 
         for (size_t i = 0; i < searchResult.Matches.size(); ++i)
         {
@@ -396,7 +396,7 @@ namespace AppInstaller::CLI::Workflow
                 Resource::String::SearchName,
                 Resource::String::SearchId,
                 Resource::String::SearchSource
-            });
+            }, 0, 0);
 
         for (size_t i = 0; i < searchResult.Matches.size(); ++i)
         {
@@ -439,7 +439,7 @@ namespace AppInstaller::CLI::Workflow
                 Resource::String::SearchVersion,
                 Resource::String::AvailableHeader,
                 Resource::String::SearchSource
-            });
+            }, 0, 0);
 
         for (const auto& match : searchResult.Matches)
         {

--- a/src/AppInstallerCommonCore/AppInstallerStrings.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerStrings.cpp
@@ -113,6 +113,11 @@ namespace AppInstaller::Utility
         return a.length() >= b.length() && ICUCaseInsensitiveEquals(a.substr(0, b.length()), b);
     }
 
+    int ICUCaseInsensitiveCompare(std::string_view a, std::string_view b)
+    {
+        return FoldCase(a).compare(FoldCase(b));
+    }
+
     std::string ConvertToUTF8(std::wstring_view input)
     {
         if (input.empty())

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -86,6 +86,10 @@ namespace AppInstaller::Utility
     // Determines if string a starts with string b, using ICU for case folding.
     bool ICUCaseInsensitiveStartsWith(std::string_view a, std::string_view b);
 
+    // Compares the two UTF8 strings in a case insensitive manner and returns their lexicographical order
+    // (a negative value if a is less than b, a positive value if a is greater than b, zero if a equals b).
+    int ICUCaseInsensitiveCompare(std::string_view a, std::string_view b);
+
     // Returns the number of grapheme clusters (characters) in an UTF8-encoded string.
     size_t UTF8Length(std::string_view input);
 


### PR DESCRIPTION
This implements #142 by extending `TableOutput` to optionally do a case-insensitive sort on one of the columns. I enabled sorting not only for the results of `winget search` as suggested in the issue but also for a few other outputs where I deemed it appropriate.

Since `TableOutput` needs to fully buffer all table rows in memory before it can sort and output the table, the `sizingBuffer` argument of the constructor has no effect when `sortColumn` is set, so at the moment I am just passing zero there.

In case sorting performance turns out to be an issue for large tables (for some reason, I was not able to build in Release mode so could not measure the performance difference), we could implement `Utility::ICUCaseInsensitiveCompare` more intelligently as it is called twice in the sort predicate. I left it simple for now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1205)