### PR TITLE
Add regex validation for productCode in schemas

### DIFF
--- a/schemas/JSON/manifests/preview/manifest.0.1.0.json
+++ b/schemas/JSON/manifests/preview/manifest.0.1.0.json
@@ -21,6 +21,7 @@
     },
     "ProductCode": {
       "type": [ "string", "null" ],
+      "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"

--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -252,6 +252,7 @@
     },
     "ProductCode": {
       "type": [ "string", "null" ],
+      "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -263,6 +263,7 @@
     },
     "ProductCode": {
       "type": [ "string", "null" ],
+      "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"

--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -289,6 +289,7 @@
     },
     "ProductCode": {
       "type": [ "string", "null" ],
+      "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -321,6 +321,7 @@
     },
     "ProductCode": {
       "type": [ "string", "null" ],
+      "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"


### PR DESCRIPTION
Winget-Create currently does not have any validation for the ProductCode field, which relies on the schema patterns found in the manifest schemas. I've added the regex validation pattern to help validate the productCode input value.

microsoft/winget-create#140

Explanation for regex:
^ indicates the start of a string.
[{]? indicates that '{' character can be optional.
[0-9a-fA-F]{8} indicates that 8 (0-9 or a-f or A-F) hexadecimal values are expected.
– represents the hyphens.
([0-9a-fA-F]{4}-){3} indicates that 4 hexadecimal values and a hyphen are expected and that this pattern is repeated {3} times.
[0-9a-fA-F]{12} indicates that 12 hexadecimal values are expected
[}]? indicates that the ‘}’ character is optional.
$ indicates the ending of the string.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1766)