### PR TITLE
Mitigate crash occuring in CompositeSource

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSource.cpp
@@ -198,6 +198,10 @@ namespace AppInstaller::Repository::Microsoft
                         THROW_HR(E_UNEXPECTED);
                     }
                 }
+                else
+                {
+                    AICLI_LOG(Repo, Verbose, << "PackageBase: No manifest was found for the package with id# '" << m_idId << "'");
+                }
 
                 return result;
             }


### PR DESCRIPTION
Fixes #2016 
(Really, mitigates, but github likes fixes)

## Change
A crash is showing up in the installed version of the installed package being null.  While this doesn't make sense, bugs don't have to!  We need a live debug repro (or time travel trace) to get to the bottom of this, so for now we will just do our best to log details and skip the offending package.  This is better than a crash for the user, but could lead to whatever is causing it to be missing in results.  Reports of that will potentially lead us to the culprit, if it isn't a system state issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2043)