### PR TITLE
Display documentations in show command

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -259,6 +259,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelCopyrightUrl);
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelDocumentations);
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelExternalDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelInstaller);
         WINGET_DEFINE_RESOURCE_STRINGID(ShowLabelInstallerLocale);

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -90,6 +90,24 @@ namespace AppInstaller::CLI::Workflow
         {
             info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelReleaseNotesUrl << ' ' << releaseNotesUrl << std::endl;
         }
+        auto documentations = manifest.CurrentLocalization.Get<Manifest::Localization::Documentations>();
+        if (!documentations.empty())
+        {
+            context.Reporter.Info() << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelDocumentations << std::endl;
+            for (const auto& documentation : documentations)
+            {
+                if (!documentation.DocumentLabel.empty())
+                {
+                    info << Execution::ManifestInfoEmphasis << documentation.DocumentLabel << ": "_liv;
+;               }
+
+                if (!documentation.DocumentUrl.empty())
+                {
+                    info << documentation.DocumentUrl << std::endl;
+                }
+            }
+        }
+
         auto agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
         if (!agreements.empty())
         {

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -99,7 +99,7 @@ namespace AppInstaller::CLI::Workflow
                 if (!documentation.DocumentLabel.empty())
                 {
                     info << Execution::ManifestInfoEmphasis << documentation.DocumentLabel << ": "_liv;
-;               }
+                }
 
                 if (!documentation.DocumentUrl.empty())
                 {

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1337,4 +1337,7 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="UnableToPurgeInstallDirectory" xml:space="preserve">
     <value>Cannot purge install directory, as it was not created by WinGet</value>
   </data>
+  <data name="ShowLabelDocumentations" xml:space="preserve">
+    <value>Documentations:</value>
+  </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1339,5 +1339,6 @@ Please specify one of them using the `--source` option to proceed.</value>
   </data>
   <data name="ShowLabelDocumentations" xml:space="preserve">
     <value>Documentations:</value>
+    <comment>Label for the list of documentation links relevant to the package</comment>
   </data>
 </root>


### PR DESCRIPTION
Resolves: #1984

- Adds support for displaying the documentation label and url provided in the manifest when invoking the show command

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2212)