### PR TITLE
Remove cancel optimization for packageQuery caller

### DIFF
--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -427,7 +427,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             }
 
             wil::unique_event progressEvent{ wil::EventOptions::None };
-            wil::unique_event cancelWaitEvent{ wil::EventOptions::None };
 
             std::atomic<winrt::Microsoft::Management::Deployment::InstallProgress> installProgress;
             queueItem->GetContext().AddProgressCallbackFunction([&installProgress, &progressEvent](
@@ -448,7 +447,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             );
 
             std::weak_ptr<Execution::OrchestratorQueueItem> weakQueueItem(queueItem);
-            cancellationToken.callback([weakQueueItem, &canCancelQueueItem, &cancelWaitEvent]
+            cancellationToken.callback([weakQueueItem, &canCancelQueueItem]
                 {
                     if (canCancelQueueItem)
                     {
@@ -458,21 +457,15 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                             Execution::ContextOrchestrator::Instance().CancelQueueItem(*strongQueueItem);
                         }
                     }
-                    else
-                    {
-                        cancelWaitEvent.SetEvent();
-                    }
                 });
 
             // Wait for completion or progress events.
             // Waiting for both on the same thread ensures that progress is never reported after the async operation itself has completed.
             bool completionEventFired = false;
-            bool cancelWaitEventFired = false;
-            HANDLE operationEvents[3];
+            HANDLE operationEvents[2];
             operationEvents[0] = progressEvent.get();
             operationEvents[1] = queueItem->GetCompletedEvent().get();
-            operationEvents[2] = cancelWaitEvent.get();
-            while (!completionEventFired && !cancelWaitEventFired)
+            while (!completionEventFired)
             {
                 DWORD dwEvent = WaitForMultipleObjects(
                     _countof(operationEvents) /* number of events */,
@@ -495,11 +488,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                     // operationEvents[1] was signaled, operation completed
                 case WAIT_OBJECT_0 + 1:
                     completionEventFired = true;
-                    break;
-
-                    // operationEvents[2] was signaled, operation is cancelled
-                case WAIT_OBJECT_0 + 2:
-                    cancelWaitEventFired = true;
                     break;
 
                     // Return value is invalid.


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

There is currently no way to remove the callbacks from the context which means the callbacks can continue to be fired after the cancel has caused the coroutine to return if the coroutine does not wait for the context to finish. This triggers a crash. In the packageManagement case, it always waits for the context to finish, but in the packageQuery case it tried to optimize that away. It would be best to eventually figure out how to bring the quicker cancel back, so I'll file a bug, but for now removing that optimization so that it no longer fails is the first priority. Cancel in the packageQuery case will now also wait until the context is finished. The operation will be marked as status == Cancelled, even though it may have still run to completion (either successfully or with an install\download failure). This is built in behavior for async operations that can't be changed, and already happens for packageManagement callers calling Cancel during the Install phase (which cannot be cancelled).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1472)