### PR TITLE
Add preview concept to allow build time determination

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -359,13 +359,13 @@ unparsable
 UNSCOPED
 UParse
 UPSERT
-URIs
+uris
 URLs
 URLZONE
 userfilesetting
 userprofile
 USHORT
-Utils
+utils
 uuid
 UWP
 VERSI

--- a/schemas/JSON/packages/packages.schema.2.0.json
+++ b/schemas/JSON/packages/packages.schema.2.0.json
@@ -13,7 +13,7 @@
     "WinGetVersion": {
       "description": "Version of winget that generated this file",
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\-preview)?$"
     },
 
     "CreationDate": {

--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -48,7 +48,7 @@ namespace AppInstaller::CLI
     void Command::OutputIntroHeader(Execution::Reporter& reporter) const
     {
         reporter.Info() <<
-            Resource::String::WindowsPackageManager << " v"_liv << Runtime::GetClientVersion() << std::endl <<
+            (Runtime::IsReleaseBuild() ? Resource::String::WindowsPackageManager : Resource::String::WindowsPackageManagerPreview) << " v"_liv << Runtime::GetClientVersion() << std::endl <<
             Resource::String::MainCopyrightNotice << std::endl;
     }
 

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -353,6 +353,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsLibrariesDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsStoreTerms);
         WINGET_DEFINE_RESOURCE_STRINGID(WindowsPackageManager);
+        WINGET_DEFINE_RESOURCE_STRINGID(WindowsPackageManagerPreview);
         WINGET_DEFINE_RESOURCE_STRINGID(WordArgumentDescription);
     };
 

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1229,11 +1229,16 @@ Please specify one of them using the `--source` option to proceed.</value>
   </data>
   <data name="WindowsPackageManager" xml:space="preserve">
     <value>Windows Package Manager</value>
+    <comment>The product name.</comment>
   </data>
   <data name="ImportIgnorePackageVersionsArgumentDescription" xml:space="preserve">
     <value>Ignore package versions in import file</value>
   </data>
   <data name="CountOutOfBoundsError" xml:space="preserve">
     <value>The requested number of results must be between 1 and 1000.</value>
+  </data>
+  <data name="WindowsPackageManagerPreview" xml:space="preserve">
+    <value>Windows Package Manager (Preview)</value>
+    <comment>The product name plus an indicator that this is a pre-release version.</comment>
   </data>
 </root>

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -269,6 +269,11 @@
       <PreprocessorDefinitions>WINGET_DISABLE_EXPERIMENTAL_FEATURES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(WingetEnableReleaseBuild)'=='true'">
+    <ClCompile>
+      <PreprocessorDefinitions>WINGET_ENABLE_RELEASE_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="DODownloader.h" />
     <ClInclude Include="Public\winget\AdminSettings.h" />

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -63,4 +63,7 @@ namespace AppInstaller::Runtime
 
     // Checks if the file system at path supports hard links
     bool SupportsHardLinks(const std::filesystem::path& path);
+
+    // Returns true if this is a release build; false if not.
+    inline constexpr bool IsReleaseBuild();
 }

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -25,6 +25,7 @@ namespace AppInstaller::Runtime
 #ifndef WINGET_DISABLE_FOR_FUZZING
         constexpr std::string_view s_SecureSettings_Relative_Packaged = "pkg"sv;
 #endif
+        constexpr std::string_view s_PreviewBuildSuffix = "-preview"sv;
 
         // Gets a boolean indicating whether the current process has identity.
         bool DoesCurrentProcessHaveIdentity()
@@ -167,6 +168,11 @@ namespace AppInstaller::Runtime
         else
         {
             strstr << VERSION_BUILD;
+        }
+
+        if (!IsReleaseBuild())
+        {
+            strstr << s_PreviewBuildSuffix;
         }
 
         return LocIndString{ strstr.str() };
@@ -442,6 +448,15 @@ namespace AppInstaller::Runtime
     bool SupportsHardLinks(const std::filesystem::path& path)
     {
         return IsNTFS(path);
+    }
+
+    constexpr bool IsReleaseBuild()
+    {
+#ifdef WINGET_ENABLE_RELEASE_BUILD
+        return true;
+#else
+        return false;
+#endif
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/binver/binver/version.h
+++ b/src/binver/binver/version.h
@@ -2,7 +2,7 @@
 #define STRINGIZE(s) STRINGIZE2(s)
 
 #define VERSION_MAJOR               1
-#define VERSION_MINOR               0
+#define VERSION_MINOR               2
 #define VERSION_BUILD               0
 #define VERSION_REVISION            0
 


### PR DESCRIPTION
## Change
Adds the ability for determining release/preview status at build time.  This is then used to change the client version and product name that we output in help.

Also bumped the client version to 1.2 as this is appropriate for preview.

## Validation
```
> wingetdev
Windows Package Manager (Preview) v1.2.2-preview
Copyright (c) Microsoft Corporation. All rights reserved.

> wingetdev -v
v1.2.2-preview
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1679)