### PR TITLE
Remove the packagedAPI experimental feature flag

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -137,13 +137,15 @@ Microsoft Store App support in WinGet is currently implemented as an experimenta
    },
 ```
 
-### packagedAPI
+### directMSI
 
-Support in WinGet for packaged callers is currently implemented as an experimental feature. It allows other programs on Windows to use the Windows Package Manager. You can enable the feature as shown below.
+This feature enables the Windows Package Manager to directly install MSI packages with the MSI APIs rather than through msiexec. 
+Note that when silent installation is used this is already in affect, as MSI packages that require elevation will fail in that scenario without it. 
+You can enable the feature as shown below.
 
 ```json
    "experimentalFeatures": {
-       "packagedAPI": true
+       "directMSI": true
    },
 ```
 ### Dependencies

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -119,23 +119,8 @@
           "type": "boolean",
           "default": false
         },
-        "list": {
-          "description": "Enable the list command while it is in development",
-          "type": "boolean",
-          "default": false
-        },
-        "upgrade": {
-          "description": "Enable the upgrade command while it is in development",
-          "type": "boolean",
-          "default": false
-        },
-        "uninstall": {
-          "description": "Enable the uninstall command while it is in development",
-          "type": "boolean",
-          "default": false
-        },
-        "restSource": {
-          "description": "Enable the rest source support while it is in development",
+        "directMSI": {
+          "description": "Enable use of MSI APIs rather than msiexec for MSI installs",
           "type": "boolean",
           "default": false
         }

--- a/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
+++ b/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
@@ -38,7 +38,6 @@ namespace AppInstallerCLIE2ETests
             ConfigureFeature("experimentalArg", true);
             ConfigureFeature("experimentalCmd", true);
             ConfigureFeature("experimentalMSStore", true);
-            ConfigureFeature("packagedAPI", true);
             var result = TestCommon.RunAICLICommand("features", "");
             Assert.True(result.StdOut.Contains("Enabled"));
         }

--- a/src/AppInstallerCommonCore/ExperimentalFeature.cpp
+++ b/src/AppInstallerCommonCore/ExperimentalFeature.cpp
@@ -43,8 +43,6 @@ namespace AppInstaller::Settings
                 return userSettings.Get<Setting::EFExperimentalArg>();
             case ExperimentalFeature::Feature::ExperimentalMSStore:
                 return userSettings.Get<Setting::EFExperimentalMSStore>();
-            case ExperimentalFeature::Feature::PackagedAPI:
-                return userSettings.Get<Setting::EFPackagedAPI>();
             case ExperimentalFeature::Feature::Dependencies:
                 return userSettings.Get<Setting::EFDependencies>();
             case ExperimentalFeature::Feature::DirectMSI:
@@ -77,8 +75,6 @@ namespace AppInstaller::Settings
             return ExperimentalFeature{ "Argument Sample", "experimentalArg", "https://aka.ms/winget-settings", Feature::ExperimentalArg };
         case Feature::ExperimentalMSStore:
             return ExperimentalFeature{ "Microsoft Store Support", "experimentalMSStore", "https://aka.ms/winget-settings", Feature::ExperimentalMSStore };
-        case Feature::PackagedAPI:
-            return ExperimentalFeature{ "Packaged API Support", "packagedAPI", "https://aka.ms/winget-settings", Feature::PackagedAPI };
         case Feature::Dependencies:
             return ExperimentalFeature{ "Show Dependencies Information", "dependencies", "https://aka.ms/winget-settings", Feature::Dependencies };
         case Feature::DirectMSI:

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -21,9 +21,9 @@ namespace AppInstaller::Settings
         {
             None = 0x0,
             ExperimentalMSStore = 0x1,
-            Dependencies = 0x4,
+            Dependencies = 0x2,
             // Before making DirectMSI non-experimental, it should be part of manifest validation.
-            DirectMSI = 0x8,
+            DirectMSI = 0x4,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -21,7 +21,6 @@ namespace AppInstaller::Settings
         {
             None = 0x0,
             ExperimentalMSStore = 0x1,
-            PackagedAPI = 0x2,
             Dependencies = 0x4,
             // Before making DirectMSI non-experimental, it should be part of manifest validation.
             DirectMSI = 0x8,

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -76,7 +76,6 @@ namespace AppInstaller::Settings
         NetworkDOProgressTimeoutInSeconds,
         InstallLocalePreference,
         InstallLocaleRequirement,
-        EFPackagedAPI,
         EFDirectMSI,
         Max
     };
@@ -124,7 +123,6 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDOProgressTimeoutInSeconds, uint32_t, std::chrono::seconds, 60s, ".network.doProgressTimeoutInSeconds"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocalePreference, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.preferences.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::EFPackagedAPI, bool, bool, false, ".experimentalFeatures.packagedAPI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
 
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -227,7 +227,6 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFExperimentalMSStore)
         WINGET_VALIDATE_PASS_THROUGH(EFDependencies)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
-        WINGET_VALIDATE_PASS_THROUGH(EFPackagedAPI)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
 
         WINGET_VALIDATE_SIGNATURE(InstallScopePreference)

--- a/src/WinGetServer/WinMain.cpp
+++ b/src/WinGetServer/WinMain.cpp
@@ -30,13 +30,6 @@ static void _releaseNotifier() noexcept
 // Check whether the packaged api is enabled and the overarching winget group policy is enabled.
 bool IsServerEnabled()
 {
-    ::AppInstaller::Utility::Version version("10.0.22000.0");
-
-    if (!::AppInstaller::Runtime::IsCurrentOSVersionGreaterThanOrEqual(version) &&
-        !::AppInstaller::Settings::ExperimentalFeature::IsEnabled(::AppInstaller::Settings::ExperimentalFeature::Feature::PackagedAPI))
-    {
-        return false;
-    }
     if (!::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet))
     {
         return false;


### PR DESCRIPTION
## Change
Remove the experimental feature flag for the COM API.  In the future we will likely add new flags for each update to the API surface to place the new functionality behind.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1419)