### PR TITLE
Fix unsupported args unit tests

### DIFF
--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1_2/ManifestV1_2-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1_2/ManifestV1_2-MultiFile-Installer.yaml
@@ -139,6 +139,8 @@ Installers:
       - InstallerReturnCode: 3
         ReturnResponse: custom
         ReturnResponseUrl: https://defaultReturnResponseUrl.com
+    UnsupportedArguments:
+      - location
   - Architecture: x64
     InstallerType: exe
     InstallerUrl: https://www.microsoft.com/msixsdk/msixsdkx64.exe
@@ -155,7 +157,5 @@ Installers:
      - InstallerReturnCode: 11
        ReturnResponse: custom
        ReturnResponseUrl: https://defaultReturnResponseUrl.com
-    UnsupportedArguments:
-      - location    
 ManifestType: installer
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -898,8 +898,9 @@ TEST_CASE("InstallFlow_UnsupportedArguments_NotProvided")
     // Verify unsupported arguments error message is not shown when not provided
     REQUIRE(context.GetTerminationHR() == S_OK);
     REQUIRE(std::filesystem::exists(installResultPath.GetPath()));
-    REQUIRE(installOutput.str().find(Resource::LocString(Resource::String::UnsupportedArgument).get() + " -o,--log") == std::string::npos);
-    REQUIRE(installOutput.str().find(Resource::LocString(Resource::String::UnsupportedArgument).get() + " -l,--location") == std::string::npos);
+    REQUIRE(installOutput.str().find(Resource::LocString(Resource::String::UnsupportedArgument).get()) == std::string::npos);
+    REQUIRE(installOutput.str().find("-o,--log") == std::string::npos);
+    REQUIRE(installOutput.str().find("-l,--location") == std::string::npos);
 }
 
 TEST_CASE("InstallFlow_ExpectedReturnCodes", "[InstallFlow][workflow]")

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -1637,7 +1637,8 @@ TEST_CASE("UpdateFlow_UpdateExeWithUnsupportedArgs", "[UpdateFlow][workflow]")
     // Verify unsupported arguments error message is shown 
     REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_UNSUPPORTED_ARGUMENT);
     REQUIRE(!std::filesystem::exists(updateResultPath.GetPath()));
-    REQUIRE(updateOutput.str().find(Resource::LocString(Resource::String::UnsupportedArgument).get() + " -l,--location") != std::string::npos);
+    REQUIRE(updateOutput.str().find(Resource::LocString(Resource::String::UnsupportedArgument).get()) != std::string::npos);
+    REQUIRE(updateOutput.str().find("-l,--location") != std::string::npos);
 }
 
 TEST_CASE("UpdateFlow_UpdatePortableWithManifest", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -547,7 +547,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
         REQUIRE(installer1.ExpectedReturnCodes.at(3).ReturnResponseEnum == ExpectedReturnCodeEnum::Custom);
         REQUIRE(installer1.ExpectedReturnCodes.at(3).ReturnResponseUrl == "https://defaultReturnResponseUrl.com");
         REQUIRE(installer1.UnsupportedArguments.size() == 1);
-        REQUIRE(installer1.UnsupportedArguments.at(1) == UnsupportedArgumentEnum::Location);
+        REQUIRE(installer1.UnsupportedArguments.at(0) == UnsupportedArgumentEnum::Location);
     }
 
     if (!isSingleton)
@@ -594,7 +594,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
             REQUIRE(installer3.ExpectedReturnCodes.at(11).ReturnResponseUrl == "https://defaultReturnResponseUrl.com");
             REQUIRE_FALSE(installer3.DisplayInstallWarnings);
             REQUIRE(installer3.UnsupportedArguments.size() == 1);
-            REQUIRE(installer3.UnsupportedArguments.at(0) == UnsupportedArgumentEnum::Location);
+            REQUIRE(installer3.UnsupportedArguments.at(0) == UnsupportedArgumentEnum::Log);
         }
 
         // Localization


### PR DESCRIPTION
Fixes several unit tests that were previously broken but didn't appear until a 1.2 schema typo was fixed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2277)