### PR TITLE
Setting for Logging Level

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -109,6 +109,7 @@ If set to true, the `telemetry.disable` setting will prevent any event from bein
 ## Logging
 
 The `logging` settings control the level of detail in log files. `--verbose-logs` will override this setting and always creates a verbose log.
+Defaults to `info` if value is not set or is invalid
 
 ### level
 

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -106,6 +106,18 @@ See [details on telemetry](../README.md#datatelemetry), and our [primary privacy
 
 If set to true, the `telemetry.disable` setting will prevent any event from being written by the program.
 
+## Logging
+
+The `logging` settings control the level of detail in log files. `--verbose-logs` will override this setting and always creates a verbose log.
+
+### level
+
+```json
+    "logging": {
+        "level": ["verbose", "info", "warning", "error", "critical"]
+    },
+```
+
 ## Network
 
 The `network` settings influence how winget uses the network to retrieve packages and metadata.

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -31,6 +31,23 @@
         }
       }
     },
+    "Logging": {
+      "description": "Logging settings",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "Preferred logging level",
+          "type": "string",
+          "enum": [
+            "verbose",
+            "info",
+            "warning",
+            "error",
+            "critical"
+          ]
+        }
+      }
+    },
     "InstallPrefReq": {
       "description": "Shared schema for preferences and requirements",
       "type": "object",
@@ -147,6 +164,12 @@
     {
       "properties": {
         "visual": { "$ref": "#/definitions/Visual" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "logging": { "$ref": "#/definitions/Logging" }
       },
       "additionalItems": true
     },

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -66,7 +66,7 @@ namespace AppInstaller::CLI
 
         // Enable all logging for this phase; we will update once we have the arguments
         Logging::Log().EnableChannel(Logging::Channel::All);
-        Logging::Log().SetLevel(Logging::Level::Info);
+        Logging::Log().SetLevel(Settings::User().Get<Settings::Setting::LoggingLevelPreference>());
         Logging::AddFileLogger();
         Logging::EnableWilFailureTelemetry();
 

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -5,6 +5,7 @@
 #include "TestSettings.h"
 #include <AppInstallerRuntime.h>
 #include <winget/Settings.h>
+#include "AppInstallerLogging.h"
 
 #include <AppInstallerErrors.h>
 
@@ -13,6 +14,7 @@
 #include <chrono>
 
 using namespace AppInstaller::Settings;
+using namespace AppInstaller::Logging;
 using namespace AppInstaller::Runtime;
 using namespace TestCommon;
 using namespace std::string_literals;
@@ -210,7 +212,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
     {
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Info);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Info")
@@ -219,7 +221,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Info);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Verbose")
@@ -228,7 +230,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Verbose);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Verbose);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Warning")
@@ -237,7 +239,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Warning);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Warning);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Error")
@@ -246,7 +248,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Error);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Error);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Critical")
@@ -255,7 +257,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Crit);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Crit);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Bad value")
@@ -264,7 +266,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Info);
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Bad value type")
@@ -273,7 +275,7 @@ TEST_CASE("SettingLoggingLevelPreference", "[settings]")
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == Level::Info);
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
 }

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -202,6 +202,82 @@ TEST_CASE("SettingProgressBar", "[settings]")
     }
 }
 
+TEST_CASE("SettingLoggingLevelPreference", "[settings]")
+{
+    DeleteUserSettingsFiles();
+
+    SECTION("Default value")
+    {
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Info")
+    {
+        std::string_view json = R"({ "logging": { "level": "info" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Verbose")
+    {
+        std::string_view json = R"({ "logging": { "level": "verbose" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Verbose);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Warning")
+    {
+        std::string_view json = R"({ "logging": { "level": "warning" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Warning);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Error")
+    {
+        std::string_view json = R"({ "logging": { "level": "error" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Error);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Critical")
+    {
+        std::string_view json = R"({ "logging": { "level": "critical" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Crit);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Bad value")
+    {
+        std::string_view json = R"({ "logging": { "level": "fake" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Bad value type")
+    {
+        std::string_view json = R"({ "logging": { "level": 5 } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingLevelPreference>() == LoggingLevel::Info);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}
+
 TEST_CASE("SettingAutoUpdateIntervalInMinutes", "[settings]")
 {
     DeleteUserSettingsFiles();

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "AppInstallerStrings.h"
+#include "AppInstallerLogging.h"
 #include "winget/GroupPolicy.h"
 #include "winget/Resources.h"
 
@@ -56,17 +57,6 @@ namespace AppInstaller::Settings
         DeliveryOptimization,
     };
 
-    // The level to use when logging command output
-    enum class LoggingLevel
-    {
-        Verbose,
-        Info,
-        Warning,
-        Error,
-        Crit,
-    };
-
-
     // Enum of settings.
     // Must start at 0 to enable direct access to variant in UserSettings.
     // Max must be last and unused.
@@ -90,9 +80,9 @@ namespace AppInstaller::Settings
         InstallArchitectureRequirement,
         InstallLocalePreference,
         InstallLocaleRequirement,
-        LoggingLevelPreference,
         EFDirectMSI,
         EnableSelfInitiatedMinidump,
+        LoggingLevelPreference,
         Max
     };
 
@@ -142,7 +132,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::LoggingLevelPreference, std::string, LoggingLevel, LoggingLevel::Info, ".logging.level"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::LoggingLevelPreference, std::string, Logging::Level, Logging::Level::Info, ".logging.level"sv);
 
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.
         template <size_t... I>

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -56,6 +56,16 @@ namespace AppInstaller::Settings
         DeliveryOptimization,
     };
 
