### PR TITLE
Make build pipeline task fail on unit tests failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,7 +163,7 @@ jobs:
     displayName: Publish Unit Test Results
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Build.ArtifactStagingDirectory)\TEST-*.xml'
+      testResultsFiles: '$(artifactsDir)\TEST-*.xml'
       failTaskOnFailedTests: true
 
   - task: DownloadSecureFile@1

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Normalize", "[strings]")
 
 TEST_CASE("NormalizedString", "[strings]")
 {
-    REQUIRE(NormalizedString("test") == "no-test");
+    REQUIRE(NormalizedString("test") == "test");
     std::string input = "test";
     REQUIRE(NormalizedString(input) == input);
 

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Normalize", "[strings]")
 
 TEST_CASE("NormalizedString", "[strings]")
 {
-    REQUIRE(NormalizedString("test") == "test");
+    REQUIRE(NormalizedString("test") == "no-test");
     std::string input = "test";
     REQUIRE(NormalizedString(input) == input);
 


### PR DESCRIPTION
Currently unit test failure does not fail the pipeline because incorrect test result path is used in publish test results task. Fixing the path makes the pipeline checking results correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1975)