### PR TITLE
Add InstallationMetadata to manifests for future deep installation detection

### DIFF
--- a/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
@@ -606,6 +606,9 @@
         "RequireExplicitUpgrade": {
           "$ref": "#/definitions/RequireExplicitUpgrade"
         },
+        "DisplayInstallWarnings": {
+          "$ref": "#/definitions/DisplayInstallWarnings"
+        },
         "UnsupportedOSArchitectures": {
           "$ref": "#/definitions/UnsupportedOSArchitectures"
         },
@@ -821,6 +824,9 @@
     },
     "RequireExplicitUpgrade": {
       "$ref": "#/definitions/RequireExplicitUpgrade"
+    },
+    "DisplayInstallWarnings": {
+      "$ref": "#/definitions/DisplayInstallWarnings"
     },
     "UnsupportedOSArchitectures": {
       "$ref": "#/definitions/UnsupportedOSArchitectures"

--- a/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
@@ -103,6 +103,7 @@
             "description": "The command alias to be used for calling the package. Only applies to the nested portable package"
           }
         },
+        "required": [ "RelativeFilePath" ],
         "description": "A nested installer file contained inside an archive"
       },
       "maxItems": 1024,

--- a/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
@@ -514,30 +514,57 @@
       ],
       "description": "The installer's elevation requirement"
     },
-    "InstalledLocation": {
-      "type": [ "string", "null" ],
-      "minLength": 1,
-      "maxLength": 2048,
-      "description": "Represents an installed package location. Used for deeper installation detection."
-    },
-    "InstalledFile": {
+    "InstallationMetadata": {
       "type": "object",
-      "title": "InstalledFile",
+      "title": "InstallationMetadata",
       "properties": {
-        "RelativeFilePath": {
-          "type": "string",
+        "DefaultInstallLocation": {
+          "type": [ "string", "null" ],
           "minLength": 1,
           "maxLength": 2048,
-          "description": "The relative path to the installed file"
+          "description": "Represents the default installed package location. Used for deeper installation detection."
         },
-        "FileSha256": {
-          "type": [ "string", "null" ],
-          "pattern": "^[A-Fa-f0-9]{64}$",
-          "description": "Sha256 is optional. Sha256 of the installed file"
+        "Files": {
+          "type": [ "array", "null" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "InstalledFile",
+            "properties": {
+              "RelativeFilePath": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "description": "The relative path to the installed file."
+              },
+              "FileSha256": {
+                "type": [ "string", "null" ],
+                "pattern": "^[A-Fa-f0-9]{64}$",
+                "description": "Optional Sha256 of the installed file."
+              },
+              "FileType": {
+                "type": [ "string", "null" ],
+                "enum": [
+                  "launch",
+                  "uninstall",
+                  "other"
+                ],
+                "description": "The optional installed file type. If not specified, the file is treated as other."
+              },
+              "InvocationParameter": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "description": "Optional parameter for invocable files."
+              }
+            },
+            "required": [ "RelativeFilePath" ],
+            "description": "Represents an installed file."
+          },
+          "description": "List of installed files."
         }
       },
-      "required": [ "RelativeFilePath" ],
-      "description": "Represents an installed file. Used for deeper installation detection."
+      "description": "Details about the installation. Used for deeper installation detection."
     },
     "Installer": {
       "type": "object",
@@ -651,11 +678,8 @@
         "ElevationRequirement": {
           "$ref": "#/definitions/ElevationRequirement"
         },
-        "DefaultInstallLocation": {
-          "$ref": "#/definitions/InstalledLocation"
-        },
-        "PrimaryExecutableFile": {
-          "$ref": "#/definitions/InstalledFile"
+        "InstallationMetadata": {
+          "$ref": "#/definitions/InstallationMetadata"
         }
       },
       "required": [
@@ -766,11 +790,8 @@
     "ElevationRequirement": {
       "$ref": "#/definitions/ElevationRequirement"
     },
-    "DefaultInstallLocation": {
-      "$ref": "#/definitions/InstalledLocation"
-    },
-    "PrimaryExecutableFile": {
-      "$ref": "#/definitions/InstalledFile"
+    "InstallationMetadata": {
+      "$ref": "#/definitions/InstallationMetadata"
     },
     "Installers": {
       "type": "array",

--- a/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.installer.1.3.0.json
@@ -514,6 +514,31 @@
       ],
       "description": "The installer's elevation requirement"
     },
+    "InstalledLocation": {
+      "type": [ "string", "null" ],
+      "minLength": 1,
+      "maxLength": 2048,
+      "description": "Represents an installed package location. Used for deeper installation detection."
+    },
+    "InstalledFile": {
+      "type": "object",
+      "title": "InstalledFile",
+      "properties": {
+        "RelativeFilePath": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "description": "The relative path to the installed file"
+        },
+        "FileSha256": {
+          "type": [ "string", "null" ],
+          "pattern": "^[A-Fa-f0-9]{64}$",
+          "description": "Sha256 is optional. Sha256 of the installed file"
+        }
+      },
+      "required": [ "RelativeFilePath" ],
+      "description": "Represents an installed file. Used for deeper installation detection."
+    },
     "Installer": {
       "type": "object",
       "properties": {
@@ -625,6 +650,12 @@
         },
         "ElevationRequirement": {
           "$ref": "#/definitions/ElevationRequirement"
+        },
+        "DefaultInstallLocation": {
+          "$ref": "#/definitions/InstalledLocation"
+        },
+        "PrimaryExecutableFile": {
+          "$ref": "#/definitions/InstalledFile"
         }
       },
       "required": [
@@ -720,6 +751,9 @@
     "RequireExplicitUpgrade": {
       "$ref": "#/definitions/RequireExplicitUpgrade"
     },
+    "DisplayInstallWarnings": {
+      "$ref": "#/definitions/DisplayInstallWarnings"
+    },
     "UnsupportedOSArchitectures": {
       "$ref": "#/definitions/UnsupportedOSArchitectures"
     },
@@ -732,8 +766,11 @@
     "ElevationRequirement": {
       "$ref": "#/definitions/ElevationRequirement"
     },
-    "DisplayInstallWarnings": {
-      "$ref": "#/definitions/DisplayInstallWarnings"
+    "DefaultInstallLocation": {
+      "$ref": "#/definitions/InstalledLocation"
+    },
+    "PrimaryExecutableFile": {
+      "$ref": "#/definitions/InstalledFile"
     },
     "Installers": {
       "type": "array",

--- a/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
@@ -145,6 +145,7 @@
             "description": "The command alias to be used for calling the package. Only applies to the nested portable package"
           }
         },
+        "required": [ "RelativeFilePath" ],
         "description": "A nested installer file contained inside an archive"
       },
       "maxItems": 1024,

--- a/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
@@ -555,6 +555,31 @@
       ],
       "description": "The installer's elevation requirement"
     },
