### PR TITLE
Fix spacing in 1.2 singleton schema

### DIFF
--- a/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
@@ -610,7 +610,7 @@
           "$ref": "#/definitions/UnsupportedOSArchitectures"
         },
         "UnsupportedArguments": {
-          "$ref": " #/definitions/UnsupportedArguments"
+          "$ref": "#/definitions/UnsupportedArguments"
         },
         "AppsAndFeaturesEntries": {
           "$ref": "#/definitions/AppsAndFeaturesEntries"


### PR DESCRIPTION
Removes an extra space in the UnsupportedArg definition in the 1.2 singleton schema

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2276)