### PR TITLE
Apply latest loc patch

### DIFF
--- a/Localization/Policies/de-DE/DesktopAppInstaller.adml
+++ b/Localization/Policies/de-DE/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@ Wenn Sie diese Einstellung nicht konfigurieren, ist die Microsoft Store-Quelle f
 Wenn Sie diese Einstellung aktivieren, ist die Microsoft Store-Quelle für den Windows-Paket-Manager verfügbar und kann nicht entfernt werden.
 
 Wenn Sie diese Einstellung deaktivieren, ist die Microsoft Store-Quelle für den Windows-Paket-Manager nicht verfügbar.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Intervall für automatische Aktualisierung der App-Installer-Quelle in Minuten festlegen</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Diese Richt Linie steuert das Intervall für die automatische Aktualisierung für Paket basierte Quellen.
+      <string id="SourceAutoUpdateInterval">Intervall für automatische Aktualisierung der App-Installer-Quelle in Minuten festlegen</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Diese Richt Linie steuert das Intervall für die automatische Aktualisierung für Paket basierte Quellen.
 
 Wenn Sie diese Einstellung deaktivieren oder nicht konfigurieren, wird das Standard Intervall oder der in den Einstellungen angegebene Wert vom Windows-Paket-Manager verwendet.
 
@@ -75,10 +75,16 @@ Wenn Sie diese Richtlinie nicht konfigurieren, können Benutzer zusätzliche Que
 Wenn Sie diese Richtlinie aktivieren, können nur die angegebenen Quellen dem Windows-Paket-Manager hinzugefügt oder von ihm entfernt werden. Die Repräsentation für jede erlaubte Quelle kann aus den installierten Quellen mit „winget source export“ bezogen werden.
 
 Wenn Sie diese Richtlinie deaktivieren, können keine zusätzlichen Quellen für den Windows-Paket-Manager konfiguriert werden.</string>
+      <string id="EnableMSAppInstallerProtocol">Aktivieren des ms-appinstaller-Protokolls für den App-Installer</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Diese Richtlinie steuert, ob Benutzer Pakete von einer Website installieren können, die das ms-appinstaller-Protokoll verwendet.
+
+Wenn Sie diese Einstellung aktivieren, können Benutzer Pakete von Websites installieren, die dieses Protokoll verwenden.
+
+Wenn Sie diese Einstellung deaktivieren oder nicht konfigurieren, können Benutzer keine Pakete von Websites installieren, die dieses Protokoll verwenden.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Intervall für automatische Aktualisierung der Quelle in Minuten</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Intervall für automatische Aktualisierung der Quelle in Minuten</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Zusätzliche Quellen: </listBox>

--- a/Localization/Policies/es-ES/DesktopAppInstaller.adml
+++ b/Localization/Policies/es-ES/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@ Si no configura esta opción, el origen de la Tienda Microsoft para el Administr
 Si habilita esta configuración, el origen de Microsoft Store para el Administrador de paquetes de Windows estará disponible y no se podrá eliminar.
 
 Si desactiva esta configuración, el origen de la Tienda Microsoft para el Administrador de paquetes de Windows no estará disponible.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Establecer el intervalo de actualización automática de la fuente del instalador de aplicaciones en minutos</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Esta directiva controla el intervalo de actualización automática de los orígenes basados en paquetes.
+      <string id="SourceAutoUpdateInterval">Establecer el intervalo de actualización automática de la fuente del instalador de aplicaciones en minutos</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Esta directiva controla el intervalo de actualización automática de los orígenes basados en paquetes.
 
 Si deshabilitas o no estableces esta configuración, el administrador de paquetes de Windows usará el valor del intervalo predeterminado o el valor especificado en la configuración.
 
@@ -75,10 +75,16 @@ Si no configura esta directiva, los usuarios podrán agregar o eliminar fuentes 
 Si habilita esta directiva, sólo las fuentes especificadas podrán agregarse o eliminarse del Administrador de paquetes de Windows. La representación de cada fuente permitida puede obtenerse de las fuentes instaladas mediante "winget source export".
 
 Si desactiva esta directiva, no se pueden configurar fuentes adicionales para el Administrador de paquetes de Windows.</string>
+      <string id="EnableMSAppInstallerProtocol">Habilitar protocolo ms-appinstaller del instalador de aplicaciones</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Esta directiva controla si los usuarios pueden instalar paquetes desde un sitio web que usa el protocolo ms-appinstaller.
+
+Si habilita esta configuración, los usuarios podrán instalar paquetes de sitios web que usen este protocolo.
+
+Si deshabilita o no establece esta configuración, los usuarios no podrán instalar paquetes de sitios web que usen este protocolo.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Intervalo de actualización automática de la fuente en minutos</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Intervalo de actualización automática de la fuente en minutos</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Orígenes adicionales: </listBox>

--- a/Localization/Policies/fr-FR/DesktopAppInstaller.adml
+++ b/Localization/Policies/fr-FR/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@ Si vous ne configurez pas ce paramètre, la source du Microsoft Store pour le Ge
 Si vous activez ce paramètre, la source du Microsoft Store pour le Gestionnaire de package Windows est disponible et ne peut pas être supprimée.
 
 Si vous désactivez ce paramètre, la source du Microsoft Store pour le Gestionnaire de package Windows n’est pas disponible.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Définir l’intervalle en minutes de mise à jour automatique de source du programme d’installation de l’application</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Cette stratégie contrôle l’intervalle de mise à jour automatique pour les sources basées sur un package.
+      <string id="SourceAutoUpdateInterval">Définir l’intervalle en minutes de mise à jour automatique de source du programme d’installation de l’application</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Cette stratégie contrôle l’intervalle de mise à jour automatique pour les sources basées sur un package.
 
 Si vous désactivez ou ne configurez pas ce paramètre, l’intervalle par défaut ou la valeur spécifiée dans les paramètres est utilisé par le gestionnaire de packages Windows.
 
@@ -75,10 +75,16 @@ Si vous ne configurez pas ce paramètre de stratégie, les utilisateurs pourront
 Si vous activez cette stratégie, seules les sources spécifiées peuvent être ajoutées ou supprimées du Gestionnaire de package Windows. La représentation de chaque source autorisée peut être obtenue à partir de sources installées à l’aide de « Winget source export ».
 
 Si vous désactivez ce paramètre de stratégie, aucune source supplémentaire ne peut être configurée pour le Gestionnaire de package Windows.</string>
+      <string id="EnableMSAppInstallerProtocol">Activer le protocole ms-appinstaller du Programme d'installation d'application</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Cette stratégie contrôle si les utilisateurs peuvent installer des packages à partir d’un site web qui utilise le protocole ms-appinstaller.
+
+Si vous activez ce paramètre, les utilisateurs peuvent installer des packages à partir de sites web qui utilisent ce protocole.
+
+Si vous désactivez ou ne configurez pas ce paramètre, les utilisateurs ne peuvent pas installer de packages à partir de sites web qui utilisent ce protocole.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Intervalle en minutes de mise à jour automatique de source</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Intervalle en minutes de mise à jour automatique de source</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Sources supplémentaires : </listBox>

--- a/Localization/Policies/it-IT/DesktopAppInstaller.adml
+++ b/Localization/Policies/it-IT/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@ Se non si configura questa impostazione, l'origine Microsoft Store per il gestor
 Se si abilita questa impostazione, l'origine Microsoft Store per Windows Gestione pacchetti sarà disponibile e non potrà essere rimossa.
 
 Se si disabilita questa impostazione, l'origine Microsoft Store per Windows Gestione pacchetti non sarà disponibile.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Imposta l'intervallo di aggiornamento automatico dell'origine del programma di installazione app in minuti</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Questo criterio Controlla l'intervallo di aggiornamento automatico per le origini basate sul pacchetto.
+      <string id="SourceAutoUpdateInterval">Imposta l'intervallo di aggiornamento automatico dell'origine del programma di installazione app in minuti</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Questo criterio Controlla l'intervallo di aggiornamento automatico per le origini basate sul pacchetto.
 
 Se si disabilita o non si configura questa impostazione, l'intervallo predefinito o il valore specificato nelle impostazioni verranno utilizzati da Windows Gestione pacchetti.
 