+    "InstalledLocation": {
+      "type": [ "string", "null" ],
+      "minLength": 1,
+      "maxLength": 2048,
+      "description": "Represents an installed package location. Used for deeper installation detection."
+    },
+    "InstalledFile": {
+      "type": "object",
+      "title": "InstalledFile",
+      "properties": {
+        "RelativeFilePath": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "description": "The relative path to the installed file"
+        },
+        "FileSha256": {
+          "type": [ "string", "null" ],
+          "pattern": "^[A-Fa-f0-9]{64}$",
+          "description": "Sha256 is optional. Sha256 of the installed file"
+        }
+      },
+      "required": [ "RelativeFilePath" ],
+      "description": "Represents an installed file. Used for deeper installation detection."
+    },
     "Installer": {
       "type": "object",
       "properties": {
@@ -652,6 +677,9 @@
         "RequireExplicitUpgrade": {
           "$ref": "#/definitions/RequireExplicitUpgrade"
         },
+        "DisplayInstallWarnings": {
+          "$ref": "#/definitions/DisplayInstallWarnings"
+        },
         "UnsupportedOSArchitectures": {
           "$ref": "#/definitions/UnsupportedOSArchitectures"
         },
@@ -663,6 +691,12 @@
         },
         "ElevationRequirement": {
           "$ref": "#/definitions/ElevationRequirement"
+        },
+        "DefaultInstallLocation": {
+          "$ref": "#/definitions/InstalledLocation"
+        },
+        "PrimaryExecutableFile": {
+          "$ref": "#/definitions/InstalledFile"
         }
       },
       "required": [
@@ -874,6 +908,9 @@
     "RequireExplicitUpgrade": {
       "$ref": "#/definitions/RequireExplicitUpgrade"
     },
+    "DisplayInstallWarnings": {
+      "$ref": "#/definitions/DisplayInstallWarnings"
+    },
     "UnsupportedOSArchitectures": {
       "$ref": "#/definitions/UnsupportedOSArchitectures"
     },
@@ -885,6 +922,12 @@
     },
     "ElevationRequirement": {
       "$ref": "#/definitions/ElevationRequirement"
+    },
+    "DefaultInstallLocation": {
+      "$ref": "#/definitions/InstalledLocation"
+    },
+    "PrimaryExecutableFile": {
+      "$ref": "#/definitions/InstalledFile"
     },
     "Installers": {
       "type": "array",

--- a/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
+++ b/schemas/JSON/manifests/v1.3.0/manifest.singleton.1.3.0.json
@@ -555,30 +555,57 @@
       ],
       "description": "The installer's elevation requirement"
     },
