### PR TITLE
Create shared DLL for winget.exe and COM server

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -574,6 +574,7 @@ UNICODESTRING
 uninstall
 uninstalling
 Unregister
+Unregisters
 untimes
 updatemanifest
 UPLEVEL

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -150,6 +150,7 @@ htm
 IAttachment
 IConfiguration
 idx
+IFACEMETHODIMP
 IGlobal
 IHelp
 IHost
@@ -251,7 +252,9 @@ nuffing
 nullopt
 NX
 objbase
+objidl
 ofile
+Outptr
 Packagedx
 packageinuse
 pathparts
@@ -288,10 +291,12 @@ rebootrequiredforinstall
 rebootrequiredtofinish
 redirector
 Redist
+REFIID
 regexes
 REGSAM
 restsource
 rhs
+riid
 roblox
 rosoft
 rowids
@@ -333,6 +338,7 @@ SYD
 SYG
 sysrefcomp
 Tagit
+TCpp
 Templating
 temppath
 testexampleinstaller

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -88,6 +88,7 @@ ctc
 Ctx
 curated
 CYRL
+Dbg
 debian
 deigh
 deleteifnotneeded
@@ -212,10 +213,12 @@ lw
 lz
 malware
 MBH
+mdmp
 megamorf
 memcpy
 middleware
 midl
+minidump
 minexample
 minschema
 missingdependency

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,7 +278,7 @@ jobs:
       runSettingsFile: 'src\x64\Release\AppInstallerCLIE2ETests\Test.runsettings'
       overrideTestrunParameters: '-PackagedContext true
                                   -AICLIPackagePath $(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release
-                                  -AICLIPath AppInstallerCLI\AppInstallerCLI.exe
+                                  -AICLIPath AppInstallerCLI\winget.exe
                                   -LooseFileRegistration true
                                   -InvokeCommandInDesktopPackage true
                                   -StaticFileRootPath $(Agent.TempDirectory)\TestLocalIndex
@@ -304,7 +304,7 @@ jobs:
       runSettingsFile: 'src\x86\Release\AppInstallerCLIE2ETests\Test.runsettings'
       overrideTestrunParameters: '-PackagedContext true
                                   -AICLIPackagePath $(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x86\Release
-                                  -AICLIPath AppInstallerCLI\AppInstallerCLI.exe
+                                  -AICLIPath AppInstallerCLI\winget.exe
                                   -LooseFileRegistration true
                                   -InvokeCommandInDesktopPackage true
                                   -StaticFileRootPath $(Agent.TempDirectory)\TestLocalIndex

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,13 @@ jobs:
                     /p:AppxBundle=Always 
                     /p:UapAppxPackageBuildMode=StoreUpload'
 
+  - task: PublishBuildArtifacts@1
+    displayName: Publish WindowsPackageManager.dll Symbols
+    inputs:
+      PathtoPublish: 'src\x64\Release\WindowsPackageManager\WindowsPackageManager.pdb'
+      ArtifactName: 'WindowsPackageManager.pdb'
+      publishLocation: 'Container'
+
   - task: PowerShell@2
     displayName: Install Tests Dependencies
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -380,13 +380,6 @@ jobs:
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish CLI Binary
-    inputs:
-      PathtoPublish: 'src\x64\Release\AppInstallerCLI\AppInstallerCLI.exe'
-      ArtifactName: 'AppInstallerCLI.exe'
-      publishLocation: 'Container'
-
-  - task: PublishBuildArtifacts@1
     displayName: Publish Util Binary
     inputs:
       PathtoPublish: 'src\x64\Release\WinGetUtil\WinGetUtil.dll'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,6 +269,16 @@ jobs:
       arguments: '-BuildRoot $(system.defaultWorkingDirectory)\src\x86\Release\LocalhostWebServer -StaticFileRoot $(Agent.TempDirectory)\TestLocalIndex -CertPath $(HTTPSDevCert.secureFilePath) -CertPassword microsoft'
     condition: succeededOrFailed()
 
+  - task: CopyFiles@2
+    displayName: 'Copy x64 Files to Package Output'
+    inputs:
+      SourceFolder: '$(system.defaultWorkingDirectory)\src\x64\Release\WindowsPackageManager'
+      TargetFolder:  '$(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release'
+      Contents: WindowsPackageManager.dll
+      CleanTargetFolder: false
+      OverWrite: true
+    condition: succeededOrFailed()
+
   - task: VSTest@2
     displayName: Run E2E Tests Packaged x64
     inputs:
@@ -293,7 +303,17 @@ jobs:
       PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
       ArtifactName: 'E2ETestPackagedx64Log'
       publishLocation: 'Container'
-    condition: succeededOrFailed()  
+    condition: succeededOrFailed()
+
+  - task: CopyFiles@2
+    displayName: 'Copy x86 Files to Package Output'
+    inputs:
+      SourceFolder: '$(system.defaultWorkingDirectory)\src\x86\Release\WindowsPackageManager'
+      TargetFolder:  '$(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x86\Release'
+      Contents: WindowsPackageManager.dll
+      CleanTargetFolder: false
+      OverWrite: true
+    condition: succeededOrFailed()
 
   - task: VSTest@2
     displayName: Run E2E Tests Packaged x86

--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -5,6 +5,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "AppInstallerCLIPackage", "AppInstallerCLIPackage\AppInstallerCLIPackage.wapproj", "{6AA3791A-0713-4548-A357-87A323E7AC3A}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4BC1F40B-36C2-4BBB-8306-76E490B13BBD} = {4BC1F40B-36C2-4BBB-8306-76E490B13BBD}
+		{2B00D362-AC92-41F3-A8D2-5B1599BDCA01} = {2B00D362-AC92-41F3-A8D2-5B1599BDCA01}
 		{1CC41A9A-AE66-459D-9210-1E572DD7BE69} = {1CC41A9A-AE66-459D-9210-1E572DD7BE69}
 		{5B6F90DF-FD19-4BAE-83D9-24DAD128E777} = {5B6F90DF-FD19-4BAE-83D9-24DAD128E777}
 	EndProjectSection
@@ -141,18 +142,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGetUtilInterop", "WinGet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGetUtilInterop.UnitTests", "WinGetUtilInterop.UnitTests\WinGetUtilInterop.UnitTests.csproj", "{68808357-902B-406C-8C19-E8E26A69DE8A}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsPackageManager", "WindowsPackageManager\WindowsPackageManager.vcxproj", "{2046B5AF-666D-4CE8-8D3E-C32C57908A56}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ManifestSchema\ManifestSchema.vcxitems*{1622da16-914f-4f57-a259-d5169003cc8c}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}*SharedItemsImports = 4
 		WinGetSchemas\WinGetSchemas.vcxitems*{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}*SharedItemsImports = 4
+		binver\binver.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
+		ManifestSchema\ManifestSchema.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
+		WinGetSchemas\WinGetSchemas.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{358bc478-0624-4ad1-a933-0422b5292af8}*SharedItemsImports = 9
 		catch2\catch2.vcxitems*{5295e21e-9868-4de2-a177-fbb97b36579b}*SharedItemsImports = 9
 		ManifestSchema\ManifestSchema.vcxitems*{5890d6ed-7c3b-40f3-b436-b54f640d9e65}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{5890d6ed-7c3b-40f3-b436-b54f640d9e65}*SharedItemsImports = 4
 		binver\binver.vcxitems*{5b6f90df-fd19-4bae-83d9-24dad128e777}*SharedItemsImports = 4
-		ManifestSchema\ManifestSchema.vcxitems*{5b6f90df-fd19-4bae-83d9-24dad128e777}*SharedItemsImports = 4
-		WinGetSchemas\WinGetSchemas.vcxitems*{5b6f90df-fd19-4bae-83d9-24dad128e777}*SharedItemsImports = 4
 		binver\binver.vcxitems*{6e36ddd7-1602-474e-b1d7-d0a7e1d5ad86}*SharedItemsImports = 9
 		ManifestSchema\ManifestSchema.vcxitems*{7d05f64d-ce5a-42aa-a2c1-e91458f061cf}*SharedItemsImports = 9
 		catch2\catch2.vcxitems*{89b1aab4-2bbc-4b65-9ed7-a01d5cf88230}*SharedItemsImports = 4
@@ -955,6 +959,44 @@ Global
 		{68808357-902B-406C-8C19-E8E26A69DE8A}.TestRelease|x64.Build.0 = Release|Any CPU
 		{68808357-902B-406C-8C19-E8E26A69DE8A}.TestRelease|x86.ActiveCfg = Release|Any CPU
 		{68808357-902B-406C-8C19-E8E26A69DE8A}.TestRelease|x86.Build.0 = Release|Any CPU
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|ARM.ActiveCfg = Debug|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|ARM.Build.0 = Debug|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|ARM64.Build.0 = Debug|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|x64.ActiveCfg = Debug|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|x64.Build.0 = Debug|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|x86.ActiveCfg = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Debug|x86.Build.0 = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|Any CPU.ActiveCfg = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|Any CPU.Build.0 = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|ARM.ActiveCfg = Debug|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|ARM.Build.0 = Debug|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|ARM64.ActiveCfg = Debug|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|ARM64.Build.0 = Debug|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|x64.ActiveCfg = Debug|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|x64.Build.0 = Debug|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|x86.ActiveCfg = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Fuzzing|x86.Build.0 = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|Any CPU.ActiveCfg = Release|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|ARM.ActiveCfg = Release|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|ARM.Build.0 = Release|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|ARM64.ActiveCfg = Release|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|ARM64.Build.0 = Release|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|x64.ActiveCfg = Release|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|x64.Build.0 = Release|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|x86.ActiveCfg = Release|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.Release|x86.Build.0 = Release|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|Any CPU.ActiveCfg = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|Any CPU.Build.0 = Debug|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|ARM.ActiveCfg = Release|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|ARM.Build.0 = Release|ARM
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|ARM64.ActiveCfg = Release|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|ARM64.Build.0 = Release|ARM64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|x64.ActiveCfg = Release|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|x64.Build.0 = Release|x64
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|x86.ActiveCfg = Release|Win32
+		{2046B5AF-666D-4CE8-8D3E-C32C57908A56}.TestRelease|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -144,16 +144,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGetUtilInterop.UnitTests
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsPackageManager", "WindowsPackageManager\WindowsPackageManager.vcxproj", "{2046B5AF-666D-4CE8-8D3E-C32C57908A56}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "COMServer", "COMServer\COMServer.vcxitems", "{409CD681-22A4-469D-88AE-CB5E4836E07A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ManifestSchema\ManifestSchema.vcxitems*{1622da16-914f-4f57-a259-d5169003cc8c}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}*SharedItemsImports = 4
 		WinGetSchemas\WinGetSchemas.vcxitems*{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}*SharedItemsImports = 4
+		COMServer\COMServer.vcxitems*{1cc41a9a-ae66-459d-9210-1e572dd7be69}*SharedItemsImports = 4
 		binver\binver.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
+		COMServer\COMServer.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
 		ManifestSchema\ManifestSchema.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
 		WinGetSchemas\WinGetSchemas.vcxitems*{2046b5af-666d-4ce8-8d3e-c32c57908a56}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{358bc478-0624-4ad1-a933-0422b5292af8}*SharedItemsImports = 9
+		COMServer\COMServer.vcxitems*{409cd681-22a4-469d-88ae-cb5e4836e07a}*SharedItemsImports = 9
 		catch2\catch2.vcxitems*{5295e21e-9868-4de2-a177-fbb97b36579b}*SharedItemsImports = 9
+		COMServer\COMServer.vcxitems*{5890d6ed-7c3b-40f3-b436-b54f640d9e65}*SharedItemsImports = 4
 		ManifestSchema\ManifestSchema.vcxitems*{5890d6ed-7c3b-40f3-b436-b54f640d9e65}*SharedItemsImports = 4
 		Valijson\Valijson.vcxitems*{5890d6ed-7c3b-40f3-b436-b54f640d9e65}*SharedItemsImports = 4
 		binver\binver.vcxitems*{5b6f90df-fd19-4bae-83d9-24dad128e777}*SharedItemsImports = 4
@@ -1019,6 +1025,7 @@ Global
 		{1487DFBB-7C53-4BD3-9B2C-9B94C6C91528} = {F2149997-295A-4593-9282-4C675DFEB670}
 		{F5CED6B6-C27F-4405-9033-6C273B8B129C} = {F2149997-295A-4593-9282-4C675DFEB670}
 		{1A47951F-5C7A-4D6D-BB5F-D77484437940} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
+		{409CD681-22A4-469D-88AE-CB5E4836E07A} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B6FDB70C-A751-422C-ACD1-E35419495857}

