### PR TITLE
Changes for sample COM caller project

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -475,6 +475,7 @@ stringstream
 strstr
 strtoll
 subcontext
+subheader
 SUBLANG
 subresource
 subselect

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.cpp
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.cpp
@@ -1,4 +1,6 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
 
 #include "App.h"
 #include "MainPage.h"

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.h
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
 #include "App.xaml.g.h"
 
 namespace winrt::AppInstallerCaller::implementation

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.xaml
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Application
     x:Class="AppInstallerCaller.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj.filters
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj.filters
@@ -25,19 +25,19 @@
     <Image Include="Assets\Wide310x150Logo.scale-200.png">
       <Filter>Assets</Filter>
     </Image>
-    <Image Include="Assets\StoreLogo.png">
-      <Filter>Assets</Filter>
-    </Image>
-    <Image Include="Assets\Square150x150Logo.scale-200.png">
-      <Filter>Assets</Filter>
-    </Image>
-    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png">
+    <Image Include="Assets\SplashScreen.scale-200.png">
       <Filter>Assets</Filter>
     </Image>
     <Image Include="Assets\Square44x44Logo.scale-200.png">
       <Filter>Assets</Filter>
     </Image>
-    <Image Include="Assets\SplashScreen.scale-200.png">
+    <Image Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\Square150x150Logo.scale-200.png">
+      <Filter>Assets</Filter>
+    </Image>
+    <Image Include="Assets\StoreLogo.png">
       <Filter>Assets</Filter>
     </Image>
     <Image Include="Assets\LockScreenLogo.scale-200.png">
@@ -50,5 +50,10 @@
   <ItemGroup>
     <None Include="PropertySheet.props" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Assets">
+      <UniqueIdentifier>{adeebf4e-70b7-41ae-936b-ded00e6e6777}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
 </Project>

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/InstallingPackageView.cpp
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/InstallingPackageView.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 #include "pch.h"
 #include "InstallingPackageView.h"
 #include "InstallingPackageView.g.cpp"

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/InstallingPackageView.h
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/InstallingPackageView.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 #pragma once
 #include "InstallingPackageView.g.h"
 

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.h
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.h
@@ -15,38 +15,29 @@ namespace winrt::AppInstallerCaller::implementation
         Windows::Foundation::Collections::IObservableVector<Deployment::CatalogPackage> InstalledApps();
         Windows::Foundation::Collections::IObservableVector<winrt::AppInstallerCaller::InstallingPackageView> InstallingPackages();
 