-    "InstalledLocation": {
-      "type": [ "string", "null" ],
-      "minLength": 1,
-      "maxLength": 2048,
-      "description": "Represents an installed package location. Used for deeper installation detection."
-    },
-    "InstalledFile": {
+    "InstallationMetadata": {
       "type": "object",
-      "title": "InstalledFile",
+      "title": "InstallationMetadata",
       "properties": {
-        "RelativeFilePath": {
-          "type": "string",
+        "DefaultInstallLocation": {
+          "type": [ "string", "null" ],
           "minLength": 1,
           "maxLength": 2048,
-          "description": "The relative path to the installed file"
+          "description": "Represents the default installed package location. Used for deeper installation detection."
         },
-        "FileSha256": {
-          "type": [ "string", "null" ],
-          "pattern": "^[A-Fa-f0-9]{64}$",
-          "description": "Sha256 is optional. Sha256 of the installed file"
+        "Files": {
+          "type": [ "array", "null" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "InstalledFile",
+            "properties": {
+              "RelativeFilePath": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "description": "The relative path to the installed file."
+              },
+              "FileSha256": {
+                "type": [ "string", "null" ],
+                "pattern": "^[A-Fa-f0-9]{64}$",
+                "description": "Optional Sha256 of the installed file."
+              },
+              "FileType": {
+                "type": [ "string", "null" ],
+                "enum": [
+                  "launch",
+                  "uninstall",
+                  "other"
+                ],
+                "description": "The optional installed file type. If not specified, the file is treated as other."
+              },
+              "InvocationParameter": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "description": "Optional parameter for invocable files."
+              }
+            },
+            "required": [ "RelativeFilePath" ],
+            "description": "Represents an installed file."
+          },
+          "description": "List of installed files."
         }
       },
-      "required": [ "RelativeFilePath" ],
-      "description": "Represents an installed file. Used for deeper installation detection."
+      "description": "Details about the installation. Used for deeper installation detection."
     },
     "Installer": {
       "type": "object",
@@ -692,11 +719,8 @@
         "ElevationRequirement": {
           "$ref": "#/definitions/ElevationRequirement"
         },
-        "DefaultInstallLocation": {
-          "$ref": "#/definitions/InstalledLocation"
-        },
-        "PrimaryExecutableFile": {
-          "$ref": "#/definitions/InstalledFile"
+        "InstallationMetadata": {
+          "$ref": "#/definitions/InstallationMetadata"
         }
       },
       "required": [
@@ -923,11 +947,8 @@
     "ElevationRequirement": {
       "$ref": "#/definitions/ElevationRequirement"
     },
-    "DefaultInstallLocation": {
-      "$ref": "#/definitions/InstalledLocation"
-    },
-    "PrimaryExecutableFile": {
-      "$ref": "#/definitions/InstalledFile"
+    "InstallationMetadata": {
+      "$ref": "#/definitions/InstallationMetadata"
     },
     "Installers": {
       "type": "array",

--- a/src/AppInstallerCLITests/TestData/ManifestV1_3-Singleton.yaml
+++ b/src/AppInstallerCLITests/TestData/ManifestV1_3-Singleton.yaml
@@ -107,6 +107,13 @@ NestedInstallerType: msi
 NestedInstallerFiles:
   - RelativeFilePath: RelativeFilePath
     PortableCommandAlias: PortableCommandAlias
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+  Files:
+    - RelativeFilePath: "main.exe"
+      FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+      FileType: launch
+      InvocationParameter: "/arg"
 
 Installers:
   - Architecture: x86

--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1_3/ManifestV1_3-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1_3/ManifestV1_3-MultiFile-Installer.yaml
@@ -78,6 +78,13 @@ NestedInstallerType: msi
 NestedInstallerFiles:
   - RelativeFilePath: RelativeFilePath
     PortableCommandAlias: PortableCommandAlias
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+  Files:
+    - RelativeFilePath: "main.exe"
+      FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+      FileType: launch
+      InvocationParameter: "/arg"
 
 Installers:
   - Architecture: x86
@@ -171,5 +178,12 @@ Installers:
         PortableCommandAlias: portableAlias1
       - RelativeFilePath: relativeFilePath2
         PortableCommandAlias: portableAlias2
+    InstallationMetadata:
+      DefaultInstallLocation: "%ProgramFiles%\\TestApp2"
+      Files:
+      - RelativeFilePath: "main2.exe"
+        FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+        FileType: other
+        InvocationParameter: "/arg2"
 ManifestType: installer
 ManifestVersion: 1.3.0

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -482,6 +482,12 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
         REQUIRE(manifest.DefaultInstallerInfo.NestedInstallerFiles.size() == 1);
         REQUIRE(manifest.DefaultInstallerInfo.NestedInstallerFiles.at(0).RelativeFilePath == "RelativeFilePath");
         REQUIRE(manifest.DefaultInstallerInfo.NestedInstallerFiles.at(0).PortableCommandAlias == "PortableCommandAlias");
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.DefaultInstallLocation == "%ProgramFiles%\\TestApp");
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.Files.size() == 1);
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.Files.at(0).RelativeFilePath == "main.exe");
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.Files.at(0).FileType == InstalledFileTypeEnum::Launch);
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.Files.at(0).FileSha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
+        REQUIRE(manifest.DefaultInstallerInfo.InstallationMetadata.Files.at(0).InvocationParameter == "/arg");
     }
 
     if (isSingleton)
