### PR TITLE
Use package tracking data to correlate in CompositeSource

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -11,7 +11,6 @@
 #include "MsiInstallFlow.h"
 #include "WorkflowBase.h"
 #include "Workflows/DependenciesFlow.h"
-#include <winget/PackageTrackingCatalog.h>
 #include <AppInstallerDeployment.h>
 
 using namespace winrt::Windows::ApplicationModel::Store::Preview::InstallControl;
@@ -683,7 +682,7 @@ namespace AppInstaller::CLI::Workflow
             return;
         }
 
-        auto trackingCatalog = PackageTrackingCatalog::CreateForSource(context.Get<Data::PackageVersion>()->GetSource());
+        auto trackingCatalog = context.Get<Data::PackageVersion>()->GetSource().GetTrackingCatalog();
 
         trackingCatalog.RecordInstall(
             context.Get<Data::Manifest>(),

--- a/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
@@ -7,7 +7,6 @@
 #include "AppInstallerMsixInfo.h"
 
 #include <AppInstallerDeployment.h>
-#include <winget/PackageTrackingCatalog.h>
 
 using namespace AppInstaller::CLI::Execution;
 using namespace AppInstaller::Manifest;
@@ -181,7 +180,7 @@ namespace AppInstaller::CLI::Workflow
         // Finally record the uninstall for each found value
         for (const auto& item : correlatedSources.Items)
         {
-            auto trackingCatalog = PackageTrackingCatalog::CreateForSource(item.FromSource);
+            auto trackingCatalog = item.FromSource.GetTrackingCatalog();
             trackingCatalog.RecordUninstall(item.Identifier);
         }
     }

--- a/src/AppInstallerCLITests/CompositeSource.cpp
+++ b/src/AppInstallerCLITests/CompositeSource.cpp
@@ -44,7 +44,7 @@ struct CompositeTestSetup
         Installed = std::make_shared<ComponentTestSource>();
         Available = std::make_shared<ComponentTestSource>();
         Composite.SetInstalledSource(Installed);
-        Composite.AddAvailableSource(Available);
+        Composite.AddAvailableSource(Source{ Available });
     }
 
     SearchResult Search()
