### PR TITLE
Fix packageId and sourceId match check for portable install

### DIFF
--- a/src/AppInstallerCLICore/Workflows/PortableInstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableInstallFlow.cpp
@@ -233,7 +233,7 @@ namespace AppInstaller::CLI::Workflow
 
             if(uninstallEntry.Exists())
             {
-                if (uninstallEntry.IsSamePortablePackageEntry(packageIdentifier, sourceIdentifier))
+                if (!uninstallEntry.IsSamePortablePackageEntry(packageIdentifier, sourceIdentifier))
                 {
                     // TODO: Replace HashOverride with --Force when argument behavior gets updated.
                     if (!context.Args.Contains(Execution::Args::Type::HashOverride))

--- a/src/AppInstallerCommonCore/PortableARPEntry.cpp
+++ b/src/AppInstallerCommonCore/PortableARPEntry.cpp
@@ -62,6 +62,7 @@ namespace AppInstaller::Registry::Portable
         }
         else
         {
+            m_exists = false;
             m_key = Key::Create(root, subKey);
         }
     }

--- a/src/AppInstallerCommonCore/Public/winget/PortableARPEntry.h
+++ b/src/AppInstallerCommonCore/Public/winget/PortableARPEntry.h
@@ -44,7 +44,7 @@ namespace AppInstaller::Registry::Portable
         Registry::Key GetKey() { return m_key; };
 
     private:
-        bool m_exists;
+        bool m_exists = false;
         Key m_key;
     };
 


### PR DESCRIPTION
Fixes a bug where the portable install flow should be checking whether ARP entry does NOT match the packageId or sourceId before blocking install.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2138)