### PR TITLE
Fixed bug where the package name wouldn't be written during upgrade.

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -664,7 +664,7 @@ namespace AppInstaller::CLI::Workflow
 
             // Extract the data needed for installing
             installContext.Add<Execution::Data::PackageVersion>(package.PackageVersion);
-            installContext.Add<Execution::Data::Manifest>(package.PackageVersion->GetManifest());
+            installContext.Add<Execution::Data::Manifest>(package.Manifest);
             installContext.Add<Execution::Data::InstalledPackageVersion>(package.InstalledPackageVersion);
             installContext.Add<Execution::Data::Installer>(package.Installer);
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

I noticed that in the latest build, the package name wouldn't print during `winget upgrade` (well, it'd print with the agreements portion, but it would not print after that when the package was actually being installed) :

<img width="856" alt="image" src="https://user-images.githubusercontent.com/21368066/135011058-10d1265e-b11a-48a9-9b93-4d5b959e1720.png">

I figured it was easy enough to fix myself, and it was! `package.PackageVersion->GetManifest())` was being used where `package.Manifest` should've been used (so that the locale info would be available).

Look at it now:

<img width="728" alt="image" src="https://user-images.githubusercontent.com/21368066/135011262-c3af0f06-df8f-4a63-9a65-66cb8ebc100c.png">


Let me know if there are any issues!



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1517)