### PR TITLE
Make schemas more strict

### DIFF
--- a/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.defaultLocale.1.0.0.json
@@ -4,13 +4,13 @@
   "description": "A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.0.0",
   "definitions": {
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package moniker or tag"
@@ -56,7 +56,7 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
@@ -82,7 +82,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -98,7 +98,7 @@
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
@@ -108,10 +108,11 @@
       "description": "The most common package term"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"

--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -16,19 +16,19 @@
       "description": "The package version"
     },
     "Locale": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$",
       "maxLength": 20,
       "description": "The installer meta-data locale"
     },
     "Channel": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 16,
       "description": "The distribution channel"
     },
     "Platform": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "Platform",
         "type": "string",
@@ -37,17 +37,18 @@
           "Windows.Universal"
         ]
       },
+      "minItems": 1,
       "maxItems": 2,
       "uniqueItems": true,
       "description": "The installer supported operating system"
     },
     "MinimumOSVersion": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$",
       "description": "The installer minimum operating system version"
     },
     "InstallerType": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "msix",
         "msi",
@@ -63,7 +64,7 @@
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
     "Scope": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "user",
         "machine"
@@ -71,7 +72,7 @@
       "description": "Scope indicates if the installer is per user or per machine"
     },
     "InstallModes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "InstallModes",
         "type": "string",
@@ -81,6 +82,7 @@
           "silentWithProgress"
         ]
       },
+      "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
       "description": "List of supported installer modes"
@@ -89,51 +91,52 @@
       "type": "object",
       "properties": {
         "Silent": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
         },
         "SilentWithProgress": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "SilentWithProgress is the value that should be passed to the installer when user chooses a non-interactive install"
         },
         "Interactive": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Interactive is the value that should be passed to the installer when user chooses an interactive install"
         },
         "InstallLocation": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "InstallLocation is the value passed to the installer for custom install location. <INSTALLPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Log": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Log is the value passed to the installer for custom log file path. <LOGPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Upgrade": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Upgrade is the value that should be passed to the installer when user chooses an upgrade"
         },
         "Custom": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
         }
-      }
+      },
+      "minProperties": 1
     },
     "InstallerSuccessCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "integer",
         "format": "long",
@@ -143,12 +146,13 @@
         "minimum": -2147483648,
         "maximum": 4294967295
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional non-zero installer success exit codes other than known default values by winget"
     },
     "UpgradeBehavior": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "install",
         "uninstallPrevious"
@@ -156,65 +160,70 @@
       "description": "The upgrade method"
     },
     "Commands": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of commands or aliases to run the package"
     },
     "Protocols": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[a-z][-a-z0-9\\.\\+]*$",
         "maxLength": 2048
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },
     "FileExtensions": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[^\\\\/:\\*\\?\"<>\\|\\x01-\\x1f]+$",
         "maxLength": 64
       },
+      "minItems": 1,
       "maxItems": 256,
       "uniqueItems": true,
       "description": "List of file extensions the package could support"
     },
     "Dependencies": {
-      "type": [ "object", "null" ],
+      "type": "object",
       "properties": {
         "WindowsFeatures": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows library dependencies"
         },
         "PackageDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -227,53 +236,58 @@
             },
             "required": [ "PackageIdentifier" ]
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of package dependencies from current source"
         },
         "ExternalDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of external package dependencies"
         }
-      }
+      },
+      "minProperties": 1
     },
     "PackageFamilyName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^[A-Za-z0-9][-\\.A-Za-z0-9]+_[A-Za-z0-9]{13}$",
       "maxLength": 255,
       "description": "PackageFamilyName for appx or msix installer. Could be used for correlation of packages across sources"
     },
     "ProductCode": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"
     },
     "Capabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer restricted capabilities"
@@ -319,7 +333,7 @@
           "description": "Sha256 is required. Sha256 of the installer"
         },
         "SignatureSha256": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "pattern": "^[A-Fa-f0-9]{64}$",
           "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
         },

--- a/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.locale.1.0.0.json
@@ -4,13 +4,13 @@
   "description": "A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.0.0",
   "definitions": {
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package tag"
@@ -37,7 +37,7 @@
       "description": "The package meta-data locale"
     },
     "Publisher": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The publisher name"
