### PR TITLE
Add URL Handler to pass winget commands from a browser

### DIFF
--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -80,12 +80,30 @@ namespace AppInstaller::CLI
         Logging::BeginLogFileCleanup();
 
         context << Workflow::ReportExecutionStage(Workflow::ExecutionStage::ParseArgs);
-
-        // Convert incoming wide char args to UTF8
         std::vector<std::string> utf8Args;
-        for (int i = 1; i < argc; ++i)
+
+        if (wcsncmp(argv[1], L"winget:", 7) == 0) {
+            // Called by URI
+            std::wstring argString = argv[1];
+            std::string uriArgs = Utility::DecodeUrl(Utility::ConvertToUTF8(argString.substr(7)));
+            size_t pos = 0;
+            while ((pos = uriArgs.find(" ")) != std::string::npos) 
+            {
+                if (pos != 0)
+                {
+                    utf8Args.emplace_back(uriArgs.substr(0, pos));
+                }
+                uriArgs.erase(0, pos + 1);
+                }
+            utf8Args.emplace_back(uriArgs);
+        }
+        else
         {
-            utf8Args.emplace_back(Utility::ConvertToUTF8(argv[i]));
+            // Convert incoming wide char args to UTF8
+            for (int i = 1; i < argc; ++i)
+            {
+                utf8Args.emplace_back(Utility::ConvertToUTF8(argv[i]));
+            }
         }
 
         AICLI_LOG(CLI, Info, << "WinGet invoked with arguments:" << [&]() {

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -25,7 +25,9 @@
   </Resources>
   <Applications>
     <Application Id="WinGetDev" Executable="AppInstallerCLI\winget.exe" EntryPoint="Windows.FullTrustApplication">
-      <uap:VisualElements DisplayName="WinGet Dev Client" Square150x150Logo="Images\Square150x150Logo.png" Square44x44Logo="Images\Square44x44Logo.png" Description="The WinGet dev client." BackgroundColor="#0078d7" AppListEntry="none" />
+      <uap:VisualElements DisplayName="WinGet Dev Client" Square150x150Logo="Images\Square150x150Logo.png" Square44x44Logo="Images\Square44x44Logo.png" Description="The WinGet dev client." BackgroundColor="#0078d7" AppListEntry="none" >
+        <uap:DefaultTile/>
+      </uap:VisualElements >
       <Extensions>
         <uap3:Extension Category="windows.appExtensionHost">
           <uap3:AppExtensionHost>
@@ -55,6 +57,11 @@
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
+        <uap:Extension Category="windows.protocol" Executable="AppInstallerCLI/winget.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap:Protocol Name="winget">
+            <uap:DisplayName>Winget</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/src/AppInstallerCommonCore/AppInstallerStrings.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerStrings.cpp
@@ -140,6 +140,35 @@ namespace AppInstaller::Utility
         return result;
     }
 
+    std::string DecodeUrl(std::string input)
+    {
+        std::string decoded = input;
+        std::smatch sm;
+        std::string haystack;
+
+        std::size_t dynamicLength = decoded.size() - 2;
+
+        if (decoded.size() < 3) return decoded;
+
+        for (int i = 0; i < dynamicLength; i++)
+        {
+
+            haystack = decoded.substr(i, 3);
+
+            if (std::regex_match(haystack, sm, std::regex("%[0-9A-F]{2}")))
+            {
+                haystack = haystack.replace(0, 1, "0x");
+                std::string rc = { (char)std::stoi(haystack, nullptr, 16) };
+                decoded = decoded.replace(decoded.begin() + i, decoded.begin() + i + 3, rc);
+            }
+
+            dynamicLength = decoded.size() - 2;
+
+        }
+
+        return decoded;
+    }
+
     std::wstring ConvertToUTF16(std::string_view input, UINT codePage)
     {
         if (input.empty())

--- a/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerStrings.h
@@ -12,6 +12,8 @@ namespace AppInstaller::Utility
     // Converts the given UTF16 string to UTF8
     std::string ConvertToUTF8(std::wstring_view input);
 
+    std::string DecodeUrl(std::string input);
+
     // Converts the given UTF8 string to UTF16
     std::wstring ConvertToUTF16(std::string_view input, UINT codePage = CP_UTF8);
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

This change would allow publishers to provide direct links to install with winget in the form `winget:install Package.ID`
This also allows users to run any winget commands from their browser using `winget:<command>`

I'm almost certain I've done quite a few things wrong here, but just trying to use it as a learning opportunity for myself. If this isn't something which the team wants to support/implement yet, let me know and I'll close the PR.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2321)