### PR TITLE
Split pipeline build job into x86 and x64

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -37,6 +37,7 @@ auxdata
 azureedge
 backend
 bcrypt
+binlog
 binver
 Bitmask
 Blog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)"
+      msbuildArgs: '/p:AppxBundlePlatforms="x86|x64"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,7 @@ jobs:
     name: HTTPSDevCert
     displayName: 'Download Kestrel Certificate'
     inputs:
-      secureFile: 'AppInstallerTest.pfx'
+      secureFile: 'HTTPSDevCertV2.pfx'
 
   - task: MSBuild@1
     displayName: Build MSIX Test Installer File

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,22 +105,15 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '-bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog
-                    /p:AppxBundlePlatforms="$(buildPlatform)"
+      msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload'
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish MSBuild binlog
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)\msbuild.binlog
-      ArtifactName: '$(buildPlatform)\msbuild.binlog'
-    condition: succeededOrFailed()
   - task: VSBuild@1
     displayName: Build Test Project
     inputs:
-      platform: '$(buildConfiguration)'
+      platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(testBuildConfiguration)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,10 +105,17 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)"
+      msbuildArgs: '/bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog
+                    /p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload'
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish MSBuild logs
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\msbuild.binlog'
+      ArtifactName: '$(buildPlatform)\msbuild.binlog'
 
   - task: VSBuild@1
     displayName: Build Test Project
@@ -136,25 +143,25 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  - task: CmdLine@2
-    displayName: Run Unit Tests Unpackaged
-    inputs:
-      script: |
-        AppInstallerCLITests.exe -logto $(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log -s -r junit -o $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml
-      workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
-    continueOnError: true
+  # - task: CmdLine@2
+  #   displayName: Run Unit Tests Unpackaged
+  #   inputs:
+  #     script: |
+  #       AppInstallerCLITests.exe -logto $(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log -s -r junit -o $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml
+  #     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+  #   continueOnError: true
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Unpackaged Log
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
-      ArtifactName: '$(buildPlatform)\TestPassUnpackagedLog'
+  # - task: PublishBuildArtifacts@1
+  #   displayName: Publish Unit Tests Unpackaged Log
+  #   inputs:
+  #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
+  #     ArtifactName: '$(buildPlatform)\TestPassUnpackagedLog'
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Unpackaged Output
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
-      ArtifactName: 'TestPassUnpackagedOutput'
+  # - task: PublishBuildArtifacts@1
+  #   displayName: Publish Unit Tests Unpackaged Output
+  #   inputs:
+  #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
+  #     ArtifactName: 'TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload
-                    /bl $(Build.ArtifactStagingDirectory)\binlog'
+                    /bl:$(Build.ArtifactStagingDirectory)\binlog'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish MSBuild binlog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,14 +123,14 @@ jobs:
     displayName: Publish MSBuild logs
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\msbuild*.binlog'
-      artifactName: '$(buildPlatform)\MSBuild'
+      artifactName: '$(buildPlatform)_MSBuild'
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Publish WindowsPackageManager.dll Symbols
     inputs:
       targetPath: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
-      artifactName: '$(buildPlatform)\WindowsPackageManager.pdb'
+      artifactName: '$(buildPlatform)_WindowsPackageManager.pdb'
 
   - task: PowerShell@2
     displayName: Install Tests Dependencies
@@ -157,13 +157,13 @@ jobs:
   #   displayName: Publish Unit Tests Unpackaged Log
   #   inputs:
   #     targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
-  #     artifactName: '$(buildPlatform)\TestPassUnpackagedLog'
+  #     artifactName: '$(buildPlatform)_TestPassUnpackagedLog'
 
   # - task: PublishPipelineArtifact@1
   #   displayName: Publish Unit Tests Unpackaged Output
   #   inputs:
   #     targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
-  #     artifactName: '$(buildPlatform)\TestPassUnpackagedOutput'
+  #     artifactName: '$(buildPlatform)_TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged
@@ -177,13 +177,13 @@ jobs:
     displayName: Publish Unit Tests Packaged Log
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
-      artifactName: '$(buildPlatform)\TestPassPackagedLog'
+      artifactName: '$(buildPlatform)_TestPassPackagedLog'
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Unit Tests Packaged Output
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
-      artifactName: '$(buildPlatform)\TestPassPackagedOutput'
+      artifactName: '$(buildPlatform)_TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
@@ -257,7 +257,7 @@ jobs:
     displayName: Publish E2E Tests Packaged Log
     inputs:
       targetPath: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
-      artifactName: '$(buildPlatform)\E2ETestPackagedLog'
+      artifactName: '$(buildPlatform)_E2ETestPackagedLog'
 
   - task: VSTest@2
     displayName: Run Com Interface Tests
@@ -291,13 +291,13 @@ jobs:
     displayName: Publish Util Binary
     inputs:
       targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
-      artifactName: '$(buildPlatform)\WinGetUtil.dll'
+      artifactName: '$(buildPlatform)_WinGetUtil.dll'
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Util Symbols
     inputs:
       targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
-      artifactName: '$(buildPlatform)\WinGetUtil.pdb'
+      artifactName: '$(buildPlatform)_WinGetUtil.pdb'
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,7 +181,7 @@ jobs:
     displayName: Publish Unit Tests Packaged Output
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
-      ArtifactName: '$(buildPlatfom)\TestPassPackagedOutput'
+      ArtifactName: '$(buildPlatform)\TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
@@ -271,7 +271,7 @@ jobs:
     displayName: 'Copy Files: WinGetUtilInterop.UnitTests'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\src\WinGetUtilInterop.UnitTests\bin\$(BuildConfiguration)\netcoreapp3.1'
-      TargetFolder:  '$(Build.ArtifactStagingDiretory)\WinGetUtilInterop.UnitTests\'
+      TargetFolder:  '$(Build.ArtifactStagingDirectory)\WinGetUtilInterop.UnitTests\'
       CleanTargetFolder: true
       OverWrite: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,12 +227,13 @@ jobs:
                                   -ExeTestInstallerPath $(buildOutDir)\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
 
+  # TODO: This does not seem to be matching the logs for x86
   - task: CopyFiles@2
     displayName: 'Copy E2E Tests Package Log to artifacts folder'
     inputs:
-      SourceFolder: '$(temp)\E2ETestLogs'
+      SourceFolder: '$(temp)'
+      Contents: 'E2ETestLogs\**'
       TargetFolder: '$(artifactsDir)\E2ETestsPackagedLog'
-    continueOnError: true
 
   - task: VSTest@2
     displayName: Run Com Interface Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,14 +123,14 @@ jobs:
     displayName: Publish MSBuild logs
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\msbuild*.binlog'
-      artifactName: '$(buildPlatform)/'
+      artifactName: '$(buildPlatform)\MSBuild'
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Publish WindowsPackageManager.dll Symbols
     inputs:
       targetPath: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
-      artifactName: '$(buildPlatform)/WindowsPackageManager.pdb'
+      artifactName: '$(buildPlatform)\WindowsPackageManager.pdb'
 
   - task: PowerShell@2
     displayName: Install Tests Dependencies
@@ -157,13 +157,13 @@ jobs:
   #   displayName: Publish Unit Tests Unpackaged Log
   #   inputs:
   #     targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
-  #     artifactName: '$(buildPlatform)/TestPassUnpackagedLog'
+  #     artifactName: '$(buildPlatform)\TestPassUnpackagedLog'
 
   # - task: PublishPipelineArtifact@1
   #   displayName: Publish Unit Tests Unpackaged Output
   #   inputs:
   #     targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
-  #     artifactName: '$(buildPlatform)/TestPassUnpackagedOutput'
+  #     artifactName: '$(buildPlatform)\TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged
@@ -177,13 +177,13 @@ jobs:
     displayName: Publish Unit Tests Packaged Log
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
-      artifactName: '$(buildPlatform)/TestPassPackagedLog'
+      artifactName: '$(buildPlatform)\TestPassPackagedLog'
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Unit Tests Packaged Output
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
-      artifactName: '$(buildPlatform)/TestPassPackagedOutput'
+      artifactName: '$(buildPlatform)\TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
@@ -257,7 +257,7 @@ jobs:
     displayName: Publish E2E Tests Packaged Log
     inputs:
       targetPath: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
-      artifactName: '$(buildPlatform)/E2ETestPackagedLog'
+      artifactName: '$(buildPlatform)\E2ETestPackagedLog'
 
   - task: VSTest@2
     displayName: Run Com Interface Tests
@@ -291,13 +291,13 @@ jobs:
     displayName: Publish Util Binary
     inputs:
       targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
-      artifactName: '$(buildPlatform)/WinGetUtil.dll'
+      artifactName: '$(buildPlatform)\WinGetUtil.dll'
 
   - task: PublishPipelineArtifact@1
     displayName: Publish Util Symbols
     inputs:
       targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
-      artifactName: '$(buildPlatform)/WinGetUtil.pdb'
+      artifactName: '$(buildPlatform)\WinGetUtil.pdb'
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,11 +105,11 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:AppxBundlePlatforms="x86|x64"
+      msbuildArgs: '-bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog
+                    /p:AppxBundlePlatforms="x86|x64"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
-                    /p:UapAppxPackageBuildMode=StoreUpload
-                    -bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog'
+                    /p:UapAppxPackageBuildMode=StoreUpload'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish MSBuild binlog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ jobs:
   variables:
     BuildVer: $[counter(dependencies.GetReleaseTag.outputs['GetTag.tag'], 1)]
     buildOutDir: $(Build.SourcesDirectory)\src\$(buildPlatform)\$(buildConfiguration)
+    artifactsDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)
 
   steps:
   - task: NuGetToolInstaller@1