+    // The level to use when logging command output
+    enum class LoggingLevel
+    {
+        Verbose,
+        Info,
+        Warning,
+        Error,
+        Crit,
+    };
+
 
     // Enum of settings.
     // Must start at 0 to enable direct access to variant in UserSettings.
@@ -80,6 +90,7 @@ namespace AppInstaller::Settings
         InstallArchitectureRequirement,
         InstallLocalePreference,
         InstallLocaleRequirement,
+        LoggingLevelPreference,
         EFDirectMSI,
         EnableSelfInitiatedMinidump,
         Max
@@ -131,6 +142,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::LoggingLevelPreference, std::string, LoggingLevel, LoggingLevel::Info, ".logging.level"sv);
 
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.
         template <size_t... I>

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -16,6 +16,7 @@ namespace AppInstaller::Settings
     using namespace std::string_view_literals;
     using namespace Runtime;
     using namespace Utility;
+    using namespace Logging;
 
     static constexpr std::string_view s_SettingEmpty =
         R"({
@@ -328,23 +329,23 @@ namespace AppInstaller::Settings
 
             if (Utility::CaseInsensitiveEquals(value, s_logging_verbose))
             {
-                return LoggingLevel::Verbose;
+                return Level::Verbose;
             }
             else if (Utility::CaseInsensitiveEquals(value, s_logging_info))
             {
-                return LoggingLevel::Info;
+                return Level::Info;
             }
             else if (Utility::CaseInsensitiveEquals(value, s_logging_warning))
             {
-                return LoggingLevel::Warning;
+                return Level::Warning;
             }
             else if (Utility::CaseInsensitiveEquals(value, s_logging_error))
             {
-                return LoggingLevel::Error;
+                return Level::Error;
             }
             else if (Utility::CaseInsensitiveEquals(value, s_logging_critical))
             {
-                return LoggingLevel::Crit;
+                return Level::Crit;
             }
             return {};
         }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -316,6 +316,38 @@ namespace AppInstaller::Settings
         {
             return std::chrono::seconds(value);
         }
+
+        WINGET_VALIDATE_SIGNATURE(LoggingLevelPreference)
+        {
+            // logging preference possible values
+            static constexpr std::string_view s_logging_verbose = "verbose";
+            static constexpr std::string_view s_logging_info = "info";
+            static constexpr std::string_view s_logging_warning = "warning";
+            static constexpr std::string_view s_logging_error = "error";
+            static constexpr std::string_view s_logging_critical = "critical";
+
+            if (Utility::CaseInsensitiveEquals(value, s_logging_verbose))
+            {
+                return LoggingLevel::Verbose;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, s_logging_info))
+            {
+                return LoggingLevel::Info;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, s_logging_warning))
+            {
+                return LoggingLevel::Warning;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, s_logging_error))
+            {
+                return LoggingLevel::Error;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, s_logging_critical))
+            {
+                return LoggingLevel::Crit;
+            }
+            return {};
+        }
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?  

Resolves #1940

This is my first time really digging into the codebase, so I wouldn't be surprised if this is entirely incorrect.
This PR allows users to set their preferred logging level to any of the levels available with the default remaining `Info`. This preference is overridden by the use of `--verbose-logs`

Tested: Manually + Unit Tests

-----



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1945)