### PR TITLE
Prevent circular dependency in global telemetry logger creation

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -553,7 +553,13 @@ namespace AppInstaller::Logging
         }
         else
         {
-            static GlobalTelemetryTraceLogger processGlobalTelemetry;
+            static std::once_flag processGlobalTelemetryOnceFlag;
+            static TelemetryTraceLogger processGlobalTelemetry;
+            std::call_once(processGlobalTelemetryOnceFlag,
+                [&]()
+                {
+                    processGlobalTelemetry.Initialize();
+                });
             return processGlobalTelemetry;
         }
     }

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -8,10 +8,13 @@
 #include <vector>
 #include <cguid.h>
 
+namespace AppInstaller::Settings
+{
+    struct UserSettings;
+}
+
 namespace AppInstaller::Logging
 {
-    struct AppInstaller::Settings::UserSettings;
-
     // This type contains the registration lifetime of the telemetry trace logging provider.
     // Due to the nature of trace logging, specific methods should be added per desired trace.
     // As there should not be a significantly large number of individual telemetry events,

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -10,6 +10,8 @@
 
 namespace AppInstaller::Logging
 {
+    struct AppInstaller::Settings::UserSettings;
+
     // This type contains the registration lifetime of the telemetry trace logging provider.
     // Due to the nature of trace logging, specific methods should be added per desired trace.
     // As there should not be a significantly large number of individual telemetry events,
@@ -35,6 +37,9 @@ namespace AppInstaller::Logging
 
         // Capture if UserSettings is enabled and set user profile path
         void Initialize();
+
+        // Try to capture if UserSettings is enabled and set user profile path, returns whether the action is successfully completed.
+        bool TryInitialize();
 
         // Store the passed in name of the Caller for COM calls
         void SetCaller(const std::string& caller);
@@ -131,6 +136,8 @@ namespace AppInstaller::Logging
     protected:
         bool IsTelemetryEnabled() const noexcept;
 
+        void InitializeInternal(const AppInstaller::Settings::UserSettings& userSettings);
+
         // Used to anonymize a string to the best of our ability.
         // Should primarily be used on failure messages or paths if needed.
         std::wstring AnonymizeString(const wchar_t* input) const noexcept;
@@ -138,6 +145,7 @@ namespace AppInstaller::Logging
 
         bool m_isSettingEnabled = true;
         std::atomic_bool m_isRuntimeEnabled{ true };
+        std::atomic_bool m_isInitialized{ false };
 
         GUID m_activityId = GUID_NULL;
         std::wstring m_telemetryCorrelationJsonW = L"{}";

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -147,13 +147,6 @@ namespace AppInstaller::Logging
         std::wstring m_userProfile;
     };
 
-    struct GlobalTelemetryTraceLogger : TelemetryTraceLogger
-    {
-        GlobalTelemetryTraceLogger() { Initialize(); }
-
-        ~GlobalTelemetryTraceLogger() = default;
-    };
-
     // Helper to make the call sites look clean.
     TelemetryTraceLogger& Telemetry();
 

--- a/src/AppInstallerCommonCore/Public/winget/ThreadGlobals.h
+++ b/src/AppInstallerCommonCore/Public/winget/ThreadGlobals.h
@@ -26,13 +26,12 @@ namespace AppInstaller::ThreadLocalStorage
         static ThreadGlobals* GetForCurrentThread();
 
     private:
-        
+
         void Initialize();
 
         std::unique_ptr<AppInstaller::Logging::DiagnosticLogger> m_pDiagnosticLogger;
         std::unique_ptr<AppInstaller::Logging::TelemetryTraceLogger> m_pTelemetryLogger;
         std::once_flag loggerInitOnceFlag;
-        
     };
 
     struct PreviousThreadGlobals

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -188,8 +188,6 @@ namespace AppInstaller::Settings
         ~UserSettings() = default;
     };
 
-    inline UserSettings const& User()
-    {
-        return UserSettings::Instance();
-    }
+    const UserSettings* TryGetUser();
+    UserSettings const& User();
 }

--- a/src/AppInstallerCommonCore/ThreadGlobals.cpp
+++ b/src/AppInstallerCommonCore/ThreadGlobals.cpp
@@ -35,7 +35,7 @@ namespace AppInstaller::ThreadLocalStorage
                 {
                     m_pDiagnosticLogger = std::make_unique<DiagnosticLogger>();
                     m_pTelemetryLogger = std::make_unique<TelemetryTraceLogger>();
-                    
+
                     // The above make_unique for TelemetryTraceLogger will either create an object or will throw which is caught below.
                     m_pTelemetryLogger->Initialize();
                 });

--- a/src/AppInstallerCommonCore/TraceLogger.cpp
+++ b/src/AppInstallerCommonCore/TraceLogger.cpp
@@ -15,7 +15,7 @@ namespace AppInstaller::Logging
 
         TraceLoggingWriteActivity(g_hTraceProvider,
             "Diagnostics",
-            nullptr, // TODO: ActivityId of the Global and COMContext telemetry to be logged in future
+            Telemetry().GetActivityId(),
             nullptr,
             TraceLoggingString(strstr.str().c_str(), "LogMessage"));
     }
@@ -28,7 +28,7 @@ namespace AppInstaller::Logging
     {
         TraceLoggingWriteActivity(g_hTraceProvider,
             "Diagnostics",
-            nullptr, // TODO: ActivityId of the Global and COMContext telemetry to be logged in future
+            Telemetry().GetActivityId(),
             nullptr,
             TraceLoggingCountedUtf8String(message.data(), static_cast<ULONG>(message.size()), "LogMessage"));
     }


### PR DESCRIPTION
Currently there is a potential circular dependency between the telemetry object and the logger object due to the need to open settings to finish telemetry construction.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1674)