@@ -105,7 +106,7 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog
+      msbuildArgs: '/bl:$(artifactsDir)\msbuild.binlog
                     /p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
@@ -117,20 +118,13 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(testBuildConfiguration)'
-      msbuildArgs: '/bl:$(Build.ArtifactStagingDirectory)\msbuild-testProject.binlog'
+      msbuildArgs: '/bl:$(artifactsDir)\msbuild-testProject.binlog'
 
-  - task: PublishPipelineArtifact@1
-    displayName: Publish MSBuild logs
+  - task: CopyFiles@2
+    displayName: 'Copy WindowsPackageManager.dll Symbols to artifacts folder'
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)\msbuild*.binlog'
-      artifactName: '$(buildPlatform)_MSBuild'
-    condition: succeededOrFailed()
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish WindowsPackageManager.dll Symbols
-    inputs:
-      targetPath: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
-      artifactName: '$(buildPlatform)_WindowsPackageManager.pdb'
+      Contents: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
+      TargetFolder: '$(artifactsDir)'
 
   - task: PowerShell@2
     displayName: Install Tests Dependencies
@@ -149,41 +143,17 @@ jobs:
   #   displayName: Run Unit Tests Unpackaged
   #   inputs:
   #     script: |
-  #       AppInstallerCLITests.exe -logto $(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log -s -r junit -o $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml
+  #       AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged.xml
   #     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
   #   continueOnError: true
-
-  # - task: PublishPipelineArtifact@1
-  #   displayName: Publish Unit Tests Unpackaged Log
-  #   inputs:
-  #     targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
-  #     artifactName: '$(buildPlatform)_TestPassUnpackagedLog'
-
-  # - task: PublishPipelineArtifact@1
-  #   displayName: Publish Unit Tests Unpackaged Output
-  #   inputs:
-  #     targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
-  #     artifactName: '$(buildPlatform)_TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged
     inputs:
       filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(Build.ArtifactStagingDirectory)\AICLI-Packaged.log -TestResultsTarget $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
