### PR TITLE
The source column is no longer shown in the table if a source was specified (list/upgrade).

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -658,6 +658,8 @@ namespace AppInstaller::CLI::Workflow
             });
 
         int availableUpgradesCount = 0;
+        auto &source = context.Get<Execution::Data::Source>();
+        bool shouldShowSource = source->IsComposite() && source->GetAvailableSources().size() > 1;
 
         for (const auto& match : searchResult.Matches)
         {
@@ -690,7 +692,7 @@ namespace AppInstaller::CLI::Workflow
                         match.Package->GetProperty(PackageProperty::Id),
                         installedVersion->GetProperty(PackageVersionProperty::Version),
                         availableVersion,
-                        context.Args.Contains(Execution::Args::Type::Source) ? ""s : sourceName
+                        shouldShowSource ? sourceName : ""s
                         });
                 }
             }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----

Resolves #1597.

Kind of jumping the gun as the issue wasn't triaged, but it was an easy fix (so no biggie if it isn't merged). It makes it consistent with the behavior of `winget search -s <source>`.

<img width="595" alt="image" src="https://user-images.githubusercontent.com/21368066/137501724-e83ff1cc-946d-4dcf-a161-635c3cf0c5c2.png">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1598)