@@ -75,10 +75,16 @@ Se non si configura questa impostazione dei criteri, gli utenti potranno aggiung
 Se si Abilita questo criterio, solo le origini specificate possono essere aggiunte o rimosse a Windows Gestione pacchetti. È possibile ottenere la rappresentazione di ogni origine aggiuntiva dalle origini installate usando 'esportazione di origine winget'.
 
 Se si disabilita questo criterio, non sarà possibile configurare altre origini per Windows Gestione pacchetti.</string>
+      <string id="EnableMSAppInstallerProtocol">Abilita protocollo del programma di installazione app ms-appinstaller</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Questo criterio controlla se gli utenti possono installare pacchetti da un sito Web che usa il protocollo ms-appinstaller.
+
+Se si abilita questa impostazione, gli utenti potranno installare pacchetti da siti Web che utilizzano questo protocollo.
+
+Se si disabilita o non si configura questa impostazione, gli utenti non potranno installare pacchetti da siti Web che utilizzano questo protocollo.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Intervallo di aggiornamento automatico di origine in minuti</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Intervallo di aggiornamento automatico di origine in minuti</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Origini aggiuntive: </listBox>

--- a/Localization/Policies/ja-JP/DesktopAppInstaller.adml
+++ b/Localization/Policies/ja-JP/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@
 この設定を有効にした場合、Windows パッケージ マネージャーの Microsoft Store ソースが利用できるようになり、削除できなくなります。
 
 この設定を無効にした場合、Windows パッケージマ ネージャーの Microsoft Store ソースは利用できなくなります。</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">アプリ インストーラー ソースの自動更新間隔を分単位で設定します</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">このポリシーでは、パッケージベースのソースの自動更新間隔を制御します。
+      <string id="SourceAutoUpdateInterval">アプリ インストーラー ソースの自動更新間隔を分単位で設定します</string>
+      <string id="SourceAutoUpdateIntervalExplanation">このポリシーでは、パッケージベースのソースの自動更新間隔を制御します。
 
 この設定を無効にした場合、または構成しなかった場合は、Windows パッケージマネージャーによって [設定] で指定した既定の間隔または値が使用されます。
 
@@ -75,10 +75,16 @@
 このポリシーを有効にすると、指定したソースのみを Windows パッケージ マネージャーに追加または Windows パッケージ マネージャーから削除できます。 許可された各ソースの表現は、「wingetsourceexport」を使用してインストールされたソースから取得できます。
 
 このポリシーを無効にすると、Windows パッケージ マネージャーに追加のソースを構成できなくなります。</string>
+      <string id="EnableMSAppInstallerProtocol">アプリ インストーラーの ms-appinstaller プロトコルを有効にする</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">このポリシーでは、ユーザーが ms-appinstaller プロトコルを使用している Web サイトからパッケージをインストールできるかどうかを制御します。
+
+この設定を有効にした場合、ユーザーは、このプロトコルを使用する Web サイトからパッケージをインストールできます。
+
+この設定を無効にするか、未構成にした場合、ユーザーはこのプロトコルを使用する Web サイトからパッケージをインストールできなくなります。</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">ソースの自動更新間隔 (分)</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">ソースの自動更新間隔 (分)</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">追加ソース: </listBox>

--- a/Localization/Policies/ko-KR/DesktopAppInstaller.adml
+++ b/Localization/Policies/ko-KR/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@
 이 설정을 사용하면 Windows 패키지 관리자용 Microsoft 스토어 원본을 사용할 수 있으며 제거할 수 없습니다.
 
 이 설정을 사용 중지하면 Windows 패키지 관리자용 Microsoft 스토어 원본을 사용할 수 없습니다.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">앱 설치 관리자 원본 자동 업데이트 간격(분) 설정</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">이 정책은 패키지 기반 원본의 자동 업데이트 간격을 제어합니다.
+      <string id="SourceAutoUpdateInterval">앱 설치 관리자 원본 자동 업데이트 간격(분) 설정</string>
+      <string id="SourceAutoUpdateIntervalExplanation">이 정책은 패키지 기반 원본의 자동 업데이트 간격을 제어합니다.
 
 이 설정을 사용하지 않거나 구성하지 않으면 기본 간격이나 설정에 지정된 값이 Windows 패키지 관리자가 사용됩니다.
 
@@ -75,10 +75,16 @@
 정책을 사용하도록 설정하는 경우 지정된 원본만 Windows 패키지 관리자에서 추가하거나 제거할 수 있습니다. 허용된 각 원본에 대한 표현은 'winget 원본 내보내기'를 사용하여 설치된 원본에서 구할 수 있습니다.
 
 이 정책을 사용하지 않도록 설정하는 경우 Windows 패키지 관리자에 대해 추가 원본을 구성할 수 없습니다.</string>
+      <string id="EnableMSAppInstallerProtocol">앱 설치 관리자 ms-appinstaller 프로토콜 사용</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">이 정책은 사용자가 ms-appinstaller 프로토콜을 사용하는 웹 사이트에서 패키지를 설치할 수 있는지 여부를 제어합니다.
+
+이 설정을 사용하면 사용자가 이 프로토콜을 사용하는 웹 사이트의 패키지를 설치할 수 있습니다.
+
+이 설정을 사용하지 않거나 구성하지 않으면 사용자가 이 프로토콜을 사용하는 웹 사이트의 패키지를 설치할 수 없습니다.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">원본 자동 업데이트 간격(분)</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">원본 자동 업데이트 간격(분)</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">추가 원본: </listBox>

--- a/Localization/Policies/pt-BR/DesktopAppInstaller.adml
+++ b/Localization/Policies/pt-BR/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@ Se você não definir essa configuração, a fonte da Microsoft Store para o Ger
 Se você habilitar essa configuração, a fonte da Microsoft Store para o Gerenciador de Pacotes do Windows estará disponível e não poderá ser removida.
 
 Se você desabilitar esta configuração, a fonte da Microsoft Store para o Gerenciador de Pacotes do Windows não estará disponível.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Definir o Intervalo de Atualização Automática da Fonte do Instalador de Aplicativo em Minutos</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Esta política controla o intervalo de atualização automática para origens baseadas em pacote.
+      <string id="SourceAutoUpdateInterval">Definir o Intervalo de Atualização Automática da Fonte do Instalador de Aplicativo em Minutos</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Esta política controla o intervalo de atualização automática para origens baseadas em pacote.
 
 Se você desabilitar ou não definir essa configuração, o intervalo padrão ou o valor especificado em configurações serão usados pelo Gerenciador de pacotes do Windows.
 
@@ -75,10 +75,16 @@ Se você não configurar esta política, os usuários poderão adicionar ou remo
 Se você habilitar essa política, apenas as fontes especificadas poderão ser adicionadas ou removidas do Gerenciador de Pacotes do Windows. A representação de cada fonte permitida pode ser obtida a partir das fontes instaladas usando a 'exportação de fonte de winget'.
 
 Se você desabilitar esta política, nenhuma fonte adicional poderá ser configurada para o Gerenciador de Pacotes do Windows.</string>
+      <string id="EnableMSAppInstallerProtocol">Ativar o protocolo ms-appinstaller do Instalador de Aplicativo</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Esta política controla se os usuários podem instalar pacotes de um site que esteja usando o protocolo ms-appinstaller.
+
+Se você habilitar essa configuração, os usuários poderão instalar pacotes de sites que usam esse protocolo.
+
+Se você desabilitar ou não definir essa configuração, os usuários não poderão instalar pacotes de sites que usam esse protocolo.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Intervalo de atualização automática da fonte em minutos</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Intervalo de atualização automática da fonte em minutos</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Fontes Adicionais: </listBox>

--- a/Localization/Policies/ru-RU/DesktopAppInstaller.adml
+++ b/Localization/Policies/ru-RU/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@
 Если включить этот параметр, источник Microsoft Store для Диспетчера пакетов Windows будет доступен, и его нельзя будет удалить.
 
 Если отключить этот параметр, источник Microsoft Store для Диспетчера пакетов Windows будет недоступен.</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">Задать интервал автоматического обновления источника Установщика приложений в минутах</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">Эта политика управляет интервалом автоматического обновления пакетных источников.
+      <string id="SourceAutoUpdateInterval">Задать интервал автоматического обновления источника Установщика приложений в минутах</string>
+      <string id="SourceAutoUpdateIntervalExplanation">Эта политика управляет интервалом автоматического обновления пакетных источников.
 
 Если отключить или не настроить этот параметр, в Диспетчере пакетов Windows будет использоваться интервал по умолчанию или значение, заданное в параметрах.
 
