### PR TITLE
Use correct Subexecution id when working on multiple packages

### DIFF
--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -79,9 +79,9 @@ namespace AppInstaller::CLI::Execution
         Manifest::ManifestInstaller Installer;
         Manifest::ScopeEnum Scope = Manifest::ScopeEnum::Unknown;
 
-        // Use this subexecution id when installing this package so that 
+        // Use this sub execution id when installing this package so that 
         // install telemetry is captured with the same sub execution id as other events in Search phase.
-        uint32_t PackageSubExecutionId;
+        uint32_t PackageSubExecutionId = 0;
     };
 
     namespace details

--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -63,8 +63,9 @@ namespace AppInstaller::CLI::Execution
             std::shared_ptr<Repository::IPackageVersion>&& installedPackageVersion,
             Manifest::Manifest&& manifest,
             Manifest::ManifestInstaller&& installer,
-            Manifest::ScopeEnum scope = Manifest::ScopeEnum::Unknown)
-            : PackageVersion(std::move(packageVersion)), InstalledPackageVersion(std::move(installedPackageVersion)), Manifest(std::move(manifest)), Installer(std::move(installer)), Scope(scope) { }
+            Manifest::ScopeEnum scope = Manifest::ScopeEnum::Unknown,
+            uint32_t packageSubExecutionId = 0)
+            : PackageVersion(std::move(packageVersion)), InstalledPackageVersion(std::move(installedPackageVersion)), Manifest(std::move(manifest)), Installer(std::move(installer)), Scope(scope), PackageSubExecutionId(packageSubExecutionId) { }
 
         std::shared_ptr<Repository::IPackageVersion> PackageVersion;
 
@@ -77,6 +78,10 @@ namespace AppInstaller::CLI::Execution
 
         Manifest::ManifestInstaller Installer;
         Manifest::ScopeEnum Scope = Manifest::ScopeEnum::Unknown;
+
+        // Use this subexecution id when installing this package so that 
+        // install telemetry is captured with the same sub execution id as other events in Search phase.
+        uint32_t PackageSubExecutionId;
     };
 
     namespace details

--- a/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
@@ -320,15 +320,13 @@ namespace AppInstaller::CLI::Workflow
                     }
                 }
 
-                Execution::PackageToInstall package{
+                packagesToInstall.emplace_back(
                     std::move(searchContext.Get<Execution::Data::PackageVersion>()),
                     std::move(searchContext.Get<Execution::Data::InstalledPackageVersion>()),
                     std::move(searchContext.Get<Execution::Data::Manifest>()),
                     std::move(searchContext.Get<Execution::Data::Installer>().value()),
                     packageRequest.Scope,
-                    subExecution.GetCurrentSubExecutionId()};
-
-                packagesToInstall.emplace_back(std::move(package));
+                    subExecution.GetCurrentSubExecutionId());
             }
         }
 

--- a/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
@@ -320,12 +320,15 @@ namespace AppInstaller::CLI::Workflow
                     }
                 }
 
-                packagesToInstall.emplace_back(
+                Execution::PackageToInstall package{
                     std::move(searchContext.Get<Execution::Data::PackageVersion>()),
                     std::move(searchContext.Get<Execution::Data::InstalledPackageVersion>()),
                     std::move(searchContext.Get<Execution::Data::Manifest>()),
                     std::move(searchContext.Get<Execution::Data::Installer>().value()),
-                    packageRequest.Scope);
+                    packageRequest.Scope,
+                    subExecution.GetCurrentSubExecutionId()};
+
+                packagesToInstall.emplace_back(std::move(package));
             }
         }
 

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -659,7 +659,7 @@ namespace AppInstaller::CLI::Workflow
         bool allSucceeded = true;
         for (auto package : context.Get<Execution::Data::PackagesToInstall>())
         {
-            Logging::SubExecutionTelemetryScope subExecution;
+            Logging::SubExecutionTelemetryScope subExecution{ package.PackageSubExecutionId };
 
             // We want to do best effort to install all packages regardless of previous failures
             auto installContextPtr = context.Clone();

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -112,11 +112,14 @@ namespace AppInstaller::CLI::Workflow
 
             updateAllFoundUpdate = true;
 
-            packagesToInstall.emplace_back(
+            Execution::PackageToInstall package{
                 std::move(updateContext.Get<Execution::Data::PackageVersion>()),
                 std::move(updateContext.Get<Execution::Data::InstalledPackageVersion>()),
                 std::move(updateContext.Get<Execution::Data::Manifest>()),
-                std::move(updateContext.Get<Execution::Data::Installer>().value()));
+                std::move(updateContext.Get<Execution::Data::Installer>().value()) };
+            package.PackageSubExecutionId = subExecution.GetCurrentSubExecutionId();
+
+            packagesToInstall.emplace_back(std::move(package));
         }
 
         if (!updateAllFoundUpdate)

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -62,7 +62,7 @@ namespace AppInstaller::Logging
     {
         std::ignore = CoCreateGuid(&m_activityId);
     }
