### PR TITLE
Add simple stats to correlation result processing script

### DIFF
--- a/tools/CorrelationTestbed/Process-CorrelationResults.ps1
+++ b/tools/CorrelationTestbed/Process-CorrelationResults.ps1
@@ -5,6 +5,7 @@ Param(
 
 $resultFile = Join-Path $ResultsPath "results.csv"
 $failedFile = Join-Path $ResultsPath "failed.csv"
+$statsFile = Join-Path $ResultsPath "stats.json"
 
 if (Test-Path $resultFile)
 {
@@ -16,22 +17,48 @@ if (Test-Path $failedFile)
     Remove-Item $failedFile -Force
 }
 
+$stats = @{
+    Total = 0
+    Missing = 0
+    Completed = 0
+    Failed = 0
+    CorrelatePackageKnown = 0
+    CorrelateArchive = 0
+}
+
+# Aggregate results in a single CSV file
 foreach ($result in (Get-ChildItem $ResultsPath -Directory))
 {
+    $stats.Total++
+
     $resultJSON = Join-Path $result.FullName "install_and_correlate.json"
-    if (-not (Test-Path $resultJSON))
+    if (Test-Path $resultJSON)
     {
+        $resultObj = (Get-Content -Path $resultJSON -Encoding utf8 | ConvertFrom-Json)
+    }
+
+    if (-not $resultObj)
+    {
+        # Result JSON file does not exist or is empty
+        $stats.Missing++
         continue
     }
 
-    $resultObj = (Get-Content -Path $resultJSON -Encoding utf8 | ConvertFrom-Json)
-
     if ($resultObj.HRESULT -eq 0)
     {
+        $stats.Completed++
+        $stats.CorrelateArchive += $resultObj.CorrelateArchive
+        $stats.CorrelatePackageKnown += $resultObj.CorrelatePackageKnown
         Export-Csv -InputObject ($resultObj | Select-Object -Property * -ExcludeProperty @("Error", "Phase", "Action", "HRESULT") ) -Path $resultFile -Append
     }
     else
     {
+        $stats.Failed++
         Export-Csv -InputObject $resultObj -Path $failedFile -Append
     }
 }
+
+# Write some stats to a file for quick evaluation
+$stats.CorrelateArchiveRatio = $stats.CorrelateArchive / $stats.Completed
+$stats.CorrelatePackageKnownRatio = $stats.CorrelatePackageKnown / $stats.Completed
+$stats | ConvertTo-Json | Out-File $statsFile -Force

--- a/tools/CorrelationTestbed/Process-CorrelationResults.ps1
+++ b/tools/CorrelationTestbed/Process-CorrelationResults.ps1
@@ -59,6 +59,7 @@ foreach ($result in (Get-ChildItem $ResultsPath -Directory))
 }
 
 # Write some stats to a file for quick evaluation
+$stats.CompletedRatio = $stats.Completed / $stats.Total
 $stats.CorrelateArchiveRatio = $stats.CorrelateArchive / $stats.Completed
 $stats.CorrelatePackageKnownRatio = $stats.CorrelatePackageKnown / $stats.Completed
 $stats | ConvertTo-Json | Out-File $statsFile -Force

--- a/tools/CorrelationTestbed/Process-CorrelationResults.ps1
+++ b/tools/CorrelationTestbed/Process-CorrelationResults.ps1
@@ -18,7 +18,7 @@ if (Test-Path $failedFile)
 
 foreach ($result in (Get-ChildItem $ResultsPath -Directory))
 {
-    $resultJSON = Join-Path $result "install_and_correlate.json"
+    $resultJSON = Join-Path $result.FullName "install_and_correlate.json"
     if (-not (Test-Path $resultJSON))
     {
         continue


### PR DESCRIPTION
This changes the script that processes correlation results to produce simple stats of how many packages were correlated successfully. This can be used to easily evaluate if the correlation heuristic is doing well.

It also fixes an issue when running the script on powershell instead of pwsh, where a path join didn't use the full path and resulted in not being able to find the result JSON files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2229)