### PR TITLE
Disable test hooks fixes

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -314,6 +314,7 @@ nunit
 nupkg
 nuspec
 OAuth
+ODR
 ofstream
 opencode
 opensource

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -211,4 +211,10 @@ namespace AppInstaller::CLI::Execution
         return m_threadGlobals;
     }
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    bool Context::ShouldExecuteWorkflowTask(const Workflow::WorkflowTask& task)
+    {
+        return (m_shouldExecuteWorkflowTask ? m_shouldExecuteWorkflowTask(task) : true);
+    }
+#endif
 }

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -132,8 +132,14 @@ namespace AppInstaller::CLI::Execution
 
 #ifndef AICLI_DISABLE_TEST_HOOKS
         // Enable tests to override behavior
-        virtual bool ShouldExecuteWorkflowTask(const Workflow::WorkflowTask&) { return true; }
+        bool ShouldExecuteWorkflowTask(const Workflow::WorkflowTask& task);
 #endif
+
+    protected:
+        // Neither virtual functions nor member fields can be inside AICLI_DISABLE_TEST_HOOKS
+        // or we could have ODR violations that lead to nasty bugs. So we will simply never
+        // use this if AICLI_DISABLE_TEST_HOOKS is defined.
+        std::function<bool(const Workflow::WorkflowTask&)> m_shouldExecuteWorkflowTask;
 
     private:
         DestructionToken m_disableCtrlHandlerOnExit = false;

--- a/src/AppInstallerCommonCore/GroupPolicy.cpp
+++ b/src/AppInstallerCommonCore/GroupPolicy.cpp
@@ -322,6 +322,7 @@ namespace AppInstaller::Settings
         return InstanceInternal();
     }
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
     void GroupPolicy::OverrideInstance(GroupPolicy* overridePolicy)
     {
         InstanceInternal(overridePolicy);
@@ -331,4 +332,5 @@ namespace AppInstaller::Settings
     {
         InstanceInternal(nullptr);
     }
+#endif
 }


### PR DESCRIPTION
## Change
Fixes to allow building with `AICLI_DISABLE_TEST_HOOKS` defined.  Specifically:
1. Exclude some function definitions whose declarations were already excluded.
2. Refactor `Context::ShouldExecuteWorkflowTask` to not be virtual as any virtual function or member field being inside `AICLI_DISABLE_TEST_HOOKS` could lead to an ODR violation if not all projects properly apply it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1501)