### PR TITLE
Fix interface casting in client dll.

### DIFF
--- a/src/Microsoft.Management.Deployment.Client/Client.CreateCompositePackageCatalogOptions.h
+++ b/src/Microsoft.Management.Deployment.Client/Client.CreateCompositePackageCatalogOptions.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Management::Deployment::factory_implementation
     {
         auto ActivateInstance() const
         {
-            return winrt::create_instance<winrt::Microsoft::Management::Deployment::PackageManager>(__uuidof(implementation::CreateCompositePackageCatalogOptions), CLSCTX_ALL);
+            return winrt::create_instance<winrt::Microsoft::Management::Deployment::CreateCompositePackageCatalogOptions>(__uuidof(implementation::CreateCompositePackageCatalogOptions), CLSCTX_ALL);
         }
     };
 }

--- a/src/Microsoft.Management.Deployment.Client/Client.FindPackagesOptions.h
+++ b/src/Microsoft.Management.Deployment.Client/Client.FindPackagesOptions.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Management::Deployment::factory_implementation
     {
         auto ActivateInstance() const
         {
-            return winrt::create_instance<winrt::Microsoft::Management::Deployment::PackageManager>(__uuidof(implementation::FindPackagesOptions), CLSCTX_ALL);
+            return winrt::create_instance<winrt::Microsoft::Management::Deployment::FindPackagesOptions>(__uuidof(implementation::FindPackagesOptions), CLSCTX_ALL);
         }
     };
 }

--- a/src/Microsoft.Management.Deployment.Client/Client.InstallOptions.h
+++ b/src/Microsoft.Management.Deployment.Client/Client.InstallOptions.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Management::Deployment::factory_implementation
     {
         auto ActivateInstance() const
         {
-            return winrt::create_instance<winrt::Microsoft::Management::Deployment::PackageManager>(__uuidof(implementation::InstallOptions), CLSCTX_ALL);
+            return winrt::create_instance<winrt::Microsoft::Management::Deployment::InstallOptions>(__uuidof(implementation::InstallOptions), CLSCTX_ALL);
         }
     };
 }

--- a/src/Microsoft.Management.Deployment.Client/Client.PackageMatchFilter.h
+++ b/src/Microsoft.Management.Deployment.Client/Client.PackageMatchFilter.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Management::Deployment::factory_implementation
     {
         auto ActivateInstance() const
         {
-            return winrt::create_instance<winrt::Microsoft::Management::Deployment::PackageManager>(__uuidof(implementation::PackageMatchFilter), CLSCTX_ALL);
+            return winrt::create_instance<winrt::Microsoft::Management::Deployment::PackageMatchFilter>(__uuidof(implementation::PackageMatchFilter), CLSCTX_ALL);
         }
     };
 }


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

Client dll change only, no effect on the packaged winget server. Due to this bug Microsoft.Management.Deployment.Client dll users would receive interface cast failure when using the non-PackageManager classes.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1673)