### PR TITLE
Portable Support as Stable Feature

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -187,11 +187,6 @@
           "description": "Enable use of MSI APIs rather than msiexec for MSI installs",
           "type": "boolean",
           "default": false
-        },
-        "portableInstall": {
-          "description": "Enable support for installing portable packages.",
-          "type": "boolean",
-          "default":  false
         }
       }
     }

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -599,7 +599,6 @@ namespace AppInstaller::CLI::Workflow
         if (installerType == InstallerTypeEnum::Portable)
         {
             context <<
-                Workflow::EnsureFeatureEnabled(Settings::ExperimentalFeature::Feature::PortableInstall) <<
                 EnsureValidArgsForPortableInstall <<
                 EnsureVolumeSupportsReparsePoints;
         }

--- a/src/AppInstallerCLIE2ETests/BaseCommand.cs
+++ b/src/AppInstallerCLIE2ETests/BaseCommand.cs
@@ -48,7 +48,6 @@ namespace AppInstallerCLIE2ETests
             ConfigureFeature("experimentalCmd", status);
             ConfigureFeature("dependencies", status);
             ConfigureFeature("directMSI", status);
-            ConfigureFeature("portableInstall", status);
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
+++ b/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
@@ -3,10 +3,6 @@
 
 namespace AppInstallerCLIE2ETests
 {
-    using System;
-    using System.IO;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using NUnit.Framework;
 
     public class FeaturesCommand : BaseCommand

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -12,12 +12,6 @@ namespace AppInstallerCLIE2ETests
         private const string InstallTestMsiProductId = @"{A5D36CF1-1993-4F63-BFB4-3ACD910D36A1}";
         private const string InstallTestMsixName = @"6c6338fe-41b7-46ca-8ba6-b5ad5312bb0e";
 
-        [OneTimeSetUp]
-        public void OneTimeSetup()
-        {
-            ConfigureFeature("portableInstall", true);
-        }
-
         [Test]
         public void InstallAppDoesNotExist()
         {

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -964,7 +964,6 @@ TEST_CASE("PortableInstallFlow", "[InstallFlow][workflow]")
     TestCommon::TempFile portableInstallResultPath("TestPortableInstalled.txt");
 
     TestCommon::TestUserSettings testSettings;
-    testSettings.Set<Setting::EFPortableInstall>(true);
 
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };

--- a/src/AppInstallerCommonCore/ExperimentalFeature.cpp
+++ b/src/AppInstallerCommonCore/ExperimentalFeature.cpp
@@ -42,8 +42,6 @@ namespace AppInstaller::Settings
                 return userSettings.Get<Setting::EFDependencies>();
             case ExperimentalFeature::Feature::DirectMSI:
                 return userSettings.Get<Setting::EFDirectMSI>();
-            case ExperimentalFeature::Feature::PortableInstall:
-                return userSettings.Get<Setting::EFPortableInstall>();
             default:
                 THROW_HR(E_UNEXPECTED);
             }
@@ -75,8 +73,6 @@ namespace AppInstaller::Settings
             return ExperimentalFeature{ "Show Dependencies Information", "dependencies", "https://aka.ms/winget-settings", Feature::Dependencies };
         case Feature::DirectMSI:
             return ExperimentalFeature{ "Direct MSI Installation", "directMSI", "https://aka.ms/winget-settings", Feature::DirectMSI };
-        case Feature::PortableInstall:
-            return ExperimentalFeature{ "Portable Installation", "portableInstall", "https://aka.ms/winget-settings", Feature::PortableInstall };
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -23,7 +23,6 @@ namespace AppInstaller::Settings
             Dependencies = 0x1,
             // Before making DirectMSI non-experimental, it should be part of manifest validation.
             DirectMSI = 0x2,
-            PortableInstall = 0x4,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -73,7 +73,6 @@ namespace AppInstaller::Settings
         EFExperimentalCmd,
         EFExperimentalArg,
         EFDependencies,
-        EFPortableInstall,
         TelemetryDisable,
         InstallScopePreference,
         InstallScopeRequirement,
@@ -129,7 +128,6 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFExperimentalCmd, bool, bool, false, ".experimentalFeatures.experimentalCmd"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFExperimentalArg, bool, bool, false, ".experimentalFeatures.experimentalArg"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDependencies, bool, bool, false, ".experimentalFeatures.dependencies"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::EFPortableInstall, bool, bool, false, ".experimentalFeatures.portableInstall"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitecturePreference, std::vector<std::string>, std::vector<Utility::Architecture>, {}, ".installBehavior.preferences.architectures"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallArchitectureRequirement, std::vector<std::string>, std::vector<Utility::Architecture>, {}, ".installBehavior.requirements.architectures"sv);

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -234,7 +234,6 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFExperimentalCmd)
         WINGET_VALIDATE_PASS_THROUGH(EFExperimentalArg)
         WINGET_VALIDATE_PASS_THROUGH(EFDependencies)
-        WINGET_VALIDATE_PASS_THROUGH(EFPortableInstall)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)


### PR DESCRIPTION
Changes:
- Makes support for portable apps stable and removes all code related to portable as an experimental feature.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2233)