--- a/src/AppInstallerCLI/main.cpp
+++ b/src/AppInstallerCLI/main.cpp
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-#include <AppInstallerCLICore.h>
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <WindowsPackageManager.h>
 
 int wmain(int argc, wchar_t const** argv)
 {
-    return AppInstaller::CLI::CoreMain(argc, argv);
+    return WindowsPackageManagerCLIMain(argc, argv);
 }

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -239,7 +239,6 @@
   <ItemGroup>
     <ClInclude Include="Argument.h" />
     <ClInclude Include="ChannelStreams.h" />
-    <ClInclude Include="COMContext.h" />
     <ClInclude Include="Command.h" />
     <ClInclude Include="Commands\COMInstallCommand.h" />
     <ClInclude Include="Commands\CompleteCommand.h" />
@@ -260,6 +259,7 @@
     <ClInclude Include="Commands\SettingsCommand.h" />
     <ClInclude Include="CompletionData.h" />
     <ClInclude Include="ContextOrchestrator.h" />
+    <ClInclude Include="Public\COMContext.h" />
     <ClInclude Include="Workflows\DependenciesFlow.h" />
     <ClInclude Include="ExecutionArgs.h" />
     <ClInclude Include="ExecutionContextData.h" />

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
@@ -152,9 +152,6 @@
     <ClInclude Include="ExecutionContext.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="COMContext.h">
-      <Filter>Public</Filter>
-    </ClInclude>
     <ClInclude Include="ContextOrchestrator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -175,6 +172,9 @@
     </ClInclude>
     <ClInclude Include="Workflows\DependencyNodeProcessor.h">
       <Filter>Workflows</Filter>
+    </ClInclude>
+    <ClInclude Include="Public\COMContext.h">
+      <Filter>Public</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -7,6 +7,7 @@
 #include "Workflows/WorkflowBase.h"
 #include <winget/UserSettings.h>
 #include "Commands/InstallCommand.h"
+#include "COMContext.h"
 
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
@@ -132,5 +133,10 @@ namespace AppInstaller::CLI
     catch (...)
     {
         return APPINSTALLER_CLI_ERROR_INTERNAL_ERROR;
+    }
+
+    void ServerInitialize()
+    {
+        AppInstaller::CLI::Execution::COMContext::SetLoggers();
     }
 }

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -9,8 +9,9 @@
 #include "Commands/InstallCommand.h"
 #include "COMContext.h"
 
-// TEMP: DEBUGGING
+#ifndef AICLI_DISABLE_TEST_HOOKS
 #include <winget/Debugging.h>