-        void InitializeUI();
-        void ToggleDevButtonClicked(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+        void ToggleDevSwitchToggled(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void FindSourcesButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
-        void StartServerButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void InstallButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void CancelButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void SearchButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
-        void RefreshButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+        void RefreshInstalledButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void ClearInstalledButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
-        void InstallingRefreshButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+        void RefreshInstallingButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void ClearInstallingButtonClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
 
         Windows::Foundation::IAsyncAction GetSources(winrt::Windows::UI::Xaml::Controls::Button button);
-        Windows::Foundation::IAsyncAction GetInstalledPackages(winrt::Windows::UI::Xaml::Controls::Button button);
-        Windows::Foundation::IAsyncAction GetInstallingPackages(winrt::Windows::UI::Xaml::Controls::Button button);
+        Windows::Foundation::IAsyncAction GetInstalledPackages(winrt::Windows::UI::Xaml::Controls::TextBlock statusText);
+        Windows::Foundation::IAsyncAction GetInstallingPackages(winrt::Windows::UI::Xaml::Controls::TextBlock statusText);
 
-        Windows::Foundation::IAsyncAction InitializeInstallUI(
-            std::wstring installAppId,
-            winrt::Windows::UI::Xaml::Controls::Button installButton,
-            winrt::Windows::UI::Xaml::Controls::Button cancelButton,
-            winrt::Windows::UI::Xaml::Controls::ProgressBar progressBar,
-            winrt::Windows::UI::Xaml::Controls::TextBlock statusText); 
         Windows::Foundation::IAsyncAction StartInstall(
             winrt::Windows::UI::Xaml::Controls::Button installButton,
             winrt::Windows::UI::Xaml::Controls::Button cancelButton,
             winrt::Windows::UI::Xaml::Controls::ProgressBar progressBar,
             winrt::Windows::UI::Xaml::Controls::TextBlock statusText);
         Windows::Foundation::IAsyncAction FindPackage(
-            winrt::Windows::UI::Xaml::Controls::Button button,
+            winrt::Windows::UI::Xaml::Controls::Button installButton,
             winrt::Windows::UI::Xaml::Controls::ProgressBar progressBar,
             winrt::Windows::UI::Xaml::Controls::TextBlock statusText);
-        Windows::Foundation::IAsyncOperation<Deployment::CatalogPackage> FindPackageAsync();
 
     private:
         Deployment::PackageManager CreatePackageManager();
@@ -59,7 +50,6 @@ namespace winrt::AppInstallerCaller::implementation
         Windows::Foundation::IAsyncOperation<Deployment::CatalogPackage> FindPackageInCatalogAsync(Deployment::PackageCatalog catalog, std::wstring packageId);
         Windows::Foundation::IAsyncOperationWithProgress<Deployment::InstallResult, Deployment::InstallProgress> InstallPackage(Deployment::CatalogPackage package);
         Windows::Foundation::IAsyncOperation<Deployment::PackageCatalog> FindSourceAsync(std::wstring packageSource);
-        Windows::Foundation::IAsyncAction StartServer();
 
         Windows::Foundation::Collections::IObservableVector<Deployment::PackageCatalogReference> m_packageCatalogs;
         Windows::Foundation::Collections::IObservableVector<Deployment::CatalogPackage> m_installedPackages;
@@ -68,7 +58,6 @@ namespace winrt::AppInstallerCaller::implementation
         std::wstring m_installAppId;
         Deployment::PackageManager m_packageManager{ nullptr };
         bool m_useDev = false;
-
     };
 }
 

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.h
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
 
 #include "InstallingPackageView.h"
 #include <winrt\Microsoft.Management.Deployment.h>

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.idl
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.idl
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 namespace AppInstallerCaller
 {
     [default_interface]

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.xaml
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.xaml
@@ -1,4 +1,6 @@
-﻿<Page
+﻿<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<Page
     x:Class="AppInstallerCaller.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.xaml
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/MainPage.xaml
@@ -8,38 +8,72 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="12">
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top">
-            <TextBlock Margin="0 12 0 0">Select catalogs to search</TextBlock>
-            <ToggleButton x:Name="toggleDevButton" Click="ToggleDevButtonClicked" HorizontalAlignment="Center" Margin="12">Use WinGetDev</ToggleButton>
-            <Button x:Name="findSourcesButton" Click="FindSourcesButtonClickHandler" HorizontalAlignment="Center" Margin="12">Find Catalogs.</Button>
-            <ListBox x:Name="catalogsListBox" ItemsSource="{x:Bind PackageCatalogs}" SelectionMode="Multiple" MaxWidth="300" MinHeight="50">
+    <Page.Resources>
+        <ResourceDictionary>
+            <Style TargetType="StackPanel">
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+            </Style>
+            <Style TargetType="Button">
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+            </Style>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid MinWidth="800" MinHeight="600">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <ToggleSwitch x:Name="toggleDevSwitch" Toggled="ToggleDevSwitchToggled">Use WinGetDev</ToggleSwitch>
+
+        <StackPanel Grid.Row="1">
+            <TextBlock Style="{StaticResource SubheaderTextBlockStyle}">Select catalog</TextBlock>
+
+            <Button x:Name="findSourcesButton" Click="FindSourcesButtonClickHandler">Find Catalogs</Button>
+            <TextBlock>Select catalog to search</TextBlock>
+            <ListBox x:Name="catalogsListBox" ItemsSource="{x:Bind PackageCatalogs}" SelectionMode="Single" Height="200">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="deployment:PackageCatalogReference">
-                        <TextBlock Text="{x:Bind Info.Name, Mode=OneWay}"/>
+                        <TextBlock Text="{x:Bind Info.Name, Mode=OneTime}"/>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ListBox>
         </StackPanel>
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="12">
-            <TextBox x:Name="catalogIdTextBox" Header="Find an app to install:" PlaceholderText="App Id"></TextBox>
-            <Button x:Name="searchButton" Click="SearchButtonClickHandler" VerticalAlignment="Bottom">🔍</Button>
-        </StackPanel>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+
+        <StackPanel Grid.Row="1" Grid.Column="1">
+            <TextBlock Style="{StaticResource SubheaderTextBlockStyle}">Install app</TextBlock>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBox x:Name="catalogIdTextBox" Header="Find an app to install:" PlaceholderText="App Id (e.g. Microsoft.Teams)"></TextBox>
+                <Button x:Name="searchButton" Click="SearchButtonClickHandler" VerticalAlignment="Bottom" Margin="0">🔍</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
                 <Button x:Name="installButton" Click="InstallButtonClickHandler" IsEnabled="False">Install</Button>
-                <Button x:Name="cancelButton" Click="CancelButtonClickHandler" Margin="12 0 0 0" IsEnabled="False">Cancel</Button>
+                <Button x:Name="cancelButton" Click="CancelButtonClickHandler" IsEnabled="False">Cancel</Button>
             </StackPanel>
-        <ProgressBar x:Name="installProgressBar" Value="0" Maximum="100" Width="200px" Margin="12" ></ProgressBar>
-        <TextBlock x:Name="installStatusText" Text="" HorizontalAlignment="Center"></TextBlock>
+
+            <ProgressBar x:Name="installProgressBar" Value="0" Maximum="100" Width="200px"/>
+            <TextBlock x:Name="installStatusText" Text="" HorizontalAlignment="Center"/>
         </StackPanel>
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top">
+
+        <StackPanel Grid.Row="2" Margin="3">
+            <TextBlock Style="{StaticResource SubheaderTextBlockStyle}">Installed apps</TextBlock>
+            <TextBlock>List installed apps from selected catalog</TextBlock>
             <StackPanel Orientation="Horizontal" >
-                <TextBlock Margin="0 12 0 0">Installed apps</TextBlock>
-                <Button x:Name="refreshButton" Click="RefreshButtonClickHandler" Margin="12 0 0 0" IsEnabled="True">Refresh</Button>
-                <Button x:Name="clearInstalledButton" Click="ClearInstalledButtonClickHandler" Margin="12 0 0 0" IsEnabled="True">Clear</Button>
+                <Button x:Name="refreshButton" Click="RefreshInstalledButtonClickHandler" IsEnabled="True">Refresh</Button>
+                <Button x:Name="clearInstalledButton" Click="ClearInstalledButtonClickHandler" IsEnabled="True">Clear</Button>
             </StackPanel>
-            <ListBox x:Name="installedListBox" ItemsSource="{x:Bind InstalledApps}" SelectionMode="Multiple" MaxWidth="300" MaxHeight="600" MinHeight="200" ScrollViewer.VerticalScrollBarVisibility="Visible">
+            <TextBlock x:Name="installedStatusText" Text=""/>
+            <ListBox x:Name="installedListBox" ItemsSource="{x:Bind InstalledApps}" Height="300" ScrollViewer.VerticalScrollBarVisibility="Visible">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="deployment:CatalogPackage">
                         <TextBlock Text="{x:Bind Name, Mode=OneWay}"/>
@@ -47,23 +81,26 @@
                 </ItemsControl.ItemTemplate>
             </ListBox>
         </StackPanel>
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top">
+
+        <StackPanel Grid.Row="2" Grid.Column="1" Margin="3">
+            <TextBlock Style="{StaticResource SubheaderTextBlockStyle}">Installing apps</TextBlock>
+            <TextBlock>List apps being installed from selected catalog</TextBlock>
             <StackPanel Orientation="Horizontal" >
-                <TextBlock Margin="0 12 0 0">Installing apps</TextBlock>
-                <Button x:Name="installingRefreshButton" Click="InstallingRefreshButtonClickHandler" Margin="12 0 0 0" IsEnabled="True">Refresh</Button>
-                <Button x:Name="installingClearInstalledButton" Click="ClearInstallingButtonClickHandler" Margin="12 0 0 0" IsEnabled="True">Clear</Button>
+                <Button x:Name="installingRefreshButton" Click="RefreshInstallingButtonClickHandler" IsEnabled="True">Refresh</Button>
+                <Button x:Name="installingClearInstalledButton" Click="ClearInstallingButtonClickHandler" IsEnabled="True">Clear</Button>
             </StackPanel>
-            <ListBox x:Name="installingListBox" ItemsSource="{x:Bind InstallingPackages}" SelectionMode="Multiple" MaxWidth="300" MaxHeight="600" MinHeight="200" ScrollViewer.VerticalScrollBarVisibility="Visible">
+            <TextBlock x:Name="installingStatusText" Text=""/>
+            <ListBox x:Name="installingListBox" ItemsSource="{x:Bind InstallingPackages}" Height="300" ScrollViewer.VerticalScrollBarVisibility="Visible">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="local:InstallingPackageView">
-                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <StackPanel HorizontalAlignment="Center">
                             <TextBlock Text="{x:Bind Package.Id, Mode=OneWay}"/>
-                            <ProgressBar Value="{x:Bind Progress, Mode=OneWay}" Maximum="100" Width="200px" Margin="12" ></ProgressBar>
+                            <ProgressBar Value="{x:Bind Progress, Mode=OneWay}" Maximum="100" Width="200px"></ProgressBar>
                             <TextBlock Text="{x:Bind StatusText, Mode=OneWay}" HorizontalAlignment="Center"></TextBlock>
                         </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ListBox>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Page>

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         IgnorableNamespaces="uap mp rescap">
   <Identity Name="SampleWinGetCaller" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="8b5526fe-0870-42b7-bde0-da8c4c7ea1aa" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -22,5 +26,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <rescap:Capability Name="packageManagement" />
   </Capabilities>
 </Package>

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/pch.cpp
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/pch.cpp
@@ -1,1 +1,3 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/pch.h
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/pch.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
 #include <windows.h>
 #include <unknwn.h>
 #include <hstring.h>


### PR DESCRIPTION
Some miscellaneous improvements for the sample COM caller project:
* Added some help labels and status messages to the UI
* Changed toggle button for using WinGetDev  to a toggle switch
* Rearranged UI elements in screen to separate elements visually and prevent them from jumping around when resizing
* Set window size to get rid of all the unneeded whitespace
* Set some global UI styles to reduce styling on individual controls
* Deleted some unused code and renamed some things to be more consistent
* Added needed capability to app manifest
* Added copyright headers to files

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1514)