@@ -75,10 +75,16 @@
 Если включить эту политику, добавлять и удалять из Диспетчера пакетов Windows можно будет только указанные источники,. Представление для каждого разрешенного можно получить из установленных источников с помощью команды "winget source export".
 
 Если отключить эту политику, задать дополнительные источники для Диспетчера пакетов Windows будет невозможно.</string>
+      <string id="EnableMSAppInstallerProtocol">Включить протокол Установщика приложений ms-appinstaller</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">Эта политика определяет, могут ли пользователи устанавливать пакеты с веб-сайта, который использует протокол ms-appinstaller.
+
+Если включить этот, пользователи смогут устанавливать пакеты с веб-сайтов, которые используют этот протокол.
+
+Если отключить или не настраивать этот параметр, пользователи не смогут устанавливать пакеты с веб-сайтов, которые используют этот протокол.</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">Интервал автоматического обновления источника в минутах</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">Интервал автоматического обновления источника в минутах</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">Дополнительные источники: </listBox>

--- a/Localization/Policies/zh-CN/DesktopAppInstaller.adml
+++ b/Localization/Policies/zh-CN/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@
 如果启用此设置，Windows 程序包管理器的 Microsoft Store 源将可用，无法删除。
 
 如果禁用此设置，Windows 程序包管理器的 Microsoft Store 源将不可用。</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">设置应用安装程序源自动更新间隔（分钟）</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">此策略控制基于程序包的源的自动更新间隔。
+      <string id="SourceAutoUpdateInterval">设置应用安装程序源自动更新间隔（分钟）</string>
+      <string id="SourceAutoUpdateIntervalExplanation">此策略控制基于程序包的源的自动更新间隔。
 
 如果禁用或未配置此设置，则 Windows 程序包管理器将使用在 "设置" 中指定的默认间隔或值。
 
@@ -75,10 +75,16 @@
 如果启用此策略，则只能从 Windows 程序包管理器中添加或删除指定的源。可使用“winget source export”从已安装的源获取每个允许的源的表示形式。
 
 如果禁用此策略，则不能为 Windows 程序包管理器配置其他源。</string>
+      <string id="EnableMSAppInstallerProtocol">启用应用安装程序 ms-appinstaller 协议</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">此策略控制用户是否可以从使用 ms-appinstaller 协议的网站安装包。
+
+如果启用此设置，则用户将能够安装来自使用此协议的网站的包。
+
+如果禁用或未配置此设置，则用户将无法安装来自使用此协议的网站的包。</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">源自动更新间隔(分钟)</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">源自动更新间隔(分钟)</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">其他源: </listBox>

--- a/Localization/Policies/zh-TW/DesktopAppInstaller.adml
+++ b/Localization/Policies/zh-TW/DesktopAppInstaller.adml
@@ -53,8 +53,8 @@
 如果您啟用此設定，Windows 封裝管理員的 Microsoft Store 來源將可供使用，且無法移除。
 
 如果您停用此設定，Windows 封裝管理員的 Microsoft Store 來源將無法使用。</string>
-      <string id="SourceAutoUpdateIntervalInMinutes">設定應用程式安裝程式來源自動更新間隔 (分鐘)</string>
-      <string id="SourceAutoUpdateIntervalInMinutesExplanation">此原則可控制套件型來源的自動更新間隔。
+      <string id="SourceAutoUpdateInterval">設定應用程式安裝程式來源自動更新間隔 (分鐘)</string>
+      <string id="SourceAutoUpdateIntervalExplanation">此原則可控制套件型來源的自動更新間隔。
 
 如果停用或未設定此設定，Windows 套件管理員將使用 [設定] 中指定的預設間隔或值。
 
@@ -75,10 +75,16 @@
 如果您啟用此原則，僅可以從 Windows 封裝管理員新增或移除指定的來源。每個允許來源的代表都可以從使用 'winget 來源匯出' 的已安裝來源取得。
 
 如果您停用此原則，則 Windows 封裝管理員無法為其他來源進行配置。</string>
+      <string id="EnableMSAppInstallerProtocol">啟用應用程式安裝程式 ms-appinstaller 通訊協定</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">此原則控制使用者是否可以從使用 ms-appinstaller 通訊協定的網站安裝套件。
+
+如果您啟用這個設定，使用者將可以從使用此通訊協定的網站安裝套件。
+
+如果您停用或未設定這個設定，使用者將無法從使用此通訊協定的網站安裝套件。</string>
     </stringTable>
     <presentationTable>
-      <presentation id="SourceAutoUpdateIntervalInMinutes">
-        <decimalTextBox refId="SourceAutoUpdateIntervalInMinutes" defaultValue="5">來源自動更新間隔 (分鐘)</decimalTextBox>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">來源自動更新間隔 (分鐘)</decimalTextBox>
       </presentation>
       <presentation id="AdditionalSources">
         <listBox refId="AdditionalSources" required="false">其他來源： </listBox>

--- a/Localization/Resources/de-DE/winget.resw
+++ b/Localization/Resources/de-DE/winget.resw
@@ -261,7 +261,7 @@ Sie können über die Einstellungsdatei „winget settings“ konfiguriert werde
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>Installiert das ausgewählte Paket. Es wird entweder durch die Suche nach einer konfigurierten Quelle gefunden, oder direkt aus dem Manifest abgerufen. Standardmäßig muss die Abfrage ohne Berücksichtigung der Groß/Kleinschreibung mit der ID, dem Namen oder dem Moniker des Pakets übereinstimmen. Andere Felder können verwendet werden, indem die entsprechende Option übergeben wird.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Installiert das angegebene Paket</value>
@@ -472,13 +472,15 @@ Sie können über die Einstellungsdatei „winget settings“ konfiguriert werde
     <value>Einstellungen öffnen oder Administratoreinstellungen festlegen</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Unerwarteter Fehler beim Laden von Einstellungen. Über prüfen Sie die Einstellungen, indem Sie den Befehl "Einstellungen" ausführen.</value>
+    <value>Unerwarteter Fehler beim Laden der Einstellungen. Überprüfen Sie Ihre Einstellungen, indem Sie den Befehl "'settings'" ausführen.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Kanal</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>Zeigt Informationen zu einem bestimmten Paket an. Standard mäßig muss die Abfrage Groß-insensitively mit der ID, dem Namen oder dem Moniker des Pakets überein stimmen. Andere Felder können verwendet werden, indem Sie Ihre entsprechende Option übergeben.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Zeigt Informationen zu einem Paket an</value>
@@ -663,13 +665,6 @@ Sie können über die Einstellungsdatei „winget settings“ konfiguriert werde
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>Es wurden keine anwendbaren Aktualisierungen gefunden.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Aktualisiert das ausgewählte Paket, das entweder durch Suchen der Liste der installierten Pakete oder direkt aus einem Manifest gefunden wurde. Standard mäßig muss die Abfrage Groß-insensitively mit der ID, dem Namen oder dem Moniker des Pakets überein stimmen. Andere Felder können verwendet werden, indem Sie Ihre entsprechende Option übergeben.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Aktualisiert das gegebene Paket</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>Nutzung</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@ Sie können über die Einstellungsdatei „winget settings“ konfiguriert werde
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>Deinstalliert das ausgewählte Paket, das entweder durch Suchen der Liste der installierten Pakete oder direkt aus einem Manifest gefunden wurde. Standard mäßig muss die Abfrage Groß-insensitively mit der ID, dem Namen oder dem Moniker des Pakets überein stimmen. Andere Felder können verwendet werden, indem Sie Ihre entsprechende Option übergeben.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Deinstalliert das angegebene Paket</value>
@@ -1218,10 +1214,11 @@ Stimmen Sie den Bedingungen zu?</value>
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>Die folgenden Pakete wurden in den Arbeitsquellen gefunden.
 Geben Sie eine option "--source" an, um den Vorgang fortzusetzen.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>Unter den Arbeitsquellen wurden keine Pakete gefunden.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Dies ist eine stabile Version des Windows-Paket-Managers. Wenn Sie experimentelle Features ausprobieren möchten, installieren Sie bitte eine Vorabversion. Anweisungen finden Sie auf GitHub unter https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@ Geben Sie eine option "--source" an, um den Vorgang fortzusetzen.</value>
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Wählen Sie die zu installierende Architektur aus</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Pakete auch dann aktualisieren, wenn ihre aktuelle Version nicht bestimmt werden kann</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>Die Versionsnummer dieses Pakets kann nicht bestimmt werden. Um trotzdem ein Upgrade durchzuführen, fügen Sie dem vorherigen Befehl das Argument „--include-unknown“ hinzu.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>Pakete haben Versionsnummern, die nicht bestimmt werden können. Wenn Sie „--include-unknown“ verwenden, werden möglicherweise weitere Ergebnisse angezeigt.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>Paket hat eine Versionsnummer, die nicht bestimmt werden kann. Wenn Sie „--include-unknown“ verwenden, werden möglicherweise weitere Ergebnisse angezeigt.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Die angegebenen Argumente können nur mit einer Abfrage verwendet werden.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Systemarchitektur</value>
   </data>
 </root>