+      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(artifactsDir)\AICLI-Packaged.log -TestResultsTarget $(artifactsDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
       workingDirectory: 'src'
     continueOnError: true
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Unit Tests Packaged Log
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
-      artifactName: '$(buildPlatform)_TestPassPackagedLog'
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Unit Tests Packaged Output
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
-      artifactName: '$(buildPlatform)_TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
@@ -253,11 +223,11 @@ jobs:
                                   -ExeTestInstallerPath $(buildOutDir)\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
 
-  - task: PublishPipelineArtifact@1
-    displayName: Publish E2E Tests Packaged Log
+  - task: CopyFiles@2
+    displayName: 'Copy E2E Tests Package Log to artifacts folder'
     inputs:
-      targetPath: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
-      artifactName: '$(buildPlatform)_E2ETestPackagedLog'
+      SourceFolder: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
+      TargetFolder: '$(artifactsDir)\E2ETestsPackagedLog'
 
   - task: VSTest@2
     displayName: Run Com Interface Tests
@@ -287,17 +257,18 @@ jobs:
       platform: 'Any CPU'
       configuration: '$(BuildConfiguration)'
 
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Util Binary
+  - task: CopyFiles@2
+    displayName: 'Copy Util to artifacts folder'
     inputs:
-      targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
-      artifactName: '$(buildPlatform)_WinGetUtil.dll'
+      Contents: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll
+                 $(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
+      TargetFolder: '$(artifactsDir)'
 
   - task: PublishPipelineArtifact@1
-    displayName: Publish Util Symbols
+    displayName: Publish Pipeline Artifacts
     inputs:
-      targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
-      artifactName: '$(buildPlatform)_WinGetUtil.pdb'
+      targetPath: '$(artifactsDir)'
+    condition: always()
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,24 +111,26 @@ jobs:
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload'
 
-  - task: PublishBuildArtifacts@1
-    displayName: Publish MSBuild logs
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\msbuild.binlog'
-      ArtifactName: '$(buildPlatform)\msbuild.binlog'
-
   - task: VSBuild@1
     displayName: Build Test Project
     inputs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(testBuildConfiguration)'
+      msbuildArgs: '/bl:$(Build.ArtifactStagingDirectory)\msbuild-testProject.binlog'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
+    displayName: Publish MSBuild logs
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)\msbuild*.binlog'
+      artifactName: '$(buildPlatform)/'
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
     displayName: Publish WindowsPackageManager.dll Symbols
     inputs:
-      PathtoPublish: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
-      ArtifactName: '$(buildPlatform)\WindowsPackageManager.pdb'
+      targetPath: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
+      artifactName: '$(buildPlatform)/WindowsPackageManager.pdb'
 
   - task: PowerShell@2
     displayName: Install Tests Dependencies
@@ -151,17 +153,17 @@ jobs:
   #     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
   #   continueOnError: true
 
-  # - task: PublishBuildArtifacts@1
+  # - task: PublishPipelineArtifact@1
   #   displayName: Publish Unit Tests Unpackaged Log
   #   inputs:
-  #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
-  #     ArtifactName: '$(buildPlatform)\TestPassUnpackagedLog'
+  #     targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
+  #     artifactName: '$(buildPlatform)/TestPassUnpackagedLog'
 
-  # - task: PublishBuildArtifacts@1
+  # - task: PublishPipelineArtifact@1
   #   displayName: Publish Unit Tests Unpackaged Output
   #   inputs:
-  #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
-  #     ArtifactName: 'TestPassUnpackagedOutput'
+  #     targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
+  #     artifactName: '$(buildPlatform)/TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged
@@ -171,17 +173,17 @@ jobs:
       workingDirectory: 'src'
     continueOnError: true
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish Unit Tests Packaged Log
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
-      ArtifactName: '$(buildPlatform)\TestPassPackagedLog'
+      targetPath: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
+      artifactName: '$(buildPlatform)/TestPassPackagedLog'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish Unit Tests Packaged Output
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
-      ArtifactName: '$(buildPlatform)\TestPassPackagedOutput'
+      targetPath: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
+      artifactName: '$(buildPlatform)/TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
@@ -251,11 +253,11 @@ jobs:
                                   -ExeTestInstallerPath $(buildOutDir)\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish E2E Tests Packaged Log
     inputs:
-      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
-      ArtifactName: '$(buildPlatform)\E2ETestPackagedLog'
+      targetPath: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
+      artifactName: '$(buildPlatform)/E2ETestPackagedLog'
 
   - task: VSTest@2
     displayName: Run Com Interface Tests
@@ -285,17 +287,17 @@ jobs:
       platform: 'Any CPU'
       configuration: '$(BuildConfiguration)'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish Util Binary
     inputs:
-      PathtoPublish: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
-      ArtifactName: '$(buildPlatform)\WinGetUtil.dll'
+      targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
+      artifactName: '$(buildPlatform)/WinGetUtil.dll'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish Util Symbols
     inputs:
-      PathtoPublish: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
-      ArtifactName: '$(buildPlatform)\WinGetUtil.pdb'
+      targetPath: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
+      artifactName: '$(buildPlatform)/WinGetUtil.pdb'
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,8 +230,9 @@ jobs:
   - task: CopyFiles@2
     displayName: 'Copy E2E Tests Package Log to artifacts folder'
     inputs:
-      SourceFolder: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
+      SourceFolder: '$(temp)\E2ETestLogs'
       TargetFolder: '$(artifactsDir)\E2ETestsPackagedLog'
+    continueOnError: true
 
   - task: VSTest@2
     displayName: Run Com Interface Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,6 @@ jobs:
       workingDirectory: 'src'
 
   # Build all solutions in the root directory.
-  #
   - task: VSBuild@1
     displayName: Build Solution
     inputs:
@@ -109,8 +108,15 @@ jobs:
       msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
-                    /p:UapAppxPackageBuildMode=StoreUpload'
+                    /p:UapAppxPackageBuildMode=StoreUpload
+                    /bl $(Build.ArtifactStagingDirectory)\binlog'
 
+  - task: PublishBuildArtifacts@1
+    displayName: Publish MSBuild binlog
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\binlog
+      ArtifactName: '$(buildPlatform)\msbuild.binlog'
+    condition: succeededOrFailed()
   - task: VSBuild@1
     displayName: Build Test Project
     inputs:
@@ -141,47 +147,47 @@ jobs:
     displayName: Run Unit Tests Unpackaged
     inputs:
       script: |
-        AppInstallerCLITests.exe -logto AICLI-Unpackaged.log -s -r junit -o TEST-AppInstallerCLI-Unpackaged.xml
+        AppInstallerCLITests.exe -logto $(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log -s -r junit -o $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml
       workingDirectory: '$(buildOutDir)\AppInstallerCLITests\'
     continueOnError: true
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Unit Tests Unpackaged Log
     inputs:
-      PathtoPublish: '$(buildOutDir)\AppInstallerCLITests\AICLI-Unpackaged.log'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log'
       ArtifactName: '$(buildPlatform)\TestPassUnpackagedLog'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Unit Tests Unpackaged Output
     inputs:
-      PathtoPublish: '$(buildOutDir)\AppInstallerCLITests\TEST-AppInstallerCLI-Unpackaged.xml'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml'
       ArtifactName: 'TestPassUnpackagedOutput'
 
   - task: PowerShell@2
     displayName: Run Unit Tests Packaged
     inputs:
       filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(buildOutDir)\AICLI-Packaged.log -TestResultsTarget $(buildOutDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
+      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(Build.ArtifactStagingDirectory)\AICLI-Packaged.log -TestResultsTarget $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
       workingDirectory: 'src'
     continueOnError: true
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Unit Tests Packaged Log
     inputs:
-      PathtoPublish: '$(buildOutDir)\AICLI-Packaged.log'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\AICLI-Packaged.log'
       ArtifactName: '$(buildPlatform)\TestPassPackagedLog'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Unit Tests Packaged Output
     inputs:
-      PathtoPublish: '$(buildOutDir)\TEST-AppInstallerCLI-Packaged.xml'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Packaged.xml'
       ArtifactName: '$(buildPlatfom)\TestPassPackagedOutput'
 
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: '$(buildOutDir)\TEST-*.xml'
+      testResultsFiles: '$(Build.ArtifactStagingDirectory)\TEST-*.xml'
       failTaskOnFailedTests: true
 
   - task: DownloadSecureFile@1
@@ -236,21 +242,20 @@ jobs:
       testAssemblyVer2: '$(buildOutDir)\AppInstallerCLIE2ETests\AppInstallerCLIE2ETests.dll'
       runSettingsFile: '$(buildOutDir)\AppInstallerCLIE2ETests\Test.runsettings'
       overrideTestrunParameters: '-PackagedContext true
-                                  -AICLIPackagePath $(System.DefaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release
+                                  -AICLIPackagePath $(System.DefaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration)
                                   -AICLIPath AppInstallerCLI\winget.exe
                                   -LooseFileRegistration true
                                   -InvokeCommandInDesktopPackage true
                                   -StaticFileRootPath $(Agent.TempDirectory)\TestLocalIndex
                                   -MsixTestInstallerPath $(Build.ArtifactStagingDirectory)\AppInstallerTestMsixInstaller.msix
-                                  -ExeTestInstallerPath $(System.DefaultWorkingDirectory)\src\x64\Release\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
+                                  -ExeTestInstallerPath $(buildOutDir)\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
-    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish E2E Tests Packaged x64 Log
+    displayName: Publish E2E Tests Packaged Log
     inputs:
       PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
-      ArtifactName: 'E2ETestPackagedx64Log'
+      ArtifactName: '$(buildPlatform)\E2ETestPackagedLog'
 
   - task: VSTest@2
     displayName: Run Com Interface Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
 
 variables:
   solution: 'src\AppInstallerCLI.sln'
-  appxPackageDir: '$(Build.ArtifactStagingDirectory)\AppxPackages\'
+  appxPackageDir: '$(Build.ArtifactStagingDirectory)/AppxPackages/'
 
 # Do not set the build version for a PR build.
 
@@ -106,7 +106,7 @@ jobs:
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
       msbuildArgs: '-bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog
-                    /p:AppxBundlePlatforms="x86|x64"
+                    /p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload'
@@ -148,7 +148,7 @@ jobs:
     inputs:
       script: |
         AppInstallerCLITests.exe -logto $(Build.ArtifactStagingDirectory)\AICLI-Unpackaged.log -s -r junit -o $(Build.ArtifactStagingDirectory)\TEST-AppInstallerCLI-Unpackaged.xml
-      workingDirectory: '$(buildOutDir)\AppInstallerCLITests\'
+      workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
     continueOnError: true
 
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,12 +109,12 @@ jobs:
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload
-                    /bl:$(Build.ArtifactStagingDirectory)\binlog'
+                    -bl:$(Build.ArtifactStagingDirectory)\msbuild.binlog'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish MSBuild binlog
     inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)\binlog
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\msbuild.binlog
       ArtifactName: '$(buildPlatform)\msbuild.binlog'
     condition: succeededOrFailed()
   - task: VSBuild@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,12 +16,8 @@ pool:
   vmImage: 'windows-latest'
 
 variables:
-  solution: 'src/AppInstallerCLI.sln'
-  buildPlatform: 'x86|x64'
-  buildConfiguration: 'Release'
-  testBuildPlatform: 'x86'
-  testBuildConfiguration: 'TestRelease'
-  appxPackageDir: '$(build.artifactStagingDirectory)\AppxPackages\\'
+  solution: 'src\AppInstallerCLI.sln'
+  appxPackageDir: '$(Build.ArtifactStagingDirectory)\AppxPackages\'
 
 # Do not set the build version for a PR build.
 
@@ -44,25 +40,39 @@ jobs:
   timeoutInMinutes: 120
   dependsOn: 'GetReleaseTag'
   condition: always()
+
+  strategy:
+    matrix:
+      x86_release:
+        buildConfiguration: 'Release'
+        buildPlatform: 'x86'
+        testBuildConfiguration: 'TestRelease'
+      x64_release:
+        buildConfiguration: 'Release'
+        buildPlatform: 'x64'
+        testBuildConfiguration: 'TestRelease'
+
   variables:
     BuildVer: $[counter(dependencies.GetReleaseTag.outputs['GetTag.tag'], 1)]
+    buildOutDir: $(Build.SourcesDirectory)\src\$(buildPlatform)\$(buildConfiguration)
+
   steps:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
-  
+
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
     inputs:
       restoreSolution: '$(solution)'
-  
+
   # Restore these UAP packages as https://github.com/NuGet/Home/issues/7796 leads to all UAP packages being skipped for restore.
   # Even though they don't need any actual restore action, they need the project.assets.json file to be created and a direct restore does that.
   - task: NuGetCommand@2
     displayName: Restore AppInstallerCLIPackage
     inputs:
       restoreSolution: 'src\AppInstallerCLIPackage\AppInstallerCLIPackage.wapproj'
-  
+
   - task: NuGetCommand@2
     displayName: Restore AppInstallerTestMsixInstaller
     inputs:
@@ -72,14 +82,14 @@ jobs:
     displayName: Restore PackagedTests
     inputs:
       restoreSolution: 'src\PackagedTests\PackagedTests.csproj'
-  
+
   # Restores only .NET core projects, but is still necessary, as without this the IndexCreationTool and LocalhostWebServer projects fail to build
   - task: DotNetCoreCLI@2
     displayName: DotNet Restore
     inputs:
       command: 'restore'
       projects: '**/*.csproj'
-  
+
   - task: PowerShell@2
     displayName: Update Binary Version
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
@@ -87,44 +97,39 @@ jobs:
       filePath: 'src\binver\Update-BinVer.ps1'
       arguments: '-TargetFile binver\binver\version.h -BuildVersion $(BuildVer)'
       workingDirectory: 'src'
-  
+
   # Build all solutions in the root directory.
+  #
   - task: VSBuild@1
     displayName: Build Solution
     inputs:
-      platform: 'x86'
+      platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" 
-                    /p:AppxPackageDir="$(appxPackageDir)" 
-                    /p:AppxBundle=Always 
+      msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)"
+                    /p:AppxPackageDir="$(appxPackageDir)"
+                    /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=StoreUpload'
 
   - task: VSBuild@1
     displayName: Build Test Project
     inputs:
-      platform: 'x86'
+      platform: '$(buildConfiguration)'
       solution: '$(solution)'
       configuration: '$(testBuildConfiguration)'
-      msbuildArgs: '/p:AppxBundlePlatforms="$(testBuildPlatform)" 
-                    /p:AppxPackageDir="$(appxPackageDir)" 
-                    /p:AppxBundle=Always 
-                    /p:UapAppxPackageBuildMode=StoreUpload'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish WindowsPackageManager.dll Symbols
     inputs:
-      PathtoPublish: 'src\x64\Release\WindowsPackageManager\WindowsPackageManager.pdb'
-      ArtifactName: 'WindowsPackageManager.pdb'
-      publishLocation: 'Container'
+      PathtoPublish: '$(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb'
+      ArtifactName: '$(buildPlatform)\WindowsPackageManager.pdb'
 
   - task: PowerShell@2
     displayName: Install Tests Dependencies
     inputs:
       targetType: 'inline'
       script: |
-        Add-AppxPackage AppInstallerCLIPackage_0.0.2.0_Test\Dependencies\x86\Microsoft.VCLibs.x86.14.00.Desktop.appx
-        Add-AppxPackage AppInstallerCLIPackage_0.0.2.0_Test\Dependencies\x64\Microsoft.VCLibs.x64.14.00.Desktop.appx
+        Add-AppxPackage AppInstallerCLIPackage_0.0.2.0_Test\Dependencies\$(buildPlatform)\Microsoft.VCLibs.$(buildPlatform).14.00.Desktop.appx
       workingDirectory: $(appxPackageDir)
 
   - task: VisualStudioTestPlatformInstaller@1
@@ -132,111 +137,52 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-# TODO: Convert tests to run based on the whether things have worked up to this point
+  - task: CmdLine@2
+    displayName: Run Unit Tests Unpackaged
+    inputs:
+      script: |
+        AppInstallerCLITests.exe -logto AICLI-Unpackaged.log -s -r junit -o TEST-AppInstallerCLI-Unpackaged.xml
+      workingDirectory: '$(buildOutDir)\AppInstallerCLITests\'
+    continueOnError: true
 
-#  - task: CmdLine@2
-#    displayName: Run Unit Tests Unpackaged x64
-#    inputs:
-#      script: |
-#        AppInstallerCLITests.exe -logto AICLI-Unpackaged-x64.log -s -r junit -o TEST-AppInstallerCLI-Unpackaged-x64.xml
-#      workingDirectory: 'src\x64\Release\AppInstallerCLITests\'
-#    condition: succeededOrFailed()
-  
-#  - task: PublishBuildArtifacts@1
-#    displayName: Publish Unit Tests Unpackaged Log x64
-#    inputs:
-#      PathtoPublish: 'src\x64\Release\AppInstallerCLITests\AICLI-Unpackaged-x64.log'
-#      ArtifactName: 'TestPassUnpackagedLog'
-#     publishLocation: 'Container'
-#    condition: succeededOrFailed()
-  
-#  - task: PublishBuildArtifacts@1
-#    displayName: Publish Unit Tests Unpackaged Output x64
-#    inputs:
-#      PathtoPublish: 'src\x64\Release\AppInstallerCLITests\TEST-AppInstallerCLI-Unpackaged-x64.xml'
-#      ArtifactName: 'TestPassUnpackagedOutput'
-#      publishLocation: 'Container'
-#    condition: succeededOrFailed()
-  
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Unit Tests Unpackaged Log
+    inputs:
+      PathtoPublish: '$(buildOutDir)\AppInstallerCLITests\AICLI-Unpackaged.log'
+      ArtifactName: '$(buildPlatform)\TestPassUnpackagedLog'
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Unit Tests Unpackaged Output
+    inputs:
+      PathtoPublish: '$(buildOutDir)\AppInstallerCLITests\TEST-AppInstallerCLI-Unpackaged.xml'
+      ArtifactName: 'TestPassUnpackagedOutput'
+
   - task: PowerShell@2
-    displayName: Run Unit Tests Packaged x64
+    displayName: Run Unit Tests Packaged
     inputs:
       filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-      arguments: '-Args "~[pips]" -BuildRoot x64\Release -PackageRoot AppInstallerCLIPackage\bin\x64\Release -LogTarget x64\Release\AICLI-Packaged-x64.log -TestResultsTarget x64\Release\TEST-AppInstallerCLI-Packaged-x64.xml -ScriptWait'
+      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(buildOutDir)\AICLI-Packaged.log -TestResultsTarget $(buildOutDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
       workingDirectory: 'src'
-    condition: succeededOrFailed()
-  
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Packaged Log x64
-    inputs:
-      PathtoPublish: 'src\x64\Release\AICLI-Packaged-x64.log'
-      ArtifactName: 'TestPassPackagedLog'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()
-  
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Packaged Output x64
-    inputs:
-      PathtoPublish: 'src\x64\Release\TEST-AppInstallerCLI-Packaged-x64.xml'
-      ArtifactName: 'TestPassPackagedOutput'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()
+    continueOnError: true
 
-#  - task: CmdLine@2
-#    displayName: Run Unit Tests Unpackaged x86
-#    inputs:
-#      script: |
-#        AppInstallerCLITests.exe -logto AICLI-Unpackaged-x86.log -s -r junit -o TEST-AppInstallerCLI-Unpackaged-x86.xml
-#      workingDirectory: 'src\x86\Release\AppInstallerCLITests\'
-#    condition: succeededOrFailed()
-  
-#  - task: PublishBuildArtifacts@1
-#    displayName: Publish Unit Tests Unpackaged Log x86
-#    inputs:
-#      PathtoPublish: 'src\x86\Release\AppInstallerCLITests\AICLI-Unpackaged-x86.log'
-#      ArtifactName: 'TestPassUnpackagedLog'
-#      publishLocation: 'Container'
-#    condition: succeededOrFailed()
-  
-#  - task: PublishBuildArtifacts@1
-#    displayName: Publish Unit Tests Unpackaged Output x86
-#    inputs:
-#      PathtoPublish: 'src\x86\Release\AppInstallerCLITests\TEST-AppInstallerCLI-Unpackaged-x86.xml'
-#      ArtifactName: 'TestPassUnpackagedOutput'
-#      publishLocation: 'Container'
-#    condition: succeededOrFailed()
-  
-  - task: PowerShell@2
-    displayName: Run Unit Tests Packaged x86
-    inputs:
-      filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-      arguments: '-Args "~[pips]" -BuildRoot x86\Release -PackageRoot AppInstallerCLIPackage\bin\x86\Release -LogTarget x86\Release\AICLI-Packaged-x86.log -TestResultsTarget x86\Release\TEST-AppInstallerCLI-Packaged-x86.xml -ScriptWait'
-      workingDirectory: 'src'
-    condition: succeededOrFailed()
-  
   - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Packaged Log x86
+    displayName: Publish Unit Tests Packaged Log
     inputs:
-      PathtoPublish: 'src\x86\Release\AICLI-Packaged-x86.log'
-      ArtifactName: 'TestPassPackagedLog'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()
-  
+      PathtoPublish: '$(buildOutDir)\AICLI-Packaged.log'
+      ArtifactName: '$(buildPlatform)\TestPassPackagedLog'
+
   - task: PublishBuildArtifacts@1
-    displayName: Publish Unit Tests Packaged Output x86
+    displayName: Publish Unit Tests Packaged Output
     inputs:
-      PathtoPublish: 'src\x86\Release\TEST-AppInstallerCLI-Packaged-x86.xml'
-      ArtifactName: 'TestPassPackagedOutput'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()
-  
+      PathtoPublish: '$(buildOutDir)\TEST-AppInstallerCLI-Packaged.xml'
+      ArtifactName: '$(buildPlatfom)\TestPassPackagedOutput'
+
   - task: PublishTestResults@2
     displayName: Publish Unit Test Results
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/TEST-*.xml'
+      testResultsFiles: '$(buildOutDir)\TEST-*.xml'
       failTaskOnFailedTests: true
-    condition: succeededOrFailed()
 
   - task: DownloadSecureFile@1
     name: AppInstallerTest
@@ -248,59 +194,55 @@ jobs:
     name: HTTPSDevCert
     displayName: 'Download Kestrel Certificate'
     inputs:
-      secureFile: 'HTTPSDevCertV2.pfx'
+      secureFile: 'AppInstallerTest.pfx'
 
   - task: MSBuild@1
     displayName: Build MSIX Test Installer File
     inputs:
-      platform: 'x86'
-      solution: 'src/AppInstallerTestMsixInstaller/AppInstallerTestMsixInstaller.wapproj'
+      platform: '$(buildPlatform)'
+      solution: 'src\AppInstallerTestMsixInstaller\AppInstallerTestMsixInstaller.wapproj'
       configuration: '$(buildConfiguration)'
       msbuildArguments: '/p:AppxPackageOutput="$(Build.ArtifactStagingDirectory)\AppInstallerTestMsixInstaller.msix"
-                         /p:AppxBundle=Never 
-                         /p:UapAppxPackageBuildMode=SideLoadOnly 
+                         /p:AppxBundle=Never
+                         /p:UapAppxPackageBuildMode=SideLoadOnly
                          /p:AppxPackageSigningEnabled=false'
-    condition: succeededOrFailed()
 
   - task: PowerShell@2
     displayName: Install Root Certificate
     inputs:
       filePath: 'src\LocalhostWebServer\InstallDevCert.ps1'
       arguments: '-pfxpath $(HTTPSDevCert.secureFilePath) -password microsoft'
-    condition: succeededOrFailed()
 
   - task: PowerShell@2
     displayName: Launch LocalhostWebServer
     inputs:
       filePath: 'src\LocalhostWebServer\Run-LocalhostWebServer.ps1'
-      arguments: '-BuildRoot $(system.defaultWorkingDirectory)\src\x86\Release\LocalhostWebServer -StaticFileRoot $(Agent.TempDirectory)\TestLocalIndex -CertPath $(HTTPSDevCert.secureFilePath) -CertPassword microsoft'
-    condition: succeededOrFailed()
+      arguments: '-BuildRoot $(buildOutDir)\LocalhostWebServer -StaticFileRoot $(Agent.TempDirectory)\TestLocalIndex -CertPath $(HTTPSDevCert.secureFilePath) -CertPassword microsoft'
 
   - task: CopyFiles@2
-    displayName: 'Copy x64 Files to Package Output'
+    displayName: 'Copy Files to Package Output'
     inputs:
-      SourceFolder: '$(system.defaultWorkingDirectory)\src\x64\Release\WindowsPackageManager'
-      TargetFolder:  '$(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release'
+      SourceFolder: '$(buildOutDir)\WindowsPackageManager'
+      TargetFolder:  'src\AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration)'
       Contents: WindowsPackageManager.dll
       CleanTargetFolder: false
       OverWrite: true
-    condition: succeededOrFailed()
 
   - task: VSTest@2
-    displayName: Run E2E Tests Packaged x64
+    displayName: Run E2E Tests Packaged
     inputs:
-      testRunTitle: 'E2E Packaged x64'
+      testRunTitle: 'E2E Packaged'
       testSelector: 'testAssemblies'
-      testAssemblyVer2: 'src\x64\Release\AppInstallerCLIE2ETests\AppInstallerCLIE2ETests.dll'
-      runSettingsFile: 'src\x64\Release\AppInstallerCLIE2ETests\Test.runsettings'
+      testAssemblyVer2: '$(buildOutDir)\AppInstallerCLIE2ETests\AppInstallerCLIE2ETests.dll'
+      runSettingsFile: '$(buildOutDir)\AppInstallerCLIE2ETests\Test.runsettings'
       overrideTestrunParameters: '-PackagedContext true
-                                  -AICLIPackagePath $(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release
+                                  -AICLIPackagePath $(System.DefaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x64\Release
                                   -AICLIPath AppInstallerCLI\winget.exe
                                   -LooseFileRegistration true
                                   -InvokeCommandInDesktopPackage true
                                   -StaticFileRootPath $(Agent.TempDirectory)\TestLocalIndex
                                   -MsixTestInstallerPath $(Build.ArtifactStagingDirectory)\AppInstallerTestMsixInstaller.msix
-                                  -ExeTestInstallerPath $(system.defaultWorkingDirectory)\src\x64\Release\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
+                                  -ExeTestInstallerPath $(System.DefaultWorkingDirectory)\src\x64\Release\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
     condition: succeededOrFailed()
 
@@ -309,89 +251,46 @@ jobs:
     inputs:
       PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Temp\E2ETestLogs'
       ArtifactName: 'E2ETestPackagedx64Log'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()
-
-  - task: CopyFiles@2
-    displayName: 'Copy x86 Files to Package Output'
-    inputs:
-      SourceFolder: '$(system.defaultWorkingDirectory)\src\x86\Release\WindowsPackageManager'
-      TargetFolder:  '$(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x86\Release'
-      Contents: WindowsPackageManager.dll
-      CleanTargetFolder: false
-      OverWrite: true
-    condition: succeededOrFailed()
-
-  - task: VSTest@2
-    displayName: Run E2E Tests Packaged x86
-    inputs:
-      testRunTitle: 'E2E Packaged x86'
-      testSelector: 'testAssemblies'
-      testAssemblyVer2: 'src\x86\Release\AppInstallerCLIE2ETests\AppInstallerCLIE2ETests.dll'
-      runSettingsFile: 'src\x86\Release\AppInstallerCLIE2ETests\Test.runsettings'
-      overrideTestrunParameters: '-PackagedContext true
-                                  -AICLIPackagePath $(system.defaultWorkingDirectory)\src\AppInstallerCLIPackage\bin\x86\Release
-                                  -AICLIPath AppInstallerCLI\winget.exe
-                                  -LooseFileRegistration true
-                                  -InvokeCommandInDesktopPackage true
-                                  -StaticFileRootPath $(Agent.TempDirectory)\TestLocalIndex
-                                  -MsixTestInstallerPath $(Build.ArtifactStagingDirectory)\AppInstallerTestMsixInstaller.msix
-                                  -ExeTestInstallerPath $(system.defaultWorkingDirectory)\src\x86\Release\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
-                                  -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
-    condition: succeededOrFailed()
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish E2E Tests Packaged x86 Log
-    inputs:
-      PathtoPublish: 'C:\Users\VssAdministrator\AppData\Local\Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir'
-      ArtifactName: 'E2ETestPackagedx86Log'
-      publishLocation: 'Container'
-    condition: succeededOrFailed()  
 
   - task: VSTest@2
     displayName: Run Com Interface Tests
     inputs:
       testRunTitle: 'Com Interface Tests'
-      platform: 'x86'
+      platform: '$(buildPlatform)'
       testSelector: 'testAssemblies'
       testAssemblyVer2: |
-        src\x86\Release\PackagedTests\PackagedTests.build.appxrecipe
-      runSettingsFile: 'src\x86\Release\PackagedTests\Test.runsettings'
-    condition: succeededOrFailed()
+        $(buildOutDir)\PackagedTests\PackagedTests.build.appxrecipe
+      runSettingsFile: '$(buildOutDir)\PackagedTests\Test.runsettings'
 
   - task: CopyFiles@2
     displayName: 'Copy Files: WinGetUtilInterop.UnitTests'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\src\WinGetUtilInterop.UnitTests\bin\$(BuildConfiguration)\netcoreapp3.1'
-      TargetFolder:  '$(build.artifactstagingdirectory)\WinGetUtilInterop.UnitTests\'
+      TargetFolder:  '$(Build.ArtifactStagingDiretory)\WinGetUtilInterop.UnitTests\'
       CleanTargetFolder: true
       OverWrite: true
-    condition: succeededOrFailed()
 
   - task: VSTest@2
     displayName: 'Run tests: WinGetUtilInterop.UnitTests'
     inputs:
       testSelector: 'testAssemblies'
       testAssemblyVer2: 'WinGetUtilInterop.UnitTests.dll'
-      searchFolder: '$(build.artifactstagingdirectory)\WinGetUtilInterop.UnitTests'
+      searchFolder: '$(Build.ArtifactStagingDirectory)\WinGetUtilInterop.UnitTests'
       codeCoverageEnabled: true
       platform: 'Any CPU'
       configuration: '$(BuildConfiguration)'
-    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Util Binary
     inputs:
-      PathtoPublish: 'src\x64\Release\WinGetUtil\WinGetUtil.dll'
-      ArtifactName: 'WinGetUtil.dll'
-      publishLocation: 'Container'
+      PathtoPublish: '$(buildOutDir)\WinGetUtil\WinGetUtil.dll'
+      ArtifactName: '$(buildPlatform)\WinGetUtil.dll'
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Util Symbols
     inputs:
-      PathtoPublish: 'src\x64\Release\WinGetUtil\WinGetUtil.pdb'
-      ArtifactName: 'WinGetUtil.pdb'
-      publishLocation: 'Container'
+      PathtoPublish: '$(buildOutDir)\WinGetUtil\WinGetUtil.pdb'
+      ArtifactName: '$(buildPlatform)\WinGetUtil.pdb'
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance
@@ -404,7 +303,7 @@ jobs:
   - task: BinSkim@3
     displayName: 'Run BinSkim '
     inputs:
-      arguments: 'analyze "$(system.defaultWorkingDirectory)\src\AppInstaller*CLI.exe" "$(system.defaultWorkingDirectory)\src\WinGet*Util.dll" --config default --recurse' 
+      arguments: 'analyze "$(System.DefaultWorkingDirectory)\src\AppInstaller*CLI.exe" "$(System.DefaultWorkingDirectory)\src\WinGet*Util.dll" --config default --recurse'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
     displayName: 'Publish Security Analysis Logs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,12 +227,10 @@ jobs:
                                   -ExeTestInstallerPath $(buildOutDir)\AppInstallerTestExeInstaller\AppInstallerTestExeInstaller.exe
                                   -PackageCertificatePath $(AppInstallerTest.secureFilePath)'
 
-  # TODO: This does not seem to be matching the logs for x86
   - task: CopyFiles@2
     displayName: 'Copy E2E Tests Package Log to artifacts folder'
     inputs:
-      SourceFolder: '$(temp)'
-      Contents: 'E2ETestLogs\**'
+      SourceFolder: '$(temp)\E2ETestLogs'
       TargetFolder: '$(artifactsDir)\E2ETestsPackagedLog'
 
   - task: VSTest@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,11 @@ jobs:
       platform: '$(buildPlatform)'
       solution: '$(solution)'
       configuration: '$(testBuildConfiguration)'
-      msbuildArgs: '/bl:$(artifactsDir)\msbuild-testProject.binlog'
+      msbuildArgs: '/bl:$(artifactsDir)\msbuild-testProject.binlog
+                    /p:AppxBundlePlatforms="$(buildPlatform)"
+                    /p:AppxPackageDir="$(appxPackageDir)"
+                    /p:AppxBundle=Always
+                    /p:UapAppxPackageBuildMode=StoreUpload'
 
   - task: CopyFiles@2
     displayName: 'Copy WindowsPackageManager.dll Symbols to artifacts folder'

--- a/src/AppInstallerCLICore/pch.h
+++ b/src/AppInstallerCLICore/pch.h
@@ -53,12 +53,12 @@
 #include <AppInstallerDownloader.h>
 #include <AppInstallerErrors.h>
 #include <AppInstallerLogging.h>
-#include <winget/RepositorySource.h>
 #include <AppInstallerRuntime.h>
 #include <AppInstallerSHA256.h>
 #include <AppInstallerStrings.h>
 #include <AppInstallerTelemetry.h>
 #include <winget/ExperimentalFeature.h>
+#include <winget/Locale.h>
 #include <winget/LocIndependent.h>
 #include <winget/ManifestYamlParser.h>
-#include <winget/Locale.h>
+#include <winget/RepositorySource.h>

--- a/src/AppInstallerCLIE2ETests/SetUpFixture.cs
+++ b/src/AppInstallerCLIE2ETests/SetUpFixture.cs
@@ -143,7 +143,7 @@ namespace AppInstallerCLIE2ETests
             else
             {
                 var value = appModelUnlockKey.GetValue("AllowDevelopmentWithoutDevLicense");
-                if (value != null && ((UInt32)value) != 0)
+                if (value != null && ((Int32)value) != 0)
                 {
                     appModelUnlockKey.SetValue("AllowDevelopmentWithoutDevLicense", 0, RegistryValueKind.DWord);
                     return true;

--- a/src/PackagedTests/PackagedTests.csproj
+++ b/src/PackagedTests/PackagedTests.csproj
@@ -28,8 +28,6 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>true</Prefer32Bit>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x64</AppxBundlePlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <PlatformTarget>x86</PlatformTarget>


### PR DESCRIPTION
# Change:
This changes the CI build pipeline to build/test x86 and x64 in two separate parallel jobs.

# Context:
On #1813 the build failed because the build machine was running out of space. We are using Microsoft Hosted agents for running the pipelines, which have only 10GB free space (according to docs; in practice it seems to be around 12GB). Upon investigation, building the solution was already taking about 9GB since we are building both x86 and x64 at the same time. Out of these, about 4GB were from pre-compiled headers; the biggest offender was the one for CommonCore, with over 800MB for each x86,x64.

I also considered trying to reduce the size of the pre-compiled headers or delete them after compilation (but didn't know how); or setting up a custom agent pool with more space (but setting it up and maintaining it seemed complicated). The idea of splitting the jobs by platform is from @yao-msft :)

By splitting into two jobs, building the solution for each one now takes only about 5GB, which puts us a safe distance from the 10GB limit.

# Change details:
* Added a matrix strategy for the build job to run the same steps for both platforms
* Renamed all build artifacts that contained the platform in the file name to now be grouped under a single folder per platform
* Removed duplicated test runs (there was one per platform)
* Moved some files generated by the pipeline from the MSBuild output directory to the pipeline's artifact staging directory
* Changed tests to run only if the build succeeded by removing the `succeededOrFailed()` condition. Added `continueOnError: true` to the tests so that it still makes it to the publish test results step if they fail.
* Also added publishing of MSBuild binlogs for diagnosing build errors

Opening as draft first to validate that the pipeline works correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1852)