### PR TITLE
Prevent duplicate installations in winget upgrade all

### DIFF
--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -18,6 +18,21 @@ namespace AppInstaller::CLI::Workflow
         {
             return (installedVersion < updateVersion || updateVersion.IsLatest());
         }
+
+        void AddToPackagesToInstallIfNotPresent(std::vector<Execution::PackageToInstall>& packagesToInstall, Execution::PackageToInstall&& package)
+        {
+            for (auto const& existing : packagesToInstall)
+            {
+                if (existing.Manifest.Id == package.Manifest.Id &&
+                    existing.Manifest.Version == package.Manifest.Version &&
+                    existing.PackageVersion->GetProperty(PackageVersionProperty::SourceIdentifier) == package.PackageVersion->GetProperty(PackageVersionProperty::SourceIdentifier))
+                {
+                    return;
+                }
+            }
+
+            packagesToInstall.emplace_back(std::move(package));
+        }
     }
 
     void SelectLatestApplicableUpdate::operator()(Execution::Context& context) const
@@ -119,7 +134,7 @@ namespace AppInstaller::CLI::Workflow
                 std::move(updateContext.Get<Execution::Data::Installer>().value()) };
             package.PackageSubExecutionId = subExecution.GetCurrentSubExecutionId();
 
-            packagesToInstall.emplace_back(std::move(package));
+            AddToPackagesToInstallIfNotPresent(packagesToInstall, std::move(package));
         }
 
         if (!updateAllFoundUpdate)


### PR DESCRIPTION
## Change
Check duplicates before adding to package install list in winget upgrade all.

## Validation
Added tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1652)