@@ -55,13 +55,13 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
     },
     "PackageName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package name"
@@ -71,7 +71,7 @@
       "description": "The package home page"
     },
     "License": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package license"
@@ -81,7 +81,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -91,22 +91,23 @@
       "description": "The package copyright page"
     },
     "ShortDescription": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 256,
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -16,31 +16,31 @@
       "description": "The package version"
     },
     "Locale": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$",
       "maxLength": 20,
       "description": "The package meta-data locale"
     },
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package moniker or tag"
     },
     "Channel": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 16,
       "description": "The distribution channel"
     },
     "Platform": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "Platform",
         "type": "string",
@@ -49,17 +49,18 @@
           "Windows.Universal"
         ]
       },
+      "minItems": 1,
       "maxItems": 2,
       "uniqueItems": true,
       "description": "The installer supported operating system"
     },
     "MinimumOSVersion": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$",
       "description": "The installer minimum operating system version"
     },
     "InstallerType": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "msix",
         "msi",
@@ -75,7 +76,7 @@
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
     "Scope": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "user",
         "machine"
@@ -83,7 +84,7 @@
       "description": "Scope indicates if the installer is per user or per machine"
     },
     "InstallModes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "InstallModes",
         "type": "string",
@@ -93,6 +94,7 @@
           "silentWithProgress"
         ]
       },
+      "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
       "description": "List of supported installer modes"
@@ -101,51 +103,52 @@
       "type": "object",
       "properties": {
         "Silent": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
         },
         "SilentWithProgress": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "SilentWithProgress is the value that should be passed to the installer when user chooses a non-interactive install"
         },
         "Interactive": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Interactive is the value that should be passed to the installer when user chooses an interactive install"
         },
         "InstallLocation": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "InstallLocation is the value passed to the installer for custom install location. <INSTALLPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Log": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Log is the value passed to the installer for custom log file path. <LOGPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Upgrade": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Upgrade is the value that should be passed to the installer when user chooses an upgrade"
         },
         "Custom": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
         }
-      }
+      },
+      "minProperties": 1
     },
     "InstallerSuccessCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "integer",
         "format": "long",        
@@ -155,12 +158,13 @@
         "minimum": -2147483648,
         "maximum": 4294967295
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional non-zero installer success exit codes other than known default values by winget"
     },
     "UpgradeBehavior": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "install",
         "uninstallPrevious"
@@ -168,65 +172,70 @@
       "description": "The upgrade method"
     },
     "Commands": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of commands or aliases to run the package"
     },
     "Protocols": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[a-z][-a-z0-9\\.\\+]*$",
         "maxLength": 2048
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },
     "FileExtensions": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[^\\\\/:\\*\\?\"<>\\|\\x01-\\x1f]+$",
         "maxLength": 64
       },
+      "minItems": 1,
       "maxItems": 256,
       "uniqueItems": true,
       "description": "List of file extensions the package could support"
     },
     "Dependencies": {
-      "type": [ "object", "null" ],
+      "type": "object",
       "properties": {
         "WindowsFeatures": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows library dependencies"
         },
         "PackageDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -239,52 +248,57 @@
             },
             "required": [ "PackageIdentifier" ]
           },
+          "minItems": 1,
           "maxItems": 16,
           "description": "List of package dependencies from current source"
         },
         "ExternalDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of external package dependencies"
         }
-      }
+      },
+      "minProperties": 1
     },
     "PackageFamilyName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^[A-Za-z0-9][-\\.A-Za-z0-9]+_[A-Za-z0-9]{13}$",
       "maxLength": 255,
       "description": "PackageFamilyName for appx or msix installer. Could be used for correlation of packages across sources"
     },
     "ProductCode": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"
     },
     "Capabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer restricted capabilities"
@@ -330,7 +344,7 @@
           "description": "Sha256 is required. Sha256 of the installer"
         },
         "SignatureSha256": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "pattern": "^[A-Fa-f0-9]{64}$",
           "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
         },