+#endif
 
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
@@ -50,8 +51,12 @@ namespace AppInstaller::CLI
     {
         init_apartment();
 
-        // TEMP
-        Debugging::EnableSelfInitiatedMinidump();
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (Settings::User().Get<Settings::Setting::EnableSelfInitiatedMinidump>())
+        {
+            Debugging::EnableSelfInitiatedMinidump();
+        }
+#endif
 
         // Enable all logging for this phase; we will update once we have the arguments
         Logging::Log().EnableChannel(Logging::Channel::All);

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -9,6 +9,9 @@
 #include "Commands/InstallCommand.h"
 #include "COMContext.h"
 
+// TEMP: DEBUGGING
+#include <winget/Debugging.h>
+
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
 using namespace AppInstaller::CLI;
@@ -46,6 +49,9 @@ namespace AppInstaller::CLI
     int CoreMain(int argc, wchar_t const** argv) try
     {
         init_apartment();
+
+        // TEMP
+        Debugging::EnableSelfInitiatedMinidump();
 
         // Enable all logging for this phase; we will update once we have the arguments
         Logging::Log().EnableChannel(Logging::Channel::All);

--- a/src/AppInstallerCLICore/Public/AppInstallerCLICore.h
+++ b/src/AppInstallerCLICore/Public/AppInstallerCLICore.h
@@ -4,5 +4,9 @@
 
 namespace AppInstaller::CLI
 {
+    // The core function to act against command line input.
     int CoreMain(int argc, wchar_t const** argv);
+
+    // Initializes the Windows Package Manager COM server.
+    void ServerInitialize();
 }

--- a/src/AppInstallerCLIE2ETests/BaseCommand.cs
+++ b/src/AppInstallerCLIE2ETests/BaseCommand.cs
@@ -45,21 +45,10 @@ namespace AppInstallerCLIE2ETests
 
         public void InitializeAllFeatures(bool status)
         {
-            string localAppDataPath = Environment.GetEnvironmentVariable(Constants.LocalAppData);
-
-            var settingsJson = new
-            {
-                experimentalFeatures = new
-                {
-                    experimentalArg = status,
-                    experimentalCmd = status,
-                    dependencies = status,
-                    directMSI = status,
-                }
-            };
-
-            var serializedSettingsJson = JsonConvert.SerializeObject(settingsJson, Formatting.Indented);
-            File.WriteAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath), serializedSettingsJson);
+            ConfigureFeature("experimentalArg", status);
+            ConfigureFeature("experimentalCmd", status);
+            ConfigureFeature("dependencies", status);
+            ConfigureFeature("directMSI", status);
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/BaseCommand.cs
+++ b/src/AppInstallerCLIE2ETests/BaseCommand.cs
@@ -12,11 +12,6 @@ namespace AppInstallerCLIE2ETests
 
     public class BaseCommand
     {
-        public string SettingsJsonFilePath => TestCommon.PackagedContext ?
-            @"Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\settings.json" :
-            @"Microsoft\WinGet\Settings\settings.json";
-        public readonly string LocalAppData = "LocalAppData";
-
         [OneTimeSetUp]
         public void BaseSetup()
         {
@@ -40,17 +35,17 @@ namespace AppInstallerCLIE2ETests
 
         public void ConfigureFeature(string featureName, bool status)
         {
-            string localAppDataPath = Environment.GetEnvironmentVariable(LocalAppData);
-            JObject settingsJson = JObject.Parse(File.ReadAllText(Path.Combine(localAppDataPath, SettingsJsonFilePath)));
+            string localAppDataPath = Environment.GetEnvironmentVariable(Constants.LocalAppData);
+            JObject settingsJson = JObject.Parse(File.ReadAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath)));
             JObject experimentalFeatures = (JObject)settingsJson["experimentalFeatures"];
             experimentalFeatures[featureName] = status;
 
-            File.WriteAllText(Path.Combine(localAppDataPath, SettingsJsonFilePath), settingsJson.ToString());
+            File.WriteAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath), settingsJson.ToString());
         }
 
         public void InitializeAllFeatures(bool status)
         {
-            string localAppDataPath = Environment.GetEnvironmentVariable(LocalAppData);
+            string localAppDataPath = Environment.GetEnvironmentVariable(Constants.LocalAppData);
 
             var settingsJson = new
             {
@@ -64,7 +59,7 @@ namespace AppInstallerCLIE2ETests
             };
 
             var serializedSettingsJson = JsonConvert.SerializeObject(settingsJson, Formatting.Indented);
-            File.WriteAllText(Path.Combine(localAppDataPath, SettingsJsonFilePath), serializedSettingsJson);
+            File.WriteAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath), serializedSettingsJson);
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -54,6 +54,9 @@ namespace AppInstallerCLIE2ETests
         public const string TestExeInstalledFileName = "TestExeInstalled.txt";
         public const string TestExeUninstallerFileName = "UninstallTestExe.bat";
 
+        // Locations
+        public const string LocalAppData = "LocalAppData";
+
         public class ErrorCode
         {
             public const int S_OK = 0;

--- a/src/AppInstallerCLIE2ETests/ListCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ListCommand.cs
@@ -22,7 +22,7 @@ namespace AppInstallerCLIE2ETests
             string productCode = guid.ToString();
             var installDir = TestCommon.GetRandomTestDir();
 
-            string localAppDataPath = System.Environment.GetEnvironmentVariable(LocalAppData);
+            string localAppDataPath = System.Environment.GetEnvironmentVariable(Constants.LocalAppData);
             string logFilePath = System.IO.Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
             logFilePath = System.IO.Path.Combine(logFilePath, "ListAfterInstall-" + System.IO.Path.GetRandomFileName() + ".log");
 

--- a/src/AppInstallerCLIE2ETests/SetUpFixture.cs
+++ b/src/AppInstallerCLIE2ETests/SetUpFixture.cs
@@ -44,7 +44,7 @@ namespace AppInstallerCLIE2ETests
                 }
                 else
                 {
-                    TestCommon.AICLIPath = TestCommon.GetTestFile("AppInstallerCli.exe");
+                    TestCommon.AICLIPath = TestCommon.GetTestFile("winget.exe");
                 }
             }
 

--- a/src/AppInstallerCLIE2ETests/SetUpFixture.cs
+++ b/src/AppInstallerCLIE2ETests/SetUpFixture.cs
@@ -4,6 +4,7 @@
 namespace AppInstallerCLIE2ETests
 {
     using Microsoft.Win32;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using NUnit.Framework;
     using System;
@@ -99,7 +100,7 @@ namespace AppInstallerCLIE2ETests
 
             TestIndexSetup.GenerateTestDirectory();
 
-            EnableWingetSelfInitiatedMinidump(true);
+            InitializeWingetSettings();
         }
 
         [OneTimeTearDown]
@@ -198,28 +199,27 @@ namespace AppInstallerCLIE2ETests
             }
         }
 
-        private void EnableWingetSelfInitiatedMinidump(bool enabled)
+        public void InitializeWingetSettings()
         {
             string localAppDataPath = Environment.GetEnvironmentVariable(Constants.LocalAppData);
-            JObject settingsJson = JObject.Parse(File.ReadAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath)));
-            JObject debugging = (JObject)settingsJson["debugging"];
 
-            if (debugging == null)
+            var settingsJson = new
             {
-                settingsJson["debugging"] = JObject.FromObject(new
+                experimentalFeatures = new
                 {
-                    debugging = new
-                    {
-                        enableSelfInitiatedMinidump = enabled
-                    }
-                });
-            }
-            else
-            {
-                debugging["enableSelfInitiatedMinidump"] = enabled;
-            }
+                    experimentalArg = false,
+                    experimentalCmd = false,
+                    dependencies = false,
+                    directMSI = false,
+                },
+                debugging = new
+                {
+                    enableSelfInitiatedMinidump = true
+                }
+            };
 
-            File.WriteAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath), settingsJson.ToString());
+            var serializedSettingsJson = JsonConvert.SerializeObject(settingsJson, Formatting.Indented);
+            File.WriteAllText(Path.Combine(localAppDataPath, TestCommon.SettingsJsonFilePath), serializedSettingsJson);
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -34,6 +34,15 @@ namespace AppInstallerCLIE2ETests
         
         public static string PackageCertificatePath { get; set; }
 
