### PR TITLE
Make VT enablement/disablement work properly

### DIFF
--- a/src/AppInstallerCLICore/ChannelStreams.cpp
+++ b/src/AppInstallerCLICore/ChannelStreams.cpp
@@ -41,6 +41,11 @@ namespace AppInstaller::CLI::Execution
         return *this;
     }
 
+    void BaseStream::SetVTEnabled(bool enabled)
+    {
+        m_VTEnabled = enabled;
+    }
+
     void BaseStream::RestoreDefault()
     {
         if (m_VTUpdated)

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -57,6 +57,8 @@ namespace AppInstaller::CLI::Execution
         BaseStream& operator<<(const VirtualTerminal::Sequence& sequence);
         BaseStream& operator<<(const VirtualTerminal::ConstructedSequence& sequence);
 
+        void SetVTEnabled(bool enabled);
+
         void RestoreDefault();
 
         void Disable();

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -82,7 +82,7 @@ namespace AppInstaller::CLI::Execution
     // Holds output formatting information.
     struct OutputStream
     {
-        OutputStream(BaseStream& out, bool enabled, bool VTEnabled);
+        OutputStream(BaseStream& out, bool enabled, bool VTEnabled = true);
 
         // Adds a format to the current value.
         void AddFormat(const VirtualTerminal::Sequence& sequence);

--- a/src/AppInstallerCLICore/ExecutionReporter.cpp
+++ b/src/AppInstallerCLICore/ExecutionReporter.cpp
@@ -19,7 +19,7 @@ namespace AppInstaller::CLI::Execution
     const Sequence& PromptEmphasis = TextFormat::Foreground::Bright;
 
     Reporter::Reporter(std::ostream& outStream, std::istream& inStream) :
-        Reporter(std::make_shared<BaseStream>(outStream, true, IsVTEnabled()), inStream)
+        Reporter(std::make_shared<BaseStream>(outStream, true, ConsoleModeRestore::Instance().IsVTEnabled()), inStream)
     {
         SetProgressSink(this);
     }
@@ -27,8 +27,8 @@ namespace AppInstaller::CLI::Execution
     Reporter::Reporter(std::shared_ptr<BaseStream> outStream, std::istream& inStream) :
         m_out(outStream),
         m_in(inStream),
-        m_progressBar(std::in_place, *m_out, IsVTEnabled()),
-        m_spinner(std::in_place, *m_out, IsVTEnabled())
+        m_progressBar(std::in_place, *m_out, ConsoleModeRestore::Instance().IsVTEnabled()),
+        m_spinner(std::in_place, *m_out, ConsoleModeRestore::Instance().IsVTEnabled())
     {
         SetProgressSink(this);
     }
@@ -74,7 +74,7 @@ namespace AppInstaller::CLI::Execution
 
     OutputStream Reporter::GetBasicOutputStream()
     {
-        return {*m_out, m_channel == Channel::Output, IsVTEnabled() };
+        return {*m_out, m_channel == Channel::Output };
     }
 
     void Reporter::SetChannel(Channel channel)
@@ -211,11 +211,6 @@ namespace AppInstaller::CLI::Execution
         {
             callback->Cancel();
         }
-    }
-
-    bool Reporter::IsVTEnabled() const
-    {
-        return ConsoleModeRestore::Instance().IsVTEnabled();
     }
 
     void Reporter::CloseOutputStream(bool forceDisable)

--- a/src/AppInstallerCLICore/ExecutionReporter.cpp
+++ b/src/AppInstallerCLICore/ExecutionReporter.cpp
@@ -102,7 +102,7 @@ namespace AppInstaller::CLI::Execution
         }
         if (style == VisualStyle::NoVT)
         {
-            m_isVTEnabled = false;
+            m_out->SetVTEnabled(false);
         }
     }
 
@@ -215,7 +215,7 @@ namespace AppInstaller::CLI::Execution
 
     bool Reporter::IsVTEnabled() const
     {
-        return m_isVTEnabled && ConsoleModeRestore::Instance().IsVTEnabled();
+        return ConsoleModeRestore::Instance().IsVTEnabled();
     }
 
     void Reporter::CloseOutputStream(bool forceDisable)

--- a/src/AppInstallerCLICore/ExecutionReporter.h
+++ b/src/AppInstallerCLICore/ExecutionReporter.h
@@ -140,8 +140,6 @@ namespace AppInstaller::CLI::Execution
 
     private:
         Reporter(std::shared_ptr<BaseStream> outStream, std::istream& inStream);
-        // Gets whether VT is enabled for this reporter.
-        bool IsVTEnabled() const;
 
         // Gets a stream for output for internal use.
         OutputStream GetBasicOutputStream();

--- a/src/AppInstallerCLICore/ExecutionReporter.h
+++ b/src/AppInstallerCLICore/ExecutionReporter.h
@@ -149,7 +149,6 @@ namespace AppInstaller::CLI::Execution
         Channel m_channel = Channel::Output;
         std::shared_ptr<BaseStream> m_out;
         std::istream& m_in;
-        bool m_isVTEnabled = true;
         std::optional<AppInstaller::Settings::VisualStyle> m_style;
         std::optional<IndefiniteSpinner> m_spinner;
         std::optional<ProgressBar> m_progressBar;


### PR DESCRIPTION
## Change
Move the VT state ownership fully into `BaseStream`, where it already really lived.  The bool in `ExecutionReporter` was not being initialized before use and could result in VT being disabled-ish (based on memory state going in), so this fixes that issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1699)