### PR TITLE
1.2 Schema Proposal for Portable and Zip InstallerTypes

### DIFF
--- a/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
@@ -63,6 +63,12 @@
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
+    "InstallerUrl": {
+      "type": "string",
+      "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
+      "maxLength": 2048,
+      "description": "The installer Url"
+    },    
     "InstallerSha256": {
       "type": "string",
       "pattern": "^[A-Fa-f0-9]{64}$",
@@ -72,6 +78,17 @@
       "type": [ "string", "null" ],
       "pattern": "^[A-Fa-f0-9]{64}$",
       "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
+    },   
+    "Architecture": {
+      "type": "string",
+      "enum": [
+        "x86",
+        "x64",
+        "arm",
+        "arm64",
+        "neutral"
+      ],
+      "description": "The installer target architecture"
     },   
     "Scope": {
       "type": [ "string", "null" ],
@@ -463,23 +480,15 @@
           "$ref": "#/definitions/MinimumOSVersion"
         },
         "Architecture": {
-          "type": "string",
-          "enum": [
-            "x86",
-            "x64",
-            "arm",
-            "arm64",
-            "neutral"
-          ],
-          "description": "The installer target architecture"
+          "$ref": "#/definitions/Architecture"
         },
         "InstallerType": {
           "$ref": "#/definitions/InstallerType"
         },
-        "NestedInstallers": {
+        "ArchiveInstallers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/NestedInstaller"
+            "$ref": "#/definitions/ArchiveInstaller"
           },
           "minItems": 1,
           "maxItems": 1024
@@ -491,10 +500,7 @@
           "$ref": "#/definitions/Scope"
         },
         "InstallerUrl": {
-          "type": "string",
-          "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
-          "maxLength": 2048,
-          "description": "The installer Url"
+          "$ref": "#/definitions/InstallerUrl"
         },
         "InstallerSha256": {
           "$ref": "#/definitions/InstallerSha256"
@@ -572,30 +578,19 @@
         "InstallerSha256"
       ]
     },
