### PR TITLE
Use AppsAndFeatures name and publisher

### DIFF
--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -147,6 +147,17 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsPackageManager", "Wi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "COMServer", "COMServer\COMServer.vcxitems", "{409CD681-22A4-469D-88AE-CB5E4836E07A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "manifests", "manifests", "{6FF8E5FE-C2D3-4991-8519-6FD12A457DDE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "v1.2.0", "v1.2.0", "{6FA346E3-2171-4D82-95FE-3EC55DC8FA1F}"
+	ProjectSection(SolutionItems) = preProject
+		..\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json
+		..\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json
+		..\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json
+		..\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json
+		..\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ManifestSchema\ManifestSchema.vcxitems*{1622da16-914f-4f57-a259-d5169003cc8c}*SharedItemsImports = 4
@@ -1026,6 +1037,8 @@ Global
 		{F5CED6B6-C27F-4405-9033-6C273B8B129C} = {F2149997-295A-4593-9282-4C675DFEB670}
 		{1A47951F-5C7A-4D6D-BB5F-D77484437940} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 		{409CD681-22A4-469D-88AE-CB5E4836E07A} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
+		{6FF8E5FE-C2D3-4991-8519-6FD12A457DDE} = {F2149997-295A-4593-9282-4C675DFEB670}
+		{6FA346E3-2171-4D82-95FE-3EC55DC8FA1F} = {6FF8E5FE-C2D3-4991-8519-6FD12A457DDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B6FDB70C-A751-422C-ACD1-E35419495857}

--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -86,21 +86,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "spelling", "spelling", "{2A
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cpprestsdk", "cpprestsdk\cpprestsdk.vcxproj", "{866C3F06-636F-4BE8-BC24-5F86ECC606A1}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "schemas", "schemas", "{92637527-6CDA-4F4A-84FD-858793776777}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "JSON", "JSON", "{F2149997-295A-4593-9282-4C675DFEB670}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "settings", "settings", "{1487DFBB-7C53-4BD3-9B2C-9B94C6C91528}"
-	ProjectSection(SolutionItems) = preProject
-		..\schemas\JSON\settings\settings.schema.0.2.json = ..\schemas\JSON\settings\settings.schema.0.2.json
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "packages", "packages", "{F5CED6B6-C27F-4405-9033-6C273B8B129C}"
-	ProjectSection(SolutionItems) = preProject
-		..\schemas\JSON\packages\packages.schema.1.0.json = ..\schemas\JSON\packages\packages.schema.1.0.json
-		..\schemas\JSON\packages\packages.schema.2.0.json = ..\schemas\JSON\packages\packages.schema.2.0.json
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "policy", "policy", "{1A47951F-5C7A-4D6D-BB5F-D77484437940}"
 	ProjectSection(SolutionItems) = preProject
 		..\doc\admx\en-US\DesktopAppInstaller.adml = ..\doc\admx\en-US\DesktopAppInstaller.adml
@@ -146,17 +131,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsPackageManager", "WindowsPackageManager\WindowsPackageManager.vcxproj", "{2046B5AF-666D-4CE8-8D3E-C32C57908A56}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "COMServer", "COMServer\COMServer.vcxitems", "{409CD681-22A4-469D-88AE-CB5E4836E07A}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "manifests", "manifests", "{6FF8E5FE-C2D3-4991-8519-6FD12A457DDE}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "v1.2.0", "v1.2.0", "{6FA346E3-2171-4D82-95FE-3EC55DC8FA1F}"
-	ProjectSection(SolutionItems) = preProject
-		..\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json
-		..\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json
-		..\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json
-		..\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json
-		..\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json = ..\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -1031,14 +1005,8 @@ Global
 		{952B513F-8A00-4D74-9271-925AFB3C6252} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 		{2ACDE176-F13F-42FA-8159-C34FA3D37837} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 		{866C3F06-636F-4BE8-BC24-5F86ECC606A1} = {60618CAC-2995-4DF9-9914-45C6FC02C995}
-		{92637527-6CDA-4F4A-84FD-858793776777} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
-		{F2149997-295A-4593-9282-4C675DFEB670} = {92637527-6CDA-4F4A-84FD-858793776777}
-		{1487DFBB-7C53-4BD3-9B2C-9B94C6C91528} = {F2149997-295A-4593-9282-4C675DFEB670}
-		{F5CED6B6-C27F-4405-9033-6C273B8B129C} = {F2149997-295A-4593-9282-4C675DFEB670}
 		{1A47951F-5C7A-4D6D-BB5F-D77484437940} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 		{409CD681-22A4-469D-88AE-CB5E4836E07A} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
-		{6FF8E5FE-C2D3-4991-8519-6FD12A457DDE} = {F2149997-295A-4593-9282-4C675DFEB670}
-		{6FA346E3-2171-4D82-95FE-3EC55DC8FA1F} = {6FF8E5FE-C2D3-4991-8519-6FD12A457DDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B6FDB70C-A751-422C-ACD1-E35419495857}

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -543,25 +543,24 @@ namespace AppInstaller::CLI::Workflow
             // Also attempt to find the entry based on the manifest data
             const auto& manifest = context.Get<Execution::Data::Manifest>();
 
-            SearchRequest nameAndPublisherRequest;
+            SearchRequest manifestSearchRequest;
+            AppInstaller::Manifest::Manifest::string_t defaultPublisher;
+            if (manifest.DefaultLocalization.Contains(Localization::Publisher))
+            {
+                defaultPublisher = manifest.DefaultLocalization.Get<Localization::Publisher>();
+            }
 
             // The default localization must contain the name or we cannot do this lookup
             if (manifest.DefaultLocalization.Contains(Localization::PackageName))
             {
                 AppInstaller::Manifest::Manifest::string_t defaultName = manifest.DefaultLocalization.Get<Localization::PackageName>();
-                AppInstaller::Manifest::Manifest::string_t defaultPublisher;
-                if (manifest.DefaultLocalization.Contains(Localization::Publisher))
-                {
-                    defaultPublisher = manifest.DefaultLocalization.Get<Localization::Publisher>();
-                }
-
-                nameAndPublisherRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::NormalizedNameAndPublisher, MatchType::Exact, defaultName, defaultPublisher));
+                manifestSearchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::NormalizedNameAndPublisher, MatchType::Exact, defaultName, defaultPublisher));
 
                 for (const auto& loc : manifest.Localizations)
                 {
                     if (loc.Contains(Localization::PackageName) || loc.Contains(Localization::Publisher))
                     {
-                        nameAndPublisherRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::NormalizedNameAndPublisher, MatchType::Exact,
+                        manifestSearchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::NormalizedNameAndPublisher, MatchType::Exact,
                             loc.Contains(Localization::PackageName) ? loc.Get<Localization::PackageName>() : defaultName,
                             loc.Contains(Localization::Publisher) ? loc.Get<Localization::Publisher>() : defaultPublisher));
                     }