@@ -408,7 +422,7 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
@@ -434,7 +448,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -450,7 +464,7 @@
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
@@ -460,10 +474,11 @@
       "description": "The most common package term"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"

--- a/schemas/JSON/manifests/v1.1.0/manifest.defaultLocale.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.defaultLocale.1.1.0.json
@@ -4,13 +4,13 @@
   "description": "A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.1.0",
   "definitions": {
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package moniker or tag"
@@ -19,13 +19,13 @@
       "type": "object",
       "properties": {
         "AgreementLabel": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 100,
           "description": "The label of the Agreement. i.e. EULA, AgeRating, etc. This field should be localized. Either Agreement or AgreementUrl is required. When we show the agreements, we would Bold the AgreementLabel"
         },
         "Agreement": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 10000,
           "description": "The agreement text content."
@@ -34,7 +34,8 @@
           "$ref": "#/definitions/Url",
           "description": "The agreement URL."
         }
-      }
+      },
+      "minProperties": 1
     }
   },
   "type": "object",
@@ -77,7 +78,7 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
@@ -103,7 +104,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -119,7 +120,7 @@
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
@@ -129,23 +130,25 @@
       "description": "The most common package term"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"
     },
     "Agreements": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Agreement"
       },
+      "minItems": 1,
       "maxItems": 128
     },
     "ReleaseNotes": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 10000,
       "description": "The package release notes"

--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -16,19 +16,19 @@
       "description": "The package version"
     },
     "Locale": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$",
       "maxLength": 20,
       "description": "The installer meta-data locale"
     },
     "Channel": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 16,
       "description": "The distribution channel"
     },
     "Platform": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "Platform",
         "type": "string",
@@ -37,17 +37,18 @@
           "Windows.Universal"
         ]
       },
+      "minItems": 1,
       "maxItems": 2,
       "uniqueItems": true,
       "description": "The installer supported operating system"
     },
     "MinimumOSVersion": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$",
       "description": "The installer minimum operating system version"
     },
     "InstallerType": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "msix",
         "msi",
@@ -63,7 +64,7 @@
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
     "Scope": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "user",
         "machine"
@@ -71,7 +72,7 @@
       "description": "Scope indicates if the installer is per user or per machine"
     },
     "InstallModes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "InstallModes",
         "type": "string",
@@ -81,6 +82,7 @@
           "silentWithProgress"
         ]
       },
+      "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
       "description": "List of supported installer modes"
@@ -89,70 +91,74 @@
       "type": "object",
       "properties": {
         "Silent": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
         },
         "SilentWithProgress": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "SilentWithProgress is the value that should be passed to the installer when user chooses a non-interactive install"
         },
         "Interactive": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Interactive is the value that should be passed to the installer when user chooses an interactive install"
         },
         "InstallLocation": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "InstallLocation is the value passed to the installer for custom install location. <INSTALLPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Log": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Log is the value passed to the installer for custom log file path. <LOGPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Upgrade": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Upgrade is the value that should be passed to the installer when user chooses an upgrade"
         },
         "Custom": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
         }
-      }
+      },
+      "minProperties": 1
     },
     "InstallerReturnCode": {
       "type": "integer",
       "format": "long",
       "not": {
-        "enum": [ 0 ]
+        "enum": [
+          0
+        ]
       },
       "minimum": -2147483648,
       "maximum": 4294967295,
       "description": "An exit code that can be returned by the installer after execution"
     },
     "InstallerSuccessCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/InstallerReturnCode"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional non-zero installer success exit codes other than known default values by winget"
     },
     "ExpectedReturnCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "object",
         "title": "ExpectedReturnCode",
@@ -180,13 +186,18 @@
               "blockedByPolicy"
             ]
           }
-        }
+        },
+        "required": [
+          "InstallerReturnCode",
+          "ReturnResponse"
+        ]
       },
+      "minItems": 1,
       "maxItems": 128,
       "description": "Installer exit codes for common errors"
     },
     "UpgradeBehavior": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "install",
         "uninstallPrevious"
