### PR TITLE
Make list show correlated source even when no upgrade is available

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -552,11 +552,16 @@ namespace AppInstaller::CLI::Workflow
                 {
                     Utility::LocIndString availableVersion, sourceName;
 
-                    if (updateAvailable)
+                    if (latestVersion)
                     {
-                        availableVersion = latestVersion->GetProperty(PackageVersionProperty::Version);
+                        if (updateAvailable)
+                        {
+                            availableVersion = latestVersion->GetProperty(PackageVersionProperty::Version);
+                            availableUpgradesCount++;
+                        }
+
+                        // Always show the source for correlated packages
                         sourceName = latestVersion->GetProperty(PackageVersionProperty::SourceName);
-                        availableUpgradesCount++;
                     }
 
                     table.OutputLine({
@@ -575,14 +580,20 @@ namespace AppInstaller::CLI::Workflow
         if (table.IsEmpty())
         {
             context.Reporter.Info() << Resource::String::NoInstalledPackageFound << std::endl;
-        } else if (m_onlyShowUpgrades) {
-            context.Reporter.Info() << availableUpgradesCount << ' ' << Resource::String::AvailableUpgrades << std::endl;
+        }
+        else
+        {
+            if (searchResult.Truncated)
+            {
+                context.Reporter.Info() << '<' << Resource::String::SearchTruncated << '>' << std::endl;
+            }
+
+            if (m_onlyShowUpgrades)
+            {
+                context.Reporter.Info() << availableUpgradesCount << ' ' << Resource::String::AvailableUpgrades << std::endl;
+            }
         }
 
-        if (searchResult.Truncated)
-        {
-            context.Reporter.Info() << '<' << Resource::String::SearchTruncated << '>' << std::endl;
-        }
     }
 
     void EnsureMatchesFromSearchResult::operator()(Execution::Context& context) const


### PR DESCRIPTION
## Change
This makes `list` show the correlated source of the latest available package even when no upgrade is available.  This makes it easier to see when packages are correlating properly via list, rather than needing to be an expert and/or inspect the local system to see how the output compares.

Before:
```
> winget list
Name                                     Id                                       Version             Available Source
-----------------------------------------------------------------------------------------------------------------------
reSearch                                 84f93aee594a430d                         2.2106.10.0
AppInstallerCaller                       8b5526fe-0870-42b7-bde0-da8c4c7ea1aa_kw… 1.0.7.0
CodeFlow                                 CodeFlow_is1                             Unknown
Dolby Access OEM                         DolbyLaboratories.DolbyAccessOEM_rz1teb… 3.9.26.0
Git                                      Git.Git                                  2.31.0.0.1          2.33.0.2  winget
HxD Hex Editor 2.5                       HxD_is1                                  2.5
Microsoft Edge                           Microsoft.Edge                           93.0.961.52
Microsoft Edge Update                    Microsoft Edge Update                    1.3.151.27
Microsoft Edge WebView2 Runtime          Microsoft.EdgeWebView2Runtime            93.0.961.47
```

After:
```
> wingetdev list
Name                                     Id                                       Version             Available Source
-----------------------------------------------------------------------------------------------------------------------
reSearch                                 84f93aee594a430d                         2.2106.10.0
AppInstallerCaller                       8b5526fe-0870-42b7-bde0-da8c4c7ea1aa_kw… 1.0.7.0
CodeFlow                                 CodeFlow_is1                             Unknown
Dolby Access OEM                         DolbyLaboratories.DolbyAccessOEM_rz1teb… 3.9.26.0
Git                                      Git.Git                                  2.31.0.0.1          2.33.0.2  winget
HxD Hex Editor 2.5                       HxD_is1                                  2.5
Microsoft Edge                           Microsoft.Edge                           93.0.961.52                   winget
Microsoft Edge Update                    Microsoft Edge Update                    1.3.151.27
Microsoft Edge WebView2 Runtime          Microsoft.EdgeWebView2Runtime            93.0.961.47                   winget
```

## Validation
Manual runs of `list` and `upgrade`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1481)