### PR TITLE
Fix correlation issue

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
@@ -271,7 +271,7 @@ namespace AppInstaller::CLI::Workflow
 
                 // Search for the current package
                 SearchRequest searchRequest;
-                searchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::Id, MatchType::CaseInsensitive, packageRequest.Id.get()));
+                searchRequest.Filters.emplace_back(PackageMatchFilter(PackageMatchField::Id, MatchType::CaseInsensitive, packageRequest.Id.get()));
 
                 auto searchContextPtr = context.Clone();
                 Execution::Context& searchContext = *searchContextPtr;

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -489,7 +489,7 @@ namespace AppInstaller::Repository
                     for (const auto& source : m_availableSources)
                     {
                         // Do not attempt to correlate local packages against this source
-                        if (!source->GetDetails().SupportCorrelation)
+                        if (!source->GetDetails().SupportInstalledSearchCorrelation)
                         {
                             continue;
                         }
@@ -578,6 +578,12 @@ namespace AppInstaller::Repository
         // Search available sources
         for (const auto& source : m_availableSources)
         {
+            // Do not attempt to correlate local packages against this source.
+            if (m_searchBehavior == CompositeSearchBehavior::Installed && !source->GetDetails().SupportInstalledSearchCorrelation)
+            {
+                continue;
+            }
+
             SearchResult availableResult;
 
             try

--- a/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/AppInstallerRepositorySource.h
@@ -102,7 +102,7 @@ namespace AppInstaller::Repository
         SourceInformation Information;
 
         // Support correlation against this source if true.
-        bool SupportCorrelation = true;
+        bool SupportInstalledSearchCorrelation = true;
     };
 
     // Fields that require user agreements.

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -93,7 +93,7 @@ namespace AppInstaller::Repository
                 details.Arg = s_Source_MSStoreDefault_Arg;
                 details.Identifier = s_Source_MSStoreDefault_Identifier;
                 details.TrustLevel = SourceTrustLevel::Trusted;
-                details.SupportCorrelation = false;
+                details.SupportInstalledSearchCorrelation = false;
                 return details;
             }
             case WellKnownSource::DesktopFrameworks:


### PR DESCRIPTION
## Change
Update the name of the `SupportCorrelation` field to better reflect the intention and correct the use to not allow available source searching when installed only semantics are being used.

Intentionally does allow available/all package searching to correlate against local packages to enable `import` to detect when packages are already present.  Also updates `import` to work better with the REST optimized search path.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1492)