### PR TITLE
Added settings to select preferred/required architecture.

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -85,7 +85,7 @@ The `architectures` behavior affects what architectures will be selected when in
 ```json
     "installBehavior": {
         "preferences": {
-            "architectures": "x64"
+            "architectures": ["x64", "arm64"]
         }
     },
 ```

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -78,6 +78,17 @@ The `locale` behavior affects the choice of installer based on installer locale.
         }
     },
 ```
+### Architecture
+
+The `architecture` behavior affects what architecture will be selected when installing a package. The matching parameter is `--architecture`. Note that only architectures compatible with your system can be selected.
+
+```json
+    "installBehavior": {
+        "preferences": {
+            "architecture": "x64"
+        }
+    },
+```
 
 ## Telemetry
 

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -78,14 +78,14 @@ The `locale` behavior affects the choice of installer based on installer locale.
         }
     },
 ```
-### Architecture
+### Architectures
 
-The `architecture` behavior affects what architecture will be selected when installing a package. The matching parameter is `--architecture`. Note that only architectures compatible with your system can be selected.
+The `architectures` behavior affects what architectures will be selected when installing a package. The matching parameter is `--architecture`. Note that only architectures compatible with your system can be selected.
 
 ```json
     "installBehavior": {
         "preferences": {
-            "architecture": "x64"
+            "architectures": "x64"
         }
     },
 ```

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -55,17 +55,21 @@
           "minItems": 1,
           "maxItems": 10
         },
-        "architecture": {
-          "description": "The architecture for a package install",
-          "type": "string",
-          "enum": [
-            "neutral",
-            "x64",
-            "x86",
-            "arm64",
-            "arm"
-          ],
-          "default": "neutral" 
+        "architectures": {
+          "description": "The architecture(s) to use for a package install",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "neutral",
+              "x64",
+              "x86",
+              "arm64",
+              "arm"
+            ],
+            "minItems": 1,
+            "maxItems": 4
+          }
         }
       }
     },

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -54,6 +54,18 @@
           },
           "minItems": 1,
           "maxItems": 10
+        },
+        "architecture": {
+          "description": "The architecture for a package install",
+          "type": "string",
+          "enum": [
+            "neutral",
+            "x64",
+            "x86",
+            "arm64",
+            "arm"
+          ],
+          "default": "neutral" 
         }
       }
     },

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -59,6 +59,7 @@
           "description": "The architecture(s) to use for a package install",
           "type": "array",
           "items": {
+            "uniqueItems": "true",
             "type": "string",
             "enum": [
               "neutral",

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -962,13 +962,19 @@ namespace AppInstaller::CLI::Workflow
         bool isUpdate = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerExecutionUseUpdate);
 
         IPackageVersion::Metadata installationMetadata;
+        Utility::Architecture requiredArchitecture = Settings::User().Get<Settings::Setting::InstallArchitectureRequirement>();
         if (isUpdate)
         {
             installationMetadata = context.Get<Execution::Data::InstalledPackageVersion>()->GetMetadata();
         }
         if (context.Args.Contains(Execution::Args::Type::InstallArchitecture))
         {
+            // arguments override settings.
             context.Add<Execution::Data::AllowedArchitectures>({ Utility::ConvertToArchitectureEnum(std::string(context.Args.GetArg(Execution::Args::Type::InstallArchitecture))) });
+        }
+        else if (requiredArchitecture != Utility::Architecture::Neutral)
+        {
+            context.Add<Execution::Data::AllowedArchitectures>({ requiredArchitecture });
         }
         ManifestComparator manifestComparator(context, installationMetadata);
         auto [installer, inapplicabilities] = manifestComparator.GetPreferredInstaller(context.Get<Execution::Data::Manifest>());

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -976,18 +976,17 @@ namespace AppInstaller::CLI::Workflow
         {
             std::vector<Utility::Architecture> requiredArchitectures = Settings::User().Get<Settings::Setting::InstallArchitectureRequirement>();
             std::vector<Utility::Architecture> optionalArchitectures = Settings::User().Get<Settings::Setting::InstallArchitecturePreference>();
-            std::set<Utility::Architecture> settingArchitectures;
+
 
             if (!requiredArchitectures.empty())
             {
-                std::copy(requiredArchitectures.begin(), requiredArchitectures.end(), std::inserter(settingArchitectures, settingArchitectures.begin()));
-                context.Add<Execution::Data::AllowedArchitectures>({ settingArchitectures.begin(), settingArchitectures.end() });
+                context.Add<Execution::Data::AllowedArchitectures>({ requiredArchitectures.begin(), requiredArchitectures.end() });
             }
             else if (!optionalArchitectures.empty())
             {
-                settingArchitectures.emplace(Utility::Architecture::Unknown);
-                std::copy(optionalArchitectures.begin(), optionalArchitectures.end(), std::inserter(settingArchitectures, settingArchitectures.begin()));
-                context.Add<Execution::Data::AllowedArchitectures>({ settingArchitectures.begin(), settingArchitectures.end() });
+                optionalArchitectures.emplace_back(Utility::Architecture::Unknown);
+                context.Add<Execution::Data::AllowedArchitectures>({ optionalArchitectures.begin(), optionalArchitectures.end() });
+                
             }
         }
         ManifestComparator manifestComparator(context, installationMetadata);

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -13,6 +13,8 @@
 #include <variant>
 #include <vector>
 
+#include "AppInstallerArchitecture.h"
+
 using namespace std::chrono_literals;
 using namespace std::string_view_literals;
 
@@ -54,6 +56,7 @@ namespace AppInstaller::Settings
         DeliveryOptimization,
     };
 