@@ -194,65 +205,70 @@
       "description": "The upgrade method"
     },
     "Commands": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of commands or aliases to run the package"
     },
     "Protocols": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[a-z][-a-z0-9\\.\\+]*$",
         "maxLength": 2048
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },
     "FileExtensions": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[^\\\\/:\\*\\?\"<>\\|\\x01-\\x1f]+$",
         "maxLength": 64
       },
+      "minItems": 1,
       "maxItems": 256,
       "uniqueItems": true,
       "description": "List of file extensions the package could support"
     },
     "Dependencies": {
-      "type": [ "object", "null" ],
+      "type": "object",
       "properties": {
         "WindowsFeatures": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows library dependencies"
         },
         "PackageDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -265,17 +281,19 @@
             },
             "required": [ "PackageIdentifier" ]
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of package dependencies from current source"
         },
         "ExternalDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of external package dependencies"
@@ -283,35 +301,37 @@
       }
     },
     "PackageFamilyName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^[A-Za-z0-9][-\\.A-Za-z0-9]+_[A-Za-z0-9]{13}$",
       "maxLength": 255,
       "description": "PackageFamilyName for appx or msix installer. Could be used for correlation of packages across sources"
     },
     "ProductCode": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"
     },
     "Capabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer restricted capabilities"
@@ -322,8 +342,9 @@
       "description": "The installer target market"
     },
     "MarketArray": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "maxItems": 256,
       "items": {
         "$ref": "#/definitions/Market"
@@ -332,45 +353,38 @@
     },
     "Markets": {
       "description": "The installer markets",
-      "type": [ "object", "null" ],
-      "oneOf": [
-        {
-          "properties": {
-            "AllowedMarkets": {
-              "$ref": "#/definitions/MarketArray"
-            }
-          },
-          "required": [ "AllowedMarkets" ]
+      "type": "object",
+      "properties": {
+        "AllowedMarkets": {
+          "$ref": "#/definitions/MarketArray"
         },
-        {
-          "properties": {
-            "ExcludedMarkets": {
-              "$ref": "#/definitions/MarketArray"
-            }
-          },
-          "required": [ "ExcludedMarkets" ]
+        "ExcludedMarkets": {
+          "$ref": "#/definitions/MarketArray"
         }
-      ]
+      },
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false
     },
     "InstallerAbortsTerminal": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer will abort terminal. Default is false"
     },
     "ReleaseDate": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "format": "date",
       "description": "The installer release date"
     },
     "InstallLocationRequired": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer requires an install location provided"
     },
     "RequireExplicitUpgrade": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer should be pinned by default from upgrade"
     },
     "UnsupportedOSArchitectures": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
       "items": {
         "type": "string",
@@ -382,25 +396,26 @@
           "arm64"
         ]
       },
+      "minItems": 1,
       "description": "List of OS architectures the installer does not support"
     },
     "AppsAndFeaturesEntry": {
       "type": "object",
       "properties": {
         "DisplayName": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 256,
           "description": "The DisplayName registry value"
         },
         "Publisher": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 256,
           "description": "The Publisher registry value"
         },
         "DisplayVersion": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 128,
           "description": "The DisplayVersion registry value"
@@ -415,11 +430,13 @@
           "$ref": "#/definitions/InstallerType"
         }
       },
+      "minProperties": 1,
       "description": "Various key values under installer's ARP entry"
     },
     "AppsAndFeaturesEntries": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "maxItems": 128,
       "items": {
         "$ref": "#/definitions/AppsAndFeaturesEntry"
@@ -427,7 +444,7 @@
       "description": "List of ARP entries."
     },
     "ElevationRequirement": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "elevationRequired",
         "elevationProhibited",
@@ -476,7 +493,7 @@
           "description": "Sha256 is required. Sha256 of the installer"
         },
         "SignatureSha256": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "pattern": "^[A-Fa-f0-9]{64}$",
           "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
         },

--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -403,19 +403,19 @@
       "type": "object",
       "properties": {
         "DisplayName": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 256,
           "description": "The DisplayName registry value"
         },
         "Publisher": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 256,
           "description": "The Publisher registry value"
         },
         "DisplayVersion": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 128,
           "description": "The DisplayVersion registry value"