--- a/Localization/Resources/es-ES/winget.resw
+++ b/Localization/Resources/es-ES/winget.resw
@@ -189,11 +189,11 @@
     <value>Se encontró un argumento posicional cuando no se esperaba nada</value>
   </data>
   <data name="FeatureDisabledMessage" xml:space="preserve">
-    <value>Esta característica es un trabajo en curso y puede cambiar drásticamente o quitarse de forma conjunta en el futuro. Para habilitarlo, edita la configuración ("winget settings") para incluir la característica experimental.</value>
+    <value>Esta característica es un trabajo en curso y puede cambiar drásticamente o quitarse por completo en el futuro. Para habilitarlo, edita la configuración ("winget settings") para incluir la característica experimental.</value>
     <comment>{Locked="winget settings"}</comment>
   </data>
   <data name="FeaturesCommandLongDescription" xml:space="preserve">
-    <value>Muestra el estado de las características experimentales. Las características experimentales se pueden activar a través de la 'winget settings'.</value>
+    <value>Muestra el estado de las características experimentales. Las características experimentales se pueden activar a través de 'winget settings'.</value>
     <comment>{Locked="winget settings"}</comment>
   </data>
   <data name="FeaturesCommandShortDescription" xml:space="preserve">
@@ -232,13 +232,13 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Calcula el hash de un archivo local, apropiado para la entrada en un manifiesto.  También puede calcular el hash del archivo de firma de un paquete MSIX para habilitar las instalaciones en streaming.</value>
   </data>
   <data name="HashCommandShortDescription" xml:space="preserve">
-    <value>Aplicación auxiliar para aplicar un algoritmo hash a los archivos del instalador</value>
+    <value>Aplicación auxiliar para aplicar un algoritmo hash a los archivos instaladores</value>
   </data>
   <data name="HelpArgumentDescription" xml:space="preserve">
     <value>Muestra la ayuda sobre el comando seleccionado</value>
   </data>
   <data name="HelpForDetails" xml:space="preserve">
-    <value>Para más información sobre un comando específico, pásalo como argumento de ayuda.</value>
+    <value>Para más información sobre un comando específico, pásalo el argumento de ayuda.</value>
   </data>
   <data name="HelpLinkPreamble" xml:space="preserve">
     <value>Puedes encontrar más ayuda en:</value>
@@ -260,8 +260,8 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>No se puede instalar el paquete porque requiere una versión superior de Windows:</value>
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
-    <value>Instala el paquete seleccionado, encontrado al buscar en una fuente configurada o bien, directamente desde un manifiesto. De forma predeterminada, la consulta debe distinguir entre mayúsculas y minúsculas el id, nombre o el moniker del paquete. Se pueden usar otros campos usando su opción apropiada.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <value>Instala el paquete seleccionado, encontrado al buscar en un origen configurado o bien, directamente desde un manifiesto. De forma predeterminada, la consulta debe coincidir con el id, nombre o el moniker del paquete sin distinguir entre mayúsculas y minúsculas. Se pueden usar otros campos usando su opción apropiada.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Instala el paquete proporcionado</value>
@@ -363,7 +363,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Error al instalar o actualizar el paquete de Microsoft Store. Código de error:</value>
   </data>
   <data name="MSStoreInstallGetEntitlementNetworkError" xml:space="preserve">
-    <value>Error en la comprobación/solicitud de la adquisición del paquete: error de conectividad</value>
+    <value>Error en la comprobación o solicitud de la adquisición del paquete: error de conectividad</value>
   </data>
   <data name="MSStoreInstallGetEntitlementNoStoreAccount" xml:space="preserve">
     <value>Error en la comprobación o solicitud de la adquisición de paquete: no se encontró la cuenta de almacenamiento</value>
@@ -378,13 +378,13 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Error al instalar o actualizar el paquete de Microsoft Store porque el cliente de Microsoft Store está bloqueado por la directiva</value>
   </data>
   <data name="MSStoreInstallTryGetEntitlement" xml:space="preserve">
-    <value>Comprobando/solicitando la adquisición del paquete...</value>
+    <value>Comprobando o solicitando la adquisición del paquete...</value>
   </data>
   <data name="MultipleInstalledPackagesFound" xml:space="preserve">
-    <value>Se encontraron varios paquetes instalados que coinciden con los criterios de entrada. Por favor, vuelve a ajustar la búsqueda.</value>
+    <value>Se encontraron varios paquetes instalados que coinciden con los criterios de entrada. Por favor, reajusta tu búsqueda.</value>
   </data>
   <data name="MultiplePackagesFound" xml:space="preserve">
-    <value>Se encontraron varios paquetes coincidentes con los criterios de entrada. Por favor, reajusta tu busqueda.</value>
+    <value>Se encontraron varios paquetes coincidentes con los criterios de entrada. Por favor, reajusta tu búsqueda.</value>
   </data>
   <data name="NameArgumentDescription" xml:space="preserve">
     <value>Filtrar resultados por nombre</value>
@@ -466,19 +466,21 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Se encontraron los siguientes errores al validar la configuración:</value>
   </data>
   <data name="SettingsCommandLongDescription" xml:space="preserve">
-    <value>Abra la configuración en el editor de texto JSON predeterminado. Si no hay un editor configurado, abra la configuración en el bloc de notas. Para conocer la configuración disponible, consulte https://aka.ms/winget-settings. Este comando también se puede utilizar para establecer la configuración del administrador proporcionando el argumento "enable" o "disable".</value>
+    <value>Abre la configuración en el editor de texto JSON predeterminado. Si no hay un editor configurado, abre la configuración en el bloc de notas. Para conocer la configuración disponible, consulte https://aka.ms/winget-settings. Este comando también se puede utilizar para establecer la configuración del administrador proporcionando el argumento "enable" o "disable".</value>
   </data>
   <data name="SettingsCommandShortDescription" xml:space="preserve">
     <value>Abrir la configuración o establecer la configuración del administrador</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Error inesperado al cargar la configuración. Para comprobar la configuración, ejecute el comando configuración.</value>
+    <value>Error inesperado al cargar la configuración. Para comprobar la configuración, ejecute el comando 'settings'.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Canal</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
-    <value>Muestra información sobre un paquete específico. De forma predeterminada, la consulta no debe distinguir entre mayúsculas y minúsculas y no distingue entre el identificador, el nombre o el moniker del paquete. Puede usar otros campos si pasa su opción adecuada.</value>
+    <value>Muestra información sobre un paquete específico. De forma predeterminada, la consulta debe coincidir con el id, nombre o el moniker del paquete sin distinguir entre mayúsculas y minúsculas. Puede usar otros campos si pasa su opción adecuada.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Muestra información sobre un paquete</value>
@@ -578,7 +580,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <comment>{Locked="source reset"}</comment>
   </data>
   <data name="SourceOpenPredefinedFailedSuggestion" xml:space="preserve">
-    <value>No se pudo abrir el origen predefinido; informa a winget mantenedores.</value>
+    <value>No se pudo abrir el origen predefinido; por favor informa a los mantenedores de winget.</value>
     <comment>{Locked="winget"}</comment>
   </data>
   <data name="SourceRemoveAll" xml:space="preserve">
@@ -663,13 +665,6 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>No se encontraron actualizaciones aplicables.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Actualiza el paquete seleccionado, ya sea buscando en la lista de paquetes instalados o directamente desde un manifiesto. De forma predeterminada, la consulta no debe distinguir entre mayúsculas y minúsculas y no distingue entre el identificador, el nombre o el moniker del paquete. Puede usar otros campos si pasa su opción adecuada.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Actualiza el paquete determinado</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>uso</value>
     <comment>The way to use the software</comment>
@@ -708,7 +703,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Los orígenes configurados son:</value>
   </data>
   <data name="OpenSourceFailedNoSourceDefined" xml:space="preserve">
