### PR TITLE
Support for x64 on ARM64

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -130,6 +130,7 @@ hhx
 HINSTANCE
 hkey
 hlocal
+hmodule
 hre
 hresults
 htm
@@ -246,6 +247,7 @@ pkindex
 PMS
 positionals
 powertoys
+processthreads
 productcode
 pseudocode
 pvk

--- a/src/AppInstallerCommonCore/Architecture.cpp
+++ b/src/AppInstallerCommonCore/Architecture.cpp
@@ -84,11 +84,11 @@ namespace AppInstaller::Utility
             {
             case Architecture::Arm64:
             {
-                GetMachineTypeAttributesHelper gmtaHelper;
+                GetMachineTypeAttributesHelper helper;
 
                 applicableArchs.push_back(Architecture::Arm64);
                 AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::Arm, IMAGE_FILE_MACHINE_ARMNT);
-                gmtaHelper.AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::X64, IMAGE_FILE_MACHINE_AMD64);
+                helper.AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::X64, IMAGE_FILE_MACHINE_AMD64);
                 AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::X86, IMAGE_FILE_MACHINE_I386);
                 applicableArchs.push_back(Architecture::Neutral);
             }

--- a/src/AppInstallerCommonCore/Architecture.cpp
+++ b/src/AppInstallerCommonCore/Architecture.cpp
@@ -32,40 +32,48 @@ namespace AppInstaller::Utility
 
         DEFINE_ENUM_FLAG_OPERATORS(MACHINE_ATTRIBUTES);
 
-        using GetMachineTypeAttributesPtr = HRESULT (WINAPI *)(USHORT Machine, MACHINE_ATTRIBUTES* MachineTypeAttributes);
+        using GetMachineTypeAttributesPtr = HRESULT(WINAPI*)(USHORT Machine, MACHINE_ATTRIBUTES* MachineTypeAttributes);
 
-        void AddArchitectureIfMachineTypeAttributesUserEnabled(std::vector<Architecture>& target, Architecture architecture, USHORT guestMachine)
+        // GetMachineTypeAttributes can apparently replace IsWow64GuestMachineSupported, but no reason to do so right now.
+        struct GetMachineTypeAttributesHelper
         {
-            wil::unique_hmodule onecoreModule;
-            onecoreModule.reset(LoadLibraryEx(L"api-ms-win-core-processthreads-l1-1-7.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32));
-            if (!onecoreModule)
+            GetMachineTypeAttributesHelper()
             {
-                AICLI_LOG(Core, Verbose, << "Could not load api-ms-win-core-processthreads-l1-1-7.dll");
-                return;
-            }
-
-            GetMachineTypeAttributesPtr getMachineTypeAttributes =
-                reinterpret_cast<GetMachineTypeAttributesPtr>(GetProcAddress(onecoreModule.get(), "GetMachineTypeAttributes"));
-            if (!getMachineTypeAttributes)
-            {
-                AICLI_LOG(Core, Verbose, << "Could not get proc address of GetMachineTypeAttributes");
-                return;
-            }
-
-            MACHINE_ATTRIBUTES attributes = MACHINE_ATTRIBUTES::None;
-            if (SUCCEEDED_LOG(getMachineTypeAttributes(guestMachine, &attributes)))
-            {
-                if (WI_IsFlagSet(attributes, MACHINE_ATTRIBUTES::UserEnabled))
+                m_module.reset(LoadLibraryEx(L"api-ms-win-core-processthreads-l1-1-7.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32));
+                if (!m_module)
                 {
-                    AICLI_LOG(Test, Info, << "UserEnabled for guest machine: " << guestMachine);
-                    target.push_back(architecture);
+                    AICLI_LOG(Core, Verbose, << "Could not load api-ms-win-core-processthreads-l1-1-7.dll");
+                    return;
                 }
-                else
+
+                m_getMachineTypeAttributes =
+                    reinterpret_cast<GetMachineTypeAttributesPtr>(GetProcAddress(m_module.get(), "GetMachineTypeAttributes"));
+                if (!m_getMachineTypeAttributes)
                 {
-                    AICLI_LOG(Test, Info, << "UserNOTEnabled for guest machine: " << guestMachine);
+                    AICLI_LOG(Core, Verbose, << "Could not get proc address of GetMachineTypeAttributes");
+                    return;
                 }
             }
-        }
+
+            void AddArchitectureIfMachineTypeAttributesUserEnabled(std::vector<Architecture>& target, Architecture architecture, USHORT guestMachine)
+            {
+                if (m_getMachineTypeAttributes)
+                {
+                    MACHINE_ATTRIBUTES attributes = MACHINE_ATTRIBUTES::None;
+                    if (SUCCEEDED_LOG(m_getMachineTypeAttributes(guestMachine, &attributes)))
+                    {
+                        if (WI_IsFlagSet(attributes, MACHINE_ATTRIBUTES::UserEnabled))
+                        {
+                            target.push_back(architecture);
+                        }
+                    }
+                }
+            }
+
+        private:
+            wil::unique_hmodule m_module;
+            GetMachineTypeAttributesPtr m_getMachineTypeAttributes = nullptr;
+        };
 
         // Gets the applicable architectures for the current machine.
         std::vector<Architecture> CreateApplicableArchitecturesVector()
@@ -75,11 +83,15 @@ namespace AppInstaller::Utility
             switch (GetSystemArchitecture())
             {
             case Architecture::Arm64:
+            {
+                GetMachineTypeAttributesHelper gmtaHelper;
+
                 applicableArchs.push_back(Architecture::Arm64);
                 AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::Arm, IMAGE_FILE_MACHINE_ARMNT);
-                AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::X64, IMAGE_FILE_MACHINE_AMD64);
+                gmtaHelper.AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::X64, IMAGE_FILE_MACHINE_AMD64);
                 AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::X86, IMAGE_FILE_MACHINE_I386);
                 applicableArchs.push_back(Architecture::Neutral);
+            }
                 break;
             case Architecture::Arm:
                 applicableArchs.push_back(Architecture::Arm);
@@ -91,9 +103,7 @@ namespace AppInstaller::Utility
                 break;
             case Architecture::X64:
                 applicableArchs.push_back(Architecture::X64);
-                AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::X86, IMAGE_FILE_MACHINE_I386);
-                AddArchitectureIfMachineTypeAttributesUserEnabled(applicableArchs, Architecture::Arm, IMAGE_FILE_MACHINE_ARMNT);
-                //AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::X86, IMAGE_FILE_MACHINE_I386);
+                AddArchitectureIfGuestMachineSupported(applicableArchs, Architecture::X86, IMAGE_FILE_MACHINE_I386);
                 applicableArchs.push_back(Architecture::Neutral);
                 break;
             default:


### PR DESCRIPTION
## Issue
Support for x64 emulation on ARM64 was [added to Windows 10 Dev builds last year](https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/).  In order for us to detect the presence of that support, a new API was needed.

## Change
This change fixes #666 by implementing dynamic loading of the API and invoking it specifically for x64 when the machine is ARM64.  The API can replace our current use of `IsWow64GuestMachineSupported`, but there is no need to take the additional risk of that change at this time.

## Validation
As we do not have any automated test bed for ARM64, I was only able to test it manually on a local device.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1441)