### PR TITLE
Display ReturnResponseUrl if present

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -226,6 +226,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PurgeInstallDirectory);
         WINGET_DEFINE_RESOURCE_STRINGID(QueryArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(RainbowArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(RelatedLink);
         WINGET_DEFINE_RESOURCE_STRINGID(RenameArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ReparsePointsNotSupportedError);
         WINGET_DEFINE_RESOURCE_STRINGID(ReportIdentityFound);

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -24,7 +24,7 @@ using namespace AppInstaller::Manifest;
 using namespace AppInstaller::Repository;
 using namespace AppInstaller::Settings;
 using namespace AppInstaller::Utility;
-
+using namespace AppInstaller::Utility::literals;
 
 namespace AppInstaller::CLI::Workflow
 {
@@ -377,6 +377,13 @@ namespace AppInstaller::CLI::Workflow
             {
                 auto returnCode = ExpectedReturnCode::GetExpectedReturnCode(expectedReturnCodeItr->second.ReturnResponseEnum);
                 context.Reporter.Error() << returnCode.Message << std::endl;
+
+                auto returnResponseUrl = expectedReturnCodeItr->second.ReturnResponseUrl;
+                if (!returnResponseUrl.empty())
+                {
+                    context.Reporter.Error() << Resource::String::RelatedLink << ": "_liv << returnResponseUrl << std::endl;
+                }
+
                 AICLI_TERMINATE_CONTEXT(returnCode.HResult);
             }
 

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1337,4 +1337,7 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="UnableToPurgeInstallDirectory" xml:space="preserve">
     <value>Cannot purge install directory, as it was not created by WinGet</value>
   </data>
+  <data name="RelatedLink" xml:space="preserve">
+    <value>Related Link</value>
+  </data>
 </root>

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_ExpectedReturnCodes.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_ExpectedReturnCodes.yaml
@@ -28,6 +28,7 @@ Installers:
             ReturnResponse: noNetwork
           - InstallerReturnCode: 8
             ReturnResponse: contactSupport
+            ReturnResponseUrl: https://TestReturnResponseUrl
           - InstallerReturnCode: 9
             ReturnResponse: rebootRequiredToFinish
           - InstallerReturnCode: 10
@@ -43,4 +44,4 @@ Installers:
           - InstallerReturnCode: 15
             ReturnResponse: blockedByPolicy
 ManifestType: singleton
-ManifestVersion: 1.1.0
+ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -814,6 +814,7 @@ TEST_CASE("InstallFlow_ExpectedReturnCodes", "[InstallFlow][workflow]")
     REQUIRE_TERMINATED_WITH(context, APPINSTALLER_CLI_ERROR_INSTALL_CONTACT_SUPPORT);
     REQUIRE(std::filesystem::exists(installResultPath.GetPath()));
     REQUIRE(installOutput.str().find(Resource::LocString(Resource::String::InstallFlowReturnCodeContactSupport).get()) != std::string::npos);
+    REQUIRE(installOutput.str().find("https://TestReturnResponseUrl") != std::string::npos);
 }
 
 TEST_CASE("InstallFlowWithNonApplicableArchitecture", "[InstallFlow][workflow]")


### PR DESCRIPTION
Resolves:  #1889

- Adds support for displaying an expectedReturnCode's returnResponseUrl if present. 
- Added a test to verify that the returnResponseUrl is correctly displayed

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2210)