### PR TITLE
Make upgrade help inform of list ability

### DIFF
--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -666,11 +666,11 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>No applicable update found.</value>
   </data>
   <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.</value>
+    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.&#13;When no arguments are given, lists the packages with upgrades available</value>
     <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Upgrades the given package</value>
+    <value>List and perform available upgrades</value>
   </data>
   <data name="Usage" xml:space="preserve">
     <value>usage</value>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -666,7 +666,7 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>No applicable update found.</value>
   </data>
   <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.&#13;When no arguments are given, shows the packages with upgrades available</value>
+    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option. When no arguments are given, shows the packages with upgrades available</value>
     <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UpgradeCommandShortDescription" xml:space="preserve">

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -666,11 +666,11 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>No applicable update found.</value>
   </data>
   <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.&#13;When no arguments are given, lists the packages with upgrades available</value>
+    <value>Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.&#13;When no arguments are given, shows the packages with upgrades available</value>
     <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>List and perform available upgrades</value>
+    <value>Shows and performs available upgrades</value>
   </data>
   <data name="Usage" xml:space="preserve">
     <value>usage</value>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  * #2033

```raw
PS > wingetdev  -?
Windows Package Manager (Preview) v1.3.2-preview
Copyright (c) Microsoft Corporation. All rights reserved.

The winget command line utility enables installing applications and other packages from the command line.

usage: winget [<command>] [<options>]

The following commands are available:
  install    Installs the given package
  show       Shows information about a package
  source     Manage sources of packages
  search     Find and show basic info of packages
  list       Display installed packages
  upgrade    Shows and performs available upgrades
  uninstall  Uninstalls the given package
  hash       Helper to hash installer files
  validate   Validates a manifest file
  settings   Open settings or set administrator settings
  features   Shows the status of experimental features
  export     Exports a list of the installed packages
  import     Installs all the packages in a file

For more details on a specific command, pass it the help argument. [-?]

The following options are available:
  -v,--version  Display the version of the tool
  --info        Display general info of the tool

More help can be found at: https://aka.ms/winget-command-help
PS > wingetdev upgrade -?
Windows Package Manager (Preview) v1.3.2-preview
Copyright (c) Microsoft Corporation. All rights reserved.

Upgrades the selected package, either found by searching the installed packages list or directly from a manifest. By default, the query must case-insensitively match the id, name, or moniker of the package. Other fields can be used by passing their appropriate option.
When no arguments are given, shows the packages with upgrades available

usage: winget upgrade [[-q] <query>] [<options>]

The following arguments are available:
  -q,--query                   The query used to search for a package

The following options are available:
  -m,--manifest                The path to the manifest of the package
  --id                         Filter results by id
  --name                       Filter results by name
  --moniker                    Filter results by moniker
  -v,--version                 Use the specified version; default is the latest version
  -s,--source                  Find package using the specified source
  -e,--exact                   Find package using exact match
  -i,--interactive             Request interactive installation; user input may be needed
  -h,--silent                  Request silent installation
  -o,--log                     Log location (if supported)
  --override                   Override arguments to be passed on to the installer
  -l,--location                Location to install to (if supported)
  --force                      Override the installer hash check
  --accept-package-agreements  Accept all license agreements for packages
  --accept-source-agreements   Accept all source agreements during source operations
  --header                     Optional Windows-Package-Manager REST source HTTP header
  --all                        Update all installed packages to latest if available
  --include-unknown            Upgrade packages even if their current version cannot be determined

More help can be found at: https://aka.ms/winget-command-upgrade
PS >
```

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2034)