### PR TITLE
Bug fix: PackageTrackingCatalog and SQLiteIndexUpdate

### DIFF
--- a/src/AppInstallerCLITests/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerCLITests/PackageTrackingCatalog.cpp
@@ -18,7 +18,7 @@ namespace
 {
     static Source SimpleTestSetup(const std::string& filePath, SourceDetails& details, Manifest& manifest, std::string& relativePath)
     {
-        SQLiteIndex index = SQLiteIndex::CreateNew(filePath, Schema::Version::Latest());
+        SQLiteIndex index = SQLiteIndex::CreateNew(filePath, Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless | SQLiteIndex::CreateOptions::DisableDependenciesSupport);
 
         TestDataFile testManifest("Manifest-Good.yaml");
         manifest = YamlParser::CreateFromPath(testManifest);

--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -509,7 +509,7 @@ TEST_CASE("SQLiteIndex_AddManifestWithDependencies_EmptyManifestVersion", "[sqli
     index.AddManifest(manifest, GetPathFromManifest(manifest));
 }
 
-TEST_CASE("SQLiteIndex_DependenciesTable_CheckConsistency", "[sqliteindex][V1_1]")
+TEST_CASE("SQLiteIndex_DependenciesTable_CheckConsistency", "[sqliteindex][V1_4]")
 {
     TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
     INFO("Using temporary file named: " << tempFile.GetPath());
@@ -965,7 +965,7 @@ TEST_CASE("SQLiteIndex_RemoveManifestFile", "[sqliteindex][V1_0]")
     REQUIRE(Schema::V1_0::CommandsTable::IsEmpty(connection));
 }
 
-TEST_CASE("SQLiteIndex_UpdateManifest", "[sqliteindex][V1_0]")
+TEST_CASE("SQLiteIndex_UpdateManifest", "[sqliteindex][V1_4]")
 {
     TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
     INFO("Using temporary file named: " << tempFile.GetPath());
@@ -981,8 +981,10 @@ TEST_CASE("SQLiteIndex_UpdateManifest", "[sqliteindex][V1_0]")
     manifest.DefaultLocalization.Add<Localization::Tags>({ "t1", "t2" });
     manifest.Installers[0].Commands = { "test1", "test2" };
 
+    
     {
-        SQLiteIndex index = SQLiteIndex::CreateNew(tempFile, { 1, 0 });
+        auto version = GENERATE(Schema::Version{ 1, 0 }, Schema::Version::Latest());
+        SQLiteIndex index = SQLiteIndex::CreateNew(tempFile, version);
 
         index.AddManifest(manifest, manifestPath);
     }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_4/Interface_1_4.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_4/Interface_1_4.cpp
@@ -24,7 +24,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_4
 
         V1_3::Interface::CreateTables(connection, options);
 
-        DependenciesTable::Create(connection);
+        if (WI_IsFlagClear(options, CreateOptions::DisableDependenciesSupport))
+        {
+            DependenciesTable::Create(connection);
+        }
 
         savepoint.Commit();
     }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -42,7 +42,7 @@ namespace AppInstaller::Repository::Microsoft::Schema
         enum class CreateOptions
         {
             // Standard
-            None = 0,
+            None = 0x0,
             // Enable support for passing in nullopt values to Add/UpdateManifest
             SupportPathless = 0x1,
             // Disable support for dependencies

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/ISQLiteIndex.h
@@ -42,9 +42,11 @@ namespace AppInstaller::Repository::Microsoft::Schema
         enum class CreateOptions
         {
             // Standard
-            None,
+            None = 0,
             // Enable support for passing in nullopt values to Add/UpdateManifest
-            SupportPathless,
+            SupportPathless = 0x1,
+            // Disable support for dependencies
+            DisableDependenciesSupport = 0x2,
         };
 
         // Creates all of the version dependent tables within the database.

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -58,7 +58,7 @@ namespace AppInstaller::Repository
                     if (!std::filesystem::exists(trackingDB))
                     {
                         std::filesystem::create_directories(trackingDB.parent_path());
-                        SQLiteIndex::CreateNew(trackingDB.u8string(), Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless);
+                        SQLiteIndex::CreateNew(trackingDB.u8string(), Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless | SQLiteIndex::CreateOptions::DisableDependenciesSupport);
                     }
                 }
 


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

**PackageTrackingCatalog**:
When dependency nodes are not found in the index, an attempt to add or update manifest by the catalog tracking feature causes a failure. In some scenarios this might be valid as the dependencies of a package might already be present in the user's machine. This fix totally disable dependencies for catalog tracking feature by adding an option to not create dependencies table and also checking for the presence of the table when there is an attempt to perform any operation on the table.  

**SQLiteIndexUpdate**:
Bug in dependencies udpate manifest causes the method to always return true even if the index wasn't modified. This pull request fixes the issue, and also extends the update manifest tests to capture 1_4 schema update.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1780)