-    
+
     const GUID* TelemetryTraceLogger::GetActivityId() const
     {
         return &m_activityId;
@@ -588,6 +588,18 @@ namespace AppInstaller::Logging
         auto expected = s_RootExecutionId;
         THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !s_subExecutionId.compare_exchange_strong(expected, ++m_sessionId),
             "Cannot create a sub execution telemetry session when a previous session exists.");
+    }
+
+    SubExecutionTelemetryScope::SubExecutionTelemetryScope(uint32_t sessionId)
+    {
+        auto expected = s_RootExecutionId;
+        THROW_HR_IF_MSG(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !s_subExecutionId.compare_exchange_strong(expected, sessionId),
+            "Cannot create a sub execution telemetry session when a previous session exists.");
+    }
+
+    uint32_t SubExecutionTelemetryScope::GetCurrentSubExecutionId()
+    {
+        return (uint32_t)s_subExecutionId;
     }
 
     SubExecutionTelemetryScope::~SubExecutionTelemetryScope()

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -597,7 +597,7 @@ namespace AppInstaller::Logging
             "Cannot create a sub execution telemetry session when a previous session exists.");
     }
 
-    uint32_t SubExecutionTelemetryScope::GetCurrentSubExecutionId()
+    uint32_t SubExecutionTelemetryScope::GetCurrentSubExecutionId() const
     {
         return (uint32_t)s_subExecutionId;
     }

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -187,11 +187,15 @@ namespace AppInstaller::Logging
     {
         SubExecutionTelemetryScope();
 
+        SubExecutionTelemetryScope(uint32_t sessionId);
+
         SubExecutionTelemetryScope(const SubExecutionTelemetryScope&) = delete;
         SubExecutionTelemetryScope& operator=(const SubExecutionTelemetryScope&) = delete;
 
         SubExecutionTelemetryScope(SubExecutionTelemetryScope&&) = default;
         SubExecutionTelemetryScope& operator=(SubExecutionTelemetryScope&&) = default;
+
+        uint32_t GetCurrentSubExecutionId();
 
         ~SubExecutionTelemetryScope();
 

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -195,7 +195,7 @@ namespace AppInstaller::Logging
         SubExecutionTelemetryScope(SubExecutionTelemetryScope&&) = default;
         SubExecutionTelemetryScope& operator=(SubExecutionTelemetryScope&&) = default;
 
-        uint32_t GetCurrentSubExecutionId();
+        uint32_t GetCurrentSubExecutionId() const;
 
         ~SubExecutionTelemetryScope();
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Issue:
- During import and upgrade flows, the sub execution id that was being used was not consistent for all events belonging to the same package as new ids were being generated in different phases.

Fix:
- This PR has changes that stores the sub execution id that was introduced for each package in search phase and re-uses it in the install phase, so that all events belonging to the same package have the same sub execution id.

Tests:
- Manually tested and verified the events sent for import and upgrade scenarios. Here are the sub exec ids used for upgrade events:
```
Console output when finding the package:
 Upgrade App name: Microsoft.VisualStudio.2019.Enterprise Sub exec id: 2
 Upgrade App name: Microsoft.WingetCreate Sub exec id: 55
 Upgrade App name: Microsoft.Teams Sub exec id: 81 
Console output when installing the package:
 Install App name: Microsoft.VisualStudio.2019.Enterprise Sub exec id: 2
 Install App name: Microsoft.WingetCreate Sub exec id: 55
 Install App name: Microsoft.Teams Sub exec id: 81

```
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1504)