### PR TITLE
Add titles to 1.1 schema for ExpectedReturnCode and UnsupportedOSArchitecture

### DIFF
--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -155,6 +155,7 @@
       "type": [ "array", "null" ],
       "items": {
         "type": "object",
+        "title": "ExpectedReturnCode",
         "properties": {
           "InstallerReturnCode": {
             "$ref": "#/definitions/InstallerReturnCode"
@@ -373,6 +374,7 @@
       "uniqueItems": true,
       "items": {
         "type": "string",
+        "title": "UnsupportedOSArchitecture",
         "enum": [
           "x86",
           "x64",

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -188,6 +188,7 @@
       "type": [ "array", "null" ],
       "items": {
         "type": "object",
+        "title": "ExpectedReturnCode",
         "properties": {
           "InstallerReturnCode": {
             "$ref": "#/definitions/InstallerReturnCode"
@@ -405,6 +406,7 @@
       "uniqueItems": true,
       "items": {
         "type": "string",
+        "title": "UnsupportedOSArchitecture",
         "enum": [
           "x86",
           "x64",


### PR DESCRIPTION
Changes:
- Adding a title description for ExpectedReturnCode and UnsupportedOSArchitecture so that WingetCreate can process those enum values when generating the model.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1862)