+        public static string SettingsJsonFilePath {
+            get
+            {
+                return PackagedContext ?
+                    @"Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\settings.json" :
+                    @"Microsoft\WinGet\Settings\settings.json";
+            }
+        }
+
         public struct RunCommandResult
         {
             public int ExitCode;

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -103,7 +103,7 @@ namespace AppInstallerCLIE2ETests
             }
             else
             {
-                throw new TimeoutException("Command run timed out.");
+                throw new TimeoutException($"Command run timed out {command} {parameters}");
             }
 
             return result;
@@ -155,7 +155,7 @@ namespace AppInstallerCLIE2ETests
 
             if (waitedTime >= timeOut)
             {
-                throw new TimeoutException("Command run timed out.");
+                throw new TimeoutException($"Command run timed out {command} {parameters}");
             }
 
             RunCommandResult result = new RunCommandResult();

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -103,7 +103,7 @@ namespace AppInstallerCLIE2ETests
             }
             else
             {
-                throw new TimeoutException($"Command run timed out {command} {parameters}");
+                throw new TimeoutException($"Direct winget command run timed out: {command} {parameters}");
             }
 
             return result;
@@ -155,7 +155,7 @@ namespace AppInstallerCLIE2ETests
 
             if (waitedTime >= timeOut)
             {
-                throw new TimeoutException($"Command run timed out {command} {parameters}");
+                throw new TimeoutException($"Packaged winget command run timed out: {command} {parameters}");
             }
 
             RunCommandResult result = new RunCommandResult();

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -140,6 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLI\AppInstallerCLI.vcxproj" />
+    <ProjectReference Include="..\WinGetServer\WinGetServer.vcxproj" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <PropertyGroup Label="Configuration">
@@ -150,42 +151,24 @@
   </PropertyGroup>
   <Target Name="IncludeWinMdInPackage" AfterTargets="_ComputeAppxPackagePayload">
     <PropertyGroup>
-      <AppInstallerCLIPath>$(OutputPath)\..\winget.exe</AppInstallerCLIPath>
-      <AppInstallerCLIPath Condition="!Exists('$(AppInstallerCLIPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\AppInstallerCLI\winget.exe</AppInstallerCLIPath>
-      <AppInstallerCLIFileName>WinGetDev.exe</AppInstallerCLIFileName>
       <WindowsPackageManagerPath>$(OutputPath)\..\WindowsPackageManager.dll</WindowsPackageManagerPath>
       <WindowsPackageManagerPath Condition="!Exists('$(WindowsPackageManagerPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\WindowsPackageManager\WindowsPackageManager.dll</WindowsPackageManagerPath>
       <WindowsPackageManagerFileName>WindowsPackageManager.dll</WindowsPackageManagerFileName>
-      <WPMServerPath>$(OutputPath)\..\WindowsPackageManagerServer.exe</WPMServerPath>
-      <WPMServerPath Condition="!Exists('$(WPMServerPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\WinGetServer\WindowsPackageManagerServer.exe</WPMServerPath>
-      <WPMServerFileName>WindowsPackageManagerServer.exe</WPMServerFileName>
       <MicrosoftManagementDeploymentPath>$(OutputPath)\..\Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentPath>
       <MicrosoftManagementDeploymentPath Condition="!Exists('$(MicrosoftManagementDeploymentPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentPath>
       <MicrosoftManagementDeploymentFileName>Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentFileName>
     </PropertyGroup>
     <ItemGroup>
-      <AppInstallerCLIItem Include="$(AppInstallerCLIPath)" />
       <WindowsPackageManagerItem Include="$(WindowsPackageManagerPath)" />
-      <WPMServerItem Include="$(WPMServerPath)" />
       <MicrosoftManagementDeploymentWinmd Include="$(MicrosoftManagementDeploymentPath)" />
     </ItemGroup>
-    <Error Condition="!Exists('$(AppInstallerCLIPath)')" Text="$(AppInstallerCLIPath) was not found" />
     <Error Condition="!Exists('$(WindowsPackageManagerPath)')" Text="$(WindowsPackageManagerPath) was not found" />
-    <Error Condition="!Exists('$(WPMServerPath)')" Text="$(WPMServerPath) was not found" />
     <Error Condition="!Exists('$(MicrosoftManagementDeploymentPath)')" Text="$(MicrosoftManagementDeploymentPath) was not found" />
-    <Message Importance="normal" Condition="Exists('$(AppInstallerCLIPath)')" Text="$(AppInstallerCLIPath) -&gt; $(AppInstallerCLIFileName)" />
     <Message Importance="normal" Condition="Exists('$(WindowsPackageManagerPath)')" Text="$(WindowsPackageManagerPath) -&gt; $(WindowsPackageManagerFileName)" />
-    <Message Importance="normal" Condition="Exists('$(WPMServerPath)')" Text="$(WPMServerPath) -&gt; $(WPMServerFileName)" />
     <Message Importance="normal" Condition="Exists('$(MicrosoftManagementDeploymentPath)')" Text="$(MicrosoftManagementDeploymentPath) -&gt; $(MicrosoftManagementDeploymentFileName)" />
     <ItemGroup>
-      <AppxPackagePayload Include="@(AppInstallerCLIItem)" KeepDuplicates="false">
-        <TargetPath>$(AppInstallerCLIFileName)</TargetPath>
-      </AppxPackagePayload>
       <AppxPackagePayload Include="@(WindowsPackageManagerItem)" KeepDuplicates="false">
         <TargetPath>$(WindowsPackageManagerFileName)</TargetPath>
-      </AppxPackagePayload>
-      <AppxPackagePayload Include="@(WPMServerItem)" KeepDuplicates="false">
-        <TargetPath>$(WPMServerFileName)</TargetPath>
       </AppxPackagePayload>
       <AppxPackagePayload Include="@(MicrosoftManagementDeploymentWinmd)" KeepDuplicates="false">
         <TargetPath>$(MicrosoftManagementDeploymentFileName)</TargetPath>

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -140,7 +140,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLI\AppInstallerCLI.vcxproj" />
-    <ProjectReference Include="..\WinGetServer\WinGetServer.vcxproj" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <PropertyGroup Label="Configuration">
@@ -151,16 +150,43 @@
   </PropertyGroup>
   <Target Name="IncludeWinMdInPackage" AfterTargets="_ComputeAppxPackagePayload">
     <PropertyGroup>
+      <AppInstallerCLIPath>$(OutputPath)\..\winget.exe</AppInstallerCLIPath>
+      <AppInstallerCLIPath Condition="!Exists('$(AppInstallerCLIPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\AppInstallerCLI\winget.exe</AppInstallerCLIPath>
+      <AppInstallerCLIFileName>WinGetDev.exe</AppInstallerCLIFileName>
+      <WindowsPackageManagerPath>$(OutputPath)\..\WindowsPackageManager.dll</WindowsPackageManagerPath>
+      <WindowsPackageManagerPath Condition="!Exists('$(WindowsPackageManagerPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\WindowsPackageManager\WindowsPackageManager.dll</WindowsPackageManagerPath>
+      <WindowsPackageManagerFileName>WindowsPackageManager.dll</WindowsPackageManagerFileName>
+      <WPMServerPath>$(OutputPath)\..\WindowsPackageManagerServer.exe</WPMServerPath>
+      <WPMServerPath Condition="!Exists('$(WPMServerPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\WinGetServer\WindowsPackageManagerServer.exe</WPMServerPath>
+      <WPMServerFileName>WindowsPackageManagerServer.exe</WPMServerFileName>
       <MicrosoftManagementDeploymentPath>$(OutputPath)\..\Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentPath>
       <MicrosoftManagementDeploymentPath Condition="!Exists('$(MicrosoftManagementDeploymentPath)')">$(TargetDir)..\..\..\..\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentPath>
       <MicrosoftManagementDeploymentFileName>Microsoft.Management.Deployment.winmd</MicrosoftManagementDeploymentFileName>
     </PropertyGroup>
     <ItemGroup>
