### PR TITLE
Update source agreement market message to be more clear

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -34,6 +34,7 @@ authz
 autocomplete
 auxdata
 azureedge
+backend
 bcrypt
 binver
 Bitmask

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1098,7 +1098,7 @@ Do you agree to the terms?</value>
     <value>One or more of the source agreements were not agreed to. Operation cancelled. Please accept the source agreements or remove the corresponding sources.</value>
   </data>
   <data name="SourceAgreementsMarketMessage" xml:space="preserve">
-    <value>The source requires current machine's geographic region to be sent to the backend service to function properly.</value>
+    <value>The source requires the current machine's 2-letter geographic region to be sent to the backend service to function properly (ex. "US").</value>
   </data>
   <data name="InstallFlowRegistrationDeferred" xml:space="preserve">
     <value>Successfully installed. Restart the application to complete the upgrade.</value>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1098,7 +1098,7 @@ Do you agree to the terms?</value>
     <value>One or more of the source agreements were not agreed to. Operation cancelled. Please accept the source agreements or remove the corresponding sources.</value>
   </data>
   <data name="SourceAgreementsMarketMessage" xml:space="preserve">
-    <value>The source requires current machine's geographic region to be sent to function properly.</value>
+    <value>The source requires current machine's geographic region to be sent to the backend service to function properly.</value>
   </data>
   <data name="InstallFlowRegistrationDeferred" xml:space="preserve">
     <value>Successfully installed. Restart the application to complete the upgrade.</value>


### PR DESCRIPTION
There's been feedback item filed claiming the source agreement market message is not clear enough so making explicit that we are sending the geographic region info to the source's backend server.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1731)