+
     // Enum of settings.
     // Must start at 0 to enable direct access to variant in UserSettings.
     // Max must be last and unused.
@@ -73,6 +76,8 @@ namespace AppInstaller::Settings
         InstallScopeRequirement,
         NetworkDownloader,
         NetworkDOProgressTimeoutInSeconds,
+        InstallArchitecturePreference,
+        InstallArchitectureRequirement,
         InstallLocalePreference,
         InstallLocaleRequirement,
         EFDirectMSI,
@@ -116,6 +121,8 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFExperimentalArg, bool, bool, false, ".experimentalFeatures.experimentalArg"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDependencies, bool, bool, false, ".experimentalFeatures.dependencies"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitecturePreference, std::string, Utility::Architecture, Utility::Architecture::Neutral, ".installBehavior.preferences.architecture"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitectureRequirement, std::string, Utility::Architecture, Utility::Architecture::Neutral, ".installBehavior.requirements.architecture"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallScopePreference, std::string, ScopePreference, ScopePreference::User, ".installBehavior.preferences.scope"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallScopeRequirement, std::string, ScopePreference, ScopePreference::None, ".installBehavior.requirements.scope"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDownloader, std::string, InstallerDownloader, InstallerDownloader::Default, ".network.downloader"sv);

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -121,8 +121,8 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFExperimentalArg, bool, bool, false, ".experimentalFeatures.experimentalArg"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDependencies, bool, bool, false, ".experimentalFeatures.dependencies"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitecturePreference, std::string, Utility::Architecture, Utility::Architecture::Neutral, ".installBehavior.preferences.architecture"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitectureRequirement, std::string, Utility::Architecture, Utility::Architecture::Neutral, ".installBehavior.requirements.architecture"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitecturePreference, std::vector<std::string>, std::vector<Utility::Architecture>, {}, ".installBehavior.preferences.architectures"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitectureRequirement, std::vector<std::string>, std::vector<Utility::Architecture>, {}, ".installBehavior.requirements.architectures"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallScopePreference, std::string, ScopePreference, ScopePreference::User, ".installBehavior.preferences.scope"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallScopeRequirement, std::string, ScopePreference, ScopePreference::None, ".installBehavior.requirements.scope"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDownloader, std::string, InstallerDownloader, InstallerDownloader::Default, ".network.downloader"sv);

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -7,6 +7,8 @@
 #include "JsonUtil.h"
 #include "winget/Settings.h"
 #include "winget/UserSettings.h"
+
+#include "AppInstallerArchitecture.h"
 #include "winget/Locale.h"
 
 namespace AppInstaller::Settings
@@ -228,7 +230,19 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
-
+        WINGET_VALIDATE_SIGNATURE(InstallArchitecturePreference)
+        {
+            Utility::Architecture arch = Utility::ConvertToArchitectureEnum(value);
+	        if (Utility::IsApplicableArchitecture(arch) != Utility::InapplicableArchitecture)
+	        {
+                return arch;
+	        }
+            return {};
+        }
+        WINGET_VALIDATE_SIGNATURE(InstallArchitectureRequirement)
+        {
+            return SettingMapping<Setting::InstallArchitecturePreference>::Validate(value);
+        }
         WINGET_VALIDATE_SIGNATURE(InstallScopePreference)
         {
             static constexpr std::string_view s_scope_user = "user";

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -230,19 +230,26 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
+
         WINGET_VALIDATE_SIGNATURE(InstallArchitecturePreference)
         {
-            Utility::Architecture arch = Utility::ConvertToArchitectureEnum(value);
-	        if (Utility::IsApplicableArchitecture(arch) != Utility::InapplicableArchitecture)
-	        {
-                return arch;
-	        }
-            return {};
+            std::vector<Utility::Architecture> archs;
+            for (auto const& i : value) {
+                Utility::Architecture arch = Utility::ConvertToArchitectureEnum(i);
+                if (Utility::IsApplicableArchitecture(arch) == Utility::InapplicableArchitecture)
+                {
+                    return {};
+                }
+                archs.emplace_back(arch);
+            }
+            return archs;
         }
+
         WINGET_VALIDATE_SIGNATURE(InstallArchitectureRequirement)
         {
             return SettingMapping<Setting::InstallArchitecturePreference>::Validate(value);
         }
+
         WINGET_VALIDATE_SIGNATURE(InstallScopePreference)
         {
             static constexpr std::string_view s_scope_user = "user";


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue? 

-----

Resolves #906.

This is the other half of #906, adding settings to select a preferred or required architecture. The required architecture behaves exactly like the `--architecture` flag, where `AllowedArchitectures` only contains the architecture that is in the setting. The preferred architecture behaves much like the preferred scope setting, where the installer entry with the preferred architecture is selected over all others, but if there isn't an installer entry with the preferred architecture, the normal rationale is used.

The fields are validated by determining if the architecture selected is compatible with the current system. By default the setting is set to `neutral`. (although if there is a reason we need to allow users to require neutral manifests, that could just as easily be `unknown`. I figured there were few scenarios where a user wouldn't want a installer that only had the relevant bits for their system over a neutral one with all of the bits.)

The only other note I have is that I decided to make these just strings instead of arrays since that's what it sounded like in the original ticket. If there's a usecase where someone wants to prefer multiple architectures, that's a quick fix (although there's only ever at most three options, so I doubt that comes up much?).

Tested: manually. I can write unit tests if necessary. 

![image](https://user-images.githubusercontent.com/21368066/142490024-e28fcabb-2563-4ea1-9ae1-31890de9f121.png)



Edit: also, sorry for the big diff on UserSettings.cpp. Visual Studio got upset that the line endings were mixed. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1727)