### PR TITLE
Added extra check for valid arguments in `upgrade`.

### DIFF
--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -43,8 +43,7 @@ namespace AppInstaller::CLI
         // either for upgrading or for listing available upgrades.
         bool HasArgumentsForMultiplePackages(Execution::Args& execArgs)
         {
-            return execArgs.Contains(Args::Type::All) ||
-                execArgs.Contains(Args::Type::IncludeUnknown);
+            return execArgs.Contains(Args::Type::All);  
         }
 
         // Determines whether there are any arguments only used as options during an upgrade,
@@ -169,7 +168,11 @@ namespace AppInstaller::CLI
 
         else if (!ShouldListUpgrade(execArgs) 
                 && !HasSearchQueryArguments(execArgs) 
-                && HasArgumentsForInstallOptions(execArgs))
+                && (execArgs.Contains(Args::Type::Log) ||
+                    execArgs.Contains(Args::Type::Override) ||
+                    execArgs.Contains(Args::Type::InstallLocation) ||
+                    execArgs.Contains(Args::Type::HashOverride) ||
+                    execArgs.Contains(Args::Type::AcceptPackageAgreements)))
         {
             throw CommandException(Resource::String::InvalidArgumentWithoutQueryError);
         }

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -17,9 +17,9 @@ namespace AppInstaller::CLI
 {
     namespace
     {
-        bool ShouldListUpgrade(Context& context)
+        bool ShouldListUpgrade(Execution::Args& execArgs)
         {
-            for (Execution::Args::Type type : context.Args.GetTypes())
+            for (Execution::Args::Type type : execArgs.GetTypes())
             {
                 if (type != Execution::Args::Type::Source && type != Execution::Args::Type::IncludeUnknown)
                 {
@@ -121,6 +121,16 @@ namespace AppInstaller::CLI
         {
             throw CommandException(Resource::String::BothManifestAndSearchQueryProvided, "");
         }
+
+        else if (!ShouldListUpgrade(execArgs) &&
+                 (!execArgs.Contains(Execution::Args::Type::Query) && 
+                 !execArgs.Contains(Execution::Args::Type::All) &&
+                 !execArgs.Contains(Execution::Args::Type::Name) &&
+                 !execArgs.Contains(Execution::Args::Type::Id) &&
+                 !execArgs.Contains(Execution::Args::Type::Moniker)))
+        {
+            throw CommandException(Resource::String::InvalidArgumentWithoutQueryError);
+        }
     }
 
     void UpgradeCommand::ExecuteInternal(Execution::Context& context) const
@@ -129,7 +139,7 @@ namespace AppInstaller::CLI
 
         // Only allow for source failures when doing a list of available upgrades.
         // We have to set it now to allow for source open failures to also just warn.
-        if (ShouldListUpgrade(context))
+        if (ShouldListUpgrade(context.Args))
         {
             context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
         }
@@ -139,7 +149,7 @@ namespace AppInstaller::CLI
             Workflow::OpenSource() <<
             Workflow::OpenCompositeSource(Repository::PredefinedSource::Installed);
 
-        if (ShouldListUpgrade(context))
+        if (ShouldListUpgrade(context.Args))
         {
             // Upgrade with no args list packages with updates available
             context <<

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -151,6 +151,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidArgumentSpecifierError);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidArgumentValueError);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidArgumentValueErrorWithoutValidValues);
+        WINGET_DEFINE_RESOURCE_STRINGID(InvalidArgumentWithoutQueryError);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidJsonFile);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidNameError);
         WINGET_DEFINE_RESOURCE_STRINGID(LicenseAgreement);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1269,4 +1269,7 @@ Please specify one of them using the `--source` option to proceed.</value>
     <value>package has a version number that cannot be determined. Use "--include-unknown" to see all results.</value>
     <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
   </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>The arguments provided can only be used with a query.</value>
+  </data>
 </root>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----

Resolves #1869.

This PR adds a extra validation for arguments in `winget upgrade`, making sure that arguments that require a package search (`--accept-package-agreements` for example) don't cause a empty package search to run.

Tested: manually.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1874)