-    <value>No se definió ninguna fuente. Agregue una con "source add" o restablezca el valor predeterminado con "source reset"</value>
+    <value>No se definió ningún origen. Agregue uno con "source add" o restablezca el valor predeterminado con "source reset"</value>
     <comment>{Locked="source add","source reset"}</comment>
   </data>
   <data name="ReportIdentityFound" xml:space="preserve">
@@ -731,7 +726,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>El instalador está bloqueado debido a una directiva</value>
   </data>
   <data name="InstallerFailedSecurityCheck" xml:space="preserve">
-    <value>El instalador no pudo realizar la comprobación de seguridad</value>
+    <value>El instalador falló la comprobación de seguridad</value>
   </data>
   <data name="InstallerFailedVirusScan" xml:space="preserve">
     <value>Un producto antivirus informa de una infección en el instalador</value>
@@ -740,7 +735,8 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Error al intentar actualizar el origen:</value>
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
-    <value>Desinstala el paquete seleccionado, encontrado al buscar en una lista de paquetes instalados o bien, directamente desde un manifiesto. De forma predeterminada, la consulta debe coincidir con el id, el nombre o el moniker distinguiendo entre mayúsculas y minúsculas. Se pueden usar otros campos usando la opción apropiada.</value>
+    <value>Desinstala el paquete seleccionado, encontrado al buscar en una lista de paquetes instalados o bien, directamente desde un manifiesto. De forma predeterminada, la consulta debe coincidir con el id, nombre o el moniker del paquete sin distinguir entre mayúsculas y minúsculas. Se pueden usar otros campos usando la opción apropiada.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Desinstala el paquete proporcionado</value>
@@ -799,7 +795,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>La versión instalada del paquete no está disponible de ningún origen:</value>
   </data>
   <data name="NoPackagesInImportFile" xml:space="preserve">
-    <value>No se encontraron paquetes en importar archivo</value>
+    <value>No se encontraron paquetes en archivo de importación</value>
   </data>
   <data name="InvalidJsonFile" xml:space="preserve">
     <value>El archivo JSON no es válido.</value>
@@ -811,10 +807,10 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Omitir los paquetes no disponibles</value>
   </data>
   <data name="ExportIncludeVersionsArgumentDescription" xml:space="preserve">
-    <value>Incluir versiones del paquete en un archivo producido</value>
+    <value>Incluir versiones del paquete en el archivo producido</value>
   </data>
   <data name="ImportIgnoreVersionsArgumentDescription" xml:space="preserve">
-    <value>Omitir las versiones del paquete de la importación del archivo</value>
+    <value>Omitir las versiones del paquete del archivo de importación</value>
   </data>
   <data name="VerifyPathFailedNotExist" xml:space="preserve">
     <value>Ruta de acceso no existe:</value>
@@ -846,7 +842,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Habilitar las funciones experimentales del instalador de aplicaciones de Windows</value>
   </data>
   <data name="PolicyEnableMSStoreSource" xml:space="preserve">
-    <value>Habilitar el instalador de aplicaciones de Windows Microsoft Store Source</value>
+    <value>Habilitar el origen Microsoft Store del instalador de aplicaciones de Windows</value>
   </data>
   <data name="PolicyEnableWinGetSettings" xml:space="preserve">
     <value>Habilitar la configuración del Administrador de paquetes de Windows</value>
@@ -905,13 +901,13 @@ La configuración está deshabilitada debido a la Directiva de grupo.</value>
     <value>El hash del instalador no coincide.</value>
   </data>
   <data name="PolicyEnableHashOverride" xml:space="preserve">
-    <value>Habilitar la anulación del hash del instalador de aplicaciones de Windows</value>
+    <value>Habilitar la sobreescritura del hash del instalador de aplicaciones de Windows</value>
   </data>
   <data name="SourceExportCommandLongDescription" xml:space="preserve">
-    <value>Exportar las fuentes actuales como JSON para la directiva de grupo.</value>
+    <value>Exportar los orígenes actuales como JSON para la directiva de grupo.</value>
   </data>
   <data name="SourceExportCommandShortDescription" xml:space="preserve">
-    <value>Orígenes actuales de exportación</value>
+    <value>Exportar los orígenes actuales</value>
   </data>
   <data name="SourceListAdditionalSource" xml:space="preserve">
     <value>Origen adicional</value>
@@ -1000,7 +996,7 @@ La configuración está deshabilitada debido a la Directiva de grupo.</value>
     <comment>For getting package type dependencies when installing from a local manifest</comment>
   </data>
   <data name="WindowsStoreTerms" xml:space="preserve">
-    <value>Términos de la Tienda Windows</value>
+    <value>Términos de Microsoft Store</value>
   </data>
   <data name="AcceptPackageAgreementsArgumentDescription" xml:space="preserve">
     <value>Aceptar todos los contratos de licencia para paquetes</value>
@@ -1088,7 +1084,7 @@ La configuración está deshabilitada debido a la Directiva de grupo.</value>
     <value>Aceptar todos los contratos de origen durante las operaciones de origen</value>
   </data>
   <data name="SourceAgreementsTitle" xml:space="preserve">
-    <value>El origen '%1' requiere que vea los siguientes contratos antes de usarlos.</value>
+    <value>El origen '%1' requiere que vea los siguientes contratos antes de usarlo.</value>
     <comment>{Locked="%1"} The value will be replaced with the source name</comment>
   </data>
   <data name="SourceAgreementsPrompt" xml:space="preserve">
@@ -1216,12 +1212,13 @@ La configuración está deshabilitada debido a la Directiva de grupo.</value>
     <value>El registro del instalador está disponible en:</value>
   </data>
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
-    <value>Se encontraron los siguientes paquetes entre los orígenes de trabajo.
+    <value>Se encontraron los siguientes paquetes entre los orígenes que funcionan.
 Especifique uno de ellos con la opción '--source' para continuar.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
-    <value>No se encontraron paquetes entre los orígenes de trabajo.</value>
+    <value>No se encontraron paquetes entre los orígenes que funcionan.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Esto es una versión estable del Administrador de paquetes de Windows. Si desea probar las características experimentales, instale una compilación de versión preliminar. Las instrucciones están disponibles en GitHub en https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@ Especifique uno de ellos con la opción '--source' para continuar.</value>
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Seleccionar la arquitectura que se va a instalar</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Actualizar paquetes aunque no se pueda determinar su versión actual</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>No se puede determinar el número de versión de este paquete. Para actualizarlo de todos modos, agregue el argumento --include-unknown al comando anterior.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>los paquetes tienen números de versión que no se pueden determinar. El uso de "--include-unknown" puede mostrar más resultados.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>el paquete tiene un número de versión que no se puede determinar. El uso de "--include-unknown" puede mostrar más resultados.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Los argumentos proporcionados solo se pueden usar con una consulta.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Arquitectura del sistema</value>
   </data>
 </root>

--- a/Localization/Resources/fr-FR/winget.resw
+++ b/Localization/Resources/fr-FR/winget.resw
@@ -261,7 +261,7 @@ Elles peuvent être configurées par le biais du fichier de paramètres « wing
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>Installe le package sélectionné, trouvé en recherchant une source configurée ou directement à partir d'un manifeste. Par défaut, la requête doit correspondre, sans respect de la casse, à l’id, au nom ou au moniker du package. D’autres champs peuvent être utilisés en transmettant leur option appropriée.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Installe le package donné</value>
@@ -472,13 +472,15 @@ Elles peuvent être configurées par le biais du fichier de paramètres « wing
     <value>Ouvrir les paramètres ou définir les paramètres d’administrateur</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Erreur inattendue lors du chargement des paramètres. Veuillez vérifier vos paramètres en exécutant la commande paramètres.</value>