@@ -571,6 +577,13 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
         // NestedInstaller metadata should not be populated unless the InstallerType is zip.
         REQUIRE(installer1.NestedInstallerType == InstallerTypeEnum::Unknown);
         REQUIRE(installer1.NestedInstallerFiles.size() == 0);
+
+        REQUIRE(installer1.InstallationMetadata.DefaultInstallLocation == "%ProgramFiles%\\TestApp");
+        REQUIRE(installer1.InstallationMetadata.Files.size() == 1);
+        REQUIRE(installer1.InstallationMetadata.Files.at(0).RelativeFilePath == "main.exe");
+        REQUIRE(installer1.InstallationMetadata.Files.at(0).FileType == InstalledFileTypeEnum::Launch);
+        REQUIRE(installer1.InstallationMetadata.Files.at(0).FileSha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
+        REQUIRE(installer1.InstallationMetadata.Files.at(0).InvocationParameter == "/arg");
     }
 
     if (!isSingleton)
@@ -633,6 +646,12 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
             REQUIRE(installer4.NestedInstallerFiles.at(0).PortableCommandAlias == "portableAlias1");
             REQUIRE(installer4.NestedInstallerFiles.at(1).RelativeFilePath == "relativeFilePath2");
             REQUIRE(installer4.NestedInstallerFiles.at(1).PortableCommandAlias == "portableAlias2");
+            REQUIRE(installer4.InstallationMetadata.DefaultInstallLocation == "%ProgramFiles%\\TestApp2");
+            REQUIRE(installer4.InstallationMetadata.Files.size() == 1);
+            REQUIRE(installer4.InstallationMetadata.Files.at(0).RelativeFilePath == "main2.exe");
+            REQUIRE(installer4.InstallationMetadata.Files.at(0).FileType == InstalledFileTypeEnum::Other);
+            REQUIRE(installer4.InstallationMetadata.Files.at(0).FileSha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
+            REQUIRE(installer4.InstallationMetadata.Files.at(0).InvocationParameter == "/arg2");
         }
 
         // Localization

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -375,6 +375,27 @@ namespace AppInstaller::Manifest
         return result;
     }
 
+    InstalledFileTypeEnum ConvertToInstalledFileTypeEnum(const std::string& in)
+    {
+        std::string inStrLower = Utility::ToLower(in);
+        InstalledFileTypeEnum result = InstalledFileTypeEnum::Unknown;
+
+        if (inStrLower == "launch")
+        {
+            result = InstalledFileTypeEnum::Launch;
+        }
+        else if (inStrLower == "uninstall")
+        {
+            result = InstalledFileTypeEnum::Uninstall;
+        }
+        else if (inStrLower == "other")
+        {
+            result = InstalledFileTypeEnum::Other;
+        }
+
+        return result;
+    }
+
     std::string_view InstallerTypeToString(InstallerTypeEnum installerType)
     {
         switch (installerType)

--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -159,6 +159,14 @@ namespace AppInstaller::Manifest
         Location
     };
 
+    enum class InstalledFileTypeEnum
+    {
+        Unknown,
+        Launch,
+        Uninstall,
+        Other,
+    };
+
     enum class ManifestTypeEnum
     {
         Singleton,
@@ -253,6 +261,20 @@ namespace AppInstaller::Manifest
         string_t PortableCommandAlias;
     };
 
