### PR TITLE
Add query or option args check for install and search command

### DIFF
--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -93,6 +93,16 @@ namespace AppInstaller::CLI
 
     void InstallCommand::ValidateArgumentsInternal(Args& execArgs) const
     {
+        if (!execArgs.Contains(Args::Type::Manifest) &&
+            !execArgs.Contains(Args::Type::Query) &&
+            !execArgs.Contains(Args::Type::Id) &&
+            !execArgs.Contains(Args::Type::Name) &&
+            !execArgs.Contains(Args::Type::Moniker) &&
+            !execArgs.Contains(Args::Type::Version))
+        {
+            throw CommandException(Resource::String::NoInstallPackageSpecified);
+        }
+
         if (execArgs.Contains(Args::Type::Manifest) &&
             (execArgs.Contains(Args::Type::Query) ||
              execArgs.Contains(Args::Type::Id) ||

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -66,6 +66,18 @@ namespace AppInstaller::CLI
         return "https://aka.ms/winget-command-search";
     }
 
+    void SearchCommand::ValidateArgumentsInternal(Args& execArgs) const
+    {
+        if (!execArgs.Contains(Args::Type::Query) &&
+            !execArgs.Contains(Args::Type::Id) &&
+            !execArgs.Contains(Args::Type::Name) &&
+            !execArgs.Contains(Args::Type::Moniker) &&
+            !execArgs.Contains(Args::Type::Tag) &&
+            !execArgs.Contains(Args::Type::Command))
+        {
+            throw CommandException(Resource::String::NoSearchPackageSpecified);
+        }
+    }
     void SearchCommand::ExecuteInternal(Context& context) const
     {
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);

--- a/src/AppInstallerCLICore/Commands/SearchCommand.h
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.h
@@ -19,6 +19,7 @@ namespace AppInstaller::CLI
         std::string HelpLink() const override;
 
     protected:
+        void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
         void ExecuteInternal(Execution::Context& context) const override;
     };
 }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -187,6 +187,8 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(NoInstalledPackageFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NoPackageFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NoPackagesFoundInImportFile);
+        WINGET_DEFINE_RESOURCE_STRINGID(NoSearchPackageSpecified);
+        WINGET_DEFINE_RESOURCE_STRINGID(NoInstallPackageSpecified);
         WINGET_DEFINE_RESOURCE_STRINGID(NoUninstallInfoFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NoVTArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(OpenSourceFailedNoMatch);

--- a/src/AppInstallerCLIE2ETests/GroupPolicy.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicy.cs
@@ -29,7 +29,7 @@ namespace AppInstallerCLIE2ETests
         public void PolicyEnableWinget()
         {
             GroupPolicyHelper.EnableWinget.Disable();
-            var result = TestCommon.RunAICLICommand("search", string.Empty);
+            var result = TestCommon.RunAICLICommand("search package", string.Empty);
             Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
         }
 

--- a/src/AppInstallerCLIE2ETests/SearchCommand.cs
+++ b/src/AppInstallerCLIE2ETests/SearchCommand.cs
@@ -11,10 +11,7 @@ namespace AppInstallerCLIE2ETests
         public void SearchWithoutArgs()
         {
             var result = TestCommon.RunAICLICommand("search", "");
-            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
-            Assert.True(result.StdOut.Contains("AppInstallerTest.TestExeInstaller"));
-            Assert.True(result.StdOut.Contains("AppInstallerTest.TestBurnInstaller"));
-            Assert.True(result.StdOut.Contains("AppInstallerTest.TestExampleInstaller"));
+            Assert.AreEqual(Constants.ErrorCode.ERROR_INVALID_CL_ARGUMENTS, result.ExitCode);
         }
 
         [Test]

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1270,9 +1270,9 @@ Please specify one of them using the `--source` option to proceed.</value>
     <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
   </data>
   <data name="NoSearchPackageSpecified" xml:space="preserve">
-    <value>No options specified. Please specify atleast one of the following options: Query, Id, Name, Moniker, Tag and Command. </value>
+    <value>No options specified. Please specify at least one of the following options: Query, Id, Name, Moniker, Tag and Command. </value>
   </data>
   <data name="NoInstallPackageSpecified" xml:space="preserve">
-    <value>No options specified. Please specify atleast one of the following options: Manifest, Query, Id, Name, Moniker and Version. </value>
+    <value>No options specified. Please specify at least one of the following options: Manifest, Query, Id, Name, Moniker and Version. </value>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1269,4 +1269,10 @@ Please specify one of them using the `--source` option to proceed.</value>
     <value>package has a version number that cannot be determined. Use "--include-unknown" to see all results.</value>
     <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
   </data>
+  <data name="NoSearchPackageSpecified" xml:space="preserve">
+    <value>No options specified. Please specify atleast one of the following options: Query, Id, Name, Moniker, Tag and Command. </value>
+  </data>
+  <data name="NoInstallPackageSpecified" xml:space="preserve">
+    <value>No options specified. Please specify atleast one of the following options: Manifest, Query, Id, Name, Moniker and Version. </value>
+  </data>
 </root>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Issue:
Currently winget install and search commands return a list of all the packages from the sources if no query or filter options are specified. Some sources might or might not support this.

Fix:
Check if winget install or search commands are followed with query or filters and prompt user to specify at least one of those.

Tested both of the commands and ensured proper error message is being displayed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1881)