-    "NestedInstaller": {
+    "ArchiveInstaller": {
       "type": "object",
       "properties": {
-        "InstallerLocale": {
-          "$ref": "#/definitions/Locale"
+        "allOf": {
+          "$ref": "#/definitions/Installer"
         },
-        "Platform": {
-          "$ref": "#/definitions/Platform"
+        "InstallerUrl": {
+          "not": {}
         },
-        "MinimumOSVersion": {
-          "$ref": "#/definitions/MinimumOSVersion"
+        "InstallerType": {
+          "not": {}
         },
-        "Architecture": {
-          "type": "string",
-          "enum": [
-            "x86",
-            "x64",
-            "arm",
-            "arm64",
-            "neutral"
-          ],
-          "description": "The installer target architecture"
-        },
-        "NestedInstallerType": {
+        "ArchiveInstallerType": {
           "type": [ "string", "null" ],
           "enum": [
             "msix",
@@ -610,90 +605,15 @@
           ],
           "description": "Enumeration of supported nested installer types that could be contained in a zip or archive file."
         },
-        "AppendPathAtProcessStart": {
-          "$ref": "#/definitions/AppendPathAtProcessStart"
-        },
         "RelativeFilePath": {
           "type": [ "string", "null" ],
           "description": "Relative path to the installer file or portable executable. Only applies to the nested installer within a Zip. "
-        },  
-        "Scope": {
-          "$ref": "#/definitions/Scope"
-        },
-        "InstallerSha256": {
-          "$ref": "#/definitions/InstallerSha256"
-        },
-        "SignatureSha256": {
-          "$ref": "#/definitions/SignatureSha256"
-        },
-        "InstallModes": {
-          "$ref": "#/definitions/InstallModes"
-        },
-        "InstallerSwitches": {
-          "$ref": "#/definitions/InstallerSwitches"
-        },
-        "InstallerSuccessCodes": {
-          "$ref": "#/definitions/InstallerSuccessCodes"
-        },
-        "ExpectedReturnCodes": {
-          "$ref": "#/definitions/ExpectedReturnCodes"
-        },
-        "UpgradeBehavior": {
-          "$ref": "#/definitions/UpgradeBehavior"
-        },
-        "Commands": {
-          "$ref": "#/definitions/Commands"
-        },
-        "Protocols": {
-          "$ref": "#/definitions/Protocols"
-        },
-        "FileExtensions": {
-          "$ref": "#/definitions/FileExtensions"
-        },
-        "Dependencies": {
-          "$ref": "#/definitions/Dependencies"
-        },
-        "PackageFamilyName": {
-          "$ref": "#/definitions/PackageFamilyName"
-        },
-        "ProductCode": {
-          "$ref": "#/definitions/ProductCode"
-        },
-        "Capabilities": {
-          "$ref": "#/definitions/Capabilities"
-        },
-        "RestrictedCapabilities": {
-          "$ref": "#/definitions/RestrictedCapabilities"
-        },
-        "Markets": {
-          "$ref": "#/definitions/Markets"
-        },
-        "InstallerAbortsTerminal": {
-          "$ref": "#/definitions/InstallerAbortsTerminal"
-        },
-        "ReleaseDate": {
-          "$ref": "#/definitions/ReleaseDate"
-        },
-        "InstallLocationRequired": {
-          "$ref": "#/definitions/InstallLocationRequired"
-        },
-        "RequireExplicitUpgrade": {
-          "$ref": "#/definitions/RequireExplicitUpgrade"
-        },
-        "UnsupportedOSArchitectures": {
-          "$ref": "#/definitions/UnsupportedOSArchitectures"
-        },
-        "AppsAndFeaturesEntries": {
-          "$ref": "#/definitions/AppsAndFeaturesEntries"
-        },
-        "ElevationRequirement": {
-          "$ref": "#/definitions/ElevationRequirement"
         }
       },
       "required": [
         "Architecture",
         "InstallerSha256",
-        "NestedInstallerType"
+        "ArchiveInstallerType"
       ]
     }
   },

--- a/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
@@ -462,6 +462,18 @@
         "InstallerType": {
           "$ref": "#/definitions/InstallerType"
         },
+        "NestedInstallers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NestedInstaller"
+          },
+          "minItems": 1,
+          "maxItems": 1024
+        },
+        "AppendPathAtProcessStart": {
+          "type": ["boolean", "null"],
+          "description": "Boolean value to indicate whether to append the install location to the PATH environment variable when the application is launched. Only applies to the Portable installerType."
+        },
         "Scope": {
           "$ref": "#/definitions/Scope"
         },
@@ -549,6 +561,124 @@
         "Architecture",
         "InstallerUrl",
         "InstallerSha256"
+      ]
+    },
+    "NestedInstaller": {
+      "type": "object",
+      "properties": {
+        "InstallerLocale": {
+          "$ref": "#/definitions/Locale"
+        },
+        "Platform": {
+          "$ref": "#/definitions/Platform"
+        },
+        "MinimumOSVersion": {
+          "$ref": "#/definitions/MinimumOSVersion"
+        },
+        "Architecture": {
+          "type": "string",
+          "enum": [
+            "x86",
+            "x64",
+            "arm",
+            "arm64",
+            "neutral"
+          ],
+          "description": "The installer target architecture"
+        },
+        "NestedInstallerType": {
+          "type": [ "string", "null" ],
+          "enum": [
+            "msi",
+            "exe",
+            "inno",
+            "nullsoft",
+            "wix",
+            "burn",
+            "pwa"
+          ],
+          "description": "Enumeration of supported nested installer types that could be contained in a zip or archive file."
+        },
+        "AppendPathAtProcessStart": {
+          "type": ["boolean", "null"],
+          "description": "Boolean value to indicate whether to append the install location to the PATH environment variable when the application is launched. Only applies to the Portable installerType."
+        },
+        "Scope": {
+          "$ref": "#/definitions/Scope"
+        },
+        "InstallerSha256": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$",
+          "description": "Sha256 is required. Sha256 of the installer"
+        },
+        "InstallModes": {
+          "$ref": "#/definitions/InstallModes"
+        },
+        "InstallerSwitches": {
+          "$ref": "#/definitions/InstallerSwitches"
+        },
+        "InstallerSuccessCodes": {
+          "$ref": "#/definitions/InstallerSuccessCodes"
+        },
+        "ExpectedReturnCodes": {
+          "$ref": "#/definitions/ExpectedReturnCodes"
+        },
+        "UpgradeBehavior": {
+          "$ref": "#/definitions/UpgradeBehavior"
+        },
+        "Commands": {
+          "$ref": "#/definitions/Commands"
+        },
+        "Protocols": {
+          "$ref": "#/definitions/Protocols"
+        },
+        "FileExtensions": {
+          "$ref": "#/definitions/FileExtensions"
+        },
+        "Dependencies": {
+          "$ref": "#/definitions/Dependencies"
+        },
+        "PackageFamilyName": {
+          "$ref": "#/definitions/PackageFamilyName"
+        },
+        "ProductCode": {
+          "$ref": "#/definitions/ProductCode"
+        },
+        "Capabilities": {
+          "$ref": "#/definitions/Capabilities"
+        },
+        "RestrictedCapabilities": {
+          "$ref": "#/definitions/RestrictedCapabilities"
+        },
+        "Markets": {
+          "$ref": "#/definitions/Markets"
+        },
+        "InstallerAbortsTerminal": {
+          "$ref": "#/definitions/InstallerAbortsTerminal"
+        },
+        "ReleaseDate": {
+          "$ref": "#/definitions/ReleaseDate"
+        },
+        "InstallLocationRequired": {
+          "$ref": "#/definitions/InstallLocationRequired"
+        },
+        "RequireExplicitUpgrade": {
+          "$ref": "#/definitions/RequireExplicitUpgrade"
+        },
+        "UnsupportedOSArchitectures": {
+          "$ref": "#/definitions/UnsupportedOSArchitectures"
+        },
+        "AppsAndFeaturesEntries": {
+          "$ref": "#/definitions/AppsAndFeaturesEntries"
+        },
+        "ElevationRequirement": {
+          "$ref": "#/definitions/ElevationRequirement"
+        }
+      },
+      "required": [
+        "Architecture",
+        "InstallerSha256",
+        "NestedInstallerType"
       ]
     }
   },