+      <AppInstallerCLIItem Include="$(AppInstallerCLIPath)" />
+      <WindowsPackageManagerItem Include="$(WindowsPackageManagerPath)" />
+      <WPMServerItem Include="$(WPMServerPath)" />
       <MicrosoftManagementDeploymentWinmd Include="$(MicrosoftManagementDeploymentPath)" />
     </ItemGroup>
+    <Error Condition="!Exists('$(AppInstallerCLIPath)')" Text="$(AppInstallerCLIPath) was not found" />
+    <Error Condition="!Exists('$(WindowsPackageManagerPath)')" Text="$(WindowsPackageManagerPath) was not found" />
+    <Error Condition="!Exists('$(WPMServerPath)')" Text="$(WPMServerPath) was not found" />
     <Error Condition="!Exists('$(MicrosoftManagementDeploymentPath)')" Text="$(MicrosoftManagementDeploymentPath) was not found" />
+    <Message Importance="normal" Condition="Exists('$(AppInstallerCLIPath)')" Text="$(AppInstallerCLIPath) -&gt; $(AppInstallerCLIFileName)" />
+    <Message Importance="normal" Condition="Exists('$(WindowsPackageManagerPath)')" Text="$(WindowsPackageManagerPath) -&gt; $(WindowsPackageManagerFileName)" />
+    <Message Importance="normal" Condition="Exists('$(WPMServerPath)')" Text="$(WPMServerPath) -&gt; $(WPMServerFileName)" />
     <Message Importance="normal" Condition="Exists('$(MicrosoftManagementDeploymentPath)')" Text="$(MicrosoftManagementDeploymentPath) -&gt; $(MicrosoftManagementDeploymentFileName)" />
     <ItemGroup>
+      <AppxPackagePayload Include="@(AppInstallerCLIItem)" KeepDuplicates="false">
+        <TargetPath>$(AppInstallerCLIFileName)</TargetPath>
+      </AppxPackagePayload>
+      <AppxPackagePayload Include="@(WindowsPackageManagerItem)" KeepDuplicates="false">
+        <TargetPath>$(WindowsPackageManagerFileName)</TargetPath>
+      </AppxPackagePayload>
+      <AppxPackagePayload Include="@(WPMServerItem)" KeepDuplicates="false">
+        <TargetPath>$(WPMServerFileName)</TargetPath>
+      </AppxPackagePayload>
       <AppxPackagePayload Include="@(MicrosoftManagementDeploymentWinmd)" KeepDuplicates="false">
         <TargetPath>$(MicrosoftManagementDeploymentFileName)</TargetPath>
       </AppxPackagePayload>

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -22,7 +22,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="WinGetDev" Executable="WinGetDev.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="WinGetDev" Executable="AppInstallerCLI\winget.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="WinGet Dev Client" Square150x150Logo="Images\Square150x150Logo.png" Square44x44Logo="Images\Square44x44Logo.png" Description="The WinGet dev client." BackgroundColor="#0078d7" AppListEntry="none" />
       <Extensions>
         <uap3:Extension Category="windows.appExtensionHost">
@@ -37,7 +37,7 @@
         </uap5:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="WindowsPackageManagerServer.exe" DisplayName="Windows Package Manager Server" LaunchAndActivationPermission="O:SYG:SYD:(A;;11;;;WD)(A;;11;;;RC)(A;;11;;;AC)(A;;11;;;AN)S:P(ML;;NX;;;S-1-16-0)">
+            <com:ExeServer Executable="WinGetServer\WindowsPackageManagerServer.exe" DisplayName="Windows Package Manager Server" LaunchAndActivationPermission="O:SYG:SYD:(A;;11;;;WD)(A;;11;;;RC)(A;;11;;;AC)(A;;11;;;AN)S:P(ML;;NX;;;S-1-16-0)">
               <com:Class Id ="74CB3139-B7C5-4B9E-9388-E6616DEA288C" DisplayName="PackageManager Server">
               </com:Class>
               <com:Class Id ="1BD8FF3A-EC50-4F69-AEEE-DF4C9D3BAA96" DisplayName="FindPackagesOptions Server">

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -22,7 +22,7 @@
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="WinGetDev" Executable="AppInstallerCLI\AppInstallerCLI.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="WinGetDev" Executable="WinGetDev.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="WinGet Dev Client" Square150x150Logo="Images\Square150x150Logo.png" Square44x44Logo="Images\Square44x44Logo.png" Description="The WinGet dev client." BackgroundColor="#0078d7" AppListEntry="none" />
       <Extensions>
         <uap3:Extension Category="windows.appExtensionHost">
@@ -37,7 +37,7 @@
         </uap5:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="WinGetServer\WindowsPackageManagerServer.exe" DisplayName="Windows Package Manager Server" LaunchAndActivationPermission="O:SYG:SYD:(A;;11;;;WD)(A;;11;;;RC)(A;;11;;;AC)(A;;11;;;AN)S:P(ML;;NX;;;S-1-16-0)">
+            <com:ExeServer Executable="WindowsPackageManagerServer.exe" DisplayName="Windows Package Manager Server" LaunchAndActivationPermission="O:SYG:SYD:(A;;11;;;WD)(A;;11;;;RC)(A;;11;;;AC)(A;;11;;;AN)S:P(ML;;NX;;;S-1-16-0)">
               <com:Class Id ="74CB3139-B7C5-4B9E-9388-E6616DEA288C" DisplayName="PackageManager Server">
               </com:Class>
               <com:Class Id ="1BD8FF3A-EC50-4F69-AEEE-DF4C9D3BAA96" DisplayName="FindPackagesOptions Server">

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -93,6 +93,7 @@
   <ImportGroup Label="Shared">
     <Import Project="..\Valijson\Valijson.vcxitems" Label="Shared" />
     <Import Project="..\ManifestSchema\ManifestSchema.vcxitems" Label="Shared" />
+    <Import Project="..\COMServer\COMServer.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -272,6 +272,7 @@
   <ItemGroup>
     <ClInclude Include="DODownloader.h" />
     <ClInclude Include="Public\winget\AdminSettings.h" />
+    <ClInclude Include="Public\winget\Debugging.h" />
     <ClInclude Include="Public\winget\DependenciesGraph.h" />
     <ClInclude Include="Public\winget\GroupPolicy.h" />
     <ClInclude Include="HttpStream\HttpClientWrapper.h" />
@@ -325,6 +326,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AdminSettings.cpp" />
+    <ClCompile Include="Debugging.cpp" />
     <ClCompile Include="DependenciesGraph.cpp" />
     <ClCompile Include="DODownloader.cpp" />
     <ClCompile Include="GroupPolicy.cpp">

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj.filters
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClInclude Include="Public\winget\DependenciesGraph.h">
       <Filter>Public\winget</Filter>
     </ClInclude>