--- a/schemas/JSON/manifests/v1.1.0/manifest.locale.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.locale.1.1.0.json
@@ -4,13 +4,13 @@
   "description": "A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.1.0",
   "definitions": {
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package tag"
@@ -19,13 +19,13 @@
       "type": "object",
       "properties": {
         "AgreementLabel": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 100,
           "description": "The label of the Agreement. i.e. EULA, AgeRating, etc. This field should be localized. Either Agreement or AgreementUrl is required. When we show the agreements, we would Bold the AgreementLabel"
         },
         "Agreement": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 10000,
           "description": "The agreement text content."
@@ -34,7 +34,8 @@
           "$ref": "#/definitions/Url",
           "description": "The agreement URL."
         }
-      }
+      },
+      "minProperties": 1
     }
   },
   "type": "object",
@@ -58,7 +59,7 @@
       "description": "The package meta-data locale"
     },
     "Publisher": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The publisher name"
@@ -76,13 +77,13 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
     },
     "PackageName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package name"
@@ -92,7 +93,7 @@
       "description": "The package home page"
     },
     "License": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package license"
@@ -102,7 +103,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -112,35 +113,37 @@
       "description": "The package copyright page"
     },
     "ShortDescription": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 256,
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"
     },
     "Agreements": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Agreement"
       },
+      "minItems": 1,
       "maxItems": 128
     },
     "ReleaseNotes": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 10000,
       "description": "The package release notes"

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -16,19 +16,19 @@
       "description": "The package version"
     },
     "Locale": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$",
       "maxLength": 20,
       "description": "The package meta-data locale"
     },
     "Url": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^([Hh][Tt][Tt][Pp][Ss]?)://.+$",
       "maxLength": 2048,
       "description": "Optional Url type"
     },
     "Tag": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 40,
       "description": "Package moniker or tag"
@@ -37,13 +37,13 @@
       "type": "object",
       "properties": {
         "AgreementLabel": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 100,
           "description": "The label of the Agreement. i.e. EULA, AgeRating, etc. This field should be localized. Either Agreement or AgreementUrl is required. When we show the agreements, we would Bold the AgreementLabel"
         },
         "Agreement": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 10000,
           "description": "The agreement text content."
@@ -55,13 +55,13 @@
       }
     },
     "Channel": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 16,
       "description": "The distribution channel"
     },
     "Platform": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "Platform",
         "type": "string",
@@ -70,17 +70,18 @@
           "Windows.Universal"
         ]
       },
+      "minItems": 1,
       "maxItems": 2,
       "uniqueItems": true,
       "description": "The installer supported operating system"
     },
     "MinimumOSVersion": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$",
       "description": "The installer minimum operating system version"
     },
     "InstallerType": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "msix",
         "msi",
@@ -96,7 +97,7 @@
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
     "Scope": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "user",
         "machine"
@@ -104,7 +105,7 @@
       "description": "Scope indicates if the installer is per user or per machine"
     },
     "InstallModes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "title": "InstallModes",
         "type": "string",
@@ -114,6 +115,7 @@
           "silentWithProgress"
         ]
       },
+      "minItems": 1,
       "maxItems": 3,
       "uniqueItems": true,
       "description": "List of supported installer modes"
@@ -122,43 +124,43 @@
       "type": "object",
       "properties": {
         "Silent": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
         },
         "SilentWithProgress": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "SilentWithProgress is the value that should be passed to the installer when user chooses a non-interactive install"
         },
         "Interactive": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Interactive is the value that should be passed to the installer when user chooses an interactive install"
         },
         "InstallLocation": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "InstallLocation is the value passed to the installer for custom install location. <INSTALLPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Log": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Log is the value passed to the installer for custom log file path. <LOGPATH> token can be included in the switch value so that winget will replace the token with user provided path"
         },
         "Upgrade": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 512,
           "description": "Upgrade is the value that should be passed to the installer when user chooses an upgrade"
         },
         "Custom": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 2048,
           "description": "Custom switches will be passed directly to the installer by winget"
