### PR TITLE
Fixed builds on VS 2022 version 17.2.

### DIFF
--- a/src/AppInstallerCommonCore/GroupPolicy.cpp
+++ b/src/AppInstallerCommonCore/GroupPolicy.cpp
@@ -133,7 +133,7 @@ namespace AppInstaller::Settings
                 return std::nullopt;
             }
 
-            std::vector<Mapping::item_t> items;
+            std::vector<typename Mapping::item_t> items;
             for (const auto& value : listKey->Values())
             {
                 auto item = Mapping::ReadAndValidateItem(value);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.h
@@ -119,14 +119,14 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         template <typename... Tables>
         static auto GetIdsById(const SQLite::Connection& connection, SQLite::rowid_t id)
         {
-            return details::ManifestTableGetIdsById_Statement(connection, id, { Tables::ValueName()... }).GetRow<Tables::id_t...>();
+            return details::ManifestTableGetIdsById_Statement(connection, id, { Tables::ValueName()... }).GetRow<typename Tables::id_t...>();
         }
 
         // Gets the values requested for the manifest with the given rowid.
         template <typename... Tables>
         static auto GetValuesById(const SQLite::Connection& connection, SQLite::rowid_t id)
         {
-            return details::ManifestTableGetValuesById_Statement(connection, id, { SQLite::Builder::QualifiedColumn{ Tables::TableName(), Tables::ValueName() }... }).GetRow<Tables::value_t...>();
+            return details::ManifestTableGetValuesById_Statement(connection, id, { SQLite::Builder::QualifiedColumn{ Tables::TableName(), Tables::ValueName() }... }).GetRow<typename Tables::value_t...>();
         }
 
         // Gets the values for rows that match the given ids.
@@ -144,7 +144,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             std::vector<std::tuple<typename ValueTables::value_t...>> result;
             while (stmt.Step())
             {
-                result.emplace_back(stmt.GetRow<ValueTables::value_t...>());
+                result.emplace_back(stmt.GetRow<typename ValueTables::value_t...>());
             }
             return result;
         }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

For those of us who ~~keep forgetting minor VS version bumps change the compiler~~ enjoy living on the bleeding edge, Visual Studio 2022 was updated to version 17.2 this week, again breaking winget builds. This PR resolves the errors, by adding a missing `typename` keyword in a couple places.

The kicker is, I can't find a changelog (publicly) that mentions what changed to cause this. Nothing in the [STL changelog](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-172) looks to be it, and the [conformance changes](https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170) don't mention it either. This seems more correct anyway, so I think it is fine, but if anyone could shed some more light that would be great!

(My daily builds broke because GitHub Actions' image was updated this week. I believe hosted ADO pools use the same images, so I think the CI for this repo may have broken too? In any case, this fixes the issue.)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2156)