@@ -544,7 +544,7 @@ TEST_CASE("CompositeSource_MultipleAvailableSources_MatchFirst", "[CompositeSour
 
     CompositeTestSetup setup;
     std::shared_ptr<ComponentTestSource> secondAvailable = std::make_shared<ComponentTestSource>();
-    setup.Composite.AddAvailableSource(secondAvailable);
+    setup.Composite.AddAvailableSource(Source{ secondAvailable });
 
     setup.Installed->Everything.Matches.emplace_back(MakeInstalled().WithPFN(pfn), Criteria());
 
@@ -582,7 +582,7 @@ TEST_CASE("CompositeSource_MultipleAvailableSources_MatchSecond", "[CompositeSou
 
     CompositeTestSetup setup;
     std::shared_ptr<ComponentTestSource> secondAvailable = std::make_shared<ComponentTestSource>();
-    setup.Composite.AddAvailableSource(secondAvailable);
+    setup.Composite.AddAvailableSource(Source{ secondAvailable });
 
     setup.Installed->Everything.Matches.emplace_back(MakeInstalled().WithPFN(pfn), Criteria());
 
@@ -611,7 +611,7 @@ TEST_CASE("CompositeSource_MultipleAvailableSources_ReverseMatchBoth", "[Composi
 
     CompositeTestSetup setup;
     std::shared_ptr<ComponentTestSource> secondAvailable = std::make_shared<ComponentTestSource>();
-    setup.Composite.AddAvailableSource(secondAvailable);
+    setup.Composite.AddAvailableSource(Source{ secondAvailable });
 
     setup.Installed->SearchFunction = [&](const SearchRequest& request)
     {
@@ -665,8 +665,8 @@ TEST_CASE("CompositeSource_AvailableSearchFailure", "[CompositeSource]")
     AvailableFails->Details.Name = "The one that fails";
 
     CompositeSource Composite("*CompositeSource_AvailableSearchFailure");
-    Composite.AddAvailableSource(AvailableSucceeds);
-    Composite.AddAvailableSource(AvailableFails);
+    Composite.AddAvailableSource(Source{ AvailableSucceeds });
+    Composite.AddAvailableSource(Source{ AvailableFails });
 
     SearchResult result = Composite.Search({});
 
@@ -706,7 +706,7 @@ TEST_CASE("CompositeSource_InstalledToAvailableCorrelationSearchFailure", "[Comp
     AvailableFails->SearchFunction = [&](const SearchRequest&) -> SearchResult { THROW_HR(expectedHR); };
     AvailableFails->Details.Name = "The one that fails";
 
-    setup.Composite.AddAvailableSource(AvailableFails);
+    setup.Composite.AddAvailableSource(Source{ AvailableFails });
 
     SearchResult result = setup.Search();
 
@@ -746,7 +746,7 @@ TEST_CASE("CompositeSource_InstalledAvailableSearchFailure", "[CompositeSource]"
     AvailableFails->SearchFunction = [&](const SearchRequest&) -> SearchResult { THROW_HR(expectedHR); };
     AvailableFails->Details.Name = "The one that fails";
 
-    setup.Composite.AddAvailableSource(AvailableFails);
+    setup.Composite.AddAvailableSource(Source{ AvailableFails });
 
     setup.Composite.SetInstalledSource(setup.Installed, CompositeSearchBehavior::AvailablePackages);
 

--- a/src/AppInstallerCLITests/CompositeSource.cpp
+++ b/src/AppInstallerCLITests/CompositeSource.cpp
@@ -54,7 +54,7 @@ struct CompositeTestSetup
     {
         Installed = std::make_shared<ComponentTestSource>("InstalledTestSource1");
         Available = std::make_shared<ComponentTestSource>("AvailableTestSource1");
-        Composite.SetInstalledSource(Installed);
+        Composite.SetInstalledSource(Source{ Installed });
         Composite.AddAvailableSource(Source{ Available });
     }
 
@@ -782,7 +782,7 @@ TEST_CASE("CompositeSource_InstalledAvailableSearchFailure", "[CompositeSource]"
 
     setup.Composite.AddAvailableSource(Source{ AvailableFails });
 
-    setup.Composite.SetInstalledSource(setup.Installed, CompositeSearchBehavior::AvailablePackages);
+    setup.Composite.SetInstalledSource(Source{ setup.Installed }, CompositeSearchBehavior::AvailablePackages);
 
     SearchRequest request;
     request.Query = RequestMatch{ MatchType::Exact, "whatever" };

--- a/src/AppInstallerCLITests/TestSource.cpp
+++ b/src/AppInstallerCLITests/TestSource.cpp
@@ -271,11 +271,6 @@ namespace TestCommon
         }
     }
 
-    bool TestSource::IsComposite() const
-    {
-        return Composite;
-    }
-
     std::shared_ptr<ISourceReference> TestSourceFactory::Create(const SourceDetails& details)
     {
         if (OnOpenWithCustomHeader)

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -82,12 +82,10 @@ namespace TestCommon
         AppInstaller::Repository::SourceInformation GetInformation() const override;
 
         AppInstaller::Repository::SearchResult Search(const AppInstaller::Repository::SearchRequest& request) const override;
-        bool IsComposite() const override;
 
         AppInstaller::Repository::SourceDetails Details = { "TestSource", "Microsoft.TestSource", "//arg", "", "*TestSource" };
         AppInstaller::Repository::SourceInformation Information;
         std::function<AppInstaller::Repository::SearchResult(const AppInstaller::Repository::SearchRequest& request)> SearchFunction;
-        bool Composite = false;
 
         TestSource() = default;
         TestSource(const AppInstaller::Repository::SourceDetails& details) : Details(details) {}

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -266,6 +266,7 @@
     <ClInclude Include="Microsoft\SQLiteIndex.h" />
     <ClInclude Include="Microsoft\SQLiteIndexSource.h" />
     <ClInclude Include="Microsoft\ConfigurableTestSourceFactory.h" />
+    <ClInclude Include="PackageTrackingCatalogSourceFactory.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Public\winget\PackageTrackingCatalog.h" />
     <ClInclude Include="Public\winget\RepositorySearch.h" />

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClInclude Include="ISource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PackageTrackingCatalogSourceFactory.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -30,6 +30,138 @@ namespace AppInstaller::Repository
             return false;
         }
 
+        // Move returns if there is only one package in the matches that is strong; otherwise returns an empty value.
+        std::shared_ptr<IPackage> FindOnlyStrongMatchFieldResult(std::vector<ResultMatch>& matches)
+        {
+            std::shared_ptr<IPackage> result;
+
+            for (auto&& match : matches)
+            {
+                AICLI_LOG(Repo, Info, << "  Checking match with package id: " << match.Package->GetProperty(PackageProperty::Id));
+
+                if (IsStrongMatchField(match.MatchCriteria.Field))
+                {
+                    if (!result)
+                    {
+                        result = std::move(match.Package);
+                    }
+                    else
+                    {
+                        AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
+                        result.reset();
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        // Gets a single matching package from the results
+        template <typename MultipleIntro, typename Indeterminate>
+        std::shared_ptr<IPackage> GetMatchingPackage(std::vector<ResultMatch>& matches, MultipleIntro&& multipleIntro, Indeterminate&& indeterminate)
+        {
+            if (matches.empty())
+            {
+                return {};
+            }
+            else if (matches.size() == 1)
+            {
+                return std::move(matches[0].Package);
+            }
+            else
+            {
+                multipleIntro();
+
+                auto result = FindOnlyStrongMatchFieldResult(matches);
+
+                if (!result)
+                {
+                    indeterminate();
+                }
+
+                return result;
+            }
+        }
+
+        // For a given package from a tracking catalog, get the latest write time.
+        // Look at all versions rather than just the latest to account for the potential of downgrading.
+        std::chrono::system_clock::time_point GetLatestTrackingPackageWriteTime(const std::shared_ptr<IPackage>& trackingPackage)
+        {
+            std::chrono::system_clock::time_point result{};
+
+            for (const auto& key : trackingPackage->GetAvailableVersionKeys())
+            {
+                auto version = trackingPackage->GetAvailableVersion(key);
+                if (version)
+                {
+                    auto metadata = version->GetMetadata();
+                    auto itr = metadata.find(PackageVersionMetadata::TrackingWriteTime);
+                    if (itr != metadata.end())
+                    {
+                        std::int64_t unixEpoch = 0;
+                        try
+                        {
+                            unixEpoch = std::stoll(itr->second);
+                        }
+                        CATCH_LOG();
+
+                        std::chrono::system_clock::time_point versionTime = Utility::ConvertUnixEpochToSystemClock(unixEpoch);
+
+                        if (versionTime > result)
+                        {
+                            result = versionTime;
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        // A composite package installed version that allows us to override the source of the version.
+        struct CompositeInstalledVersion : public IPackageVersion
+        {
+            CompositeInstalledVersion(std::shared_ptr<IPackageVersion> baseInstalledVersion, Source trackingSource) :
+                m_baseInstalledVersion(std::move(baseInstalledVersion)), m_trackingSource(std::move(trackingSource))
+            {}
+
+            Utility::LocIndString GetProperty(PackageVersionProperty property) const override
+            {
+                return m_baseInstalledVersion->GetProperty(property);
+            }
+
+            std::vector<Utility::LocIndString> GetMultiProperty(PackageVersionMultiProperty property) const override
+            {
+                return m_baseInstalledVersion->GetMultiProperty(property);
+            }
+
+            Manifest::Manifest GetManifest() override
+            {
+                return m_baseInstalledVersion->GetManifest();
+            }
+
+            Source GetSource() const override
+            {
+                // If there is a tracking source, use it instead to indicate that it came from there.
+                if (m_trackingSource)
+                {
+                    return m_trackingSource;
+                }
+
+                return m_baseInstalledVersion->GetSource();
+            }
+
+            Metadata GetMetadata() const override
+            {
+                return m_baseInstalledVersion->GetMetadata();
+            }
+
+        private:
+            std::shared_ptr<IPackageVersion> m_baseInstalledVersion;
+            Source m_trackingSource;
+        };
+
         // A composite package for the CompositeSource.
         struct CompositePackage : public IPackage
         {
@@ -50,6 +182,10 @@ namespace AppInstaller::Repository
             Utility::LocIndString GetProperty(PackageProperty property) const override
             {
                 std::shared_ptr<IPackageVersion> truth = GetLatestAvailableVersion();
+                if (!truth && m_trackingPackage)
+                {
+                    truth = m_trackingPackage->GetLatestAvailableVersion();
+                }
                 if (!truth)
                 {
                     truth = GetInstalledVersion();
@@ -70,7 +206,14 @@ namespace AppInstaller::Repository
             {
                 if (m_installedPackage)
                 {
-                    return m_installedPackage->GetInstalledVersion();
+                    if (m_trackingSource)
+                    {
+                        return std::make_shared<CompositeInstalledVersion>(m_installedPackage->GetInstalledVersion(), m_trackingSource);
+                    }
+                    else
+                    {
+                        return m_installedPackage->GetInstalledVersion();
+                    }
                 }
 
                 return {};
@@ -149,15 +292,28 @@ namespace AppInstaller::Repository
                 return m_availablePackage;
             }
 
+            const std::shared_ptr<IPackage>& GetTrackingPackage()
+            {
+                return m_trackingPackage;
+            }
+
             void SetAvailablePackage(std::shared_ptr<IPackage> availablePackage)
             {
                 m_availablePackage = std::move(availablePackage);
+            }
+
+            void SetTracking(Source trackingSource, std::shared_ptr<IPackage> trackingPackage)
+            {
+                m_trackingSource = std::move(trackingSource);
+                m_trackingPackage = std::move(trackingPackage);
             }
 
         private:
             std::shared_ptr<IPackage> m_installedPackage;
             Utility::LocIndString m_installedChannel;
             std::shared_ptr<IPackage> m_availablePackage;
+            Source m_trackingSource;
+            std::shared_ptr<IPackage> m_trackingPackage;
         };
 
         // The comparator compares the ResultMatch by MatchType first, then Field in a predefined order.
@@ -260,6 +416,16 @@ namespace AppInstaller::Repository
                         SystemReferenceStrings.emplace(std::move(srs));
                     }
                 }
+
+                SearchRequest CreateInclusionsSearchRequest() const
+                {
+                    SearchRequest result;
+                    for (const auto& srs : SystemReferenceStrings)
+                    {
+                        srs.AddToFilters(result.Inclusions);
+                    }
+                    return result;
+                }
             };
 
             // For a given package version, prepares the results for it.
@@ -293,6 +459,34 @@ namespace AppInstaller::Repository
                 for (auto const& versionKey : availableMatch.Package->GetAvailableVersionKeys())
                 {
                     auto packageVersion = availableMatch.Package->GetAvailableVersion(versionKey);
+                    AddSystemReferenceStrings(packageVersion.get(), result);
+                }
+                return result;
+            }
+
+            // Check for a package already in the result that should have been correlated already.
+            // If we find one, see if we should upgrade it's match criteria.
+            // If we don't, return package data for further use.
+            std::optional<PackageData> CheckForExistingResultFromTrackingPackageMatch(const ResultMatch& trackingMatch)
+            {
+                for (auto& match : Matches)
+                {
+                    const std::shared_ptr<IPackage>& trackingPackage = match.Package->GetTrackingPackage();
+                    if (trackingPackage && trackingPackage->IsSame(trackingMatch.Package.get()))
+                    {
+                        if (ResultMatchComparator{}(trackingMatch, match))
+                        {
+                            match.MatchCriteria = trackingMatch.MatchCriteria;
+                        }
+
+                        return {};
+                    }
+                }
+
+                PackageData result;
+                for (auto const& versionKey : trackingMatch.Package->GetAvailableVersionKeys())
+                {
+                    auto packageVersion = trackingMatch.Package->GetAvailableVersion(versionKey);
                     AddSystemReferenceStrings(packageVersion.get(), result);
                 }
                 return result;
@@ -347,6 +541,32 @@ namespace AppInstaller::Repository
                 return false;
             }
 
+            SearchResult SearchAndHandleFailures(const Source& source, const SearchRequest& request)
+            {
+                SearchResult result;
+
+                try
+                {
+                    result = source.Search(request);
+                }
+                catch (...)
+                {
+                    if (AddFailureIfSourceNotPresent({ source.GetDetails().Name, std::current_exception() }))
+                    {
+                        LOG_CAUGHT_EXCEPTION();
+                        AICLI_LOG(Repo, Warning, << "Failed to search source for correlation: " << source.GetDetails().Name);
+                    }
+                }
+
+                // Move failures into the result
+                for (SearchResult::Failure& failure : result.Failures)
+                {
+                    AddFailureIfSourceNotPresent(std::move(failure));
+                }
+
+                return result;
+            }
+
             std::vector<CompositeResultMatch> Matches;
             bool Truncated = false;
             std::vector<SearchResult::Failure> Failures;
@@ -399,6 +619,29 @@ namespace AppInstaller::Repository
                 }
             }
         };
+
+        std::shared_ptr<IPackage> GetTrackedPackageFromAvailableSource(CompositeResult& result, const Source& source, const Utility::LocIndString& identifier)
+        {
+            SearchRequest directRequest;
+            directRequest.Filters.emplace_back(PackageMatchField::Id, MatchType::CaseInsensitive, identifier.get());
+
+            SearchResult directResult = result.SearchAndHandleFailures(source, directRequest);
+
+            if (directResult.Matches.empty())
+            {
+                AICLI_LOG(Repo, Warning, << "Did not find Id [" << identifier << "] in tracked source: " << source.GetDetails().Name);
+            }
+            else if (directResult.Matches.size() == 1)
+            {
+                return std::move(directResult.Matches[0].Package);
+            }
+            else
+            {
+                AICLI_LOG(Repo, Warning, << "Found multiple results for Id [" << identifier << "] in tracked source: " << source.GetDetails().Name);
+            }
+
+            return {};
+        }
     }
 
     CompositeSource::CompositeSource(std::string identifier)
@@ -466,172 +709,90 @@ namespace AppInstaller::Repository
             {
                 auto compositePackage = std::make_shared<CompositePackage>(std::move(match.Package));
 
-                // Create a search request to run against all available sources
-                SearchRequest systemReferenceSearch;
-
                 auto installedVersion = compositePackage->GetInstalledVersion();
                 auto installedPackageData = result.GetSystemReferenceStrings(installedVersion.get());
 
+                // Create a search request to run against all available sources
                 if (!installedPackageData.SystemReferenceStrings.empty())
                 {
-                    for (const auto& srs : installedPackageData.SystemReferenceStrings)
-                    {
-                        srs.AddToFilters(systemReferenceSearch.Inclusions);
-                    }
+                    SearchRequest systemReferenceSearch = installedPackageData.CreateInclusionsSearchRequest();
 
+                    Source trackedSource;
                     std::shared_ptr<IPackage> trackingPackage;
+                    std::chrono::system_clock::time_point trackingPackageTime;
                     std::shared_ptr<IPackage> availablePackage;
 
                     // Check the tracking catalog first to see if there is a correlation there.
                     // TODO: When the issue with support for multiple available packages is fixed, this should move into
                     //       the below available sources loop as we will check all sources at that point.
-                    //for (const auto& source : m_availableSources)
-                    {
-                        //auto trackingCatalog = source.GetTrackingCatalog();
-                        //SearchResult trackingResult;
-
-                        //try
-                        //{
-                        //    trackingResult = trackingCatalog.Search(systemReferenceSearch);
-                        //}
-                        //catch (...)
-                        //{
-                        //    if (result.AddFailureIfSourceNotPresent({ source->GetDetails().Name, std::current_exception() }))
-                        //    {
-                        //        LOG_CAUGHT_EXCEPTION();
-                        //        AICLI_LOG(Repo, Warning, << "Failed to search source for correlation: " << source->GetDetails().Name);
-                        //    }
-                        //}
-
-                        //// Move failures into the single result
-                        //for (SearchResult::Failure& failure : availableResult.Failures)
-                        //{
-                        //    result.AddFailureIfSourceNotPresent(std::move(failure));
-                        //}
-
-                        //if (availableResult.Matches.empty())
-                        //{
-                        //    continue;
-                        //}
-
-                        //if (availableResult.Matches.size() == 1)
-                        //{
-                        //    availablePackage = std::move(availableResult.Matches[0].Package);
-                        //}
-                        //else // availableResult.Matches.size() > 1
-                        //{
-                        //    AICLI_LOG(Repo, Info,
-                        //        << "Found multiple matches for installed package [" << installedVersion->GetProperty(PackageVersionProperty::Id) <<
-                        //        "] in source [" << source->GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
-
-                        //    // More than one match found for the system reference; run some heuristics to check for a match
-                        //    for (auto&& availableMatch : availableResult.Matches)
-                        //    {
-                        //        AICLI_LOG(Repo, Info, << "  Checking match with package id: " <<
-                        //            availableMatch.Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Id));
-
-                        //        if (IsStrongMatchField(availableMatch.MatchCriteria.Field))
-                        //        {
-                        //            if (!availablePackage)
-                        //            {
-                        //                availablePackage = std::move(availableMatch.Package);
-                        //            }
-                        //            else
-                        //            {
-                        //                AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
-                        //                availablePackage.reset();
-                        //                break;
-                        //            }
-                        //        }
-                        //    }
-
-                        //    if (!availablePackage)
-                        //    {
-                        //        AICLI_LOG(Repo, Warning, << "  Appropriate available package could not be determined");
-                        //    }
-                        //}
-
-                        //// We found some matching packages here, don't keep going
-                        //break;
-                    }
-
-                    // Search sources and add to result
                     for (const auto& source : m_availableSources)
                     {
-                        // Do not attempt to correlate local packages against this source
-                        if (!source.GetDetails().SupportInstalledSearchCorrelation)
-                        {
-                            continue;
-                        }
+                        auto trackingCatalog = source.GetTrackingCatalog();
+                        SearchResult trackingResult = trackingCatalog.Search(systemReferenceSearch);
 
-                        SearchResult availableResult;
+                        std::shared_ptr<IPackage> candidatePackage = GetMatchingPackage(trackingResult.Matches,
+                            [&]() {
+                                AICLI_LOG(Repo, Info,
+                                    << "Found multiple matches for installed package [" << installedVersion->GetProperty(PackageVersionProperty::Id) <<
+                                    "] in tracking catalog for source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
+                            }, [&] {
+                                AICLI_LOG(Repo, Warning, << "  Appropriate tracking package could not be determined");
+                            });
 
-                        try
+                        // Determine the candidate package with the latest install time
+                        if (candidatePackage)
                         {
-                            availableResult = source.Search(systemReferenceSearch);
-                        }
-                        catch (...)
-                        {
-                            if (result.AddFailureIfSourceNotPresent({ source.GetDetails().Name, std::current_exception() }))
+                            std::chrono::system_clock::time_point candidateTime = GetLatestTrackingPackageWriteTime(candidatePackage);
+
+                            if (!trackingPackage || candidateTime > trackingPackageTime)
                             {
-                                LOG_CAUGHT_EXCEPTION();
-                                AICLI_LOG(Repo, Warning, << "Failed to search source for correlation: " << source.GetDetails().Name);
+                                trackedSource = source;
+                                trackingPackage = std::move(candidatePackage);
+                                trackingPackageTime = candidateTime;
                             }
                         }
+                    }
 
-                        // Move failures into the single result
-                        for (SearchResult::Failure& failure : availableResult.Failures)
-                        {
-                            result.AddFailureIfSourceNotPresent(std::move(failure));
-                        }
+                    // Directly search for the available package from tracking information.
+                    if (trackingPackage)
+                    {
+                        availablePackage = GetTrackedPackageFromAvailableSource(result, trackedSource, trackingPackage->GetProperty(PackageProperty::Id));
+                    }
 
-                        if (availableResult.Matches.empty())
+                    if (!availablePackage)
+                    {
+                        // Search sources and add to result
+                        for (const auto& source : m_availableSources)
                         {
-                            continue;
-                        }
-
-                        if (availableResult.Matches.size() == 1)
-                        {
-                            availablePackage = std::move(availableResult.Matches[0].Package);
-                        }
-                        else // availableResult.Matches.size() > 1
-                        {
-                            AICLI_LOG(Repo, Info,
-                                << "Found multiple matches for installed package [" << installedVersion->GetProperty(PackageVersionProperty::Id) <<
-                                "] in source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
-
-                            // More than one match found for the system reference; run some heuristics to check for a match
-                            for (auto&& availableMatch : availableResult.Matches)
+                            // Do not attempt to correlate local packages against this source
+                            if (!source.GetDetails().SupportInstalledSearchCorrelation)
                             {
-                                AICLI_LOG(Repo, Info, << "  Checking match with package id: " <<
-                                    availableMatch.Package->GetLatestAvailableVersion()->GetProperty(PackageVersionProperty::Id));
-
-                                if (IsStrongMatchField(availableMatch.MatchCriteria.Field))
-                                {
-                                    if (!availablePackage)
-                                    {
-                                        availablePackage = std::move(availableMatch.Package);
-                                    }
-                                    else
-                                    {
-                                        AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
-                                        availablePackage.reset();
-                                        break;
-                                    }
-                                }
+                                continue;
                             }
 
-                            if (!availablePackage)
-                            {
-                                AICLI_LOG(Repo, Warning, << "  Appropriate available package could not be determined");
-                            }
-                        }
+                            SearchResult availableResult = result.SearchAndHandleFailures(source, systemReferenceSearch);
 
-                        // We found some matching packages here, don't keep going
-                        break;
+                            if (availableResult.Matches.empty())
+                            {
+                                continue;
+                            }
+
+                            availablePackage = GetMatchingPackage(availableResult.Matches,
+                                [&]() {
+                                    AICLI_LOG(Repo, Info,
+                                        << "Found multiple matches for installed package [" << installedVersion->GetProperty(PackageVersionProperty::Id) <<
+                                        "] in source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
+                                }, [&] {
+                                    AICLI_LOG(Repo, Warning, << "  Appropriate available package could not be determined");
+                                });
+
+                            // We found some matching packages here, don't keep going
+                            break;
+                        }
                     }
 
                     compositePackage->SetAvailablePackage(std::move(availablePackage));
+                    compositePackage->SetTracking(std::move(trackedSource), std::move(trackingPackage));
                 }
 
                 // Move the installed result into the composite result
@@ -648,30 +809,60 @@ namespace AppInstaller::Repository
         // Search available sources
         for (const auto& source : m_availableSources)
         {
+            // Search the tracking catalog as it can potentially get better correlations
+            auto trackingCatalog = source.GetTrackingCatalog();
+            SearchResult trackingResult = trackingCatalog.Search(request);
+
+            for (auto&& match : trackingResult.Matches)
+            {
+                // Check for a package already in the result that should have been correlated already.
+                auto packageData = result.CheckForExistingResultFromTrackingPackageMatch(match);
+
+                // If found existing package in the result, continue
+                if (!packageData)
+                {
+                    continue;
+                }
+
+                // If no package was found that was already in the results, do a correlation lookup with the installed
+                // source to create a new composite package entry if we find any packages there.
+                if (packageData && !packageData->SystemReferenceStrings.empty())
+                {
+                    // Create a search request to run against the installed source
+                    SearchRequest systemReferenceSearch = packageData->CreateInclusionsSearchRequest();
+
+                    // Correlate against installed (allow exceptions out as we own the installed source)
+                    SearchResult installedCrossRef = m_installedSource->Search(systemReferenceSearch);
+
+                    std::shared_ptr<IPackage> installedPackage = GetMatchingPackage(installedCrossRef.Matches,
+                        [&]() {
+                            AICLI_LOG(Repo, Info,
+                                << "Found multiple matches for tracking package [" << match.Package->GetProperty(PackageProperty::Id) <<
+                                "] in source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
+                        }, [&] {
+                            AICLI_LOG(Repo, Warning, << "  Appropriate installed package could not be determined");
+                        });
+
+                    if (installedPackage && !result.ContainsInstalledPackage(installedPackage.get()))
+                    {
+                        auto compositePackage = std::make_shared<CompositePackage>(
+                            std::move(installedPackage),
+                            GetTrackedPackageFromAvailableSource(result, source, match.Package->GetProperty(PackageProperty::Id)));
+
+                        compositePackage->SetTracking(source, std::move(match.Package));
+
+                        result.Matches.emplace_back(std::move(compositePackage), match.MatchCriteria);
+                    }
+                }
+            }
+
             // Do not attempt to correlate local packages against this source.
             if (m_searchBehavior == CompositeSearchBehavior::Installed && !source.GetDetails().SupportInstalledSearchCorrelation)
             {
                 continue;
             }
 
-            SearchResult availableResult;
-
-            try
-            {
-                availableResult = source.Search(request);
-            }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                AICLI_LOG(Repo, Warning, << "Failed to search source: " << source.GetDetails().Name);
-                result.AddFailureIfSourceNotPresent({ source.GetDetails().Name, std::current_exception() });
-            }
-
-            // Move failures into the single result
-            for (auto& failure : availableResult.Failures)
-            {
-                result.AddFailureIfSourceNotPresent(std::move(failure));
-            }
+            SearchResult availableResult = result.SearchAndHandleFailures(source, request);
 
             for (auto&& match : availableResult.Matches)
             {
@@ -690,45 +881,19 @@ namespace AppInstaller::Repository
                 if (packageData && !packageData->SystemReferenceStrings.empty())
                 {
                     // Create a search request to run against the installed source
-                    SearchRequest systemReferenceSearch;
-                    for (const auto& srs : packageData->SystemReferenceStrings)
-                    {
-                        srs.AddToFilters(systemReferenceSearch.Inclusions);
-                    }
+                    SearchRequest systemReferenceSearch = packageData->CreateInclusionsSearchRequest();
 
                     // Correlate against installed (allow exceptions out as we own the installed source)
                     SearchResult installedCrossRef = m_installedSource->Search(systemReferenceSearch);
 
-                    std::shared_ptr<IPackage> installedPackage;
-                    if (installedCrossRef.Matches.size() == 1)
-                    {
-                        installedPackage = std::move(installedCrossRef.Matches[0].Package);
-                    }
-                    else if (installedCrossRef.Matches.size() > 1)
-                    {
-                        AICLI_LOG(Repo, Info,
-                            << "Found multiple matches for available package [" << match.Package->GetProperty(PackageProperty::Id) <<
-                            "] in source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
-
-                        // More than one match found for the system reference; run some heuristics to check for a match
-                        for (auto&& crossRef : installedCrossRef.Matches)
-                        {
-                            AICLI_LOG(Repo, Info, << "  Checking match with package id: " << crossRef.Package->GetProperty(PackageProperty::Id));
-                            if (IsStrongMatchField(crossRef.MatchCriteria.Field))
-                            {
-                                if (!installedPackage)
-                                {
-                                    installedPackage = std::move(crossRef.Package);
-                                }
-                                else
-                                {
-                                    AICLI_LOG(Repo, Info, << "  Found multiple packages with strong match fields");
-                                    installedPackage.reset();
-                                    break;
-                                }
-                            }
-                        }
-                    }
+                    std::shared_ptr<IPackage> installedPackage = GetMatchingPackage(installedCrossRef.Matches,
+                        [&]() {
+                            AICLI_LOG(Repo, Info,
+                                << "Found multiple matches for available package [" << match.Package->GetProperty(PackageProperty::Id) <<
+                                "] in source [" << source.GetIdentifier() << "] when searching for [" << systemReferenceSearch.ToString() << "]");
+                        }, [&] {
+                            AICLI_LOG(Repo, Warning, << "  Appropriate installed package could not be determined");
+                        });
 
                     if (installedPackage && !result.ContainsInstalledPackage(installedPackage.get()))
                     {

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -693,6 +693,26 @@ namespace AppInstaller::Repository
     // Next the search is performed against the available sources and correlated with the installed source. A result will only
     // be added if there exists an installed package that was not found by the initial search.
     // This allows for search terms to find installed packages by their available metadata, as well as the local values.
+    //
+    // Search flow:
+    //  Installed :: Search incoming request
+    //  For each result
+    //      For each available source
+    //          Tracking :: Search system references
+    //      If tracking found
+    //          Available :: Search tracking ID
+    //      If no available, for each available source
+    //          Available :: Search system references
+    // 
+    //  For each available source
+    //      Tracking :: Search incoming request
+    //      For each result
+    //          Installed :: Search system references
+    //          If found
+    //              Available :: Search tracking ID
+    //      Available :: Search incoming request
+    //      For each result
+    //          Installed :: Search system references
     SearchResult CompositeSource::SearchInstalled(const SearchRequest& request) const
     {
         CompositeResult result;

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -683,7 +683,7 @@ namespace AppInstaller::Repository
         m_availableSources.emplace_back(source);
     }
 
-    void CompositeSource::SetInstalledSource(std::shared_ptr<ISource> source, CompositeSearchBehavior searchBehavior)
+    void CompositeSource::SetInstalledSource(Source source, CompositeSearchBehavior searchBehavior)
     {
         m_installedSource = std::move(source);
         m_searchBehavior = searchBehavior;
@@ -722,7 +722,7 @@ namespace AppInstaller::Repository
         if (m_searchBehavior == CompositeSearchBehavior::AllPackages || m_searchBehavior == CompositeSearchBehavior::Installed)
         {
             // Search installed source (allow exceptions out as we own the installed source)
-            SearchResult installedResult = m_installedSource->Search(request);
+            SearchResult installedResult = m_installedSource.Search(request);
             result.Truncated = installedResult.Truncated;
 
             for (auto&& match : installedResult.Matches)
@@ -852,7 +852,7 @@ namespace AppInstaller::Repository
                     SearchRequest systemReferenceSearch = packageData->CreateInclusionsSearchRequest();
 
                     // Correlate against installed (allow exceptions out as we own the installed source)
-                    SearchResult installedCrossRef = m_installedSource->Search(systemReferenceSearch);
+                    SearchResult installedCrossRef = m_installedSource.Search(systemReferenceSearch);
 
                     std::shared_ptr<IPackage> installedPackage = GetMatchingPackage(installedCrossRef.Matches,
                         [&]() {
@@ -904,7 +904,7 @@ namespace AppInstaller::Repository
                     SearchRequest systemReferenceSearch = packageData->CreateInclusionsSearchRequest();
 
                     // Correlate against installed (allow exceptions out as we own the installed source)
-                    SearchResult installedCrossRef = m_installedSource->Search(systemReferenceSearch);
+                    SearchResult installedCrossRef = m_installedSource.Search(systemReferenceSearch);
 
                     std::shared_ptr<IPackage> installedPackage = GetMatchingPackage(installedCrossRef.Matches,
                         [&]() {

--- a/src/AppInstallerRepositoryCore/CompositeSource.h
+++ b/src/AppInstallerRepositoryCore/CompositeSource.h
@@ -42,7 +42,7 @@ namespace AppInstaller::Repository
         bool HasAvailableSource() const { return !m_availableSources.empty(); }
 
         // Sets the installed source to be composited.
-        void SetInstalledSource(std::shared_ptr<ISource> source, CompositeSearchBehavior searchBehavior = CompositeSearchBehavior::Installed);
+        void SetInstalledSource(Source source, CompositeSearchBehavior searchBehavior = CompositeSearchBehavior::Installed);
 
     private:
         // Performs a search when an installed source is present.
@@ -51,7 +51,7 @@ namespace AppInstaller::Repository
         // Performs a search when no installed source is present.
         SearchResult SearchAvailable(const SearchRequest& request) const;
 
-        std::shared_ptr<ISource> m_installedSource;
+        Source m_installedSource;
         std::vector<Source> m_availableSources;
         SourceDetails m_details;
         CompositeSearchBehavior m_searchBehavior;

--- a/src/AppInstallerRepositoryCore/CompositeSource.h
+++ b/src/AppInstallerRepositoryCore/CompositeSource.h
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #pragma once
 #include "ISource.h"
 

--- a/src/AppInstallerRepositoryCore/CompositeSource.h
+++ b/src/AppInstallerRepositoryCore/CompositeSource.h
@@ -28,20 +28,16 @@ namespace AppInstaller::Repository
         // Must be suitable for filesystem names.
         const std::string& GetIdentifier() const override;
 
-        // Gets a value indicating whether this source is a composite of other sources,
-        // and thus the packages may come from disparate sources as well.
-        bool IsComposite() const override { return true; }
-
-        // Gets the available sources if the source is composite.
-        std::vector<std::shared_ptr<ISource>> GetAvailableSources() const override { return m_availableSources; }
-
         // Execute a search on the source.
         SearchResult Search(const SearchRequest& request) const override;
 
         // ~ISource
 
         // Adds an available source to be aggregated.
-        void AddAvailableSource(std::shared_ptr<ISource> source);
+        void AddAvailableSource(const Source& source);
+
+        // Gets the available sources if the source is composite.
+        std::vector<Source> GetAvailableSources() const { return m_availableSources; }
 
         // Checks if any available sources are present
         bool HasAvailableSource() const { return !m_availableSources.empty(); }
@@ -57,7 +53,7 @@ namespace AppInstaller::Repository
         SearchResult SearchAvailable(const SearchRequest& request) const;
 
         std::shared_ptr<ISource> m_installedSource;
-        std::vector<std::shared_ptr<ISource>> m_availableSources;
+        std::vector<Source> m_availableSources;
         SourceDetails m_details;
         CompositeSearchBehavior m_searchBehavior;
     };

--- a/src/AppInstallerRepositoryCore/ISource.h
+++ b/src/AppInstallerRepositoryCore/ISource.h
@@ -24,13 +24,6 @@ namespace AppInstaller::Repository
 
         // Execute a search on the source.
         virtual SearchResult Search(const SearchRequest& request) const = 0;
-
-        // Gets a value indicating whether this source is a composite of other sources,
-        // and thus the packages may come from disparate sources as well.
-        virtual bool IsComposite() const { return false; }
-
-        // Gets the available sources if the source is composite.
-        virtual std::vector<std::shared_ptr<ISource>> GetAvailableSources() const { return {}; }
     };
 
     // Internal interface to represents source information; basically SourceDetails but with methods to enable differential behaviors.

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "winget/PackageTrackingCatalog.h"
+#include "PackageTrackingCatalogSourceFactory.h"
 #include "winget/RepositorySource.h"
 #include "Microsoft/SQLiteIndexSource.h"
 #include "AppInstallerDateTime.h"
@@ -28,6 +29,108 @@ namespace AppInstaller::Repository
             result /= c_PackageTrackingFileName;
             return result;
         }
+
+        struct PackageTrackingCatalogSourceReference : public ISourceReference
+        {
+            PackageTrackingCatalogSourceReference(const SourceDetails& details) : m_details(details) {}
+
+            SourceDetails& GetDetails() override
+            {
+                return m_details;
+            }
+
+            std::string GetIdentifier() override
+            {
+                return m_details.Identifier;
+            }
+
+            SourceInformation GetInformation() override
+            {
+                return {};
+            }
+
+            // Set custom header. Returns false if custom header is not supported.
+            bool SetCustomHeader(std::optional<std::string> header) override
+            {
+                return false;
+            }
+
+            std::shared_ptr<ISource> Open(IProgressCallback&) override
+            {
+                m_details.Arg = Utility::MakeSuitablePathPart(m_details.Data);
+                std::filesystem::path trackingDB = GetPackageTrackingFilePath(m_details.Arg);
+
+                std::string lockName = CreateNameForCPRWL(m_details.Arg);
+
+                if (!std::filesystem::exists(trackingDB))
+                {
+                    auto exclusiveLock = Synchronization::CrossProcessReaderWriteLock::LockExclusive(lockName);
+
+                    if (!std::filesystem::exists(trackingDB))
+                    {
+                        std::filesystem::create_directories(trackingDB.parent_path());
+                        SQLiteIndex::CreateNew(trackingDB.u8string(), Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless);
+                    }
+                }
+
+                auto lock = Synchronization::CrossProcessReaderWriteLock::LockShared(lockName);
+
+                SQLiteIndex index = SQLiteIndex::Open(trackingDB.u8string(), SQLiteIndex::OpenDisposition::ReadWrite);
+
+                // TODO: Check schema version and upgrade as necessary when there is a relevant new schema.
+                //       Could write this all now but it will be better tested when there is a new schema.
+
+                return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), std::move(lock));
+            }
+
+        private:
+            // Store the indentifier of the source in the Data field.
+            SourceDetails m_details;
+        };
+
+        struct PackageTrackingCatalogSourceFactoryImpl : public ISourceFactory
+        {
+            std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
+            {
+                THROW_HR_IF(E_INVALIDARG, !Utility::CaseInsensitiveEquals(details.Type, PackageTrackingCatalogSourceFactory::Type()));
+
+                return std::make_shared<PackageTrackingCatalogSourceReference>(details);
+            }
+
+            bool Add(SourceDetails&, IProgressCallback&) override final
+            {
+                THROW_HR(E_NOTIMPL);
+            }
+
+            bool Update(const SourceDetails&, IProgressCallback&) override final
+            {
+                THROW_HR(E_NOTIMPL);
+            }
+
+            bool Remove(const SourceDetails& details, IProgressCallback& progress) override final
+            {
+                THROW_HR_IF(E_INVALIDARG, !Utility::CaseInsensitiveEquals(details.Type, PackageTrackingCatalogSourceFactory::Type()));
+
+                std::string pathName = Utility::MakeSuitablePathPart(details.Data);
+
+                std::string lockName = CreateNameForCPRWL(pathName);
+                auto lock = Synchronization::CrossProcessReaderWriteLock::LockExclusive(lockName, progress);
+
+                if (!lock)
+                {
+                    return false;
+                }
+
+                std::filesystem::path trackingDB = GetPackageTrackingFilePath(pathName);
+
+                if (std::filesystem::exists(trackingDB))
+                {
+                    std::filesystem::remove(trackingDB);
+                }
+
+                return true;
+            }
+        };
     }
 
     struct PackageTrackingCatalog::implementation
@@ -51,43 +154,19 @@ namespace AppInstaller::Repository
             THROW_HR(E_INVALIDARG);
         }
 
-        std::string pathName = Utility::MakeSuitablePathPart(sourceIdentifier);
-
-        std::string lockName = CreateNameForCPRWL(pathName);
-        auto lock = Synchronization::CrossProcessReaderWriteLock::LockShared(lockName);
-
-        std::filesystem::path trackingDB = GetPackageTrackingFilePath(pathName);
-
-        if (!std::filesystem::exists(trackingDB))
-        {
-            lock.Release();
-            lock = Synchronization::CrossProcessReaderWriteLock::LockExclusive(lockName);
-
-            if (!std::filesystem::exists(trackingDB))
-            {
-                std::filesystem::create_directories(trackingDB.parent_path());
-                SQLiteIndex::CreateNew(trackingDB.u8string(), Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless);
-            }
-
-            lock.Release();
-            lock = Synchronization::CrossProcessReaderWriteLock::LockShared(lockName);
-        }
-
-        SQLiteIndex index = SQLiteIndex::Open(trackingDB.u8string(), SQLiteIndex::OpenDisposition::ReadWrite);
-
-        // TODO: Check schema version and upgrade as necessary when there is a relevant new schema.
-        //       Could write this all now but it will be better tested when there is a new schema.
-
         // Create fake details for the source while stashing some information that might be helpful for debugging
         SourceDetails details;
+        details.Type = PackageTrackingCatalogSourceFactory::Type();
         details.Identifier = "*Tracking";
         details.Name = "Tracking for "s + source.GetDetails().Name;
         details.Origin = SourceOrigin::PackageTracking;
-        details.Arg = pathName;
+        details.Data = sourceIdentifier;
+
+        ProgressCallback dummyProgress;
 
         PackageTrackingCatalog result;
         result.m_implementation = std::make_shared<PackageTrackingCatalog::implementation>();
-        result.m_implementation->Source = std::make_shared<SQLiteIndexSource>(details, std::move(index), std::move(lock));
+        result.m_implementation->Source = std::dynamic_pointer_cast<SQLiteIndexSource>(ISourceFactory::GetForType(details.Type)->Create(details)->Open(dummyProgress));
 
         return result;
     }
@@ -99,17 +178,14 @@ namespace AppInstaller::Repository
             THROW_HR(E_INVALIDARG);
         }
 
-        std::string pathName = Utility::MakeSuitablePathPart(identifier);
+        // Create details to pass to the factory; the identifier of the source is passed in the Data field.
+        SourceDetails dummyDetails;
+        dummyDetails.Type = PackageTrackingCatalogSourceFactory::Type();
+        dummyDetails.Data = identifier;
 
-        std::string lockName = CreateNameForCPRWL(pathName);
-        auto lock = Synchronization::CrossProcessReaderWriteLock::LockExclusive(lockName);
+        ProgressCallback dummyProgress;
 
-        std::filesystem::path trackingDB = GetPackageTrackingFilePath(pathName);
-
-        if (std::filesystem::exists(trackingDB))
-        {
-            std::filesystem::remove(trackingDB);
-        }
+        ISourceFactory::GetForType(dummyDetails.Type)->Remove(dummyDetails, dummyProgress);
     }
 
     PackageTrackingCatalog::operator bool() const
@@ -201,5 +277,10 @@ namespace AppInstaller::Repository
                 }
             }
         }
+    }
+
+    std::unique_ptr<ISourceFactory> PackageTrackingCatalogSourceFactory::Create()
+    {
+        return std::make_unique<PackageTrackingCatalogSourceFactoryImpl>();
     }
 }

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -44,17 +44,6 @@ namespace AppInstaller::Repository
                 return m_details.Identifier;
             }
 
-            SourceInformation GetInformation() override
-            {
-                return {};
-            }
-
-            // Set custom header. Returns false if custom header is not supported.
-            bool SetCustomHeader(std::optional<std::string> header) override
-            {
-                return false;
-            }
-
             std::shared_ptr<ISource> Open(IProgressCallback&) override
             {
                 m_details.Arg = Utility::MakeSuitablePathPart(m_details.Data);
@@ -84,7 +73,7 @@ namespace AppInstaller::Repository
             }
 
         private:
-            // Store the indentifier of the source in the Data field.
+            // Store the identifier of the source in the Data field.
             SourceDetails m_details;
         };
 

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "winget/PackageTrackingCatalog.h"
+#include "winget/RepositorySource.h"
 #include "Microsoft/SQLiteIndexSource.h"
 #include "AppInstallerDateTime.h"
 
@@ -109,6 +110,11 @@ namespace AppInstaller::Repository
         {
             std::filesystem::remove(trackingDB);
         }
+    }
+
+    PackageTrackingCatalog::operator bool() const
+    {
+        return static_cast<bool>(m_implementation);
     }
 
     SearchResult PackageTrackingCatalog::Search(const SearchRequest& request) const

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalogSourceFactory.h
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalogSourceFactory.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "SourceFactory.h"
+
+using namespace std::string_view_literals;
+
+
+namespace AppInstaller::Repository
+{
+    // Enable test to inject a custom tracking source by integrating the internal source creation into the standard flows.
+    // If overriding, the opened ISource must be a SQLiteIndexSource or the code will fail.
+    struct PackageTrackingCatalogSourceFactory
+    {
+        // Get the type string for this source.
+        static constexpr std::string_view Type()
+        {
+            using namespace std::string_view_literals;
+            return "Microsoft.PackageTracking"sv;
+        }
+
+        // Creates a source factory for this type.
+        static std::unique_ptr<ISourceFactory> Create();
+    };
+}

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
@@ -29,7 +29,7 @@ namespace AppInstaller::Repository
         // Removes the package tracking catalog for a given source identifier.
         static void RemoveForSource(const std::string& identifier);
 
-        // Determines if the curent object holds anything.
+        // Determines if the current object holds anything.
         operator bool() const;
 
         // Execute a search against the catalog.

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
@@ -1,16 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
-#include <Public/winget/RepositorySource.h>
+#include <AppInstallerStrings.h>
+#include <winget/Manifest.h>
 
 #include <memory>
 
 
 namespace AppInstaller::Repository
 {
+    struct Source;
+    struct SearchRequest;
+    struct SearchResult;
+    enum class PackageVersionMetadata;
+
     // A catalog for tracking package actions from a given source.
     struct PackageTrackingCatalog
     {
+        friend Source;
+
         PackageTrackingCatalog();
         PackageTrackingCatalog(const PackageTrackingCatalog&);
         PackageTrackingCatalog& operator=(const PackageTrackingCatalog&);
@@ -18,12 +26,11 @@ namespace AppInstaller::Repository
         PackageTrackingCatalog& operator=(PackageTrackingCatalog&&) noexcept;
         ~PackageTrackingCatalog();
 
-        // Creates or opens the tracking catalog for the given source.
-        // TODO: Make creation exclusive to the refactored Source type.
-        static PackageTrackingCatalog CreateForSource(const Source& source);
-
-        // Removes the package tracking catalog for a given source.
+        // Removes the package tracking catalog for a given source identifier.
         static void RemoveForSource(const std::string& identifier);
+
+        // Determines if the curent object holds anything.
+        operator bool() const;
 
         // Execute a search against the catalog.
         // Note that the packages in the results have the versions under "available" in order to
@@ -56,6 +63,10 @@ namespace AppInstaller::Repository
 
         // Records an uninstall of the given package.
         void RecordUninstall(const Utility::LocIndString& packageIdentifier);
+
+    protected:
+        // Creates or opens the tracking catalog for the given source.
+        static PackageTrackingCatalog CreateForSource(const Source& source);
 
     private:
         struct implementation;

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include <Public/winget/RepositorySearch.h>
+#include <Public/winget/PackageTrackingCatalog.h>
 #include <AppInstallerProgress.h>
 
 #include <chrono>
@@ -174,6 +175,7 @@ namespace AppInstaller::Repository
             CompositeSearchBehavior searchBehavior = CompositeSearchBehavior::Installed);
 
         // Constructor for creating a Source object from an existing ISource.
+        // Should only be used internally by ISource implementations to return the value from IPackageVersion::GetSource.
         Source(std::shared_ptr<ISource> source);
 
         // Bool operator to check if a source reference is successfully acquired.
@@ -244,6 +246,9 @@ namespace AppInstaller::Repository
         // Remove source. Source remove command.
         bool Remove(IProgressCallback& progress);
 
+        // Gets the tracking catalog for the current source.
+        PackageTrackingCatalog GetTrackingCatalog() const;
+
         // Drop source. Source reset command.
         static bool DropSource(std::string_view name);
 
@@ -256,5 +261,7 @@ namespace AppInstaller::Repository
         std::vector<std::shared_ptr<ISourceReference>> m_sourceReferences;
         std::shared_ptr<ISource> m_source;
         bool m_isSourceToBeAdded = false;
+        bool m_isComposite = false;
+        mutable PackageTrackingCatalog m_trackingCatalog;
     };
 }

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -291,7 +291,7 @@ namespace AppInstaller::Repository
             compositeSource->AddAvailableSource(availableSource.m_source);
         }
 
-        compositeSource->SetInstalledSource(installedSource.m_source, searchBehavior);
+        compositeSource->SetInstalledSource(installedSource, searchBehavior);
 
         m_source = compositeSource;
         m_isComposite = true;

--- a/src/AppInstallerRepositoryCore/SourceFactory.h
+++ b/src/AppInstallerRepositoryCore/SourceFactory.h
@@ -37,5 +37,8 @@ namespace AppInstaller::Repository
         // Removes the source from the given details.
         // Return value indicates whether the action completed.
         virtual bool Remove(const SourceDetails& details, IProgressCallback& progress) = 0;
+
+        // Gets the factory for the given type.
+        static std::unique_ptr<ISourceFactory> GetForType(std::string_view type);
     };
 }


### PR DESCRIPTION
## Change
This change leverages the tracking data that is stored per source to correlate installed packages to available packages.  This will currently provide no additional benefit with the `winget` source, as we aren't doing the work yet to determine the best fit system artifact when none of our current correlation attempts succeed.  It will help the `msstore` source to correlate as that is currently lacking in support to search system references.

## Validation
Existing regression tests and new tests added for the tracking catalog.  Modified the tracking catalog to enable the existing test infrastructure to inject custom data.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1671)