### PR TITLE
Create machinery for disabling experimental features

### DIFF
--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -231,6 +231,11 @@
       <PreprocessorDefinitions>AICLI_DISABLE_TEST_HOOKS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(WingetDisableExperimentalFeatures)'=='true'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINGET_DISABLE_EXPERIMENTAL_FEATURES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Argument.h" />
     <ClInclude Include="ChannelStreams.h" />

--- a/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
@@ -27,6 +27,9 @@ namespace AppInstaller::CLI
 
     void FeaturesCommand::ExecuteInternal(Execution::Context& context) const
     {
+#ifdef WINGET_DISABLE_EXPERIMENTAL_FEATURES
+        context.Reporter.Info() << Resource::String::FeaturesMessageDisabledByBuild << std::endl;
+#else
         if (GroupPolicies().IsEnabled(TogglePolicy::Policy::ExperimentalFeatures) &&
             GroupPolicies().IsEnabled(TogglePolicy::Policy::Settings))
         {
@@ -61,5 +64,6 @@ namespace AppInstaller::CLI
             // Better work hard to get some out there!
             context.Reporter.Info() << Resource::String::NoExperimentalFeaturesMessage << std::endl;
         }
+#endif
     }
 }

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -48,7 +48,7 @@ namespace AppInstaller::CLI
 
         // Enable all logging for this phase; we will update once we have the arguments
         Logging::Log().EnableChannel(Logging::Channel::All);
-        Logging::Log().SetLevel(Logging::Level::Verbose);
+        Logging::Log().SetLevel(Logging::Level::Info);
         Logging::AddFileLogger();
         Logging::EnableWilFailureTelemetry();
 
@@ -100,9 +100,9 @@ namespace AppInstaller::CLI
             command->ParseArguments(invocation, context.Args);
 
             // Change logging level to Info if Verbose not requested
-            if (!context.Args.Contains(Execution::Args::Type::VerboseLogs))
+            if (context.Args.Contains(Execution::Args::Type::VerboseLogs))
             {
-                Logging::Log().SetLevel(Logging::Level::Info);
+                Logging::Log().SetLevel(Logging::Level::Verbose);
             }
 
             context.UpdateForArgs();

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -65,6 +65,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesFeature);
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesLink);
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesMessage);
+        WINGET_DEFINE_RESOURCE_STRINGID(FeaturesMessageDisabledByBuild);
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesMessageDisabledByPolicy);
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesProperty);
         WINGET_DEFINE_RESOURCE_STRINGID(FeaturesStatus);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1165,4 +1165,8 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>No packages were found among the working sources.</value>
   </data>
+  <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
+    <value>This is a stable release of the Windows Package Manager. If you would like to try experimental features, please install a pre-release build. Instructions are available on GitHub at https://github.com/microsoft/winget-cli.</value>
+    <comment>{Locked="Windows Package Manager","GitHub","https://github.com/microsoft/winget-cli"}</comment>
+  </data>
 </root>

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -264,6 +264,11 @@
       <PreprocessorDefinitions>AICLI_DISABLE_TEST_HOOKS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(WingetDisableExperimentalFeatures)'=='true'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINGET_DISABLE_EXPERIMENTAL_FEATURES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="DODownloader.h" />
     <ClInclude Include="Public\winget\AdminSettings.h" />

--- a/src/AppInstallerCommonCore/ExperimentalFeature.cpp
+++ b/src/AppInstallerCommonCore/ExperimentalFeature.cpp
@@ -17,6 +17,11 @@ namespace AppInstaller::Settings
                 return true;
             }
 
+#ifdef WINGET_DISABLE_EXPERIMENTAL_FEATURES
+            UNREFERENCED_PARAMETER(userSettings);
+            return false;
+#else
+
             if (!GroupPolicies().IsEnabled(TogglePolicy::Policy::ExperimentalFeatures))
             {
                 AICLI_LOG(Core, Info, <<
@@ -40,6 +45,7 @@ namespace AppInstaller::Settings
             default:
                 THROW_HR(E_UNEXPECTED);
             }
+#endif
         }
     }
 

--- a/src/AppInstallerCommonCore/GroupPolicy.cpp
+++ b/src/AppInstallerCommonCore/GroupPolicy.cpp
@@ -57,7 +57,7 @@ namespace AppInstaller::Settings
                 return std::nullopt;
             }
 
-            AICLI_LOG(Core, Info, << "Found policy '" << valueName << "', Value: " << *intValue);
+            AICLI_LOG(Core, Verbose, << "Found policy '" << valueName << "', Value: " << *intValue);
             return (bool)*intValue;
         }
 

--- a/src/AppInstallerCommonCore/Settings.cpp
+++ b/src/AppInstallerCommonCore/Settings.cpp
@@ -25,7 +25,7 @@ namespace AppInstaller::Settings
 
         void LogSettingAction(std::string_view action, const StreamDefinition& def)
         {
-            AICLI_LOG(Core, Info, << "Setting action: " << action << ", Type: " << ToString(def.Type) << ", Name: " << def.Path);
+            AICLI_LOG(Core, Verbose, << "Setting action: " << action << ", Type: " << ToString(def.Type) << ", Name: " << def.Path);
         }
 
         // A settings container.

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -121,12 +121,12 @@ namespace AppInstaller::Settings
                     // Add it to the map
                     settings[S].emplace<details::SettingIndex(S)>(
                         std::forward<typename details::SettingMapping<S>::value_t>(validatedValue.value()));
-                    AICLI_LOG(Core, Info, << "Valid setting from Group Policy. Field: " << path << " Value: " << GetValueString(policyValue.value()));
+                    AICLI_LOG(Core, Verbose, << "Valid setting from Group Policy. Field: " << path << " Value: " << GetValueString(policyValue.value()));
                 }
                 else
                 {
                     auto valueAsString = GetValueString(policyValue.value());
-                    AICLI_LOG(Core, Info, << "Invalid setting from Group Policy. Field: " << path << " Value: " << valueAsString);
+                    AICLI_LOG(Core, Error, << "Invalid setting from Group Policy. Field: " << path << " Value: " << valueAsString);
                     warnings.emplace_back(StringResource::String::SettingsWarningInvalidValueFromPolicy, path, valueAsString);
                 }
 
@@ -148,7 +148,7 @@ namespace AppInstaller::Settings
                         // Finally add it to the map
                         settings[S].emplace<details::SettingIndex(S)>(
                             std::forward<typename details::SettingMapping<S>::value_t>(validatedValue.value()));
-                        AICLI_LOG(Core, Info, << "Valid setting. Field: " << path << " Value: " << GetValueString(jsonValue.value()));
+                        AICLI_LOG(Core, Verbose, << "Valid setting. Field: " << path << " Value: " << GetValueString(jsonValue.value()));
                     }
                     else
                     {
@@ -165,7 +165,7 @@ namespace AppInstaller::Settings
             }
             else
             {
-                AICLI_LOG(Core, Info, << "Setting " << path << " not found. Using default");
+                AICLI_LOG(Core, Verbose, << "Setting " << path << " not found. Using default");
             }
         }
 


### PR DESCRIPTION
## Change
Create the ability to disable experimental features in the build.  Also causes the `features` command to inform the user.

Also made the default logs a bit less verbose around settings because I was tired of seeing that all the time.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1490)