+    <value>Erreur inattendue lors du chargement des paramètres. Vérifiez vos paramètres en exécutant la commande 'settings'.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Canal</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>Affiche des informations sur un package spécifique. Par défaut, la requête doit correspondre de façon non sensible à la casse à l’ID, au nom ou au moniker du package. D’autres champs peuvent être utilisés en passant l’option appropriée.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Affiche des informations sur un package</value>
@@ -663,13 +665,6 @@ Elles peuvent être configurées par le biais du fichier de paramètres « wing
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>Aucune mise à jour applicable trouvée.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Mises à niveau du paquet sélectionné, trouvé en recherchant les paquets installés ou directement à partir d'un manifeste. Par défaut, la requête doit correspondre, sans respect de la casse, à l’identification, au nom ou au moniker du paquet. D’autres champs peuvent être utilisés en passant leur option appropriée.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Met à niveau le package donné</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>consommation</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@ Elles peuvent être configurées par le biais du fichier de paramètres « wing
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>Désinstalle le package sélectionné, que vous avez trouvé en effectuant une recherche dans la liste des packages installés ou directement à partir d’un manifeste. Par défaut, la requête doit correspondre de façon non sensible à la casse à l’ID, au nom ou au moniker du package. D’autres champs peuvent être utilisés en passant l’option appropriée.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Désinstallation du paquet donné</value>
@@ -1218,10 +1214,11 @@ Acceptez-vous les conditions ?</value>
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>Les packages suivants ont été trouvés parmi les sources de travail.
 Spécifiez l’un d’entre eux à l’aide de l’option '--source' pour continuer.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>Aucun package n’a été trouvé parmi les sources de travail.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Il s’agit d’une version stable du Gestionnaire de package Windows. Si vous voulez essayer des fonctionnalités expérimentales, installez une version préliminaire. Des instructions sont disponibles sur GitHub : https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@ Spécifiez l’un d’entre eux à l’aide de l’option '--source' pour contin
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Sélectionner l’architecture à installer</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Mettre à niveau les packages même si leur version actuelle ne peut pas être déterminée</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>Impossible de déterminer le numéro de version de ce package. Pour le mettre à niveau quand même, ajoutez l’argument --include-unknown à votre commande précédente.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>les packages ont un numéro de version qui ne peut pas être déterminé. L’utilisation de « --include-unknown » peut afficher plus de résultats.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>le package a un numéro de version qui ne peut pas être déterminé. L’utilisation de « --include-unknown » peut afficher plus de résultats.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Les arguments fournis ne peuvent être utilisés qu’avec une requête.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Architecture du système</value>
   </data>
 </root>

--- a/Localization/Resources/it-IT/winget.resw
+++ b/Localization/Resources/it-IT/winget.resw
@@ -261,7 +261,7 @@ Possono essere configurati tramite il file di impostazioni ' winget settings '.<
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>Installa il pacchetto selezionato, trovato cercando una fonte configurata o direttamente da un manifesto. Per impostazione predefinita, la query deve essere non sensibile alle maiuscole e minuscole, corrispondere all'ID, al nome o al moniker del pacchetto. Gli altri campi possono essere utilizzati passando all'opzione appropriata.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Installa il pacchetto specificato</value>
@@ -472,13 +472,15 @@ Possono essere configurati tramite il file di impostazioni ' winget settings '.<
     <value>Aprire le impostazioni o predisporre le impostazioni di amministratore</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Errore imprevisto durante il caricamento delle impostazioni. Verificare le impostazioni eseguendo il comando impostazioni.</value>
+    <value>Errore imprevisto durante il caricamento delle impostazioni. Verificare le impostazioni eseguendo il comando 'settings'.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Canale</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>Visualizza informazioni su un pacchetto specifico. Per impostazione predefinita, la query deve essere insensitively con l'ID, il nome o il moniker del pacchetto. Altri campi possono essere utilizzati passando l'opzione appropriata.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Mostra informazioni su un pacchetto</value>
@@ -663,13 +665,6 @@ Possono essere configurati tramite il file di impostazioni ' winget settings '.<
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>Non è stato trovato alcun aggiornamento applicabile.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Aggiorna il pacchetto selezionato, trovato eseguendo la ricerca nell'elenco dei pacchetti installati o direttamente da un manifesto. Per impostazione predefinita, la query deve essere insensitively con l'ID, il nome o il moniker del pacchetto. Altri campi possono essere utilizzati passando l'opzione appropriata.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Aggiorna il pacchetto specificato</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>uso</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@ Possono essere configurati tramite il file di impostazioni ' winget settings '.<
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>Disinstalla il pacchetto selezionato, trovato mediante la ricerca dell'elenco dei pacchetti installati o direttamente da un manifesto. Per impostazione predefinita, la query deve essere insensitively con l'ID, il nome o il moniker del pacchetto. Altri campi possono essere utilizzati passando l'opzione appropriata.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Disinstalla il pacchetto specificato</value>
@@ -1218,10 +1214,11 @@ Accetti le condizioni?</value>
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>Sono stati trovati i pacchetti seguenti tra le origini di lavoro.
 Specificare uno di questi valori usando l'opzione '--source' per continuare.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>Non sono stati trovati pacchetti tra le origini di lavoro.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Questa è una release stabile di Gestione pacchetti Windows. Se desideri provare funzionalità sperimentali, installa una build preliminare. Istruzioni disponibili su GitHub all'indirizzo https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@ Specificare uno di questi valori usando l'opzione '--source' per continuare.</va
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Selezionare l'architettura da installare</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Aggiorna i pacchetti anche se non è possibile determinare la versione corrente</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>Non è possibile determinare il numero di versione di questo pacchetto. Per aggiornarlo comunque, aggiungere l'argomento --include-unknown al comando precedente.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>i pacchetti contengono numeri di versione che non possono essere determinati. L'uso di "--include-unknown" può mostrare altri risultati.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>il pacchetto ha un numero di versione che non può essere determinato. L'uso di "--include-unknown" può mostrare altri risultati.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Gli argomenti specificati possono essere usati solo con una query.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Architettura di sistema</value>
   </data>
 </root>

--- a/Localization/Resources/ja-JP/winget.resw
+++ b/Localization/Resources/ja-JP/winget.resw
@@ -261,7 +261,7 @@
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>構成されたソースを検索するか、マニフェストから直接検索して見つけた選択されたパッケージをインストールします。既定では、クエリはパッケージの ID、名前、モニカーに大文字小文字の区別なく一致する必要があります。その他のフィールドは、適切なオプションを渡すことで使用することができます。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>指定されたパッケージをインストール</value>
@@ -472,13 +472,15 @@
     <value>設定を開くか、管理者設定を設定する</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>設定の読み込み中に予期しないエラーが発生しました。Settings コマンドを実行して、設定を確認してください。</value>
