### PR TITLE
Fix file overwrite warning displayed on clean first install

### DIFF
--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -428,10 +428,10 @@ namespace AppInstaller::CLI::Workflow
                 AICLI_LOG(CLI, Info, << "Unable to create symlink. '" << symlinkFullPath << "points to an existing directory.");
                 AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_PORTABLE_SYMLINK_PATH_IS_DIRECTORY);
             }
-            else
+            else if (std::filesystem::remove(symlinkFullPath))
             {
-                context.Reporter.Warn() << Resource::String::OverwritingExistingFileAtMessage << symlinkFullPath.u8string() << std::endl;
-                std::filesystem::remove(symlinkFullPath);
+                AICLI_LOG(CLI, Info, << "Removed existing file at " << symlinkFullPath);
+                context.Reporter.Warn() << Resource::String::OverwritingExistingFileAtMessage << ' ' << symlinkFullPath.u8string() << std::endl;
             }
 
             std::filesystem::create_symlink(targetFullPath, symlinkFullPath);

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -160,7 +160,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void InstallPortableExe()
         {
-            string installDir = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Packages");
+            string installDir = TestCommon.GetPortablePackagesDirectory();
             string packageId, commandAlias, fileName, packageDirName, productCode;
             packageId = "AppInstallerTest.TestPortableExe";
             packageDirName = productCode = packageId + "_" + Constants.TestSourceIdentifier;
@@ -251,15 +251,15 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void InstallPortableFailsWithCleanup()
         {
-            string winGetDir = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet");
-            string installDir = Path.Combine(winGetDir, "Packages");
+            string installDir = TestCommon.GetPortablePackagesDirectory();
+            string winGetDir = Directory.GetParent(installDir).FullName;
             string packageId, commandAlias, fileName, packageDirName, productCode;
             packageId = "AppInstallerTest.TestPortableExe";
             packageDirName = productCode = packageId + "_" + Constants.TestSourceIdentifier;
             commandAlias = fileName = "AppInstallerTestExeInstaller.exe";
 
             // Create a directory with the same name as the symlink in order to cause install to fail.
-            string symlinkDirectory = Path.Combine(winGetDir, "Links");
+            string symlinkDirectory = TestCommon.GetPortableSymlinkDirectory();
             string conflictDirectory = Path.Combine(symlinkDirectory, commandAlias);
             Directory.CreateDirectory(conflictDirectory);
 
@@ -276,7 +276,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void ReinstallPortable()
         {
-            string installDir = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Packages");
+            string installDir = TestCommon.GetPortablePackagesDirectory();
             string packageId, commandAlias, fileName, packageDirName, productCode;
             packageId = "AppInstallerTest.TestPortableExe";
             packageDirName = productCode = packageId + "_" + Constants.TestSourceIdentifier;
@@ -285,7 +285,7 @@ namespace AppInstallerCLIE2ETests
             var result = TestCommon.RunAICLICommand("install", "AppInstallerTest.TestPortableExe");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
 
-            string symlinkDirectory = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Links");
+            string symlinkDirectory = TestCommon.GetPortableSymlinkDirectory();
             string symlinkPath = Path.Combine(symlinkDirectory, commandAlias);
 
             // Clean first install should not display file overwrite message.

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -274,6 +274,34 @@ namespace AppInstallerCLIE2ETests
         }
 
         [Test]
+        public void ReinstallPortable()
+        {
+            string installDir = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Packages");
+            string packageId, commandAlias, fileName, packageDirName, productCode;
+            packageId = "AppInstallerTest.TestPortableExe";
+            packageDirName = productCode = packageId + "_" + Constants.TestSourceIdentifier;
+            commandAlias = fileName = "AppInstallerTestExeInstaller.exe";
+
+            var result = TestCommon.RunAICLICommand("install", "AppInstallerTest.TestPortableExe");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+
+            string symlinkDirectory = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Links");
+            string symlinkPath = Path.Combine(symlinkDirectory, commandAlias);
+
+            // Clean first install should not display file overwrite message.
+            Assert.True(result.StdOut.Contains("Successfully installed"));
+            Assert.False(result.StdOut.Contains($"Overwriting existing file: {symlinkPath}"));
+
+            // Perform second install and verify that file overwrite message is displayed.
+            var result2 = TestCommon.RunAICLICommand("install", "AppInstallerTest.TestPortableExe");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result2.ExitCode);
+            Assert.True(result2.StdOut.Contains("Successfully installed"));
+            Assert.True(result2.StdOut.Contains($"Overwriting existing file: {symlinkPath}"));
+
+            TestCommon.VerifyPortablePackage(Path.Combine(installDir, packageDirName), commandAlias, fileName, productCode, true);
+        }
+
+        [Test]
         public void InstallZipWithExe()
         {
             var installDir = TestCommon.GetRandomTestDir();

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -280,6 +280,16 @@ namespace AppInstallerCLIE2ETests
             return RunCommand("powershell", $"Get-AppxPackage \"{name}\" | Remove-AppxPackage");
         }
 
+        public static string GetPortableSymlinkDirectory()
+        {
+            return Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Links");
+        }
+
+        public static string GetPortablePackagesDirectory()
+        {
+            return Path.Combine(Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Packages");
+        }
+
         public static void VerifyPortablePackage(
             string installDir,
             string commandAlias,
@@ -290,7 +300,7 @@ namespace AppInstallerCLIE2ETests
             string exePath = Path.Combine(installDir, filename);
             bool exeExists = File.Exists(exePath);
 
-            string symlinkDirectory = Path.Combine(System.Environment.GetEnvironmentVariable("LocalAppData"), "Microsoft", "WinGet", "Links");
+            string symlinkDirectory = GetPortableSymlinkDirectory();
             string symlinkPath = Path.Combine(symlinkDirectory, commandAlias);
             bool symlinkExists = File.Exists(symlinkPath);
 


### PR DESCRIPTION
Fixes #2327 

Changes:
Fixes a big where the file overwrite warning was shown on every install including clean first installs. Modified the logic so that the warning only shows if a file is removed.

Tests:
Added an E2E test that installs a portable package twice. Verifies that the warning is only shown during the second install and not the first.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2375)