### PR TITLE
Fix crash when resource.pri is not present

### DIFF
--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -868,9 +868,21 @@ namespace AppInstaller::CLI
         {
             std::string message = GetUserPresentableMessage(hre);
             Logging::Telemetry().LogException(command->FullName(), "winrt::hresult_error", message);
-            context.Reporter.Error() <<
-                Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
-                message << std::endl;
+            try
+            {
+                context.Reporter.Error() <<
+                    Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
+                    message << std::endl;
+            }
+            // If resource.pri is not present trying to log using Resource will throw the exception
+            // again. Default to English message.
+            catch (const winrt::hresult_error&)
+            {
+                context.Reporter.Error() <<
+                    "An unexpected error occurred while executing the command:"  << ' ' << std::endl <<
+                    message << std::endl;
+            }
+            
             return hre.code();
         }
         catch (const Settings::GroupPolicyException& e)

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -125,7 +125,16 @@ namespace AppInstaller::CLI
             return APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY;
         }
 
-        return Execute(context, command);
+        try
+        {
+            return Execute(context, command);
+        }
+        catch (hresult_error const& e)
+        {
+            AICLI_LOG(CLI, Error, << "Error " << e.to_abi() << " with message '" << e.message().c_str() <<
+                "' encountered while executing command");
+            return e.to_abi();
+        }
     }
     // End of the line exceptions that are not ever expected.
     // Telemetry cannot be reliable beyond this point, so don't let these happen.

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -125,16 +125,7 @@ namespace AppInstaller::CLI
             return APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY;
         }
 
-        try
-        {
-            return Execute(context, command);
-        }
-        catch (hresult_error const& e)
-        {
-            AICLI_LOG(CLI, Error, << "Error " << e.to_abi() << " with message '" << e.message().c_str() <<
-                "' encountered while executing command");
-            return e.to_abi();
-        }
+        return Execute(context, command);
     }
     // End of the line exceptions that are not ever expected.
     // Telemetry cannot be reliable beyond this point, so don't let these happen.

--- a/src/AppInstallerCLICore/Resources.cpp
+++ b/src/AppInstallerCLICore/Resources.cpp
@@ -4,7 +4,6 @@
 #include "Resources.h"
 
 using namespace AppInstaller::Utility::literals;
-using namespace winrt;
 
 namespace AppInstaller::CLI::Resource
 {
@@ -22,9 +21,10 @@ namespace AppInstaller::CLI::Resource
         {
             m_wingetLoader = winrt::Windows::ApplicationModel::Resources::ResourceLoader::GetForViewIndependentUse(L"winget");
         }
-        catch (hresult_error const& e)
+        catch (const winrt::hresult_error& hre)
         {
-            AICLI_LOG(CLI, Error, << "Failure loading resource file with error: " << e.to_abi());
+            // This message cannot be localized.
+            AICLI_LOG(CLI, Error, << "Failure loading resource file with error: " << hre.code());
             throw;
         }
     }

--- a/src/AppInstallerCLICore/Resources.cpp
+++ b/src/AppInstallerCLICore/Resources.cpp
@@ -4,7 +4,7 @@
 #include "Resources.h"
 
 using namespace AppInstaller::Utility::literals;
-
+using namespace winrt;
 
 namespace AppInstaller::CLI::Resource
 {
@@ -18,7 +18,15 @@ namespace AppInstaller::CLI::Resource
 
     Loader::Loader()
     {
-        m_wingetLoader = winrt::Windows::ApplicationModel::Resources::ResourceLoader::GetForViewIndependentUse(L"winget");
+        try
+        {
+            m_wingetLoader = winrt::Windows::ApplicationModel::Resources::ResourceLoader::GetForViewIndependentUse(L"winget");
+        }
+        catch (hresult_error const& e)
+        {
+            AICLI_LOG(CLI, Error, << "Failure loading resource file with error: " << e.to_abi());
+            throw;
+        }
     }
 
     std::string Loader::ResolveString(


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Resolves #409 

When resource.pri is not present a winrt::hresult_error is thrown by the loader. We then catch the exception and try to log using a localized string which makes the exception be thrown again.

This changes adds a try catch in winrt::hresult_error catch. The new catch will default to the english message for UnexpectedErrorExecutingCommand. Also add logging when the loader fails.