+    <ClInclude Include="Public\winget\Debugging.h">
+      <Filter>Public\winget</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -318,6 +321,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DependenciesGraph.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Debugging.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/AppInstallerCommonCore/Debugging.cpp
+++ b/src/AppInstallerCommonCore/Debugging.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Public/winget/Debugging.h"
+#include "Public/AppInstallerRuntime.h"
+#include "Public/AppInstallerDateTime.h"
+
+namespace AppInstaller::Debugging
+{
+    namespace
+    {
+        constexpr std::string_view c_minidumpPrefix = "Minidump";
+        constexpr std::string_view c_minidumpExtension = ".mdmp";
+
+        struct SelfInitiatedMinidumpHelper
+        {
+            SelfInitiatedMinidumpHelper() : m_keepFile(false)
+            {
+                m_filePath = Runtime::GetPathTo(Runtime::PathName::DefaultLogLocation);
+                m_filePath /= c_minidumpPrefix.data() + ('-' + Utility::GetCurrentTimeForFilename() + c_minidumpExtension.data());
+
+                m_file.reset(CreateFile(m_filePath.wstring().c_str(), GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+                THROW_LAST_ERROR_IF(!m_file);
+
+                SetUnhandledExceptionFilter(UnhandledExceptionCallback);
+            }
+
+            ~SelfInitiatedMinidumpHelper()
+            {
+                if (!m_keepFile)
+                {
+                    m_file.reset();
+                    DeleteFile(m_filePath.wstring().c_str());
+                }
+            }
+
+            static SelfInitiatedMinidumpHelper& Instance()
+            {
+                static SelfInitiatedMinidumpHelper instance;
+                return instance;
+            }
+
+            static LONG WINAPI UnhandledExceptionCallback(EXCEPTION_POINTERS* ExceptionInfo)
+            {
+                MINIDUMP_EXCEPTION_INFORMATION exceptionInformation{};
+                // The unhandled exception filter is executed in the context of the failing thread.
+                exceptionInformation.ThreadId = GetCurrentThreadId();
+                exceptionInformation.ExceptionPointers = ExceptionInfo;
+                exceptionInformation.ClientPointers = FALSE;
+
+                std::thread([&]() {
+                    MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), Instance().m_file.get(), MiniDumpNormal, &exceptionInformation, nullptr, nullptr);
+                    Instance().m_keepFile = true;
+                }).join();
+
+                return EXCEPTION_CONTINUE_SEARCH;
+            }
+
+        private:
+            std::filesystem::path m_filePath;
+            wil::unique_handle m_file;
+            std::atomic_bool m_keepFile;
+        };
+    }
+
+    void EnableSelfInitiatedMinidump()
+    {
+        // Force object creation and thus enabling of the crash detection.
+        SelfInitiatedMinidumpHelper::Instance();
+    }
+}

--- a/src/AppInstallerCommonCore/Public/winget/Debugging.h
+++ b/src/AppInstallerCommonCore/Public/winget/Debugging.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+namespace AppInstaller::Debugging
+{
+    // Enables a self initiated minidump on certain process level failures.
+    void EnableSelfInitiatedMinidump();
+}

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -76,6 +76,7 @@ namespace AppInstaller::Settings
         InstallLocalePreference,
         InstallLocaleRequirement,
         EFDirectMSI,
+        EnableSelfInitiatedMinidump,
         Max
     };
 
@@ -122,6 +123,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocalePreference, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.preferences.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
 
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.
         template <size_t... I>

--- a/src/AppInstallerCommonCore/SHA256.cpp
+++ b/src/AppInstallerCommonCore/SHA256.cpp
@@ -6,7 +6,6 @@
 #include "Public/AppInstallerSHA256.h"
 #include "Public/AppInstallerRuntime.h"
 #include "Public/AppInstallerErrors.h"
-#include "Public/AppInstallerLogging.h"
 
 using namespace AppInstaller::Runtime;
 
@@ -143,8 +142,6 @@ namespace AppInstaller::Utility {
 
     SHA256::HashBuffer SHA256::ComputeHash(std::istream& in)
     {
-        // TODO: DELETE ALL LOGGING FROM HERE
-        AICLI_LOG(Core, Info, << "Starting ComputeHash: stream is " << in.rdstate());
         // Throw exceptions on badbit
         auto excState = in.exceptions();
         auto revertExcState = wil::scope_exit([excState, &in]() { in.exceptions(excState); });
@@ -157,20 +154,15 @@ namespace AppInstaller::Utility {
 
         while (in.good())
         {
-            AICLI_LOG(Core, Info, << "Reading stream");
             in.read((char*)(buffer.get()), bufferSize);
-            AICLI_LOG(Core, Info, << "  read " << in.gcount() << " bytes");
             if (in.gcount())
             {
-                AICLI_LOG(Core, Info, << "  adding to hash");
                 hasher.Add(buffer.get(), static_cast<size_t>(in.gcount()));
             }
-            AICLI_LOG(Core, Info, << "  stream is " << in.rdstate());
         }
 
         if (in.eof())
         {
-            AICLI_LOG(Core, Info, << "Returning hash");
             return hasher.Get();
         }
         else

--- a/src/AppInstallerCommonCore/SHA256.cpp
+++ b/src/AppInstallerCommonCore/SHA256.cpp
@@ -6,6 +6,7 @@
 #include "Public/AppInstallerSHA256.h"
 #include "Public/AppInstallerRuntime.h"
 #include "Public/AppInstallerErrors.h"
+#include "Public/AppInstallerLogging.h"
 
 using namespace AppInstaller::Runtime;
 
@@ -142,6 +143,8 @@ namespace AppInstaller::Utility {
 
     SHA256::HashBuffer SHA256::ComputeHash(std::istream& in)
     {
+        // TODO: DELETE ALL LOGGING FROM HERE
+        AICLI_LOG(Core, Info, << "Starting ComputeHash: stream is " << in.rdstate());
         // Throw exceptions on badbit
         auto excState = in.exceptions();
         auto revertExcState = wil::scope_exit([excState, &in]() { in.exceptions(excState); });
@@ -154,15 +157,20 @@ namespace AppInstaller::Utility {
 
         while (in.good())
         {
+            AICLI_LOG(Core, Info, << "Reading stream");
             in.read((char*)(buffer.get()), bufferSize);
+            AICLI_LOG(Core, Info, << "  read " << in.gcount() << " bytes");
             if (in.gcount())
             {
+                AICLI_LOG(Core, Info, << "  adding to hash");
                 hasher.Add(buffer.get(), static_cast<size_t>(in.gcount()));
             }
+            AICLI_LOG(Core, Info, << "  stream is " << in.rdstate());
         }
 
         if (in.eof())
         {
+            AICLI_LOG(Core, Info, << "Returning hash");
             return hasher.Get();
         }
         else

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -227,6 +227,7 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFDependencies)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
+        WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
 
         WINGET_VALIDATE_SIGNATURE(InstallScopePreference)
         {

--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -12,6 +12,7 @@
 #include <wow64apiset.h>
 #include <icu.h>
 #include <msi.h>
+#include <DbgHelp.h>
 
 #include "TraceLogging.h"
 

--- a/src/COMServer/COMServer.vcxitems
+++ b/src/COMServer/COMServer.vcxitems
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <ItemsProjectGuid>{409cd681-22a4-469d-88ae-cb5e4836e07a}</ItemsProjectGuid>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>__WRL_DISABLE_STATIC_INITIALIZE__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/Microsoft.Management.Deployment/CreateCompositePackageCatalogOptions.cpp
+++ b/src/Microsoft.Management.Deployment/CreateCompositePackageCatalogOptions.cpp
@@ -9,6 +9,7 @@
 #include "CreateCompositePackageCatalogOptions.h"
 #pragma warning( pop )
 #include "CreateCompositePackageCatalogOptions.g.cpp"
+#include "Helpers.h"
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
@@ -24,5 +25,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         m_compositeSearchBehavior = value;
     }
-    CoCreatableCppWinRtClass(CreateCompositePackageCatalogOptions);
+
+    CoCreatableMicrosoftManagementDeploymentClass(CreateCompositePackageCatalogOptions);
 }

--- a/src/Microsoft.Management.Deployment/FindPackagesOptions.cpp
+++ b/src/Microsoft.Management.Deployment/FindPackagesOptions.cpp
@@ -9,6 +9,7 @@
 #include "FindPackagesOptions.h"
 #pragma warning( pop )
 #include "FindPackagesOptions.g.cpp"
+#include "Helpers.h"
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
@@ -28,5 +29,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         m_resultLimit = value;
     }
-    CoCreatableCppWinRtClass(FindPackagesOptions);
+
+    CoCreatableMicrosoftManagementDeploymentClass(FindPackagesOptions);
 }

--- a/src/Microsoft.Management.Deployment/Helpers.h
+++ b/src/Microsoft.Management.Deployment/Helpers.h
@@ -1,7 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 #pragma once
+#include <winget/GroupPolicy.h>
+#include <wil\cppwinrt_wrl.h>
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
+    // Enable custom code to run before creating any object through the factory.
+    // Currently that means requiring the overall WinGet policy to be enabled.
+    template <typename TCppWinRTClass>
+    class wrl_factory_for_winrt_com_class : public ::wil::wrl_factory_for_winrt_com_class<TCppWinRTClass>
+    {
+    public:
+        IFACEMETHODIMP CreateInstance(_In_opt_::IUnknown* unknownOuter, REFIID riid, _COM_Outptr_ void** object) noexcept try
+        {
+            *object = nullptr;
+            RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, !::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet));
+
+            return ::wil::wrl_factory_for_winrt_com_class<TCppWinRTClass>::CreateInstance(unknownOuter, riid, object);
+        }
+        CATCH_RETURN()
+    };
+
+#define CoCreatableMicrosoftManagementDeploymentClass(className) \
+    CoCreatableClassWithFactory(className, ::winrt::Microsoft::Management::Deployment::implementation::wrl_factory_for_winrt_com_class<className>)
+
     enum class Capability
     {
         PackageManagement,

--- a/src/Microsoft.Management.Deployment/Helpers.h
+++ b/src/Microsoft.Management.Deployment/Helpers.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
+#include <AppInstallerErrors.h>
 #include <winget/GroupPolicy.h>
 #include <wil\cppwinrt_wrl.h>
 

--- a/src/Microsoft.Management.Deployment/InstallOptions.cpp
+++ b/src/Microsoft.Management.Deployment/InstallOptions.cpp
@@ -10,6 +10,7 @@
 #pragma warning( pop )
 #include "InstallOptions.g.cpp"
 #include "Converters.h"
+#include "Helpers.h"
 
 #include <AppInstallerArchitecture.h>
 
@@ -103,5 +104,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         return m_allowedArchitectures;
     }
