### PR TITLE
Moved "Installing Dependencies" message to only print if there are dependencies to install.

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
@@ -155,8 +155,6 @@ namespace AppInstaller::CLI::Workflow
             return;
         }
 
-        info << Resource::String::DependenciesFlowInstall << std::endl;
-
         context << OpenDependencySource;
         if (context.IsTerminated())
         {
@@ -236,6 +234,11 @@ namespace AppInstaller::CLI::Workflow
 
                 dependencyPackageContexts.emplace_back(std::move(dependencyContextPtr));
             }
+        }
+
+        if (!dependencyPackageContexts.empty())
+        {
+            info << Resource::String::DependenciesFlowInstall << std::endl;
         }
 
         // Install dependencies in the correct order


### PR DESCRIPTION

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

Small change to make sure that the "Installing Dependencies: " string only prints if there are actually dependencies installing. The way it was, if all of the dependencies were already installed it looked like the package the user requested *was* a dependency.

```
PS C:\Users\easton> wingetdev install handbrake
Found HandBrake [HandBrake.HandBrake] Version 1.5.1
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
This package requires the following dependencies:
  - Packages
      Microsoft.dotnetRuntime.5-x64
Downloading https://github.com/HandBrake/HandBrake/releases/download/1.5.1/HandBrake-1.5.1-x86_64-Win_GUI.exe
  ██████████████████████████████  19.4 MB / 19.4 MB
Successfully verified installer hash
Starting package install...
Successfully installed
```
(Note how the 6th line isn't "Installing Dependencies")

I suppose the other change should be that the "This package requires the following dependencies" list shouldn't be presented if you have all of the dependencies already installed (since if you want the full list you can get it via `winget show` anyway), but that'll probably require a couple changes to `ReportDependencies()`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1851)