### PR TITLE
Show source identifier with `source list`

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -242,6 +242,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListData);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListField);
+        WINGET_DEFINE_RESOURCE_STRINGID(SourceListIdentifier);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListName);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListNoneFound);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceListNoSources);

--- a/src/AppInstallerCLICore/Workflows/SourceFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SourceFlow.cpp
@@ -139,6 +139,7 @@ namespace AppInstaller::CLI::Workflow
             table.OutputLine({ Resource::Loader::Instance().ResolveString(Resource::String::SourceListType), source.Type });
             table.OutputLine({ Resource::Loader::Instance().ResolveString(Resource::String::SourceListArg), source.Arg });
             table.OutputLine({ Resource::Loader::Instance().ResolveString(Resource::String::SourceListData), source.Data });
+            table.OutputLine({ Resource::Loader::Instance().ResolveString(Resource::String::SourceListIdentifier), source.Identifier });
 
             if (source.LastUpdateTime == Utility::ConvertUnixEpochToSystemClock(0))
             {

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -544,6 +544,10 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Name</value>
     <comment>The name of the source.</comment>
   </data>
+  <data name="SourceListIdentifier" xml:space="preserve">
+    <value>Identifier</value>
+    <comment>The source's unique identifier.</comment>
+  </data>
   <data name="SourceListNoneFound" xml:space="preserve">
     <value>Did not find a source named:</value>
   </data>

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -39,6 +39,9 @@ namespace AppInstaller::Repository::Rest
                 THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_NOT_REMOTE, !Utility::IsUrlRemote(details.Arg));
                 THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_NOT_SECURE, !Utility::IsUrlSecure(details.Arg));
 
+                RestClient restClient = RestClient::Create(details.Arg, details.CustomHeader);
+                details.Identifier = restClient.GetSourceIdentifier();
+
                 return true;
             }
 


### PR DESCRIPTION
* Show source identifier when doing `source list <name>`. This can be useful for creating json files for import.
* Get the source identifier when adding a REST source to ensure it is added to the sources yaml. We were getting it only when opening the source so it wouldn't get saved and could not show it with source list. Existing sources are not updated.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1455)