### PR TITLE
Ensure available packages match with a single installed package

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -641,17 +641,14 @@ namespace AppInstaller::CLI::Workflow
         }
 
         // Report dependencies
-        DependencyList allDependencies;
-        for (auto package : context.Get<Execution::Data::PackagesToInstall>())
+        if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::Dependencies))
         {
-            if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::Dependencies))
+            DependencyList allDependencies;
+            for (auto package : context.Get<Execution::Data::PackagesToInstall>())
             {
                 allDependencies.Add(package.Installer.Dependencies);
             }
-        }
 
-        if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::Dependencies))
-        {
             context.Add<Execution::Data::Dependencies>(allDependencies);
             context << Workflow::ReportDependencies(m_dependenciesReportMessage);
         }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -194,7 +194,7 @@ namespace AppInstaller::CLI::Workflow
     // Ensures that there is only one result in the search.
     // Required Args: bool indicating if the search result is from installed source
     // Inputs: SearchResult
-    // Outputs: None
+    // Outputs: Package
     struct EnsureOneMatchFromSearchResult : public WorkflowTask
     {
         EnsureOneMatchFromSearchResult(bool isFromInstalledSource) :

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -568,27 +568,23 @@ namespace AppInstaller::Repository
                         for (auto&& crossRef : installedCrossRef.Matches)
                         {
                             AICLI_LOG(Repo, Info, << "  Checking match with package id: " << crossRef.Package->GetProperty(PackageProperty::Id));
-
-                            if (!result.ContainsInstalledPackage(crossRef.Package.get()))
+                            if (IsStrongMatchField(crossRef.MatchCriteria.Field))
                             {
-                                if (IsStrongMatchField(crossRef.MatchCriteria.Field))
+                                if (!installedPackage)
                                 {
-                                    if (!installedPackage)
-                                    {
-                                        installedPackage = std::move(crossRef.Package);
-                                    }
-                                    else
-                                    {
-                                        AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
-                                        installedPackage.reset();
-                                        break;
-                                    }
+                                    installedPackage = std::move(crossRef.Package);
+                                }
+                                else
+                                {
+                                    AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
+                                    installedPackage.reset();
+                                    break;
                                 }
                             }
                         }
                     }
 
-                    if (installedPackage)
+                    if (installedPackage && !result.ContainsInstalledPackage(installedPackage.get()))
                     {
                         foundInstalledMatch = true;
                         result.Matches.emplace_back(std::make_shared<CompositePackage>(std::move(installedPackage), std::move(match.Package)), match.MatchCriteria);

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -569,17 +569,20 @@ namespace AppInstaller::Repository
                         {
                             AICLI_LOG(Repo, Info, << "  Checking match with package id: " << crossRef.Package->GetProperty(PackageProperty::Id));
 
-                            if (IsStrongMatchField(crossRef.MatchCriteria.Field))
+                            if (!result.ContainsInstalledPackage(crossRef.Package.get()))
                             {
-                                if (!installedPackage)
+                                if (IsStrongMatchField(crossRef.MatchCriteria.Field))
                                 {
-                                    installedPackage = std::move(crossRef.Package);
-                                }
-                                else
-                                {
-                                    AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
-                                    installedPackage.reset();
-                                    break;
+                                    if (!installedPackage)
+                                    {
+                                        installedPackage = std::move(crossRef.Package);
+                                    }
+                                    else
+                                    {
+                                        AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
+                                        installedPackage.reset();
+                                        break;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
When searching for installed packages matching an available package, if there were multiple matches we would create multiple results for the search. This caused commands that require a single match, like import or upgrade, to fail. Modified to select a single installed package as match if it has a strong match (product code or package family name).

This partially fixes #983 in that import and upgrade now won't fail for packages like Teams, but does not address the underlying issue of how we should deal with packages that have multiple ARP entries.

---

Also, modified dependencies code to check the experimental feature only once.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1473)