### PR TITLE
Update portable spec with symlink solution design

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -522,6 +522,7 @@ subselect
 substr
 SWIPECONTROL
 SYMED
+symlink
 Sys
 sz
 TARG

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -523,6 +523,7 @@ substr
 SWIPECONTROL
 SYMED
 symlink
+symlinks
 Sys
 sz
 TARG

--- a/doc/specs/#182 - Support for installation of portable standalone apps.md
+++ b/doc/specs/#182 - Support for installation of portable standalone apps.md
@@ -73,7 +73,7 @@ By default, portable apps will be installed with the "User" scope unless specifi
 
 If the user chooses to install the same package but from a secondary source, the Windows Package Manager will append the source name to subdirectory. For example, if GitLabRunner is installed a second time but from the msstore, then the full path would be "%LOCALAPPDATA%/Microsoft/WinGet/Packages/Gitlab.GitLabRunner_msstore/". 
 
-The same behavior will be applied when creating a symlink in order to avoid overwriting an existing symlink of the same package but from a different source. Using the same example, the generated symlink for GitLabRunner from the mstore will have a full path of "%LOCALAPPDATA%/Microsoft/WinGet/Links/Gitlab.GitLabRunner_msstore.exe/"
+The same behavior will be applied when creating a symlink in order to avoid overwriting an existing symlink of the same package but from a different source. Using the same example, the generated symlink for GitLabRunner from the msstore will have a full path of "%LOCALAPPDATA%/Microsoft/WinGet/Links/Gitlab.GitLabRunner_msstore.exe/"
 
 ### Upgrade
 


### PR DESCRIPTION
The changes in this PR add specifications regarding the usage of symlinks to support installing portable apps. This is a change from our initial design which originally wrote to the "App Paths" registry as a means of registering/installing portable apps. However, this was determined to be insufficient as this would not support execution from the command prompt.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2075)