### PR TITLE
Print the upgrade table during `upgrade --all`

### DIFF
--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -155,6 +155,7 @@ namespace AppInstaller::CLI
                 SearchSourceForMany <<
                 HandleSearchResultFailures <<
                 EnsureMatchesFromSearchResult(true) <<
+                ReportListResult(true) <<
                 UpdateAllApplicable;
         }
         else if (context.Args.Contains(Execution::Args::Type::Manifest))

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -208,7 +208,7 @@ namespace AppInstaller::CLI::Workflow
                 AICLI_TERMINATE_CONTEXT(showContext.GetTerminationHR());
             }
 
-            hasPackageAgreements |= !showContext.Get<Execution::Data::Manifest>().CurrentLocalization.Get<AppInstaller::Manifest::Localization::Agreements>().empty();
+            hasPackageAgreements |= true;
         }
 
         // If any package has agreements, ensure they are accepted

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -191,7 +191,12 @@ namespace AppInstaller::CLI::Workflow
         bool hasPackageAgreements = false;
         for (auto& packageContext : context.Get<Execution::Data::PackagesToInstall>())
         {
-            // Show agreements for each package
+            // Show agreements for each package that has one
+            auto agreements = packageContext->Get<Execution::Data::Manifest>().CurrentLocalization.Get<AppInstaller::Manifest::Localization::Agreements>();
+            if (agreements.empty())
+            {
+                continue;
+            }
             Execution::Context& showContext = *packageContext;
             auto previousThreadGlobals = showContext.SetForCurrentThread();
 

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -188,6 +188,7 @@ namespace AppInstaller::CLI::Workflow
         else
         {
             context.Add<Execution::Data::PackagesToInstall>(std::move(packagesToInstall));
+            context.Reporter.Info() << std::endl;
             context <<
                 InstallMultiplePackages(
                     Resource::String::InstallAndUpgradeCommandsReportDependencies,


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Resolves #1858.

This PR changes the `upgrade --all` flow to print the table of available upgrades before running the upgrades, giving the user a more friendly list of upgrades (as opposed to several lines of `Workflow::ReportManifestIdentityWithVersion`). 

I had to make a change to `EnsurePackageAgreementsAcceptanceForMultipleInstallers`, namely, that it now gets the manifest and checks to see if there are any agreements before printing anything. ~~This is less efficient if there is an agreement, but since most packages don't have agreements right now, it shouldn't (on average) change performance.~~ (Edit: this doesn't change performance really at all, see below).

I reused the upgrade table from `winget upgrade` for this too, if a different appearance would be better then I can make a new table. Speaking of appearance, I know that nobody from MS commented on that ticket, so if anyone thinks it is better the other way then I can close this.

Tested: manually.

![image](https://user-images.githubusercontent.com/21368066/150378056-bb5ed0f0-7b24-4546-9325-a5419a21cae5.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1866)