-    CoCreatableCppWinRtClass(InstallOptions);
+
+    CoCreatableMicrosoftManagementDeploymentClass(InstallOptions);
 }

--- a/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
+++ b/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
@@ -73,6 +73,7 @@
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
+    <Import Project="..\COMServer\COMServer.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -585,5 +585,5 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         return GetInstallOperation(canCancelQueueItem, std::move(queueItem));
     }
 
-    CoCreatableCppWinRtClass(PackageManager);
+    CoCreatableMicrosoftManagementDeploymentClass(PackageManager);
 }

--- a/src/Microsoft.Management.Deployment/PackageMatchFilter.cpp
+++ b/src/Microsoft.Management.Deployment/PackageMatchFilter.cpp
@@ -12,6 +12,7 @@
 #include "PackageMatchFilter.h"
 #pragma warning( pop )
 #include "PackageMatchFilter.g.cpp"
+#include "Helpers.h"
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
@@ -45,5 +46,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         m_value = value;
     }
-    CoCreatableCppWinRtClass(PackageMatchFilter);
+
+    CoCreatableMicrosoftManagementDeploymentClass(PackageMatchFilter);
 }

--- a/src/WinGetServer/WinGetServer.vcxproj
+++ b/src/WinGetServer/WinGetServer.vcxproj
@@ -100,7 +100,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <SDLCheck>true</SDLCheck>
       <EnablePREfast>true</EnablePREfast>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\AppInstallerCLICore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerRepositoryCore\Public;$(ProjectDir)..\AppInstallerCommonCore\Public;$(ProjectDir)..\JsonCppLib\json;$(ProjectDir)..\JsonCppLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\WindowsPackageManager;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,23 +141,8 @@
     <None Include="PropertySheet.props" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AppInstallerCommonCore\AppInstallerCommonCore.vcxproj">
-      <Project>{5890d6ed-7c3b-40f3-b436-b54f640d9e65}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\AppInstallerRepositoryCore\AppInstallerRepositoryCore.vcxproj">
-      <Project>{5eb88068-5fb9-4e69-89b2-72dbc5e068f9}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\cpprestsdk\cpprestsdk.vcxproj">
-      <Project>{866c3f06-636f-4be8-bc24-5f86ecc606a1}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\JsonCppLib\JsonCppLib.vcxproj">
-      <Project>{82b39fda-e86b-4713-a873-9d56de00247a}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\YamlCppLib\YamlCppLib.vcxproj">
-      <Project>{8bb94bb8-374f-4294-bca1-c7811514a6b7}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.Management.Deployment\Microsoft.Management.Deployment.vcxproj">
-      <Project>{1cc41a9a-ae66-459d-9210-1e572dd7be69}</Project>
+    <ProjectReference Include="..\WindowsPackageManager\WindowsPackageManager.vcxproj">
+      <Project>{2046b5af-666d-4ce8-8d3e-c32c57908a56}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/WinGetServer/WinMain.cpp
+++ b/src/WinGetServer/WinMain.cpp
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #include <winrt/Microsoft.Management.Deployment.h>
 #include <wrl/module.h>
-#include <winget/ExperimentalFeature.h>
-#include <winget/GroupPolicy.h>
 #include "COMContext.h"
-#include "AppInstallerRuntime.h"
-#include "AppInstallerVersions.h"
 
 using namespace winrt::Microsoft::Management::Deployment;
 
@@ -27,17 +22,6 @@ static void _releaseNotifier() noexcept
     _comServerExitEvent.SetEvent();
 }
 
-// Check whether the packaged api is enabled and the overarching winget group policy is enabled.
-bool IsServerEnabled()
-{
-    if (!::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet))
-    {
-        return false;
-    }
-
-    return true;
-}
-
 int __stdcall wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int)
 {
     winrt::init_apartment();
@@ -55,11 +39,6 @@ int __stdcall wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int
     auto& module = ::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::OutOfProc>::Create(&_releaseNotifier);
     try
     {
-        if (!IsServerEnabled())
-        {
-            return 0;
-        }
-
         // Register all the CoCreatableClassWrlCreatorMapInclude classes
         RETURN_IF_FAILED(module.RegisterObjects());
         _comServerExitEvent.wait();

--- a/src/WindowsPackageManager/PropertySheet.props
+++ b/src/WindowsPackageManager/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+    <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/xlang/tree/master/src/package/cppwinrt/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/src/WindowsPackageManager/Source.def
+++ b/src/WindowsPackageManager/Source.def
@@ -1,0 +1,7 @@
+LIBRARY     WindowsPackageManager
+EXPORTS
+    WindowsPackageManagerCLIMain
+    WindowsPackageManagerServerInitialize
+    WindowsPackageManagerServerModuleCreate
+    WindowsPackageManagerServerModuleRegister
+    WindowsPackageManagerServerModuleUnregister

--- a/src/WindowsPackageManager/WindowsPackageManager.h
+++ b/src/WindowsPackageManager/WindowsPackageManager.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+extern "C"
+{
+#define WINDOWS_PACKAGE_MANAGER_API_CALLING_CONVENTION  __stdcall
+#define WINDOWS_PACKAGE_MANAGER_API HRESULT WINDOWS_PACKAGE_MANAGER_API_CALLING_CONVENTION
+
+    using WindowsPackageManagerServerModuleTerminationCallback = void (*)();
+
+    // The core function to act against command line input.
+    int WINDOWS_PACKAGE_MANAGER_API_CALLING_CONVENTION WindowsPackageManagerCLIMain(int argc, wchar_t const** argv);
+
+    // Initializes the Windows Package Manager COM server.
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerInitialize();
+
+    // Creates the server module with the given termination callback.
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleCreate(WindowsPackageManagerServerModuleTerminationCallback callback);
+
+    // Registers the server module class factories.
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleRegister();
+
+    // Unregisters the server module class factories.
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleUnregister();
+}

--- a/src/WindowsPackageManager/WindowsPackageManager.vcxproj
+++ b/src/WindowsPackageManager/WindowsPackageManager.vcxproj
@@ -6,9 +6,9 @@
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{5b6f90df-fd19-4bae-83d9-24dad128e777}</ProjectGuid>
+    <ProjectGuid>{2046B5AF-666D-4CE8-8D3E-C32C57908A56}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <RootNamespace>AppInstallerCLI</RootNamespace>
+    <RootNamespace>WindowsPackageManager</RootNamespace>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
@@ -50,7 +50,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
@@ -82,6 +82,8 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
     <Import Project="..\binver\binver.vcxitems" Label="Shared" />
+    <Import Project="..\ManifestSchema\ManifestSchema.vcxitems" Label="Shared" />
+    <Import Project="..\WinGetSchemas\WinGetSchemas.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -96,7 +98,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <LinkIncremental>true</LinkIncremental>
@@ -104,7 +105,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <LinkIncremental>true</LinkIncremental>
@@ -112,7 +112,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
@@ -120,7 +119,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -128,7 +126,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -136,7 +133,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <LinkIncremental>false</LinkIncremental>
@@ -144,7 +140,6 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <LinkIncremental>false</LinkIncremental>
@@ -152,25 +147,22 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <TargetName>winget</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
-      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj /D _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;$(ProjectDir)..\JsonCppLib\json;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;$(ProjectDir)..\JsonCppLib\json;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;$(ProjectDir)..\JsonCppLib\json;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</TreatWarningAsError>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</TreatWarningAsError>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
@@ -188,8 +180,15 @@
       <EnablePREfast Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</EnablePREfast>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Windows</SubSystem>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Source.def</ModuleDefinitionFile>
       <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">wininet.lib;shell32.lib;winsqlite3.lib;shlwapi.lib;icuuc.lib;icuin.lib;urlmon.lib;Advapi32.lib;winhttp.lib;onecoreuap.lib;msi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
@@ -205,7 +204,7 @@
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;$(ProjectDir)..\JsonCppLib\json;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatWarningAsError>
       <ControlFlowGuard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ControlFlowGuard>
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdcpp17</LanguageStandard>
@@ -222,10 +221,10 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir);$(ProjectDir)..\WindowsPackageManager\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir);$(ProjectDir)..\AppInstallerCLICore\Public\;$(ProjectDir)..\AppInstallerCommonCore;$(ProjectDir)..\AppInstallerRepositoryCore;$(ProjectDir)..\AppInstallerCommonCore\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</TreatWarningAsError>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</TreatWarningAsError>
       <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</TreatWarningAsError>
