### PR TITLE
Remove duplicated message about unknown versions

### DIFF
--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -195,9 +195,5 @@ namespace AppInstaller::CLI::Workflow
                     APPINSTALLER_CLI_ERROR_UPDATE_ALL_HAS_FAILURE,
                     { APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE });
         }
-        if (unknownPackagesCount > 0 && !context.Args.Contains(Execution::Args::Type::IncludeUnknown))
-        {
-            context.Reporter.Info() << unknownPackagesCount << " " << (unknownPackagesCount == 1 ? Resource::String::UpgradeUnknownCountSingle : Resource::String::UpgradeUnknownCount) << std::endl;
-        }
     }
 }


### PR DESCRIPTION
- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

It turns out that this message is displayed twice, without a reason. Example:

```console
$ winget upgrade --all
Name  Id             Version Available Source
---------------------------------------------
gsudo gerardog.gsudo 1.0.2.0 1.1.0     winget
1 upgrades available.
10 packages have version numbers that cannot be determined. Use "--include-unknown" to see all results.

(1/1) Found gsudo [gerardog.gsudo] Version 1.1.0
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/gerardog/gsudo/releases/download/v1.1.0/gsudoSetup.msi
  ██████████████████████████████   364 KB /  364 KB
Successfully verified installer hash
Starting package install...
Successfully installed

10 packages have version numbers that cannot be determined. Use "--include-unknown" to see all results.

$ winget upgrade --all
No installed package found matching input criteria.
10 packages have version numbers that cannot be determined. Use "--include-unknown" to see all results.
No applicable update found.
10 packages have version numbers that cannot be determined. Use "--include-unknown" to see all results.
```

This PR removes the latter duplicated message.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1982)