### PR TITLE
Add policy definition for ms-appinstaller to ADMX

### DIFF
--- a/doc/admx/DesktopAppInstaller.admx
+++ b/doc/admx/DesktopAppInstaller.admx
@@ -116,5 +116,15 @@
         <list id="AllowedSources" key="Software\Policies\Microsoft\Windows\AppInstaller\AllowedSources" valuePrefix="" />
       </elements>
     </policy>
+    <policy name="EnableMSAppInstallerProtocol" class="Machine" displayName="$(string.EnableMSAppInstallerProtocol)" explainText="$(string.EnableMSAppInstallerProtocolExplanation)" key="Software\Policies\Microsoft\Windows\AppInstaller" valueName="EnableMSAppInstallerProtocol">
+      <parentCategory ref="AppInstaller" />
+      <supportedOn ref="windows:SUPPORTED_Windows_10_0_RS5" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
   </policies>
 </policyDefinitions>

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -75,6 +75,12 @@ If you do not configure this policy, users will be able to add or remove additio
 If you enable this policy, only the sources specified can be added or removed from the Windows Package Manager. The representation for each allowed source can be obtained from installed sources using 'winget source export'.
 
 If you disable this policy, no additional sources can be configured for the Windows Package Manager.</string>
+      <string id="EnableMSAppInstallerProtocol">Enable App Installer ms-appinstaller protocol</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">This policy controls whether users can install packages from a website that is using the ms-appinstaller protocol.
+
+If you enable this setting, users will be able to install packages from websites that use this protocol.
+
+If you disable or do not configure this setting, users will not be able to install packages from websites that use this protocol.</string>
     </stringTable>
     <presentationTable>
       <presentation id="SourceAutoUpdateInterval">


### PR DESCRIPTION
Adding a group policy definition for ms-appinstaller to the ADMX/ADML.

This is not directly related to winget, but to App Installer. Adding here as the same policy definition is used for both.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2038)