### PR TITLE
Added check for maximum size of downloaded file names

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -64,9 +64,9 @@ namespace AppInstaller::CLI::Workflow
             // Get file name from download URI
             std::filesystem::path filename = GetFileNameFromURI(context.Get<Execution::Data::Installer>()->Url);
 
-            // Assuming that we find a stem value in the URI, use it.
+            // Assuming that we find a safe stem value in the URI, use it.
             // This should be extremely common, but just in case fall back to the older name style.
-            if (filename.has_stem())
+            if (filename.has_stem() && filename.string().size() < MAX_PATH)
             {
                 filename = filename.stem();
             }

--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -63,10 +63,11 @@ namespace AppInstaller::CLI::Workflow
         {
             // Get file name from download URI
             std::filesystem::path filename = GetFileNameFromURI(context.Get<Execution::Data::Installer>()->Url);
+            std::wstring_view installerExtension = GetInstallerFileExtension(context);
 
             // Assuming that we find a safe stem value in the URI, use it.
             // This should be extremely common, but just in case fall back to the older name style.
-            if (filename.has_stem() && filename.string().size() < MAX_PATH)
+            if (filename.has_stem() && ((filename.string().size() + installerExtension.size()) < MAX_PATH))
             {
                 filename = filename.stem();
             }
@@ -76,7 +77,7 @@ namespace AppInstaller::CLI::Workflow
                 filename = Utility::ConvertToUTF16(manifest.Id + '.' + manifest.Version);
             }
 
-            filename += GetInstallerFileExtension(context);
+            filename += installerExtension;
 
             return filename;
         }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Resolves #1808.

This PR adds a check to GetInstallerPostHashValidationFileName that ensures that the filename in the URL does not exceed 260 characters (the maximum ~~path size~~ file name size in Windows). If it does, then the "older" naming style (`manifest.version.ext`) is used for the downloaded file. Technically this could still fail if the full length of the path is 260 instead of just the file name, but I thought that was fairly unlikely. If it isn't I can adjust for that too.

Tested: manually via the manifest given in the issue. As always, I'm happy to add tests if needed.

Edit: corrected explanation, thanks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1842)