### PR TITLE
Remove motw before calling IAttachmentExecute::Save

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -409,7 +409,7 @@ namespace AppInstaller::CLI::Workflow
             else if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerHashMatched))
             {
                 const auto& installer = context.Get<Execution::Data::Installer>();
-                HRESULT hr = Utility::ApplyMotwUsingIAttachmentExecuteIfApplicable(context.Get<Execution::Data::InstallerPath>(), installer.value().Url);
+                HRESULT hr = Utility::ApplyMotwUsingIAttachmentExecuteIfApplicable(context.Get<Execution::Data::InstallerPath>(), installer.value().Url, URLZONE_INTERNET);
 
                 // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
                 if (hr != S_OK)

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -284,7 +284,7 @@ namespace AppInstaller::Utility
         AICLI_LOG(Core, Info, << "Finished removing motw");
     }
 
-    HRESULT ApplyMotwUsingIAttachmentExecuteIfApplicable(const std::filesystem::path& filePath, const std::string& source)
+    HRESULT ApplyMotwUsingIAttachmentExecuteIfApplicable(const std::filesystem::path& filePath, const std::string& source, URLZONE zoneIfScanFailure)
     {
         AICLI_LOG(Core, Info, << "Started applying motw using IAttachmentExecute to " << filePath);
 
@@ -326,6 +326,13 @@ namespace AppInstaller::Utility
         aesThread.join();
 
         AICLI_LOG(Core, Info, << "Finished applying motw using IAttachmentExecute. Result: " << hr << " IAttachmentExecute::Save() result: " << aesSaveResult);
+
+        // Reapply desired zone upon scan failure.
+        // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
+        if (aesSaveResult != S_OK && std::filesystem::exists(filePath))
+        {
+            ApplyMotwIfApplicable(filePath, zoneIfScanFailure);
+        }
 
         return aesSaveResult;
     }

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -66,6 +66,9 @@ namespace AppInstaller::Utility
     // Apply Mark of the web if the target file is on NTFS, otherwise does nothing.
     void ApplyMotwIfApplicable(const std::filesystem::path& filePath, URLZONE zone);
 
+    // Remove Mark of the web if the target file is on NTFS, otherwise does nothing.
+    void RemoveMotwIfApplicable(const std::filesystem::path& filePath);
+
     // Apply Mark of the web using IAttachmentExecute::Save if the target file is on NTFS, otherwise does nothing.
     // This method only does a best effort since Attachment Execution Service may be disabled.
     // If IAttachmentExecute::Save is successfully invoked and the scan failed, the failure HRESULT is returned.

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -72,5 +72,6 @@ namespace AppInstaller::Utility
     // Apply Mark of the web using IAttachmentExecute::Save if the target file is on NTFS, otherwise does nothing.
     // This method only does a best effort since Attachment Execution Service may be disabled.
     // If IAttachmentExecute::Save is successfully invoked and the scan failed, the failure HRESULT is returned.
-    HRESULT ApplyMotwUsingIAttachmentExecuteIfApplicable(const std::filesystem::path& filePath, const std::string& source);
+    // zoneIfScanFailure: URLZONE to apply if IAttachmentExecute::Save scan failed.
+    HRESULT ApplyMotwUsingIAttachmentExecuteIfApplicable(const std::filesystem::path& filePath, const std::string& source, URLZONE zoneIfScanFailure);
 }


### PR DESCRIPTION
This fixes the "winget downloaded installers do not honor url zone settings" issue brought up in #797

## Change
IAttachmentExecute::Save() api does not clear existing Motw if the url is in trusted zone. This change puts the downloaded file in a clean state before calling the IAttachmentExecute::Save() method.

## Validation
Manually set break points and inspect Motw values are as expected and url zone settings are honored.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1491)