@@ -169,23 +171,26 @@
       "type": "integer",
       "format": "long",
       "not": {
-        "enum": [ 0 ]
+        "enum": [
+          0
+        ]
       },
       "minimum": -2147483648,
       "maximum": 4294967295,
       "description": "An exit code that can be returned by the installer after execution"
     },
     "InstallerSuccessCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/InstallerReturnCode"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional non-zero installer success exit codes other than known default values by winget"
     },
     "ExpectedReturnCodes": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "object",
         "title": "ExpectedReturnCode",
@@ -213,13 +218,15 @@
               "blockedByPolicy"
             ]
           }
-        }
+        },
+        "minProperties": 1
       },
+      "minItems": 1,
       "maxItems": 128,
       "description": "Installer exit codes for common errors"
     },
     "UpgradeBehavior": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "install",
         "uninstallPrevious"
@@ -227,65 +234,70 @@
       "description": "The upgrade method"
     },
     "Commands": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of commands or aliases to run the package"
     },
     "Protocols": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[a-z][-a-z0-9\\.\\+]*$",
         "maxLength": 2048
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },
     "FileExtensions": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "pattern": "^[^\\\\/:\\*\\?\"<>\\|\\x01-\\x1f]+$",
         "maxLength": 64
       },
+      "minItems": 1,
       "maxItems": 256,
       "uniqueItems": true,
       "description": "List of file extensions the package could support"
     },
     "Dependencies": {
-      "type": [ "object", "null" ],
+      "type": "object",
       "properties": {
         "WindowsFeatures": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of Windows library dependencies"
         },
         "PackageDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "object",
             "properties": {
@@ -296,54 +308,61 @@
                 "$ref": "#/definitions/PackageVersion"
               }
             },
-            "required": [ "PackageIdentifier" ]
+            "required": [
+              "PackageIdentifier"
+            ]
           },
+          "minItems": 1,
           "maxItems": 16,
           "description": "List of package dependencies from current source"
         },
         "ExternalDependencies": {
-          "type": [ "array", "null" ],
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 128
           },
+          "minItems": 1,
           "maxItems": 16,
           "uniqueItems": true,
           "description": "List of external package dependencies"
         }
-      }
+      },
+      "minProperties": 1
     },
     "PackageFamilyName": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "pattern": "^[A-Za-z0-9][-\\.A-Za-z0-9]+_[A-Za-z0-9]{13}$",
       "maxLength": 255,
       "description": "PackageFamilyName for appx or msix installer. Could be used for correlation of packages across sources"
     },
     "ProductCode": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 255,
       "description": "ProductCode could be used for correlation of packages across sources"
     },
     "Capabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "type": "string",
         "minLength": 1,
         "maxLength": 40
       },
+      "minItems": 1,
       "maxItems": 1000,
       "uniqueItems": true,
       "description": "List of appx or msix installer restricted capabilities"
@@ -354,8 +373,9 @@
       "description": "The installer target market"
     },
     "MarketArray": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "maxItems": 256,
       "items": {
         "$ref": "#/definitions/Market"
@@ -364,45 +384,38 @@
     },
     "Markets": {
       "description": "The installer markets",
-      "type": [ "object", "null" ],
-      "oneOf": [
-        {
-          "properties": {
-            "AllowedMarkets": {
-              "$ref": "#/definitions/MarketArray"
-            }
-          },
-          "required": [ "AllowedMarkets" ]
+      "type": "object",
+      "properties": {
+        "AllowedMarkets": {
+          "$ref": "#/definitions/MarketArray"
         },
-        {
-          "properties": {
-            "ExcludedMarkets": {
-              "$ref": "#/definitions/MarketArray"
-            }
-          },
-          "required": [ "ExcludedMarkets" ]
+        "ExcludedMarkets": {
+          "$ref": "#/definitions/MarketArray"
         }
-      ]
+      },
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false
     },
     "InstallerAbortsTerminal": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer will abort terminal. Default is false"
     },
     "ReleaseDate": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "format": "date",
       "description": "The installer release date"
     },
     "InstallLocationRequired": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer requires an install location provided"
     },
     "RequireExplicitUpgrade": {
-      "type": [ "boolean", "null" ],
+      "type": "boolean",
       "description": "Indicates whether the installer should be pinned by default from upgrade"
     },
     "UnsupportedOSArchitectures": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
       "items": {
         "type": "string",
@@ -420,19 +433,19 @@
       "type": "object",
       "properties": {
         "DisplayName": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 256,
           "description": "The DisplayName registry value"
         },
         "Publisher": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 256,
           "description": "The Publisher registry value"
         },
         "DisplayVersion": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "minLength": 1,
           "maxLength": 128,
           "description": "The DisplayVersion registry value"
