### PR TITLE
Fix test task overrides

### DIFF
--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -306,9 +306,6 @@ namespace
             Override(wto);
         }
 
-        // For clone
-        TestContext(std::ostream& out, std::istream& in, std::shared_ptr<std::vector<WorkflowTaskOverride>> overrides) : TestContext(out, in, true, overrides) {}
-
         ~TestContext()
         {
             if (!m_isClone)
@@ -330,7 +327,7 @@ namespace
 
         std::unique_ptr<Context> Clone() override
         {
-            auto clone = std::make_unique<TestContext>(m_out, m_in, m_overrides);
+            auto clone = std::make_unique<TestContext>(m_out, m_in, true, m_overrides);
             clone->SetFlags(this->GetFlags());
             return clone;
         }

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -306,6 +306,26 @@ namespace
             Override(wto);
         }
 
+        TestContext(std::ostream& out, std::istream& in, bool isClone, std::shared_ptr<std::vector<WorkflowTaskOverride>> overrides) :
+            m_out(out), m_in(in), m_overrides(overrides), m_isClone(isClone), Context(out, in)
+        {
+            m_shouldExecuteWorkflowTask = [this](const Workflow::WorkflowTask& task)
+            {
+                auto itr = std::find_if(m_overrides->begin(), m_overrides->end(), [&](const WorkflowTaskOverride& wto) { return wto.Target == task; });
+
+                if (itr == m_overrides->end())
+                {
+                    return true;
+                }
+                else
+                {
+                    itr->Used = true;
+                    itr->Override(*this);
+                    return false;
+                }
+            };
+        }
+
         ~TestContext()
         {
             if (!m_isClone)
@@ -333,26 +353,6 @@ namespace
         }
 
     private:
-        TestContext(std::ostream& out, std::istream& in, bool isClone, std::shared_ptr<std::vector<WorkflowTaskOverride>> overrides) :
-            m_out(out), m_in(in), m_overrides(overrides), m_isClone(isClone), Context(out, in)
-        {
-            m_shouldExecuteWorkflowTask = [this](const Workflow::WorkflowTask& task)
-            {
-                auto itr = std::find_if(m_overrides->begin(), m_overrides->end(), [&](const WorkflowTaskOverride& wto) { return wto.Target == task; });
-
-                if (itr == m_overrides->end())
-                {
-                    return true;
-                }
-                else
-                {
-                    itr->Used = true;
-                    itr->Override(*this);
-                    return false;
-                }
-            };
-        }
-
         std::shared_ptr<std::vector<WorkflowTaskOverride>> m_overrides;
         std::ostream& m_out;
         std::istream& m_in;

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -119,6 +119,10 @@ namespace
             {
                 input = request.Inclusions[0].Value;
             }
+            else if (!request.Filters.empty())
+            {
+                input = request.Filters[0].Value;
+            }
 
             // Empty query should return all exe, msix and msstore installer
             if (input.empty() || input == "AppInstallerCliTest.TestExeInstaller")


### PR DESCRIPTION
Fix test context to always use the task overrides, not only after cloning the context.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1526)