### PR TITLE
Fix exceptions breaking out of the multi-package install loop

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -438,12 +438,21 @@ namespace AppInstaller::CLI::Workflow
             auto previousThreadGlobals = installContext.SetForCurrentThread();
 
             installContext << Workflow::ReportIdentityAndInstallationDisclaimer;
-            if (!m_ignorePackageDependencies)
+
+            // Prevent individual exceptions from breaking out of the loop
+            try
             {
-                installContext << Workflow::ManagePackageDependencies(m_dependenciesReportMessage);
+                if (!m_ignorePackageDependencies)
+                {
+                    installContext << Workflow::ManagePackageDependencies(m_dependenciesReportMessage);
+                }
+                installContext << Workflow::DownloadInstaller;
+                installContext << Workflow::InstallPackageInstaller;
             }
-            installContext << Workflow::DownloadInstaller;
-            installContext << Workflow::InstallPackageInstaller;
+            catch (...)
+            {
+                installContext.SetTerminationHR(Workflow::HandleException(installContext, std::current_exception()));
+            }
 
             installContext.Reporter.Info() << std::endl;
 


### PR DESCRIPTION
Fixes #1442

## Change
Wrap the subexecution with a try/catch to prevent exceptions from breaking out of the mult-package install loop.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2089)