### PR TITLE
Fix crash that can occur when failure pointers are null

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -219,10 +219,10 @@ namespace AppInstaller::Logging
 
             m_summary.FailureHResult = failure.hr;
             m_summary.FailureMessage = anonMessage;
-            m_summary.FailureModule = failure.pszModule;
+            m_summary.FailureModule = StringOrEmptyIfNull(failure.pszModule);
             m_summary.FailureThreadId = failure.threadId;
             m_summary.FailureType = ConvertWilFailureTypeToFailureType(failure.type);
-            m_summary.FailureFile = failure.pszFile;
+            m_summary.FailureFile = StringOrEmptyIfNull(failure.pszFile);
             m_summary.FailureLine = failure.uLineNumber;
         }
 

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -177,4 +177,17 @@ namespace AppInstaller::Utility
     {
         return ConvertContainerToString(container, [](const auto& item) { return item; });
     }
+
+    template <typename CharType>
+    std::basic_string<CharType> StringOrEmptyIfNull(const CharType* string)
+    {
+        if (string)
+        {
+            return { string };
+        }
+        else
+        {
+            return {};
+        }
+    }
 }


### PR DESCRIPTION
Previously on Watson...

These pointers can apparently be null, leading to a crash trying to read them.  So don't do that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1880)