@@ -447,11 +460,13 @@
           "$ref": "#/definitions/InstallerType"
         }
       },
+      "minProperties": 1,
       "description": "Various key values under installer's ARP entry"
     },
     "AppsAndFeaturesEntries": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "maxItems": 128,
       "items": {
         "$ref": "#/definitions/AppsAndFeaturesEntry"
@@ -459,7 +474,7 @@
       "description": "List of ARP entries."
     },
     "ElevationRequirement": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "enum": [
         "elevationRequired",
         "elevationProhibited",
@@ -508,7 +523,7 @@
           "description": "Sha256 is required. Sha256 of the installer"
         },
         "SignatureSha256": {
-          "type": [ "string", "null" ],
+          "type": "string",
           "pattern": "^[A-Fa-f0-9]{64}$",
           "description": "SignatureSha256 is recommended for appx or msix. It is the sha256 of signature file inside appx or msix. Could be used during streaming install if applicable"
         },
@@ -613,7 +628,7 @@
       "description": "The publisher privacy page or the package privacy page"
     },
     "Author": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 2,
       "maxLength": 256,
       "description": "The package author"
@@ -639,7 +654,7 @@
       "description": "The license page"
     },
     "Copyright": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 512,
       "description": "The package copyright"
@@ -655,7 +670,7 @@
       "description": "The short package description"
     },
     "Description": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 3,
       "maxLength": 10000,
       "description": "The full package description"
@@ -665,23 +680,25 @@
       "description": "The most common package term"
     },
     "Tags": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Tag"
       },
+      "minItems": 1,
       "maxItems": 16,
       "uniqueItems": true,
       "description": "List of additional package search terms"
     },
     "Agreements": {
-      "type": [ "array", "null" ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/Agreement"
       },
+      "minItems": 1,
       "maxItems": 128
     },
     "ReleaseNotes": {
-      "type": [ "string", "null" ],
+      "type": "string",
       "minLength": 1,
       "maxLength": 10000,
       "description": "The package release notes"

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -433,19 +433,19 @@
       "type": "object",
       "properties": {
         "DisplayName": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 256,
           "description": "The DisplayName registry value"
         },
         "Publisher": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 256,
           "description": "The Publisher registry value"
         },
         "DisplayVersion": {
-          "type": "string",
+          "type": ["string", "null"],
           "minLength": 1,
           "maxLength": 128,
           "description": "The DisplayVersion registry value"


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

The current schemas allow for some weird things to pass validation. Some JSON examples are at the bottom [here](https://www.jsonschemavalidator.net/s/jbqOELwy)

This PR does a few things
* Makes any field which is a string not able to be null - Due to the way schema validation works, this should mean that if a string property is present, then it is required to be not null, and, if the property is not present, it doesn't get validated against anyways, so this should still pass validation
* Makes all array types have a minimum of 1 item - There should never be a case where an array would be empty. If such a case exists, it would be for an installer level node to override a root level node, in which case the root level node should be moved to the installer level. All other cases, the property would be excluded from the manifest
* Makes object types have a minimum of 1 property - There should never be a case where an object would be empty. If such a case exists, it would again be for the case of overriding a root level node. 
* Makes any field which is a boolean not able to be null - This should mean that if a boolean property is present then it is required to be either true or false, and if the property is not present, it doesn't get validated anyways and should still pass validation
* Makes `InstallerReturnCode` and `ReturnResponse` required for each expected return code
* Changes the logic of markets to be easier to read - It should be functionally the same, but is a bit simpler

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2056)