### PR TITLE
CurrentLocalization is now populated for dependency manifests.

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DependencyNodeProcessor.cpp
+++ b/src/AppInstallerCLICore/Workflows/DependencyNodeProcessor.cpp
@@ -65,13 +65,14 @@ namespace AppInstaller::CLI::Workflow
         }
 
         m_nodeManifest = m_nodePackageLatestVersion->GetManifest();
+        m_nodeManifest.ApplyLocale();
+
         if (m_nodeManifest.Installers.empty())
         {
             error << Resource::String::DependenciesFlowNoInstallerFound << " " << Utility::Normalize(m_nodeManifest.Id);
             AICLI_LOG(CLI, Error, << "Installer not found for manifest " << m_nodeManifest.Id << " with version" << m_nodeManifest.Version);
             return DependencyNodeProcessorResult::Error;
         }
-        m_nodeManifest.ApplyLocale();
 
         std::optional<AppInstaller::Manifest::ManifestInstaller> installer;
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

I noticed that the package name wasn't being shown when dependencies were installed, and it was because `ApplyLocale()` was never called on the dependencies. So I fixed that.

Before:
![image](https://user-images.githubusercontent.com/21368066/139293703-39332271-f330-4a74-b5c3-62739471122d.png)


After: 
![image](https://user-images.githubusercontent.com/21368066/139293061-79ea2653-2739-45c4-bda0-6bb715574ff1.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1655)