### PR TITLE
Fix incorrect processing of PackageMatchFields in rest client

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -326,6 +326,7 @@ nonexistentsetting
 NONINFRINGEMENT
 norestart
 normalizednameandpublisher
+normalizedpackagenameandpublisher
 NOTHROW
 NOTIMPL
 NOTNULL
@@ -352,6 +353,8 @@ OUTOFDISKSPACE
 OUTOFMEMORY
 OWC
 packagefamilyname
+packageidentifier
+packagename
 PACKAGESSCHEMA
 Params
 params

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/SearchRequestSerializer_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/SearchRequestSerializer_1_0.cpp
@@ -144,8 +144,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0::Json
         }
 
         filter[JsonHelper::GetUtilityString(PackageMatchField)] = web::json::value::string(JsonHelper::GetUtilityString(matchField.value()));
-        AppInstaller::Repository::RequestMatch requestMatch{ packageMatchFilter.Type, packageMatchFilter.Value };
-        std::optional<web::json::value> requestMatchJson = GetRequestMatchJsonObject(requestMatch);
+        std::optional<web::json::value> requestMatchJson = GetRequestMatchJsonObject(packageMatchFilter);
 
         if (!requestMatchJson)
         {

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Interface.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Interface.h
@@ -29,6 +29,8 @@ namespace AppInstaller::Repository::Rest::Schema::V1_1
         SearchResult GetSearchResult(const web::json::value& searchResponseObject) const override;
         std::vector<Manifest::Manifest> GetParsedManifests(const web::json::value& manifestsResponseObject) const override;
 
+        PackageMatchField ConvertStringToPackageMatchField(std::string_view field) const;
+
     private:
         IRestClient::Information m_information;
     };


### PR DESCRIPTION
The names used in PackageMatchFields in rest spec is different from the default names in winget code, so we have to create a separate method to convert PackageMatchFields in rest client.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1659)