### PR TITLE
Allow PackageFamilyName to be declared with non msix installers

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -473,6 +473,9 @@
     <CopyFileToFolders Include="TestData\Manifest-Good-DefaultExpectedReturnCodeInInstallerSuccessCodes.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\Manifest-Encoding-ANSI.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -378,6 +378,9 @@
     <CopyFileToFolders Include="TestData\Manifest-Good-MultiLocale.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\Manifest-Good-Spaces.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml
@@ -1,0 +1,24 @@
+PackageIdentifier: Microsoft.WinAppSdk
+Publisher: Microsoft
+PackageName: WinAppSdk
+PackageVersion: 1.0
+License: Microsoft Software License
+MinimumOSVersion: 10.0.17763.0
+Tags:
+- winappsdk
+ShortDescription: WinAppSdk
+PackageUrl: https://github.com/microsoft/WindowsAppSDK
+Installers:
+- Architecture: x86
+  InstallerType: exe
+  InstallerUrl: https://thisistest.com/testindex/installer/WindowsAppRuntimeInstall.exe
+  InstallerSha256: b565f45da868b637686d4c098e9e4c3e16424cff1ed2f19d5665602fdd8dfba6
+  PackageFamilyName: MicrosoftCorporationII.WindowsAppRuntime.Main.1.0_8wekyb3d8bbwe
+  AppsAndFeaturesEntries:
+  - InstallerType: msix
+  InstallerSwitches:
+    Silent: /s
+    SilentWithProgress: /s
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml
@@ -5,13 +5,13 @@ PackageVersion: 1.0
 License: Microsoft Software License
 MinimumOSVersion: 10.0.17763.0
 Tags:
-- winappsdk
+- WinAppSdk
 ShortDescription: WinAppSdk
 PackageUrl: https://github.com/microsoft/WindowsAppSDK
 Installers:
 - Architecture: x86
   InstallerType: exe
-  InstallerUrl: https://thisistest.com/testindex/installer/WindowsAppRuntimeInstall.exe
+  InstallerUrl: https://ThisIsTest.com/TestIndex/installer/WindowsAppRuntimeInstall.exe
   InstallerSha256: b565f45da868b637686d4c098e9e4c3e16424cff1ed2f19d5665602fdd8dfba6
   PackageFamilyName: MicrosoftCorporationII.WindowsAppRuntime.Main.1.0_8wekyb3d8bbwe
   AppsAndFeaturesEntries:

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -221,6 +221,7 @@ TEST_CASE("ReadGoodManifests", "[ManifestValidation]")
         { "Manifest-Good-Minimum-InstallerType.yaml" },
         { "Manifest-Good-Switches.yaml" },
         { "Manifest-Good-DefaultExpectedReturnCodeInInstallerSuccessCodes.yaml" },
+        { "Manifest-Good-PackageFamilyNameOnExe-Ver1_2.yaml" },
     };
 
     for (auto const& testCase : TestCases)

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -97,7 +97,8 @@ namespace AppInstaller::Manifest
             }
 
             // Validate system reference strings if they are set at the installer level
-            if (!installer.PackageFamilyName.empty() && !DoesInstallerTypeUsePackageFamilyName(installer.InstallerType))
+            // Allow PackageFamilyName to be declared with non msix installers to support nested installer scenarios after manifest version 1.1
+            if (manifest.ManifestVersion <= ManifestVer{ s_ManifestVersionV1_1 } && !installer.PackageFamilyName.empty() && !DoesInstallerTypeUsePackageFamilyName(installer.InstallerType))
             {
                 resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotSupportPackageFamilyName, "InstallerType", InstallerTypeToString(installer.InstallerType));
             }


### PR DESCRIPTION
## Change
To support nested installers, allow PackageFamilyName to be declared with non msix installers starting from manifest version 1.2

## Validation
Added unit tests.
Validated manually install, upgrade and uninstall works correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1944)