### PR TITLE
Add support for installRoot and addToPath install behavior in settings

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -79,8 +79,8 @@
       "type": "string",
       "default":  "%LOCALAPPDATA%/WinGet"
     },
-    "AddToPathVariable": {
-      "description": "Boolean value indicating whether the installed location should be added to the PATH environment variable. Applies to the portable installer type.",
+    "AddToPathEnvironment": {
+      "description": "Boolean value indicating whether the installed location should be added to the PATH environment. Applies to the portable installer type.",
       "type": "boolean",
       "default": true
     },
@@ -90,8 +90,8 @@
       "properties": {
         "preferences": { "$ref": "#/definitions/InstallPrefReq" },
         "requirements": { "$ref": "#/definitions/InstallPrefReq" },
-        "binaryFilesInstallLocation": { "$ref": "#/definitions/BinaryFilesInstallLocation" },
-        "addToPathEnvironmentVariable": { "$ref": "#/definitions/AddToPathEnvironmentVariable" }
+        "binaryFilesInstallLocation": { "$ref": "#/definitions/InstallRoot" },
+        "addToPathEnvironmentVariable": { "$ref": "#/definitions/AddToPathEnvironment" }
       }
     },
     "Telemetry": {

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -74,12 +74,24 @@
         }
       }
     },
+    "InstallRoot": {
+      "description": "The root directory where packages are installed to. Applies to the portable installer type.",
+      "type": "string",
+      "default":  "%LOCALAPPDATA%/WinGet"
+    },
+    "AddToPathVariable": {
+      "description": "Boolean value indicating whether the installed location should be added to the PATH environment variable. Applies to the portable installer type.",
+      "type": "boolean",
+      "default": true
+    },
     "InstallBehavior": {
       "description": "Install settings",
       "type": "object",
       "properties": {
         "preferences": { "$ref": "#/definitions/InstallPrefReq" },
-        "requirements": { "$ref": "#/definitions/InstallPrefReq" }
+        "requirements": { "$ref": "#/definitions/InstallPrefReq" },
+        "binaryFilesInstallLocation": { "$ref": "#/definitions/BinaryFilesInstallLocation" },
+        "addToPathEnvironmentVariable": { "$ref": "#/definitions/AddToPathEnvironmentVariable" }
       }
     },
     "Telemetry": {

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -47,6 +47,8 @@ namespace AppInstaller::Runtime
         SecureSettings,
         // The value of %USERPROFILE%.
         UserProfile,
+        // The default location where packages are installed to for the portable installerType.
+        DefaultInstallRoot,
     };
 
     // Gets the path to the requested location.

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "AppInstallerStrings.h"
+#include "AppInstallerRuntime.h"
 #include "winget/GroupPolicy.h"
 #include "winget/Resources.h"
 
@@ -80,6 +81,8 @@ namespace AppInstaller::Settings
         InstallArchitectureRequirement,
         InstallLocalePreference,
         InstallLocaleRequirement,
+        InstallRoot,
+        AddToPathVariable,
         EFDirectMSI,
         EnableSelfInitiatedMinidump,
         Max
@@ -129,6 +132,8 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDOProgressTimeoutInSeconds, uint32_t, std::chrono::seconds, 60s, ".network.doProgressTimeoutInSeconds"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocalePreference, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.preferences.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallRoot, std::string, std::filesystem::path, {}, ".installBehavior.installRoot"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::AddToPathVariable, bool, bool, true, ".installBehavior.addToPathVariable"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
 
@@ -187,6 +192,22 @@ namespace AppInstaller::Settings
 
             return std::get<details::SettingIndex(S)>(itr->second);
         }
+
+        // Specialization for InstallRoot setting value to handle default value.
+        template <>
+        details::SettingMapping<Setting::InstallRoot>::value_t Get<Setting::InstallRoot>() const
+        {
+            // May need to modify this code to make it better.
+            auto itr = m_settings.find(Setting::InstallRoot);
+            if (itr == m_settings.end())
+            {
+                // return default path instead of default value.
+                return Runtime::GetPathTo(Runtime::PathName::DefaultInstallRoot);
+            }
+
+            return std::get<details::SettingIndex(Setting::InstallRoot)>(itr->second);
+        }
+
 
     protected:
         UserSettingsType m_type = UserSettingsType::Default;

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -82,7 +82,7 @@ namespace AppInstaller::Settings
         InstallLocalePreference,
         InstallLocaleRequirement,
         InstallRoot,
-        AddToPathVariable,
+        AddToPathEnvironment,
         EFDirectMSI,
         EnableSelfInitiatedMinidump,
         Max
@@ -133,7 +133,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocalePreference, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.preferences.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallRoot, std::string, std::filesystem::path, {}, ".installBehavior.installRoot"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::AddToPathVariable, bool, bool, true, ".installBehavior.addToPathVariable"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::AddToPathEnvironment, bool, bool, true, ".installBehavior.addToPathEnvironment"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
 
@@ -197,7 +197,6 @@ namespace AppInstaller::Settings
         template <>
         details::SettingMapping<Setting::InstallRoot>::value_t Get<Setting::InstallRoot>() const
         {
-            // May need to modify this code to make it better.
             auto itr = m_settings.find(Setting::InstallRoot);
             if (itr == m_settings.end())
             {

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -309,6 +309,10 @@ namespace AppInstaller::Runtime
                 result = GetKnownFolderPath(FOLDERID_Profile);
                 create = false;
                 break;
+            case PathName::DefaultInstallRoot:
+                result = GetKnownFolderPath(FOLDERID_LocalAppData);
+                result /= s_DefaultTempDirectory;
+                break;
             default:
                 THROW_HR(E_UNEXPECTED);
             }
@@ -348,6 +352,10 @@ namespace AppInstaller::Runtime
             case PathName::UserProfile:
                 result = GetKnownFolderPath(FOLDERID_Profile);
                 create = false;
+                break;
+            case PathName::DefaultInstallRoot:
+                result = GetKnownFolderPath(FOLDERID_LocalAppData);
+                result /= s_DefaultTempDirectory;
                 break;
             default:
                 THROW_HR(E_UNEXPECTED);

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -228,7 +228,7 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFExperimentalArg)
         WINGET_VALIDATE_PASS_THROUGH(EFDependencies)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
-        WINGET_VALIDATE_PASS_THROUGH(AddToPathVariable)
+        WINGET_VALIDATE_PASS_THROUGH(AddToPathEnvironment)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
 

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -228,8 +228,31 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFExperimentalArg)
         WINGET_VALIDATE_PASS_THROUGH(EFDependencies)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
+        WINGET_VALIDATE_PASS_THROUGH(AddToPathVariable)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
+
+        WINGET_VALIDATE_SIGNATURE(InstallRoot)
+        {
+            const std::filesystem::path installRoot = value;
+
+            if (!std::filesystem::exists(installRoot))
+            {
+                try
+                {
+                    if (!std::filesystem::create_directories(installRoot))
+                    {
+                        return {};
+                    }
+                }
+                catch (...)
+                {
+                    return {};
+                }
+            }
+
+            return installRoot;
+        }
 
         WINGET_VALIDATE_SIGNATURE(InstallArchitecturePreference)
         {


### PR DESCRIPTION
Changes:
- Add support for InstallRoot and AddToPathEnvironment fields to settings.
- Added validation of InstallRoot value to check if the provided path already exists. If not, create the directories

Tests:
- Added tests to verify that the values for the newly added fields are processed successfully. 



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1948)