### PR TITLE
Add product code and PFN to enable existing searches

### DIFF
--- a/src/Microsoft.Management.Deployment/Converters.cpp
+++ b/src/Microsoft.Management.Deployment/Converters.cpp
@@ -29,6 +29,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         case ::AppInstaller::Repository::PackageMatchField::Tag:
             matchField = Microsoft::Management::Deployment::PackageMatchField::Tag;
             break;
+        case ::AppInstaller::Repository::PackageMatchField::ProductCode:
+            matchField = Microsoft::Management::Deployment::PackageMatchField::ProductCode;
+            break;
+        case ::AppInstaller::Repository::PackageMatchField::PackageFamilyName:
+            matchField = Microsoft::Management::Deployment::PackageMatchField::PackageFamilyName;
+            break;
         default:
             matchField = Microsoft::Management::Deployment::PackageMatchField::Id;
             break;
@@ -55,6 +61,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             break;
         case Microsoft::Management::Deployment::PackageMatchField::Tag:
             matchField = ::AppInstaller::Repository::PackageMatchField::Tag;
+            break;
+        case Microsoft::Management::Deployment::PackageMatchField::ProductCode:
+            matchField = ::AppInstaller::Repository::PackageMatchField::ProductCode;
+            break;
+        case Microsoft::Management::Deployment::PackageMatchField::PackageFamilyName:
+            matchField = ::AppInstaller::Repository::PackageMatchField::PackageFamilyName;
             break;
         default:
             matchField = ::AppInstaller::Repository::PackageMatchField::Id;

--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -50,9 +50,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
         auto capability = winrt::Windows::Security::Authorization::AppCapabilityAccess::AppCapability::CreateWithProcessIdForUser(nullptr, GetStringForCapability(requiredCapability), callerProcessId);
         status = capability.CheckAccess();
-        RETURN_HR_IF(E_ACCESSDENIED, status != winrt::Windows::Security::Authorization::AppCapabilityAccess::AppCapabilityAccessStatus::Allowed);
 
-        return S_OK;
+        return (status != winrt::Windows::Security::Authorization::AppCapabilityAccess::AppCapabilityAccessStatus::Allowed ? E_ACCESSDENIED : S_OK);
     }
 
     HRESULT EnsureComCallerHasCapability(Capability requiredCapability)
@@ -64,9 +63,9 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         // and packageQuery does not need to be declared separately.
         if (FAILED(hr) && requiredCapability == Capability::PackageQuery)
         {
-            return EnsureProcessHasCapability(Capability::PackageManagement, callerProcessId);
+            hr = EnsureProcessHasCapability(Capability::PackageManagement, callerProcessId);
         }
-        return hr;
+        RETURN_HR(hr);
     }
 
     // Best effort at getting caller info. This should only be used for logging.

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Management.Deployment
 {
-    [contractversion(2)]
+    [contractversion(3)]
     apicontract WindowsPackageManagerContract{};
 
     /// State of the install.
@@ -283,9 +283,12 @@ namespace Microsoft.Management.Deployment
         Moniker,
         Command,
         Tag,
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 3)]
+        {
+            PackageFamilyName,
+            ProductCode,
+        }
         /// DESIGN NOTE: The following PackageFieldMatchOption from winget/RepositorySearch.h are not implemented in V1.
-        /// PackageFamilyName,
-        /// ProductCode,
         /// NormalizedNameAndPublisher,
     };
 

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
@@ -26,6 +26,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <rescap:Capability Name="packageQuery" />
     <rescap:Capability Name="packageManagement" />
   </Capabilities>
 </Package>

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/Package.appxmanifest
@@ -26,7 +26,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
-    <rescap:Capability Name="packageQuery" />
     <rescap:Capability Name="packageManagement" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
## Change
Add `ProductCode` and `PackageFamilyName` values to enum to enable the existing search capabilities through COM.

Also updates the sample caller to have the `packageQuery` capability as I found that it did not during some manual testing.

## Validation
Manual update to sample app to try it out.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1677)