### PR TITLE
Icelandic localization tool description wording

### DIFF
--- a/Localization/Resources/is-IS/winget.resw
+++ b/Localization/Resources/is-IS/winget.resw
@@ -637,7 +637,7 @@ Hægt er að grinnstilla þá í stillingaskránni „winget settings“.</value
     <value>Tilkynningar þriðju aðila</value>
   </data>
   <data name="ToolDescription" xml:space="preserve">
-    <value>Winget-skipanalínubúnaðurinn gerir það kleift að setja upp forrit of aðra pakka úr skipanalínunni.</value>
+    <value>Winget-skipanalínubúnaðurinn gerir það kleift að setja upp forrit og aðra pakka frá skipanalínunni.</value>
   </data>
   <data name="ToolInfoArgumentDescription" xml:space="preserve">
     <value>Sýna almennar upplýsingar um verkfærið</value>


### PR DESCRIPTION
Changed two words in the icelandic localization for the toolDescription string:
- The word "of" should be "og" (the word of is like "too much" which makes no sense) and, 
- "úr" should be "frá" (The difference is in grammar, úr is like "out of", whereas frá is simply from. You are not installing out of the command line)

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----
