### PR TITLE
Mitigate crash that can occur when installed version is null

### DIFF
--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -343,7 +343,11 @@ namespace AppInstaller::Repository
             {
                 if (m_installedPackage)
                 {
-                    return std::make_shared<CompositeInstalledVersion>(m_installedPackage->GetInstalledVersion(), m_trackingSource, m_overrideInstalledVersion);
+                    auto installedVersion = m_installedPackage->GetInstalledVersion();
+                    if (installedVersion)
+                    {
+                        return std::make_shared<CompositeInstalledVersion>(std::move(installedVersion), m_trackingSource, m_overrideInstalledVersion);
+                    }
                 }
 
                 return {};
@@ -444,10 +448,14 @@ namespace AppInstaller::Repository
             {
                 if (m_installedPackage && m_availablePackage)
                 {
-                    auto installedType = Manifest::ConvertToInstallerTypeEnum(m_installedPackage->GetInstalledVersion()->GetMetadata()[PackageVersionMetadata::InstalledType]);
-                    if (Manifest::DoesInstallerTypeSupportArpVersionRange(installedType))
+                    auto installedVersion = m_installedPackage->GetInstalledVersion();
+                    if (installedVersion)
                     {
-                        m_overrideInstalledVersion = GetMappedInstalledVersion(m_installedPackage->GetInstalledVersion()->GetProperty(PackageVersionProperty::Version), m_availablePackage);
+                        auto installedType = Manifest::ConvertToInstallerTypeEnum(installedVersion->GetMetadata()[PackageVersionMetadata::InstalledType]);
+                        if (Manifest::DoesInstallerTypeSupportArpVersionRange(installedType))
+                        {
+                            m_overrideInstalledVersion = GetMappedInstalledVersion(installedVersion->GetProperty(PackageVersionProperty::Version), m_availablePackage);
+                        }
                     }
                 }
             }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -101,6 +101,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
                 // Get the last version in the list (the highest version) and its rowid
                 const std::string& latestVersion = versions.back().ToString();
                 versionIdOpt = VersionTable::SelectIdByValue(connection, latestVersion);
+
+                if (!versionIdOpt)
+                {
+                    AICLI_LOG(Repo, Warning, << "Did not find a Version row for the latest version { " << latestVersion << " }");
+                }
             }
             else
             {
@@ -109,7 +114,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
             if (!versionIdOpt)
             {
-                AICLI_LOG(Repo, Info, << "Did not find a Version { " << version << " }");
+                AICLI_LOG(Repo, Info, << "Did not find a Version for { " << version << " }");
                 return {};
             }
 


### PR DESCRIPTION
Mitigates #2273 for 1.3, but another change will hopefully be able to fully fix it.

## Change
Protect against the installed package returning a null installed version.  This should prevent crashes, while hiding the package from view.

I suspect that embedded nulls in the registry strings are causing the issues, and a future change will try to address that more comprehensively.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2278)