### PR TITLE
Fix unit tests in pipeline

### DIFF
--- a/src/AppInstallerCLITests/CustomHeader.cpp
+++ b/src/AppInstallerCLITests/CustomHeader.cpp
@@ -50,6 +50,7 @@ namespace
                 if (!headers.has(customHeader.first) ||
                     (utility::conversions::to_utf8string(customHeader.second).compare(utility::conversions::to_utf8string(headers[customHeader.first]))) != 0)
                 {
+                    response.set_body(utf16string{ L"Bad Request" });
                     response.set_status_code(web::http::status_codes::BadRequest);
                     return pplx::task_from_result(response);
                 }

--- a/src/AppInstallerCLITests/TestRestRequestHandler.cpp
+++ b/src/AppInstallerCLITests/TestRestRequestHandler.cpp
@@ -13,7 +13,11 @@ std::shared_ptr<TestRestRequestHandler> GetTestRestRequestHandler(
         pplx::task<web::http::http_response>
         {
             web::http::http_response response;
-            if (!sampleResponseString.empty())
+            if (sampleResponseString.empty())
+            {
+                response.set_body(utf16string{});
+            }
+            else
             {
                 response.set_body(web::json::value::parse(sampleResponseString));
             }

--- a/src/AppInstallerCLITests/main.cpp
+++ b/src/AppInstallerCLITests/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
         else if ("-logto"s == argv[i])
         {
             ++i;
-            Logging::AddFileLogger(std::string_view{ argv[i] });
+            Logging::AddFileLogger(std::filesystem::path{ argv[i] });
         }
         else if ("-tdd"s == argv[i])
         {


### PR DESCRIPTION
## Change
This fixes:
- REST tests that were deadlocking due to not setting the response body in the test helpers.
- The `-logto` unit test argument to now properly be the actual log path again.
- The test script to fail on timeout rather than simply ending.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1529)