+    struct InstalledFile
+    {
+        string_t RelativeFilePath;
+        std::vector<BYTE> FileSha256;
+        InstalledFileTypeEnum FileType = InstalledFileTypeEnum::Other;
+        string_t InvocationParameter;
+    };
+
+    struct InstallationMetadataInfo
+    {
+        string_t DefaultInstallLocation;
+        std::vector<InstalledFile> Files;
+    };
+
     InstallerTypeEnum ConvertToInstallerTypeEnum(const std::string& in);
 
     UpdateBehaviorEnum ConvertToUpdateBehaviorEnum(const std::string& in);
@@ -270,6 +292,8 @@ namespace AppInstaller::Manifest
     ManifestTypeEnum ConvertToManifestTypeEnum(const std::string& in);
 
     ExpectedReturnCodeEnum ConvertToExpectedReturnCodeEnum(const std::string& in);
+
+    InstalledFileTypeEnum ConvertToInstalledFileTypeEnum(const std::string& in);
 
     std::string_view InstallerTypeToString(InstallerTypeEnum installerType);
 

--- a/src/AppInstallerCommonCore/Public/winget/ManifestInstaller.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestInstaller.h
@@ -104,5 +104,7 @@ namespace AppInstaller::Manifest
         ElevationRequirementEnum ElevationRequirement = ElevationRequirementEnum::Unknown;
 
         MarketsInfo Markets;
+
+        InstallationMetadataInfo InstallationMetadata;
     };
 }

--- a/src/AppInstallerCommonCore/Public/winget/ManifestYamlPopulator.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestYamlPopulator.h
@@ -43,6 +43,8 @@ namespace AppInstaller::Manifest
         std::vector<FieldProcessInfo> AppsAndFeaturesEntryFieldInfos;
         std::vector<FieldProcessInfo> DocumentationFieldInfos;
         std::vector<FieldProcessInfo> NestedInstallerFileFieldInfos;
+        std::vector<FieldProcessInfo> InstallationMetadataFieldInfos;
+        std::vector<FieldProcessInfo> InstallationMetadataFilesFieldInfos;
 
         // These pointers are referenced in the processing functions in manifest field process info table.
         AppInstaller::Manifest::Manifest* m_p_manifest = nullptr;
@@ -57,6 +59,8 @@ namespace AppInstaller::Manifest
         AppInstaller::Manifest::AppsAndFeaturesEntry* m_p_appsAndFeaturesEntry = nullptr;
         AppInstaller::Manifest::Documentation* m_p_documentation = nullptr;
         AppInstaller::Manifest::NestedInstallerFile* m_p_nestedInstallerFile = nullptr;
+        AppInstaller::Manifest::InstallationMetadataInfo* m_p_installationMetadata = nullptr;
+        AppInstaller::Manifest::InstalledFile* m_p_installedFile = nullptr;
 
         // Cache of Installers node and Localization node
         YAML::Node const* m_p_installersNode = nullptr;
@@ -74,6 +78,8 @@ namespace AppInstaller::Manifest
         std::vector<FieldProcessInfo> GetAppsAndFeaturesEntryFieldProcessInfo(const ManifestVer& manifestVersion);
         std::vector<FieldProcessInfo> GetDocumentationFieldProcessInfo(const ManifestVer& manifestVersion);
         std::vector<FieldProcessInfo> GetNestedInstallerFileFieldProcessInfo(const ManifestVer& manifestVersion);
+        std::vector<FieldProcessInfo> GetInstallationMetadataFieldProcessInfo(const ManifestVer& manifestVersion);
+        std::vector<FieldProcessInfo> GetInstallationMetadataFilesFieldProcessInfo(const ManifestVer& manifestVersion);
 
         // This method takes YAML root node and list of manifest field info.
         // Yaml lib does not support case insensitive search and it allows duplicate keys. If duplicate keys exist,
@@ -91,6 +97,7 @@ namespace AppInstaller::Manifest
         std::vector<ValidationError> ProcessExpectedReturnCodesNode(const YAML::Node& returnCodesNode);
         std::vector<ValidationError> ProcessDocumentationsNode(const YAML::Node& documentationsNode);
         std::vector<ValidationError> ProcessNestedInstallerFilesNode(const YAML::Node& nestedInstallerFilesNode);
+        std::vector<ValidationError> ProcessInstallationMetadataFilesNode(const YAML::Node& installedFilesNode);
 
         std::vector<ValidationError> PopulateManifestInternal(
             const YAML::Node& rootNode,


### PR DESCRIPTION
Also fixed v1.2 schema where DisplayInstallWarning is used in multi-file schema but missing in singleton schema.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2350)