### PR TITLE
Localize the product name per recommendation

### DIFF
--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -48,7 +48,7 @@ namespace AppInstaller::CLI
     void Command::OutputIntroHeader(Execution::Reporter& reporter) const
     {
         reporter.Info() <<
-            Resource::FixedString::ProductName << " v"_liv << Runtime::GetClientVersion() << std::endl <<
+            Resource::String::WindowsPackageManager << " v"_liv << Runtime::GetClientVersion() << std::endl <<
             Resource::String::MainCopyrightNotice << std::endl;
     }
 

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -339,6 +339,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsFeaturesDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsLibrariesDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsStoreTerms);
+        WINGET_DEFINE_RESOURCE_STRINGID(WindowsPackageManager);
         WINGET_DEFINE_RESOURCE_STRINGID(WordArgumentDescription);
     };
 

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1182,6 +1182,9 @@ Please specify one of them using the `--source` option to proceed.</value>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>This is a stable release of the Windows Package Manager. If you would like to try experimental features, please install a pre-release build. Instructions are available on GitHub at https://github.com/microsoft/winget-cli.</value>
-    <comment>{Locked="Windows Package Manager","GitHub","https://github.com/microsoft/winget-cli"}</comment>
+    <comment>{Locked="https://github.com/microsoft/winget-cli"}</comment>
+  </data>
+  <data name="WindowsPackageManager" xml:space="preserve">
+    <value>Windows Package Manager</value>
   </data>
 </root>


### PR DESCRIPTION
## Change
Per recommendation of the internal localization team, the product name should be localized.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1498)