### PR TITLE
Remove correlation blocker for remote->local in some cases

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -215,10 +215,10 @@
     <ClCompile Include="Archive.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
-    <ClCompile Include="Filesystem.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="FolderFileWatcher.cpp">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="Filesystem.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
   </ItemGroup>
@@ -482,7 +482,7 @@
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\TestZip.zip">
       <Filter>TestData</Filter>
-    </CopyFileToFolders>    
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_NoApplicableArchitecture.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
@@ -527,7 +527,7 @@
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_MultipleNonPortableNestedInstallers.yaml">
       <Filter>TestData</Filter>
-    </CopyFileToFolders>    
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallerArgTest_Msi_WithSwitches.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
@@ -569,7 +569,7 @@
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_ZipWithExe.yaml">
       <Filter>TestData</Filter>
-    </CopyFileToFolders>    
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\ImportFile-Good.json">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/FolderFileWatcher.cpp
+++ b/src/AppInstallerCLITests/FolderFileWatcher.cpp
@@ -187,10 +187,12 @@ TEST_CASE("FolderFileWatcher_CreateNewFilesAndDelete", "[FolderFileWatcher]")
         TempFile tempFile3(dirToWatch.GetPath(), "file3_", ".txt");
         tempFile3Path = tempFile3.GetPath();
         WriteText(tempFile3Path);
+        std::filesystem::remove(tempFile3Path);
 
         TempFile tempFile4(newTestDir, "file4_", ".txt");
         tempFile4Path = tempFile4.GetPath();
         WriteText(tempFile4Path);
+        std::filesystem::remove(tempFile4Path);
     }
 
     std::this_thread::sleep_for(100ms);
@@ -358,10 +360,12 @@ TEST_CASE("FolderFileWatcher_Extension_CreateNewFilesAndDelete", "[FolderFileWat
         TempFile tempFile3(dirToWatch.GetPath(), "file3_", ".txt");
         tempFile3Path = tempFile3.GetPath();
         WriteText(tempFile3Path);
+        std::filesystem::remove(tempFile3Path);
 
         TempFile tempFile4(newTestDir, "file4_", ".txt");
         tempFile4Path = tempFile4.GetPath();
         WriteText(tempFile4Path);
+        std::filesystem::remove(tempFile4Path);
     }
 
     std::this_thread::sleep_for(100ms);

--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -60,7 +60,7 @@
 #include <vector>
 
 #pragma warning( push )
-#pragma warning ( disable : 6001 6285 6287 6340 6388 )
+#pragma warning ( disable : 6001 6285 6287 6340 6387 6388 28196 )
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <wil/result_macros.h>

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -1054,12 +1054,6 @@ namespace AppInstaller::Repository
                 }
             }
 
-            // Do not attempt to correlate local packages against this source.
-            if (m_searchBehavior == CompositeSearchBehavior::Installed && !source.GetDetails().SupportInstalledSearchCorrelation)
-            {
-                continue;
-            }
-
             SearchResult availableResult = result.SearchAndHandleFailures(source, request);
 
             for (auto&& match : availableResult.Matches)


### PR DESCRIPTION
## Change
Remove a correlation block that was put in place to make things consistent, but was also preventing things like `winget uninstall PREINSTALLED-THING-THAT-IS-IN-STORE`.

Also fixes a build warning and test cases from an unrelated checkin.

## Validation
Can now `list` things using the Store ID even though you did not explicitly install them from the Store with `winget`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2362)