### PR TITLE
remove plain

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -26,7 +26,6 @@
           "enum": [
             "accent",
             "rainbow",
-            "plain",
             "retro"
           ]
         }


### PR DESCRIPTION
remove "plain" as documentation does not show it, and is a invalid settings option in winget, removal as it's a non-functional option and would benefit confused text editor users to match the options shown in the documentation and available settings in the actual winget.

This proposal can be canceled if the implementation of "plain" is planed further down the road.

- [Y ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [N ] Are you working against an Issue?

-----
"Are you working against an issue?" No issue has been filed for this, in fact the fix might be a little bit premature as it was filed _before_ a issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1700)