@@ -248,10 +247,17 @@
       <EnablePREfast Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</EnablePREfast>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Windows</SubSystem>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Source.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Source.def</ModuleDefinitionFile>
       <AdditionalDependencies Condition="'$(Configuration)'=='Release'">wininet.lib;shell32.lib;winsqlite3.lib;shlwapi.lib;icuuc.lib;icuin.lib;urlmon.lib;Advapi32.lib;winhttp.lib;onecoreuap.lib;msi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
@@ -268,25 +274,49 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="WindowsPackageManager.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="PropertySheet.props" />
+    <None Include="Source.def" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\WindowsPackageManager\WindowsPackageManager.vcxproj">
-      <Project>{2046b5af-666d-4ce8-8d3e-c32c57908a56}</Project>
+    <ProjectReference Include="..\AppInstallerCLICore\AppInstallerCLICore.vcxproj">
+      <Project>{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\AppInstallerCommonCore\AppInstallerCommonCore.vcxproj">
+      <Project>{5890d6ed-7c3b-40f3-b436-b54f640d9e65}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\AppInstallerRepositoryCore\AppInstallerRepositoryCore.vcxproj">
+      <Project>{5eb88068-5fb9-4e69-89b2-72dbc5e068f9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\cpprestsdk\cpprestsdk.vcxproj">
+      <Project>{866c3f06-636f-4be8-bc24-5f86ecc606a1}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\JsonCppLib\JsonCppLib.vcxproj">
+      <Project>{82b39fda-e86b-4713-a873-9d56de00247a}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Management.Deployment\Microsoft.Management.Deployment.vcxproj">
+      <Project>{1cc41a9a-ae66-459d-9210-1e572dd7be69}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\YamlCppLib\YamlCppLib.vcxproj">
+      <Project>{8bb94bb8-374f-4294-bca1-c7811514a6b7}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>

--- a/src/WindowsPackageManager/WindowsPackageManager.vcxproj
+++ b/src/WindowsPackageManager/WindowsPackageManager.vcxproj
@@ -85,6 +85,7 @@
     <Import Project="..\binver\binver.vcxitems" Label="Shared" />
     <Import Project="..\ManifestSchema\ManifestSchema.vcxitems" Label="Shared" />
     <Import Project="..\WinGetSchemas\WinGetSchemas.vcxitems" Label="Shared" />
+    <Import Project="..\COMServer\COMServer.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/src/WindowsPackageManager/WindowsPackageManager.vcxproj
+++ b/src/WindowsPackageManager/WindowsPackageManager.vcxproj
@@ -13,6 +13,7 @@
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
+    <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/src/WindowsPackageManager/WindowsPackageManager.vcxproj.filters
+++ b/src/WindowsPackageManager/WindowsPackageManager.vcxproj.filters
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="WindowsPackageManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+    <None Include="packages.config" />
+    <None Include="Source.def">
+      <Filter>Source Files</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/WindowsPackageManager/main.cpp
+++ b/src/WindowsPackageManager/main.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include <wil/result_macros.h>
+#include <wrl/module.h>
+#include <winrt/Microsoft.Management.Deployment.h>
+
+#include "WindowsPackageManager.h"
+
+#include <AppInstallerCLICore.h>
+
+using namespace winrt::Microsoft::Management::Deployment;
+
+CoCreatableClassWrlCreatorMapInclude(PackageManager);
+CoCreatableClassWrlCreatorMapInclude(FindPackagesOptions);
+CoCreatableClassWrlCreatorMapInclude(CreateCompositePackageCatalogOptions);
+CoCreatableClassWrlCreatorMapInclude(InstallOptions);
+CoCreatableClassWrlCreatorMapInclude(PackageMatchFilter);
+
+extern "C"
+{
+    int WINDOWS_PACKAGE_MANAGER_API_CALLING_CONVENTION WindowsPackageManagerCLIMain(int argc, wchar_t const** argv) try
+    {
+        return AppInstaller::CLI::CoreMain(argc, argv);
+    }
+    CATCH_RETURN();
+
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerInitialize() try
+    {
+        AppInstaller::CLI::ServerInitialize();
+        return S_OK;
+    }
+    CATCH_RETURN();
+
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleCreate(WindowsPackageManagerServerModuleTerminationCallback callback) try
+    {
+        ::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::OutOfProc>::Create(callback);
+        return S_OK;
+    }
+    CATCH_RETURN();
+
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleRegister() try
+    {
+        RETURN_HR(::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::OutOfProc>::GetModule().RegisterObjects());
+    }
+    CATCH_RETURN();
+
+    WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerServerModuleUnregister() try
+    {
+        RETURN_HR(::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::OutOfProc>::GetModule().UnregisterObjects());
+    }
+    CATCH_RETURN();
+}

--- a/src/WindowsPackageManager/main.cpp
+++ b/src/WindowsPackageManager/main.cpp
@@ -20,6 +20,7 @@ extern "C"
 {
     int WINDOWS_PACKAGE_MANAGER_API_CALLING_CONVENTION WindowsPackageManagerCLIMain(int argc, wchar_t const** argv) try
     {
+        ::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::InProc>::Create();
         return AppInstaller::CLI::CoreMain(argc, argv);
     }
     CATCH_RETURN();

--- a/src/WindowsPackageManager/packages.config
+++ b/src/WindowsPackageManager/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210505.3" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
+</packages>


### PR DESCRIPTION
## Change
Compile all of the primary code into a new DLL, then leverage it from both winget.exe and the COM server.

## Validation
Manually validated both wingetdev and COM server to ensure at least minimal functionality.  Since the code itself was not change, being able to access both indicates success.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1687)