### PR TITLE
Make rename retry more frequently for longer, then try making a hardlink

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -203,7 +203,9 @@ namespace AppInstaller::CLI::Workflow
             //    This seems to fix things in certain cases, so we do it.
             try
             {
-                std::ofstream targetFile{ to };
+                {
+                    std::ofstream targetFile{ to };
+                }
                 std::filesystem::rename(from, to);
                 return;
             }

--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -221,7 +221,7 @@ namespace AppInstaller::CLI::Workflow
             }
 
             // 4. Finally, attempt to use a hard link if available or copy if not.
-            if (Runtime::SupportsHardlinks(from))
+            if (Runtime::SupportsHardLinks(from))
             {
                 // Create a hard link to the file; the installer will be left in the temp directory afterward
                 // but it is better to succeed the operation and leave a file around than to fail.

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -61,6 +61,6 @@ namespace AppInstaller::Runtime
     // Checks if the file system is NTFS
     bool IsNTFS(const std::filesystem::path& filePath);
 
-    // Checks if the file system at path supports hardlinks
+    // Checks if the file system at path supports hard links
     bool SupportsHardLinks(const std::filesystem::path& path);
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -60,4 +60,7 @@ namespace AppInstaller::Runtime
 
     // Checks if the file system is NTFS
     bool IsNTFS(const std::filesystem::path& filePath);
+
+    // Checks if the file system at path supports hardlinks
+    bool SupportsHardlinks(const std::filesystem::path& path);
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -62,5 +62,5 @@ namespace AppInstaller::Runtime
     bool IsNTFS(const std::filesystem::path& filePath);
 
     // Checks if the file system at path supports hardlinks
-    bool SupportsHardlinks(const std::filesystem::path& path);
+    bool SupportsHardLinks(const std::filesystem::path& path);
 }

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -439,7 +439,7 @@ namespace AppInstaller::Runtime
         return _wcsicmp(fileSystemName, L"NTFS") == 0;
     }
 
-    bool SupportsHardlinks(const std::filesystem::path& path)
+    bool SupportsHardLinks(const std::filesystem::path& path)
     {
         return IsNTFS(path);
     }

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -409,6 +409,9 @@ namespace AppInstaller::Runtime
         return wil::test_token_membership(nullptr, SECURITY_NT_AUTHORITY, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS);
     }
 
+    // TODO: Replace this function with proper checks for supported functionality rather
+    //       than simply relying on "is it NTFS?", even if those functions delegate to
+    //       this one for the answer.
     bool IsNTFS(const std::filesystem::path& filePath)
     {
         wil::unique_hfile fileHandle{ CreateFileW(

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -439,6 +439,11 @@ namespace AppInstaller::Runtime
         return _wcsicmp(fileSystemName, L"NTFS") == 0;
     }
 
+    bool SupportsHardlinks(const std::filesystem::path& path)
+    {
+        return IsNTFS(path);
+    }
+
 #ifndef AICLI_DISABLE_TEST_HOOKS
     void TestHook_SetPathOverride(PathName target, const std::filesystem::path& path)
     {


### PR DESCRIPTION
## Change
We already had a single retry after a 250ms wait for our `rename` of the installer to make it shell actionable with the correct extension.  This change makes it try every 100ms for 500ms, then use `copy_file` with a hard link option as a fall back.

The hard link is better than a true copy, as it won't take up more space.  But it won't get cleaned up on a successful install either.

Long term we should put in some background cleanup to remove old installers that were abandoned due to failures.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1497)