### PR TITLE
Change format to long for installer success codes

### DIFF
--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -136,6 +136,7 @@
       "type": [ "array", "null" ],
       "items": {
         "type": "integer",
+        "format": "long",
         "not": {
           "enum": [ 0 ]
         },

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -148,6 +148,7 @@
       "type": [ "array", "null" ],
       "items": {
         "type": "integer",
+        "format": "long",        
         "not": {
           "enum": [ 0 ]
         },

--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -134,6 +134,7 @@
     },
     "InstallerReturnCode": {
       "type": "integer",
+      "format": "long",
       "not": {
         "enum": [ 0 ]
       },

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -167,6 +167,7 @@
     },
     "InstallerReturnCode": {
       "type": "integer",
+      "format": "long",
       "not": {
         "enum": [ 0 ]
       },


### PR DESCRIPTION
Resolves an issue where the installer success codes for some manifests were larger than the range of an int datatype, which can cause issues for winget-create's model as it is expecting a valid int. 

 https://github.com/microsoft/winget-create/issues/155


Changes the integer format to long in the v1.0 and v1.1 schema to increase the range of values.

Verification:
- Passes all unit tests 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1533)