### PR TITLE
Add support for UnsupportedOSArchitectures manifest element

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -104,11 +104,12 @@ namespace AppInstaller::CLI::Workflow
 
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
-                if (CheckAllowedArchitecture(installer.Arch) == Utility::InapplicableArchitecture)
+                if (CheckAllowedArchitecture(installer.Arch) == Utility::InapplicableArchitecture ||
+                    IsSystemArchitectureUnsupportedByInstaller(installer))
                 {
                     return InapplicabilityFlags::MachineArchitecture;
                 }
-                
+
                 return InapplicabilityFlags::None;
             }
 
@@ -118,12 +119,18 @@ namespace AppInstaller::CLI::Workflow
                 if (Utility::IsApplicableArchitecture(installer.Arch) == Utility::InapplicableArchitecture)
                 {
                     result = "Machine is not compatible with ";
+                    result += Utility::ToString(installer.Arch);
+                }
+                else if (IsSystemArchitectureUnsupportedByInstaller(installer))
+                {
+                    result = "System architecture is unsupported by installer";
                 }
                 else
                 {
                     result = "Architecture was excluded by caller : ";
+                    result += Utility::ToString(installer.Arch);
                 }
-                result += Utility::ToString(installer.Arch);
+
                 return result;
             }
 
@@ -151,6 +158,15 @@ namespace AppInstaller::CLI::Workflow
                 {
                     return Utility::IsApplicableArchitecture(architecture, m_allowedArchitectures);
                 }
+            }
+
+            bool IsSystemArchitectureUnsupportedByInstaller(const ManifestInstaller& installer)
+            {
+                auto unsupportedItr = std::find(
+                    installer.UnsupportedOSArchitectures.begin(),
+                    installer.UnsupportedOSArchitectures.end(),
+                    Utility::GetSystemArchitecture());
+                return unsupportedItr != installer.UnsupportedOSArchitectures.end();
             }
 
             std::string GetAllowedArchitecturesString()

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -989,7 +989,6 @@ namespace AppInstaller::CLI::Workflow
             std::vector<Utility::Architecture> requiredArchitectures = Settings::User().Get<Settings::Setting::InstallArchitectureRequirement>();
             std::vector<Utility::Architecture> optionalArchitectures = Settings::User().Get<Settings::Setting::InstallArchitecturePreference>();
 
-
             if (!requiredArchitectures.empty())
             {
                 context.Add<Execution::Data::AllowedArchitectures>({ requiredArchitectures.begin(), requiredArchitectures.end() });
@@ -998,7 +997,6 @@ namespace AppInstaller::CLI::Workflow
             {
                 optionalArchitectures.emplace_back(Utility::Architecture::Unknown);
                 context.Add<Execution::Data::AllowedArchitectures>({ optionalArchitectures.begin(), optionalArchitectures.end() });
-                
             }
         }
         ManifestComparator manifestComparator(context, installationMetadata);

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -24,7 +24,14 @@ struct ManifestComparatorTestContext : public NullStream, Context
     ManifestComparatorTestContext() : NullStream(), Context(*m_nullOut, *m_nullIn) {}
 };
 
-const ManifestInstaller& AddInstaller(Manifest& manifest, Architecture architecture, InstallerTypeEnum installerType, ScopeEnum scope = ScopeEnum::Unknown, std::string minOSVersion = {}, std::string locale = {})
+const ManifestInstaller& AddInstaller(
+    Manifest& manifest,
+    Architecture architecture,
+    InstallerTypeEnum installerType,
+    ScopeEnum scope = ScopeEnum::Unknown,
+    std::string minOSVersion = {},
+    std::string locale = {},
+    std::vector<Architecture> unsupportedOSArchitectures = {})
 {
     ManifestInstaller toAdd;
     toAdd.Arch = architecture;
@@ -32,6 +39,7 @@ const ManifestInstaller& AddInstaller(Manifest& manifest, Architecture architect
     toAdd.Scope = scope;
     toAdd.MinOSVersion = minOSVersion;
     toAdd.Locale = locale;
+    toAdd.UnsupportedOSArchitectures = unsupportedOSArchitectures;
 
     manifest.Installers.emplace_back(std::move(toAdd));
 
@@ -508,6 +516,46 @@ TEST_CASE("ManifestComparator_AllowedArchitecture", "[manifest_comparator]")
 
         RequireInstaller(result, x86);
         RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::MachineArchitecture, InapplicabilityFlags::MachineArchitecture });
+    }
+}
+
+TEST_CASE("ManifestComparator_UnsupportedOSArchitecture", "[manifest_comparator]")
+{
+    auto systemArchitecture = GetSystemArchitecture();
+    auto applicableArchitectures = GetApplicableArchitectures();
+
+    // Try to find an applicable architecture that is not the system architecture
+    auto itr = std::find_if(applicableArchitectures.begin(), applicableArchitectures.end(), [&](const auto& arch) { return arch != systemArchitecture; });
+    if (itr == applicableArchitectures.end())
+    {
+        // This test requires having an applicable architecture different from the system one.
+        // TODO: Does this actually happen in any arch we use?
+        return;
+    }
+
+    auto applicableArchitecture = *itr;
+
+    Manifest manifest;
+
+    SECTION("System is unsupported")
+    {
+        ManifestInstaller installer = AddInstaller(manifest, applicableArchitecture, InstallerTypeEnum::Msi, {}, {}, {}, { systemArchitecture });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        REQUIRE(!result);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::MachineArchitecture });
+    }
+    SECTION("Other is unsupported")
+    {
+        ManifestInstaller installer = AddInstaller(manifest, applicableArchitecture, InstallerTypeEnum::Msi, {}, {}, {}, { applicableArchitecture });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, installer);
+        REQUIRE(inapplicabilities.empty());
     }
 }
 


### PR DESCRIPTION
Adding support for `UnsupportedOSArchitectures` manifest entry by extending `MachineArchitectureComparator` to add a check that the system architecture is not listed as unsupported.

Closes #993

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1807)