### PR TITLE
Minor bug fixes

### DIFF
--- a/src/AppInstallerCLICore/Commands/SourceCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.cpp
@@ -84,17 +84,19 @@ namespace AppInstaller::CLI
             Workflow::AddSource <<
             Workflow::OpenSourceForSourceAdd;
 
-        if (context.IsTerminated() &&
-            (context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED ||
-             context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_AGREEMENTS_NOT_ACCEPTED))
+        if (context.IsTerminated())
         {
-            auto contextForRemovePtr = context.Clone();
-            Context& contextForRemove = *contextForRemovePtr;
-            contextForRemove.Args.AddArg(Args::Type::SourceName, context.Args.GetArg(Args::Type::SourceName));
+            if (context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED ||
+                context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_AGREEMENTS_NOT_ACCEPTED)
+            {
+                auto contextForRemovePtr = context.Clone();
+                Context& contextForRemove = *contextForRemovePtr;
+                contextForRemove.Args.AddArg(Args::Type::SourceName, context.Args.GetArg(Args::Type::SourceName));
 
-            contextForRemove <<
-                Workflow::GetSourceListWithFilter <<
-                Workflow::RemoveSources;
+                contextForRemove <<
+                    Workflow::GetSourceListWithFilter <<
+                    Workflow::RemoveSources;
+            }
         }
         else
         {

--- a/src/AppInstallerCLIE2ETests/BaseCommand.cs
+++ b/src/AppInstallerCLIE2ETests/BaseCommand.cs
@@ -58,7 +58,8 @@ namespace AppInstallerCLIE2ETests
                 {
                     experimentalArg = status,
                     experimentalCmd = status,
-                    experimentalMSStore = status,
+                    dependencies = status,
+                    directMSI = status,
                 }
             };
 


### PR DESCRIPTION
## Change
Use the current set of experimentals in the tests.

Fix a bug that would cause the "Done" string to be output in certain cases where the `source add` failed (requiring elevation for instance).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1494)