### PR TITLE
Update VCLibs file hash in correlation test script

### DIFF
--- a/tools/CorrelationTestbed/Test-CorrelationInSandbox.ps1
+++ b/tools/CorrelationTestbed/Test-CorrelationInSandbox.ps1
@@ -164,7 +164,7 @@ $ProgressPreference = $oldProgressPreference
 $vcLibsUwp = @{
   fileName = 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
   url      = 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
-  hash     = 'A39CEC0E70BE9E3E48801B871C034872F1D7E5E8EEBE986198C019CF2C271040'
+  hash     = '9BFDE6CFCC530EF073AB4BC9C4817575F63BE1251DD75AAA58CB89299697A569'
   folderInLocal = Join-Path ${env:ProgramFiles(x86)} "Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail\x64"
 }
 $uiLibsUwp = @{


### PR DESCRIPTION
Update the hash for the VCLibs package to the latest version. See microsoft/winget-pkgs#65810


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2326)