### PR TITLE
Expose simple applicable installer check in Com api

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -974,7 +974,7 @@ namespace AppInstaller::CLI::Workflow
         bool isUpdate = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerExecutionUseUpdate);
 
         IPackageVersion::Metadata installationMetadata;
-        
+
         if (isUpdate)
         {
             installationMetadata = context.Get<Execution::Data::InstalledPackageVersion>()->GetMetadata();

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -206,6 +206,12 @@ namespace Microsoft.Management.Deployment
             CompareResult CompareToVersion(String versionString);
         }
 
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 4)]
+        {
+            /// Checks if this package version has at least one applicable installer.
+            Boolean HasApplicableInstaller { get; };
+        }
+
         /// DESIGN NOTE:
         /// GetManifest from IPackageVersion in winget/RepositorySearch is not implemented in V1. That class has 
         /// a lot of fields and no one requesting it.

--- a/src/Microsoft.Management.Deployment/PackageVersionInfo.cpp
+++ b/src/Microsoft.Management.Deployment/PackageVersionInfo.cpp
@@ -8,7 +8,10 @@
 #include "PackageCatalogInfo.h"
 #include "PackageCatalog.h"
 #include "CatalogPackage.h"
+#include "ComContext.h"
 #include "Workflows/WorkflowBase.h"
+#include "Workflows/ManifestComparator.h"
+#include "winget/RepositorySearch.h"
 #include "AppInstallerVersions.h"
 #include "Converters.h"
 #include <wil\cppwinrt_wrl.h>
@@ -111,6 +114,15 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         {
             return CompareResult::Equal;
         }
+    }
+    bool PackageVersionInfo::HasApplicableInstaller()
+    {
+        AppInstaller::CLI::Execution::COMContext context;
+        AppInstaller::Repository::IPackageVersion::Metadata installationMetadata;
+        AppInstaller::CLI::Workflow::ManifestComparator manifestComparator{ context, installationMetadata };
+        AppInstaller::Manifest::Manifest manifest = m_packageVersion->GetManifest();
+        auto result = manifestComparator.GetPreferredInstaller(manifest);
+        return result.installer.has_value();
     }
     std::shared_ptr<::AppInstaller::Repository::IPackageVersion> PackageVersionInfo::GetRepositoryPackageVersion()
     { 

--- a/src/Microsoft.Management.Deployment/PackageVersionInfo.h
+++ b/src/Microsoft.Management.Deployment/PackageVersionInfo.h
@@ -23,7 +23,9 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVectorView<hstring> ProductCodes();
         winrt::Microsoft::Management::Deployment::PackageCatalog PackageCatalog();
         winrt::Microsoft::Management::Deployment::CompareResult CompareToVersion(hstring versionString);
-        
+        // Contract version 4
+        bool HasApplicableInstaller();
+
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         winrt::Microsoft::Management::Deployment::PackageCatalog m_packageCatalog{ nullptr };


### PR DESCRIPTION
## Change
Exposes a simple check of applicable installer for install. This does not consider installed version during the check. To check against installed version for upgrade, we might want to expose something on the package level when asks come(enhanced version of IsUpgradeAvailable).

## Validation
Manually verified the code works as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1974)