### PR TITLE
Allow upgrades in packages that register a different installer type

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -214,8 +214,20 @@ namespace AppInstaller::CLI::Workflow
 
             std::string ExplainInapplicable(const Manifest::ManifestInstaller& installer) override
             {
-                std::string result = "Installed package type is not compatible with ";
-                result += Manifest::InstallerTypeToString(installer.InstallerType);
+                std::string result = "Installed package type '" + std::string{ Manifest::InstallerTypeToString(m_installedType) } +
+                    "' is not compatible with installer type " + std::string{ Manifest::InstallerTypeToString(installer.InstallerType) };
+
+                std::string arpInstallerTypes;
+                for (const auto& entry : installer.AppsAndFeaturesEntries)
+                {
+                    arpInstallerTypes += " " + std::string{ Manifest::InstallerTypeToString(entry.InstallerType) };
+                }
+
+                if (!arpInstallerTypes.empty())
+                {
+                    result += ", or with accepted type(s)" + arpInstallerTypes;
+                }
+
                 return result;
             }
 

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -194,7 +194,17 @@ namespace AppInstaller::CLI::Workflow
 
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
+                // The installer is applicable if it's type or any of its ARP entries' type matches the installed type
                 if (Manifest::IsInstallerTypeCompatible(installer.InstallerType, m_installedType))
+                {
+                    return InapplicabilityFlags::None;
+                }
+
+                auto itr = std::find_if(
+                    installer.AppsAndFeaturesEntries.begin(),
+                    installer.AppsAndFeaturesEntries.end(),
+                    [=](AppsAndFeaturesEntry arpEntry) { return Manifest::IsInstallerTypeCompatible(arpEntry.InstallerType, m_installedType); });
+                if (itr != installer.AppsAndFeaturesEntries.end())
                 {
                     return InapplicabilityFlags::None;
                 }

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -515,6 +515,9 @@
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe_ARPInstallerType.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe_2.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -435,6 +435,9 @@
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe_ARPInstallerType.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe_2.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/UpdateFlowTest_Exe_ARPInstallerType.yaml
+++ b/src/AppInstallerCLITests/TestData/UpdateFlowTest_Exe_ARPInstallerType.yaml
@@ -1,0 +1,22 @@
+# Similar content to UpdateFlowTest_Exe.yaml, but with an AppsAndFeaturesEntry specifying installer type
+PackageIdentifier: AppInstallerCliTest.TestExeInstaller
+PackageVersion: 2.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test Installer
+Publisher: Microsoft Corporation
+Moniker: AICLITestExe
+License: Test
+AppsAndFeaturesEntries:
+  - InstallerType: msix
+InstallerSwitches:
+  Custom: /custom /ver2.0.0.0
+  SilentWithProgress: /silentwithprogress
+  Silent: /silence
+  Update: /update
+Installers:
+  - Architecture: x86
+    InstallerUrl: https://ThisIsNotUsed
+    InstallerType: exe
+    InstallerSha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+ManifestType: singleton
+ManifestVersion: 1.1.0


### PR DESCRIPTION
* Modified the applicability check in `InstalledTypeComparator` to also consider the installer types listed under `AppsAndFeaturesEntries`
* Extended string returned from `ExplainInapplicable` to also mention the installed type and other types accepted by the manifest.

Closes #1242. Validated that upgrading PowerToys (mentioned in that issue) worked correctly using a local manifest edited to include the `AppsAndFeaturesEntries` and installed type `msi`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1796)