--- a/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
@@ -67,7 +67,12 @@
       "type": "string",
       "pattern": "^[A-Fa-f0-9]{64}$",
       "description": "Sha256 is required. Sha256 of the installer"
-    },    
+    }, 
+    "SignatureSha256": {
+      "type": [ "string", "null" ],
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
+    },   
     "Scope": {
       "type": [ "string", "null" ],
       "enum": [
@@ -495,9 +500,7 @@
           "$ref": "#/definitions/InstallerSha256"
         },
         "SignatureSha256": {
-          "type": [ "string", "null" ],
-          "pattern": "^[A-Fa-f0-9]{64}$",
-          "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
+          "$ref": "#/definitions/SignatureSha256"
         },
         "InstallModes": {
           "$ref": "#/definitions/InstallModes"
@@ -595,7 +598,9 @@
         "NestedInstallerType": {
           "type": [ "string", "null" ],
           "enum": [
+            "msix",
             "msi",
+            "appx",
             "exe",
             "inno",
             "nullsoft",
@@ -608,11 +613,18 @@
         "AppendPathAtProcessStart": {
           "$ref": "#/definitions/AppendPathAtProcessStart"
         },
+        "RelativeFilePath": {
+          "type": [ "string", "null" ],
+          "description": "Relative path to the installer file or portable executable. Only applies to the nested installer within a Zip. "
+        },  
         "Scope": {
           "$ref": "#/definitions/Scope"
         },
         "InstallerSha256": {
           "$ref": "#/definitions/InstallerSha256"
+        },
+        "SignatureSha256": {
+          "$ref": "#/definitions/SignatureSha256"
         },
         "InstallModes": {
           "$ref": "#/definitions/InstallModes"
@@ -641,8 +653,17 @@
         "Dependencies": {
           "$ref": "#/definitions/Dependencies"
         },
+        "PackageFamilyName": {
+          "$ref": "#/definitions/PackageFamilyName"
+        },
         "ProductCode": {
           "$ref": "#/definitions/ProductCode"
+        },
+        "Capabilities": {
+          "$ref": "#/definitions/Capabilities"
+        },
+        "RestrictedCapabilities": {
+          "$ref": "#/definitions/RestrictedCapabilities"
         },
         "Markets": {
           "$ref": "#/definitions/Markets"

--- a/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
@@ -63,6 +63,11 @@
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
+    "InstallerSha256": {
+      "type": "string",
+      "pattern": "^[A-Fa-f0-9]{64}$",
+      "description": "Sha256 is required. Sha256 of the installer"
+    },    
     "Scope": {
       "type": [ "string", "null" ],
       "enum": [
@@ -370,6 +375,10 @@
       "type": [ "boolean", "null" ],
       "description": "Indicates whether the installer should be pinned by default from upgrade"
     },
+    "AppendPathAtProcessStart": {
+      "type": ["boolean", "null"],
+      "description": "Boolean value to indicate whether to append the install location to the PATH environment variable when the application is launched. Only applies to the Portable installerType."
+    },
     "UnsupportedOSArchitectures": {
       "type": [ "array", "null" ],
       "uniqueItems": true,
@@ -471,8 +480,7 @@
           "maxItems": 1024
         },
         "AppendPathAtProcessStart": {
-          "type": ["boolean", "null"],
-          "description": "Boolean value to indicate whether to append the install location to the PATH environment variable when the application is launched. Only applies to the Portable installerType."
+          "$ref": "#/definitions/AppendPathAtProcessStart"
         },
         "Scope": {
           "$ref": "#/definitions/Scope"
@@ -484,9 +492,7 @@
           "description": "The installer Url"
         },
         "InstallerSha256": {
-          "type": "string",
-          "pattern": "^[A-Fa-f0-9]{64}$",
-          "description": "Sha256 is required. Sha256 of the installer"
+          "$ref": "#/definitions/InstallerSha256"
         },
         "SignatureSha256": {
           "type": [ "string", "null" ],
@@ -595,21 +601,18 @@
             "nullsoft",
             "wix",
             "burn",
-            "pwa"
+            "portable"
           ],
           "description": "Enumeration of supported nested installer types that could be contained in a zip or archive file."
         },
         "AppendPathAtProcessStart": {
-          "type": ["boolean", "null"],
-          "description": "Boolean value to indicate whether to append the install location to the PATH environment variable when the application is launched. Only applies to the Portable installerType."
+          "$ref": "#/definitions/AppendPathAtProcessStart"
         },
         "Scope": {
           "$ref": "#/definitions/Scope"
         },
         "InstallerSha256": {
-          "type": "string",
-          "pattern": "^[A-Fa-f0-9]{64}$",
-          "description": "Sha256 is required. Sha256 of the installer"
+          "$ref": "#/definitions/InstallerSha256"
         },
         "InstallModes": {
           "$ref": "#/definitions/InstallModes"
@@ -638,17 +641,8 @@
         "Dependencies": {
           "$ref": "#/definitions/Dependencies"
         },
-        "PackageFamilyName": {
-          "$ref": "#/definitions/PackageFamilyName"
-        },
         "ProductCode": {
           "$ref": "#/definitions/ProductCode"
-        },
-        "Capabilities": {
-          "$ref": "#/definitions/Capabilities"
-        },
-        "RestrictedCapabilities": {
-          "$ref": "#/definitions/RestrictedCapabilities"
         },
         "Markets": {
           "$ref": "#/definitions/Markets"

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -91,6 +91,16 @@
         }
       }
     },
+    "WinGetInstallerUserRoot": {
+      "description": "The default root directory where packages are installed to under User scope. Applies to the portable installer type.",
+      "type": "string",
+      "default":  "%LOCALAPPDATA%/WPM_Packages/User"
+    },
+    "WinGetInstallerMachineRoot": {
+      "description": "The default root directory where packages are installed to under Machine scope. Applies to the portable installer type.",
+      "type": "string",
+      "default":  "%LOCALAPPDATA%/WPM_Packages/Machine"
+    },
     "InstallBehavior": {
       "description": "Install settings",
       "type": "object",

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -91,12 +91,12 @@
         }
       }
     },
-    "WinGetInstallerUserRoot": {
+    "PortableAppUserRoot": {
       "description": "The default root directory where packages are installed to under User scope. Applies to the portable installer type.",
       "type": "string",
       "default":  "%LOCALAPPDATA%/WPM_Packages/User"
     },
-    "WinGetInstallerMachineRoot": {
+    "PortableAppMachineRoot": {
       "description": "The default root directory where packages are installed to under Machine scope. Applies to the portable installer type.",
       "type": "string",
       "default":  "%LOCALAPPDATA%/WPM_Packages/Machine"


### PR DESCRIPTION
Related to:
* #182 
* #140 
* #1891

This PR adds the necessary schema changes to support installing portable apps and zip files. 

Changes:

<ins>**Settings schema:**</ins>
- Addition of ~~WinGetInstallerUserRoot~~ _"PortablePackageUserRoot"_ to allow the user to specify the default root directory where portable apps should be installed to under User scope.
- Addition of ~~WinGetInstallerMachineRoot~~ _"PortablePackageMachineRoot"_ to allow the user to specify the default root directory where portable apps should be installed to under Machine scope.

<ins>**InstallerManifest schema:**</ins>

Changes to 'Installer' object:
- Addition of  ~~NestedInstallers~~ _"ArchiveInstallers"_ which is an object array of ~~NestedInstaller~~ _"ArchiveInstaller"_
- Addition of _"AppendPathToProcess"_ which is utilized during the installation of portable apps. We will be registering the app using the [App Paths registry subkey](https://docs.microsoft.com/en-us/windows/win32/shell/app-registration#using-the-app-paths-subkey). This value would be used to determine whether we should create a ‘Path’ string value in the registry to indicate whether to pre-pend the ‘Path’ value to the PATH environment variable on a per-application, per-process basis

Addition of ~~NestedInstaller~~ _"ArchiveInstaller"_ object:
- Similar to the existing 'Installer' object but more refined to fit the zip scenario. 
- Addition of _"RelativeFilePath"_ to declare the relative file path to the installer/portable exe that will be installed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/1989)