@@ -575,8 +574,18 @@ namespace AppInstaller::CLI::Workflow
                 {
                     if (std::find(productCodes.begin(), productCodes.end(), installer.ProductCode) == productCodes.end())
                     {
-                        nameAndPublisherRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::Exact, installer.ProductCode));
+                        manifestSearchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::Exact, installer.ProductCode));
                         productCodes.emplace_back(installer.ProductCode);
+                    }
+                }
+
+                for (const auto& appsAndFeaturesEntry : installer.AppsAndFeaturesEntries)
+                {
+                    if (!appsAndFeaturesEntry.DisplayName.empty())
+                    {
+                        manifestSearchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::NormalizedNameAndPublisher, MatchType::Exact,
+                            appsAndFeaturesEntry.DisplayName,
+                            appsAndFeaturesEntry.Publisher.empty() ? defaultPublisher : appsAndFeaturesEntry.Publisher));
                     }
                 }
             }
@@ -584,9 +593,9 @@ namespace AppInstaller::CLI::Workflow
             SearchResult findByManifest;
 
             // Don't execute this search if it would just find everything
-            if (!nameAndPublisherRequest.IsForEverything())
+            if (!manifestSearchRequest.IsForEverything())
             {
-                findByManifest = arpSource.Search(nameAndPublisherRequest);
+                findByManifest = arpSource.Search(manifestSearchRequest);
             }
 
             // Cross reference the changes with the search results


### PR DESCRIPTION
## Change
Places the values from the `AppsAndFeaturesEntries` into the index, and uses them in the post-install ARP entry detection.

## Validation
Added a test to ensure that the values were added and searched in a simple case.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2042)