### PR TITLE
Check symlink target before removal

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -341,6 +341,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SourceUpdateCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceUpdateOne);
         WINGET_DEFINE_RESOURCE_STRINGID(SystemArchitecture);
+        WINGET_DEFINE_RESOURCE_STRINGID(SymlinkModified);
         WINGET_DEFINE_RESOURCE_STRINGID(TagArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ThankYou);
         WINGET_DEFINE_RESOURCE_STRINGID(ThirdPartSoftwareNotices);

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -451,14 +451,14 @@ namespace AppInstaller::CLI::Workflow
             const auto& symlinkPath = uninstallEntry[PortableValueName::PortableSymlinkFullPath];
             if (symlinkPath.has_value())
             {
-                const std::filesystem::path& symlinkPathValue = symlinkPath.value().GetValue<Value::Type::UTF16String>();
+                const std::filesystem::path& symlinkPathValue = symlinkPath->GetValue<Value::Type::UTF16String>();
                 if (std::filesystem::is_symlink(std::filesystem::symlink_status(symlinkPathValue)))
                 {
                     const auto& targetPath = uninstallEntry[PortableValueName::PortableTargetFullPath];
                     if (targetPath.has_value())
                     {
                         const std::filesystem::path& symlinkTargetPath = std::filesystem::read_symlink(symlinkPathValue);
-                        const std::filesystem::path& targetPathValue = targetPath.value().GetValue<Value::Type::UTF16String>();
+                        const std::filesystem::path& targetPathValue = targetPath->GetValue<Value::Type::UTF16String>();
                         if (symlinkTargetPath != targetPathValue)
                         {
                             AICLI_LOG(CLI, Warning, << "Portable symlink not deleted; Symlink points to a different target exe: " << symlinkTargetPath <<

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -452,10 +452,28 @@ namespace AppInstaller::CLI::Workflow
             if (symlinkPath.has_value())
             {
                 const std::filesystem::path& symlinkPathValue = symlinkPath.value().GetValue<Value::Type::UTF16String>();
-
-                if (!std::filesystem::remove(symlinkPathValue))
+                if (std::filesystem::is_symlink(std::filesystem::symlink_status(symlinkPathValue)))
                 {
-                    AICLI_LOG(CLI, Info, << "Portable symlink not found; Unable to delete portable symlink: " << symlinkPathValue);
+                    const auto& targetPath = uninstallEntry[PortableValueName::PortableTargetFullPath];
+                    if (targetPath.has_value())
+                    {
+                        const std::filesystem::path& symlinkTargetPath = std::filesystem::read_symlink(symlinkPathValue);
+                        const std::filesystem::path& targetPathValue = targetPath.value().GetValue<Value::Type::UTF16String>();
+                        if (symlinkTargetPath != targetPathValue)
+                        {
+                            AICLI_LOG(CLI, Info, << "Portable symlink not deleted; Symlink points to a different target exe: " << symlinkTargetPath <<
+                                "; Expected target exe: " << targetPathValue);
+                            context.Reporter.Warn() << Resource::String::SymlinkModified << std::endl;
+                        }
+                        else if (!std::filesystem::remove(symlinkPathValue))
+                        {
+                            AICLI_LOG(CLI, Info, << "Portable symlink not found; Unable to delete portable symlink: " << symlinkPathValue);
+                        }
+                    }
+                    else
+                    {
+                        AICLI_LOG(CLI, Info, << "The registry value for [TargetFullPath] does not exist");
+                    }
                 }
             }
             else

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -461,7 +461,7 @@ namespace AppInstaller::CLI::Workflow
                         const std::filesystem::path& targetPathValue = targetPath.value().GetValue<Value::Type::UTF16String>();
                         if (symlinkTargetPath != targetPathValue)
                         {
-                            AICLI_LOG(CLI, Info, << "Portable symlink not deleted; Symlink points to a different target exe: " << symlinkTargetPath <<
+                            AICLI_LOG(CLI, Warning, << "Portable symlink not deleted; Symlink points to a different target exe: " << symlinkTargetPath <<
                                 "; Expected target exe: " << targetPathValue);
                             context.Reporter.Warn() << Resource::String::SymlinkModified << std::endl;
                         }

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\AppInstallerCLIE2ETests\</OutDir>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86</Platforms>

--- a/src/AppInstallerCLIE2ETests/UninstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/UninstallCommand.cs
@@ -80,7 +80,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void UninstallPortableWithProductCode()
         {
-            // Uninstall a Portable
+            // Uninstall a Portable with ProductCode
             string installDir = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Packages");
             string packageId, commandAlias, fileName, packageDirName, productCode;
             packageId = "AppInstallerTest.TestPortableExe";
@@ -92,6 +92,33 @@ namespace AppInstallerCLIE2ETests
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully uninstalled"));
             TestCommon.VerifyPortablePackage(Path.Combine(installDir, packageDirName), commandAlias, fileName, productCode, false);
+        }
+
+        [Test]
+        public void UninstallPortableModifiedSymlink()
+        {
+            string packageId, commandAlias;  
+            packageId = "AppInstallerTest.TestPortableExe";
+            commandAlias = "AppInstallerTestExeInstaller.exe";
+
+            TestCommon.RunAICLICommand("install", $"{packageId}");
+
+            string symlinkDirectory = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Links");
+            string symlinkPath = Path.Combine(symlinkDirectory, commandAlias);
+
+            // Replace symlink with modified symlink
+            File.Delete(symlinkPath);
+            File.CreateSymbolicLink(symlinkPath, "fakeTargetExe");
+            var result = TestCommon.RunAICLICommand("uninstall", $"{packageId}");
+
+            // Remove modified symlink as to not interfere with other tests
+            bool modifiedSymlinkExists = File.Exists(symlinkPath);
+            File.Delete(symlinkPath);
+
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+            Assert.True(result.StdOut.Contains("Successfully uninstalled"));
+            Assert.True(result.StdOut.Contains("Portable symlink not deleted as it points to a target exe that is different than expected"));
+            Assert.True(modifiedSymlinkExists, "Modified symlink should still exist");
         }
 
         [Test]

--- a/src/AppInstallerCLIE2ETests/UninstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/UninstallCommand.cs
@@ -108,16 +108,16 @@ namespace AppInstallerCLIE2ETests
 
             // Replace symlink with modified symlink
             File.Delete(symlinkPath);
-            File.CreateSymbolicLink(symlinkPath, "fakeTargetExe");
+            FileSystemInfo modifiedSymlinkInfo = File.CreateSymbolicLink(symlinkPath, "fakeTargetExe");
             var result = TestCommon.RunAICLICommand("uninstall", $"{packageId}");
 
             // Remove modified symlink as to not interfere with other tests
-            bool modifiedSymlinkExists = File.Exists(symlinkPath);
-            File.Delete(symlinkPath);
+            bool modifiedSymlinkExists = modifiedSymlinkInfo.Exists;
+            modifiedSymlinkInfo.Delete();
 
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully uninstalled"));
-            Assert.True(result.StdOut.Contains("Portable symlink not deleted as it points to a target exe that is different than expected"));
+            Assert.True(result.StdOut.Contains("Portable symlink not deleted as it was modified and points to a different target exe"));
             Assert.True(modifiedSymlinkExists, "Modified symlink should still exist");
         }
 

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1349,4 +1349,7 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="ShowLabelInstallationNotes" xml:space="preserve">
     <value>InstallationNotes:</value>
   </data>
+  <data name="SymlinkModified" xml:space="preserve">
+    <value>Portable symlink not deleted as it was modified and points to a different target exe</value>
+  </data>
 </root>


### PR DESCRIPTION
Resolves #2190 

Changes:
- Checks the target of the portable symlink to verify that it matches the target exe path that is stored in ARP.

Tests:
- Upgraded E2E tests to .NET6.0 to use File.CreateSymbolicLink()
- Added Uninstall Test to verify that the symlink will not be deleted if it does not match the target exe path.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2242)