+    <value>設定の読み込み中に予期しないエラーが発生しました。'settings' コマンドを実行して、設定を確認してください。</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>チャネル</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>特定のパッケージの情報を表示します。既定では、クエリはパッケージの ID、名前、モニカーに大文字小文字の区別なく一致する必要があります。その他のフィールドは、適切なオプションを渡すことで使用することができます。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>パッケージに関する情報を表示します</value>
@@ -663,13 +665,6 @@
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>適用可能な更新は見つかりませんでした。</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>インストールされたパッケージ リスト、またはマニフェストから直接検索し、選択されたパッケージをアップグレードします。既定では、クエリはパッケージの ID、名前、モニカーに大文字小文字の区別なく一致する必要があります。その他のフィールドは、適切なオプションを渡すことで使用することができます。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>指定されたパッケージをアップグレードします</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>使用状況</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>インストールされているパッケージリスト、またはマニフェストから検索し、選択したパッケージをアンインストールします。既定では、クエリはパッケージのID、名前、モニカーと大文字と小文字の区別なく一致する必要があります。その他のフィールドは、適切なオプションを渡すことで使用することができます。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>指定されたパッケージをアンインストール</value>
@@ -1218,10 +1214,11 @@
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>作業ソースの中以下のパッケージが見つかりました。
 続行するには、'--source' オプションを使用していずれかのパッケージを指定してください。</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>作業ソースの中にパッケージが見つかりませんでした。</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>これは、Windows パッケージ マネージャーの安定版リリースです。実験的な機能を試したい場合は、プレリリース ビルドをインストールしてください。手順は、GitHub (https://github.com/microsoft/winget-cli) で入手できます。</value>
@@ -1249,5 +1246,26 @@
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>アーキテクチャを選択してインストール</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>現在のバージョンを特定できない場合でもパッケージをアップグレードする</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>このパッケージのバージョン番号を特定できません。とにかくアップグレードするには、前のコマンドに引数 --include-unknown を追加します。</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>パッケージのバージョン番号を判別できません。"--include-unknown" を使用すると、その他の結果が表示される場合があります。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>パッケージのバージョン番号を判別できません。"--include-unknown" を使用すると、その他の結果が表示される場合があります。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>指定された引数はクエリでのみ使用できます。</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>システム アーキテクチャ</value>
   </data>
 </root>

--- a/Localization/Resources/ko-KR/winget.resw
+++ b/Localization/Resources/ko-KR/winget.resw
@@ -261,7 +261,7 @@
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>구성된 원본을 검색하거나 매니페스트에서 직접 검색하여 선택한 패키지를 설치합니다. 기본적으로 쿼리는 패키지의 ID, 이름 또는 모니커와 대/소문자를 구분하지 않고 일치해야 합니다. 다른 필드는 적절한 옵션을 전달하여 사용할 수 있습니다.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>지정된 패키지를 설치합니다.</value>
@@ -472,13 +472,15 @@
     <value>설정 열기 또는 관리자 설정 설정</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>설정을 로드하는 동안 예기치 않은 오류가 발생했습니다. 설정 명령을 실행하여 설정을 확인하십시오.</value>
+    <value>설정을 로드하는 동안 예기치 않은 오류가 발생했습니다. 'settings' 명령을 실행하여 설정을 확인하세요.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>채널</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>특정 패키지에 대한 정보를 표시합니다. 기본적으로 쿼리는 패키지의 ID, 이름 또는 모양과 대/소문자를 구분하지 않는 다섯 번이 어려져야 합니다. 적절한 옵션을 전달하여 다른 필드를 사용할 수 있습니다.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>패키지에 대한 정보 표시</value>
@@ -663,13 +665,6 @@
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>적용 가능한 업데이트를 찾을 수 없습니다.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>설치된 패키지 목록을 검색하거나 매니페스트에서 직접 찾은 선택한 패키지를 업그레이드합니다. 기본적으로 쿼리는 패키지의 ID, 이름 또는 모양과 대/소문자를 구분하지 않는 다섯 번이 어려져야 합니다. 적절한 옵션을 전달하여 다른 필드를 사용할 수 있습니다.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>주어진 패키지 업그레이드</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>사용</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>설치된 패키지 목록을 검색하거나 매니페스트에서 직접 찾은 선택한 패키지를 제거합니다. 기본적으로 쿼리는 패키지의 ID, 이름 또는 모양과 대/소문자를 구분하지 않는 것이 어떻게 되아야 합니다. 적절한 옵션을 전달하여 다른 필드를 사용할 수 있습니다.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>지정된 패키지를 제거</value>
@@ -1218,10 +1214,11 @@
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>다음 패키지가 작업 원본에서 발견되었습니다.
 계속하려면 '--source' 옵션을 사용하여 둘 중 하나를 지정하세요.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>작업 원본 중 패키지를 찾을 수 없습니다.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>이 릴리스는 Windows 패키지 관리자의 안정적인 릴리스입니다. 실험적인 기능을 사용해 보려면 시험판 빌드를 설치하세요. 지침은 GitHub(https://github.com/microsoft/winget-cli)에서 확인할 수 있습니다.</value>
@@ -1249,5 +1246,26 @@
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>설치할 아키텍처 선택</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>현재 버전을 확인할 수 없는 경우에도 패키지 업그레이드</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>이 패키지의 버전 번호를 확인할 수 없습니다. 그래도 업그레이드하려면 이전 명령에 인수 --include-unknown 추가하세요.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>패키지에 확인할 수 없는 버전 번호가 있습니다. "--include-unknown" 사용하면 더 많은 결과가 표시될 수 있습니다.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>패키지에 확인할 수 없는 버전 번호가 있습니다. "--include-unknown" 사용하면 더 많은 결과가 표시될 수 있습니다.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>제공된 인수는 쿼리에서만 사용할 수 있습니다.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>시스템 아키텍처</value>
   </data>
 </root>

--- a/Localization/Resources/pt-BR/winget.resw
+++ b/Localization/Resources/pt-BR/winget.resw
@@ -261,7 +261,7 @@ Eles podem ser configurados por meio do arquivo de configurações ' winget sett
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>Instala o pacote selecionado, localizado ao pesquisar uma fonte configurada ou diretamente de um manifesto. Por padrão, a consulta deve diferenciar maiúsculas e minúsculas na identificação, no nome ou no moniker do pacote. Outros campos podem ser usados ​​passando a opção apropriada.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Instalar um determinado pacote</value>
@@ -472,13 +472,15 @@ Eles podem ser configurados por meio do arquivo de configurações ' winget sett
     <value>Abra as configurações ou defina as configurações do administrador</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Erro inesperado ao carregar as configurações. Verifique suas configurações executando o comando configurações.</value>
+    <value>Erro inesperado ao carregar as configurações. Verifique suas configurações executando o 'settings' comando.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Canal</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>Mostra informações sobre um pacote específico. Por padrão, a consulta deve corresponder de forma insensível à ID, ao nome ou ao moniker do pacote. Outros campos podem ser usados passando a opção apropriada.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Mostra informações sobre um pacote</value>
@@ -663,13 +665,6 @@ Eles podem ser configurados por meio do arquivo de configurações ' winget sett
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>Nenhuma atualização aplicável foi encontrada.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Atualiza o pacote selecionado, encontrado pesquisando a lista de pacotes instalados ou diretamente de um manifesto. Por padrão, a consulta deve corresponder de forma insensível à ID, ao nome ou ao moniker do pacote. Outros campos podem ser usados passando a opção apropriada.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Atualiza o pacote fornecido</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>uso</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@ Eles podem ser configurados por meio do arquivo de configurações ' winget sett
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>Desinstala o pacote selecionado, encontrado pesquisando a lista de pacotes instalados ou diretamente de um manifesto. Por padrão, a consulta deve corresponder de forma insensível à ID, ao nome ou ao moniker do pacote. Outros campos podem ser usados passando a opção apropriada.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Desinstala um determinado pacote</value>
@@ -1218,10 +1214,11 @@ Você concorda com os termos?</value>
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>Os seguintes pacotes foram encontrados entre as fontes de trabalho.
 Especifique um deles usando a opção '--source' para continuar.</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>Nenhum pacote foi encontrado entre as fontes de trabalho.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Esta é uma versão estável do Gerenciador de Pacotes do Windows. Se quiser experimentar os recursos experimentais, instale uma versão de pré-lançamento. As instruções estão disponíveis no GitHub em https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@ Especifique um deles usando a opção '--source' para continuar.</value>
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Selecione a arquitetura a ser instalada</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Atualizar pacotes mesmo que a versão atual não seja determinada</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>Não é possível determinar o número de versão deste pacote. Para atualizá-lo mesmo assim, adicione o argumento --include-unknown ao comando anterior.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>pacotes têm números de versão que não podem ser determinados. Usar "--include-unknown" pode mostrar mais resultados.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>o pacote tem um número de versão que não pode ser determinado. Usar "--include-unknown" pode mostrar mais resultados.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Os argumentos fornecidos só podem ser usados com uma consulta.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Arquitetura do Sistema</value>
   </data>
 </root>

--- a/Localization/Resources/ru-RU/winget.resw
+++ b/Localization/Resources/ru-RU/winget.resw
@@ -261,7 +261,7 @@
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>Устанавливает выбранный пакет, обнаруженный либо путем поиска в настроенном источнике, либо непосредственно из манифеста. По умолчанию запрос должен сравнить идентификатор, имя или моникер пакета (без учета регистра). Можно использовать и другие поля, указав соответствующий параметр.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>Установка указанного пакета</value>
@@ -472,13 +472,15 @@
     <value>Открыть параметры или настроить параметры администратора</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>Непредвиденная ошибка при загрузке параметров. Проверьте параметры, выполнив команду "Параметры".</value>
+    <value>Непредвиденная ошибка при загрузке параметров. Проверьте параметры, выполнив команду 'settings'.</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>Канал</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>Отображает сведения о конкретном пакете. По умолчанию запрос должен сравнить идентификатор, имя или моникер пакета (без учета регистра). Можно использовать и другие поля, указав соответствующий параметр.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>Показывает сведения о пакете</value>
@@ -663,13 +665,6 @@
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>Применимые обновления не найдены.</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>Обновление выбранного пакета, обнаруженного путем поиска в списке установленных пакетов либо непосредственно из манифеста. По умолчанию запрос должен соответствовать идентификатору, имени или моникеру пакета (без учета регистра). Можно использовать и другие поля, указав соответствующий параметр.</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>Обновление указанного пакета</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>использование</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>Удаление выбранного пакета, обнаруженного путем поиска в списке установленных пакетов либо непосредственно из манифеста. По умолчанию запрос должен соответствовать идентификатору, имени или моникеру пакета (без учета регистра). Можно использовать и другие поля, указав соответствующий параметр.</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>Удаление указанного пакета</value>
@@ -1218,10 +1214,11 @@
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>Среди рабочих источников найдены следующие пакеты.
 Чтобы продолжить, укажите один из них, используя параметр "--source".</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>Пакеты не найдены среди рабочих источников.</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>Это стабильный выпуск Диспетчера пакетов Windows. Чтобы попробовать экспериментальные функции, установите предварительную сборку. Инструкции доступны в GitHub по ссылке https://github.com/microsoft/winget-cli.</value>
@@ -1249,5 +1246,26 @@
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>Выберите архитектуру для установки</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>Обновить пакеты, даже если не удается определить их текущую версию</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>Невозможно определить номер версии этого пакета. Чтобы все равно обновить его, добавьте аргумент --include-unknown к предыдущей команде.</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>Невозможно определить номер версии пакетов. Попробуйте использовать аргумент "--include-unknown" для получения более подробных результатов.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>Невозможно определить номер версии пакета. Попробуйте использовать аргумент "--include-unknown" для получения более подробных результатов.</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>Указанные аргументы можно использовать только с запросом.</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>Архитектура системы</value>
   </data>
 </root>

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -261,7 +261,7 @@
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>安装选定的程序包，该程序包可以通过搜索配置的源找到，也可以直接从清单中找到。默认情况下，查询必须以不区分大小写的方式匹配程序包的 ID、名称或名字对象。可通过传递相应的选项来使用其他字段。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>安装给定的程序包</value>
@@ -472,13 +472,15 @@
     <value>打开设置或设置管理员设置</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>加载设置时出现意外错误。请运行 "设置" 命令以验证您的设置。</value>
+    <value>加载设置时出现意外错误。请运行'settings'命令来验证你的设置。</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>频道</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>显示有关特定程序包的信息。默认情况下，查询必须以不区分大小写的方式匹配程序包的 ID、名称或名字对象。可通过传递相应的选项来使用其他字段。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>显示包的相关信息</value>
@@ -663,13 +665,6 @@
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>找不到适用的更新。</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>通过搜索已安装的程序包列表或直接从清单升级所选的程序包。默认情况下，查询必须 insensitively 匹配程序包的 id、名称或名字对象。可通过传递适当的选项来使用其他字段。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>升级给定的程序包</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>使用情况</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>通过搜索已安装的程序包列表或直接从清单中卸载选择的程序包。默认情况下，查询必须 insensitively 匹配程序包的 id、名称或名字对象。可通过传递适当的选项来使用其他字段。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>卸载给定的程序包</value>
@@ -1218,10 +1214,11 @@
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>在工作源中找到以下包。
 请使用"--source"选项指定其中一个选项以继续。</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>在工作源中找不到任何包。</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>这是 Windows 程序包管理器的稳定版本。如果要尝试实验性功能，请安装预发布版本。请前往 https://github.com/microsoft/winget-cli 查看 GitHub 说明。</value>
@@ -1249,5 +1246,26 @@
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>选择要安装的体系结构</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>即使无法确定其当前版本，也可升级包</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>无法确定此包的版本号。若要继续升级，请将参数--include-unknown添加到上一命令。</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>包具有无法确定的版本号。使用 “--include-unknown” 可能会显示更多结果。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>包具有无法确定的版本号。使用 “--include-unknown” 可能会显示更多结果。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>提供的参数只能与查询一起使用。</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>系统体系结构</value>
   </data>
 </root>

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -261,7 +261,7 @@
   </data>
   <data name="InstallCommandLongDescription" xml:space="preserve">
     <value>可透過搜尋設定的來源或直接從資訊清單來安裝選取的套件。根據預設，查詢必須布區分大小寫地符合該套件的識別碼、名稱或連結路徑。您可以透過傳遞適當的選像，來使用其他欄位。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="InstallCommandShortDescription" xml:space="preserve">
     <value>安裝指定的套件</value>
@@ -472,13 +472,15 @@
     <value>開啟設定或設定系統管理員設定</value>
   </data>
   <data name="SettingsWarnings" xml:space="preserve">
-    <value>載入設定時發生意外的錯誤。請執行 [設定] 命令以驗證您的設定。</value>
+    <value>載入設定時發生未預期的錯誤。請執行 'settings' 命令以驗證您的設定。</value>
+    <comment>{Locked="'settings'"}</comment>
   </data>
   <data name="ShowChannel" xml:space="preserve">
     <value>頻道</value>
   </data>
   <data name="ShowCommandLongDescription" xml:space="preserve">
     <value>顯示特定封裝的資訊。根據預設，查詢必須 insensitively 符合封裝的識別碼、名稱或名字物件。您可以透過傳遞適當的選項來使用其他欄位。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="ShowCommandShortDescription" xml:space="preserve">
     <value>顯示套件相關資訊</value>
@@ -663,13 +665,6 @@
   <data name="UpdateNotApplicable" xml:space="preserve">
     <value>找不到適用的更新。</value>
   </data>
-  <data name="UpgradeCommandLongDescription" xml:space="preserve">
-    <value>透過搜尋已安裝的套件清單或直接從資訊清單來升級選取的套件。根據預設，查詢必須 insensitively 符合封裝的識別碼、名稱或名字物件。您可以透過傳遞適當的選項來使用其他欄位。</value>
-    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated.</comment>
-  </data>
-  <data name="UpgradeCommandShortDescription" xml:space="preserve">
-    <value>升級指定的套件</value>
-  </data>
   <data name="Usage" xml:space="preserve">
     <value>使用</value>
     <comment>The way to use the software</comment>
@@ -741,6 +736,7 @@
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
     <value>可透過搜尋已安裝的套件或直接從資訊清單中，解除安裝已選取的套件。根據預設，查詢必須不區分大小寫地符合該套件的識別碼、名稱或連結路徑。您可以透過傳遞適當的選項，來使用其他欄位。</value>
+    <comment>id, name, and moniker are all named values in our context, and may benefit from not being translated. The match must be for any of them, with comparison ignoring case.</comment>
   </data>
   <data name="UninstallCommandShortDescription" xml:space="preserve">
     <value>解除安裝指定的套件</value>
@@ -1218,10 +1214,11 @@
   <data name="SearchFailureErrorListMatches" xml:space="preserve">
     <value>在工作來源中找到下列套件。
 請使用 '--source' 選項指定其中一個以繼續。</value>
-    <comment>{Locked="--source"}</comment>
+    <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>在工作來源中找不到任何套件。</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
   </data>
   <data name="FeaturesMessageDisabledByBuild" xml:space="preserve">
     <value>這是 Windows 封裝管理員的穩定版本。如果您想要嘗試實驗性功能，請安裝發行前版本組建。可於 https://github.com/microsoft/winget-cli 的 GitHub 上找到指示。</value>
@@ -1249,5 +1246,26 @@
   </data>
   <data name="InstallArchitectureArgumentDescription" xml:space="preserve">
     <value>選取要安裝的架構</value>
+  </data>
+  <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
+    <value>升級套件，即使無法判斷其目前版本</value>
+  </data>
+  <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
+    <value>無法判斷此套件的版本號碼。若要繼續升級，請將引數 「--include-unknown」新增至先前的命令。</value>
+    <comment>{Locked="--include-unknown"}</comment>
+  </data>
+  <data name="UpgradeUnknownCount" xml:space="preserve">
+    <value>無法判斷套件的版本號碼。使用「--include-unknown」可能會顯示更多結果。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions. </comment>
+  </data>
+  <data name="UpgradeUnknownCountSingle" xml:space="preserve">
+    <value>無法判斷套件的版本號碼。使用「--include-unknown」可能會顯示更多結果。</value>
+    <comment>{Locked="--include-unknown"} This string is preceded by a (integer) number of packages that do not have notated versions.</comment>
+  </data>
+  <data name="InvalidArgumentWithoutQueryError" xml:space="preserve">
+    <value>提供的引數只能與查詢一起使用。</value>
+  </data>
+  <data name="SystemArchitecture" xml:space="preserve">
+    <value>系統架構</value>
   </data>
 </root>


### PR DESCRIPTION
This patch has 100% of the localizations for the strings up to commit 0f4d66e122d38a775c189c37d03aaabd74f8c36f.

This includes the changes from #1846 and the localizations for the updated ADML in #2038. The patch also removed the outdated localizations for the strings changed in #2034, which we should get next time we run the pipeline as they were already submitted.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2045)