### PR TITLE
Fixed issues preventing compilation on VS 2022 17.1.

### DIFF
--- a/src/AppInstallerCommonCore/Public/winget/Registry.h
+++ b/src/AppInstallerCommonCore/Public/winget/Registry.h
@@ -13,6 +13,9 @@ namespace AppInstaller::Registry
 {
     namespace details
     {
+        template<DWORD>
+        constexpr bool dependent_false = false;
+
         template <DWORD Type>
         struct ValueTypeSpecifics
         {
@@ -20,7 +23,7 @@ namespace AppInstaller::Registry
 
             static value_t Convert(const std::vector<BYTE>& data)
             {
-                static_assert(false, "No Type specific override has been supplied");
+                static_assert(dependent_false<Type>, "No Type specific override has been supplied");
             }
         };
 

--- a/src/AppInstallerRepositoryCore/SQLiteWrapper.h
+++ b/src/AppInstallerRepositoryCore/SQLiteWrapper.h
@@ -32,20 +32,23 @@ namespace AppInstaller::Repository::SQLite
 
     namespace details
     {
+        template<typename>
+        constexpr bool dependent_false = false;
+
         template <typename T, typename = void>
         struct ParameterSpecificsImpl
         {
             static T& ToLog(T&&)
             {
-                static_assert(false, "No type specific override has been supplied");
+                static_assert(dependent_false<T>, "No type specific override has been supplied");
             }
             static void Bind(sqlite3_stmt*, int, T&&)
             {
-                static_assert(false, "No type specific override has been supplied");
+                static_assert(dependent_false<T>, "No type specific override has been supplied");
             }
             static T GetColumn(sqlite3_stmt*, int)
             {
-                static_assert(false, "No type specific override has been supplied");
+                static_assert(dependent_false<T>, "No type specific override has been supplied");
             }
         };
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----

For some reason[^1], Visual Studio 2022's newest update (17.1.0) made source breaking changes to the C++ compiler. In two instances, these prevented winget from compiling. I believe @yao-msft was running into these issues in #1990, but here's the fix.

Basically, there was a conformance change to the compiler where if you had a `static_assert` that could be evaluated without knowing the type, then the compiler would always evaluate it to the same value. Many of the `static_assert` calls that were checking to see if a type had an override had to be made dependent on the type so the compiler wouldn't optimize the check away.

More reading here: https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-a-non-dependent-static_assert

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2000)

[^1]: Most likely because engagement with the 17.0 error list was too low ;)