### PR TITLE
Ensure default values are passed to nested installers within zip

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -195,6 +195,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(NameArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(NestedInstallerNotFound);
         WINGET_DEFINE_RESOURCE_STRINGID(NestedInstallerNotSpecified);
+        WINGET_DEFINE_RESOURCE_STRINGID(NestedInstallerNotSupported);
         WINGET_DEFINE_RESOURCE_STRINGID(NoApplicableInstallers);
         WINGET_DEFINE_RESOURCE_STRINGID(NoExperimentalFeaturesMessage);
         WINGET_DEFINE_RESOURCE_STRINGID(NoInstalledPackageFound);

--- a/src/AppInstallerCLICore/Workflows/ArchiveFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ArchiveFlow.cpp
@@ -71,6 +71,13 @@ namespace AppInstaller::CLI::Workflow
 
         if (IsArchiveType(installer.BaseInstallerType))
         {
+            if (!IsNestedInstallerTypeSupported(installer.NestedInstallerType))
+            {
+                AICLI_LOG(CLI, Error, << "Nested installer type not supported: " << installer.NestedInstallerType);
+                context.Reporter.Error() << Resource::String::NestedInstallerNotSupported << std::endl;
+                AICLI_TERMINATE_CONTEXT(ERROR_NOT_SUPPORTED);
+            }
+
             auto const& nestedInstallerFiles = installer.NestedInstallerFiles;
             if (nestedInstallerFiles.empty())
             {

--- a/src/AppInstallerCLICore/Workflows/ArchiveFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ArchiveFlow.cpp
@@ -69,7 +69,7 @@ namespace AppInstaller::CLI::Workflow
     {
         auto installer = context.Get<Execution::Data::Installer>().value();
 
-        if (IsArchiveType(installer.InstallerType))
+        if (IsArchiveType(installer.BaseInstallerType))
         {
             auto const& nestedInstallerFiles = installer.NestedInstallerFiles;
             if (nestedInstallerFiles.empty())

--- a/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
@@ -217,7 +217,7 @@ namespace AppInstaller::CLI::Workflow
                 Logging::Telemetry().LogSelectedInstaller(
                     static_cast<int>(itr->second.Installer.Arch),
                     itr->second.Installer.Url,
-                    Manifest::InstallerTypeToString(itr->second.Installer.InstallerType),
+                    Manifest::InstallerTypeToString(itr->second.Installer.EffectiveInstallerType()),
                     Manifest::ScopeToString(itr->second.Installer.Scope),
                     itr->second.Installer.Locale);
 

--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -33,7 +33,7 @@ namespace AppInstaller::CLI::Workflow
         std::wstring_view GetInstallerFileExtension(Execution::Context& context)
         {
             const auto& installer = context.Get<Execution::Data::Installer>();
-            switch (installer->InstallerType)
+            switch (installer->BaseInstallerType)
             {
             case InstallerTypeEnum::Burn:
             case InstallerTypeEnum::Exe:
@@ -143,7 +143,7 @@ namespace AppInstaller::CLI::Workflow
         if (!context.Contains(Execution::Data::InstallerPath))
         {
             const auto& installer = context.Get<Execution::Data::Installer>().value();
-            switch (installer.InstallerType)
+            switch (installer.BaseInstallerType)
             {
             case InstallerTypeEnum::Exe:
             case InstallerTypeEnum::Burn:
@@ -183,7 +183,7 @@ namespace AppInstaller::CLI::Workflow
     void CheckForExistingInstaller(Execution::Context& context)
     {
         const auto& installer = context.Get<Execution::Data::Installer>().value();
-        if (installer.InstallerType == InstallerTypeEnum::MSStore)
+        if (installer.EffectiveInstallerType() == InstallerTypeEnum::MSStore)
         {
             // No installer is downloaded in this case
             return;
@@ -415,12 +415,12 @@ namespace AppInstaller::CLI::Workflow
             auto existingFileHash = SHA256::ComputeHash(inStream);
             context.Add<Execution::Data::HashPair>(std::make_pair(installer.Sha256, existingFileHash));
         }
-        else if (installer.InstallerType == InstallerTypeEnum::MSStore)
+        else if (installer.EffectiveInstallerType() == InstallerTypeEnum::MSStore)
         {
             // No installer file in this case
             return;
         }
-        else if (installer.InstallerType == InstallerTypeEnum::Msix && !installer.SignatureSha256.empty())
+        else if (installer.EffectiveInstallerType() == InstallerTypeEnum::Msix && !installer.SignatureSha256.empty())
         {
             // We didn't download the installer file before. Just verify the signature hash again.
             context << GetMsixSignatureHash;

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -77,7 +77,7 @@ namespace AppInstaller::CLI::Workflow
         {
             auto installer = context.Get<Execution::Data::Installer>().value();
 
-            if (IsArchiveType(installer.InstallerType))
+            if (IsArchiveType(installer.BaseInstallerType))
             {
                 context <<
                     Workflow::EnsureFeatureEnabled(Settings::ExperimentalFeature::Feature::ZipInstall);
@@ -217,7 +217,7 @@ namespace AppInstaller::CLI::Workflow
 
     void ShowInstallationDisclaimer(Execution::Context& context)
     {
-        auto installerType = context.Get<Execution::Data::Installer>().value().InstallerType;
+        auto installerType = context.Get<Execution::Data::Installer>().value().EffectiveInstallerType();
 
         if (installerType == InstallerTypeEnum::MSStore)
         {
@@ -387,7 +387,7 @@ namespace AppInstaller::CLI::Workflow
 
     void ExecuteInstaller(Execution::Context& context)
     {
-        context << Workflow::ExecuteInstallerForType(context.Get<Execution::Data::Installer>().value().InstallerType);
+        context << Workflow::ExecuteInstallerForType(context.Get<Execution::Data::Installer>().value().BaseInstallerType);
     }
 
     void ArchiveInstall(Execution::Context& context)
@@ -645,7 +645,7 @@ namespace AppInstaller::CLI::Workflow
         // Ensure that installer type might actually write to ARP, otherwise this is a waste of time
         auto installer = context.Get<Execution::Data::Installer>();
 
-        if (installer && MightWriteToARP(installer->InstallerType))
+        if (installer && MightWriteToARP(installer->EffectiveInstallerType()))
         {
             Repository::Correlation::ARPCorrelationData data;
             data.CapturePreInstallSnapshot();

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -13,7 +13,7 @@ std::ostream& operator<<(std::ostream& out, const AppInstaller::Manifest::Manife
 {
     return out << '[' <<
         AppInstaller::Utility::ToString(installer.Arch) << ',' <<
-        AppInstaller::Manifest::InstallerTypeToString(installer.InstallerType) << ',' <<
+        AppInstaller::Manifest::InstallerTypeToString(installer.EffectiveInstallerType()) << ',' <<
         AppInstaller::Manifest::ScopeToString(installer.Scope) << ',' <<
         installer.Locale << ']';
 }
@@ -30,7 +30,7 @@ namespace AppInstaller::CLI::Workflow
             {
                 // Unvirtualized resources restricted capability is only supported for >= 10.0.18362
                 // TODO: Add support for OS versions that don't support virtualization.
-                if (installer.InstallerType == InstallerTypeEnum::Portable && !Runtime::IsCurrentOSVersionGreaterThanOrEqual(Utility::Version("10.0.18362")))
+                if (installer.EffectiveInstallerType() == InstallerTypeEnum::Portable && !Runtime::IsCurrentOSVersionGreaterThanOrEqual(Utility::Version("10.0.18362")))
                 {
                     return InapplicabilityFlags::OSVersion;
                 }
@@ -218,7 +218,7 @@ namespace AppInstaller::CLI::Workflow
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
                 // The installer is applicable if it's type or any of its ARP entries' type matches the installed type
-                if (Manifest::IsInstallerTypeCompatible(installer.InstallerType, m_installedType))
+                if (Manifest::IsInstallerTypeCompatible(installer.EffectiveInstallerType(), m_installedType))
                 {
                     return InapplicabilityFlags::None;
                 }
@@ -238,7 +238,7 @@ namespace AppInstaller::CLI::Workflow
             std::string ExplainInapplicable(const Manifest::ManifestInstaller& installer) override
             {
                 std::string result = "Installed package type '" + std::string{ Manifest::InstallerTypeToString(m_installedType) } +
-                    "' is not compatible with installer type " + std::string{ Manifest::InstallerTypeToString(installer.InstallerType) };
+                    "' is not compatible with installer type " + std::string{ Manifest::InstallerTypeToString(installer.EffectiveInstallerType()) };
 
                 std::string arpInstallerTypes;
                 for (const auto& entry : installer.AppsAndFeaturesEntries)
@@ -256,7 +256,7 @@ namespace AppInstaller::CLI::Workflow
 
             bool IsFirstBetter(const Manifest::ManifestInstaller& first, const Manifest::ManifestInstaller& second) override
             {
-                return (first.InstallerType == m_installedType && second.InstallerType != m_installedType);
+                return (first.EffectiveInstallerType() == m_installedType && second.EffectiveInstallerType() != m_installedType);
             }
 
         private:
@@ -287,7 +287,7 @@ namespace AppInstaller::CLI::Workflow
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
                 // We have to assume the unknown scope will match our required scope, or the entire catalog would stop working for upgrade.
-                if (installer.Scope == Manifest::ScopeEnum::Unknown || installer.Scope == m_requirement || DoesInstallerIgnoreScopeFromManifest(installer))
+                if (installer.Scope == Manifest::ScopeEnum::Unknown || installer.Scope == m_requirement || DoesInstallerTypeIgnoreScopeFromManifest(installer.EffectiveInstallerType()))
                 {
                     return InapplicabilityFlags::None;
                 }
@@ -342,7 +342,7 @@ namespace AppInstaller::CLI::Workflow
 
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
-                if (m_requirement == Manifest::ScopeEnum::Unknown || installer.Scope == m_requirement || DoesInstallerIgnoreScopeFromManifest(installer))
+                if (m_requirement == Manifest::ScopeEnum::Unknown || installer.Scope == m_requirement || DoesInstallerTypeIgnoreScopeFromManifest(installer.EffectiveInstallerType()))
                 {
                     return InapplicabilityFlags::None;
                 }

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -653,7 +653,7 @@ namespace AppInstaller::CLI::Workflow
 
     void EnsureSupportForPortableInstall(Execution::Context& context)
     {
-        auto installerType = context.Get<Execution::Data::Installer>().value().InstallerType;
+        auto installerType = context.Get<Execution::Data::Installer>().value().EffectiveInstallerType();
 
         if (installerType == InstallerTypeEnum::Portable)
         {

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -173,7 +173,7 @@ namespace AppInstaller::CLI::Workflow
         info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstaller << std::endl;
         if (installer)
         {
-            info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerType << ' ' << Manifest::InstallerTypeToString(installer->InstallerType) << std::endl;
+            info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerType << ' ' << Manifest::InstallerTypeToString(installer->BaseInstallerType) << std::endl;
             if (!installer->Locale.empty())
             {
                 info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerLocale << ' ' << installer->Locale << std::endl;

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -173,7 +173,18 @@ namespace AppInstaller::CLI::Workflow
         info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstaller << std::endl;
         if (installer)
         {
-            info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerType << ' ' << Manifest::InstallerTypeToString(installer->BaseInstallerType) << std::endl;
+            Manifest::InstallerTypeEnum effectiveInstallerType = installer->EffectiveInstallerType();
+            Manifest::InstallerTypeEnum baseInstallerType = installer->BaseInstallerType;
+            if (effectiveInstallerType == baseInstallerType)
+            {
+                info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerType << ' ' << Manifest::InstallerTypeToString(effectiveInstallerType) << std::endl;
+            }
+            else
+            {
+                info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerType << ' ' << Manifest::InstallerTypeToString(effectiveInstallerType) << " (" <<
+                    Manifest::InstallerTypeToString(baseInstallerType) << ')' << std::endl;
+            }
+
             if (!installer->Locale.empty())
             {
                 info << "  "_liv << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelInstallerLocale << ' ' << installer->Locale << std::endl;

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -73,7 +73,7 @@ namespace AppInstaller::CLI::Workflow
                 Logging::Telemetry().LogSelectedInstaller(
                     static_cast<int>(installer->Arch),
                     installer->Url,
-                    Manifest::InstallerTypeToString(installer->InstallerType),
+                    Manifest::InstallerTypeToString(installer->EffectiveInstallerType()),
                     Manifest::ScopeToString(installer->Scope),
                     installer->Locale);
 

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1027,7 +1027,7 @@ namespace AppInstaller::CLI::Workflow
             Logging::Telemetry().LogSelectedInstaller(
                 static_cast<int>(installer->Arch),
                 installer->Url,
-                Manifest::InstallerTypeToString(installer->InstallerType),
+                Manifest::InstallerTypeToString(installer->EffectiveInstallerType()),
                 Manifest::ScopeToString(installer->Scope),
                 installer->Locale);
         }
@@ -1072,7 +1072,7 @@ namespace AppInstaller::CLI::Workflow
             {
                 searchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::Exact, installer.ProductCode));
             }
-            else if (installer.InstallerType == Manifest::InstallerTypeEnum::Portable)
+            else if (installer.EffectiveInstallerType() == Manifest::InstallerTypeEnum::Portable)
             {
                 const auto& productCode = Utility::MakeSuitablePathPart(manifest.Id + "_" + source.GetIdentifier());
                 searchRequest.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::CaseInsensitive, Utility::Normalize(productCode)));

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -96,11 +96,6 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void InstallMSI()
         {
-            if (string.IsNullOrEmpty(TestCommon.MsiInstallerPath))
-            {
-                Assert.Ignore("MSI installer not available");
-            }
-
             var installDir = TestCommon.GetRandomTestDir();
             var result = TestCommon.RunAICLICommand("install", $"TestMsiInstaller --silent -l {installDir}");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
@@ -355,14 +350,9 @@ namespace AppInstallerCLIE2ETests
             Assert.True(result.StdOut.Contains("Invalid relative file path to the nested installer; path points to a location outside of the install directory"));
         }
 
-        [Test, Ignore("Re-enable as part of fixing #2392")]
+        [Test]
         public void InstallZipWithMsi()
         {
-            if (string.IsNullOrEmpty(TestCommon.MsiInstallerPath))
-            {
-                Assert.Ignore("MSI installer not available");
-            }
-
             var installDir = TestCommon.GetRandomTestDir();
             var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestZipInstallerWithMsi --silent -l {installDir}");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);

--- a/src/AppInstallerCLIE2ETests/ListCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ListCommand.cs
@@ -22,6 +22,8 @@ namespace AppInstallerCLIE2ETests
             string productCode = guid.ToString();
             var installDir = TestCommon.GetRandomTestDir();
 
+            // DisplayName must be set to avoid conflicts with other packages that use the same exe installer.
+            string displayName = "TestExeInstaller";
             string localAppDataPath = System.Environment.GetEnvironmentVariable(Constants.LocalAppData);
             string logFilePath = System.IO.Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
             logFilePath = System.IO.Path.Combine(logFilePath, "ListAfterInstall-" + System.IO.Path.GetRandomFileName() + ".log");
@@ -29,7 +31,7 @@ namespace AppInstallerCLIE2ETests
             var result = TestCommon.RunAICLICommand("list", productCode);
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
 
-            result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestExeInstaller --override \"/InstallDir {installDir} /ProductID {productCode} /LogFile {logFilePath}\"");
+            result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestExeInstaller --override \"/InstallDir {installDir} /ProductID {productCode} /LogFile {logFilePath} /DisplayName {displayName}\"");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
 
             result = TestCommon.RunAICLICommand("list", productCode);

--- a/src/AppInstallerCLIE2ETests/Test.runsettings
+++ b/src/AppInstallerCLIE2ETests/Test.runsettings
@@ -15,7 +15,8 @@
        InvokeCommandInDesktopPackage: Bool to indicate using Invoke-CommandInDesktopPackage for test execution.
                                       This is used when AppExecutionAlias is not available, or disabled.
        StaticFileRootPath: Path to the set of static test files that will be served as the source for testing purposes.
-	   MsixTestInstallerPath : The MSIX (or APPX) Installer executable under test.
+       MsiTestInstallerPath: The Msi Installer executable under test.
+	   MsixTestInstallerPath: The MSIX (or APPX) Installer executable under test.
 	   ExeTestInstallerPath: The Exe Installer executable under test.
 	   PackageCertificatePath: Signing Certificate Path used to certify Index Source Package
   -->
@@ -27,6 +28,7 @@
 	  <Parameter name="LooseFileRegistration" value="false" />
 	  <Parameter name="InvokeCommandInDesktopPackage" value="false" />
 	  <Parameter name="StaticFileRootPath" value="\TestLocalIndex" />
+	  <Parameter name="MsiTestInstallerPath" value="MsiTestInstaller.msi" />
 	  <Parameter name="MsixTestInstallerPath" value="MsixTestInstaller.msix" />
 	  <Parameter name="ExeTestInstallerPath" value="ExeTestInstaller.exe" />
 	  <Parameter name="PackageCertificatePath" value="certificate.pfx"/>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1397,4 +1397,7 @@ Please specify one of them using the `--source` option to proceed.</value>
     <value>The following packages have an upgrade available, but require explicit targeting for upgrade:</value>
     <comment>"require explicit targeting for upgrade" means that the package will not be upgraded with all others unless an extra flag is added, or the package is mentioned explicitly</comment>
   </data>
+  <data name="NestedInstallerNotSupported" xml:space="preserve">
+    <value>The nested installer type is not supported</value>
+  </data>
 </root>

--- a/src/AppInstallerCLITests/ARPChanges.cpp
+++ b/src/AppInstallerCLITests/ARPChanges.cpp
@@ -59,7 +59,7 @@ struct TestContext : public Context
     {
         // Put installer in to control whether arp change code cares to run
         Manifest::ManifestInstaller installer;
-        installer.InstallerType = installerType;
+        installer.BaseInstallerType = installerType;
         Add<Data::Installer>(std::move(installer));
 
         // Put in an empty manifest by default

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -298,6 +298,9 @@
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_MultipleNonPortableNestedInstallers.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\ImportFile-Bad-Invalid.json">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -531,6 +531,9 @@
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_MultipleNonPortableNestedInstallers.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallerArgTest_Msi_WithSwitches.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -36,7 +36,7 @@ const ManifestInstaller& AddInstaller(
 {
     ManifestInstaller toAdd;
     toAdd.Arch = architecture;
-    toAdd.InstallerType = installerType;
+    toAdd.BaseInstallerType = installerType;
     toAdd.Scope = scope;
     toAdd.MinOSVersion = minOSVersion;
     toAdd.Locale = locale;
@@ -63,7 +63,7 @@ void RequireInstaller(const std::optional<ManifestInstaller>& actual, const Mani
 {
     REQUIRE(actual);
     REQUIRE(actual->Arch == expected.Arch);
-    REQUIRE(actual->InstallerType == expected.InstallerType);
+    REQUIRE(actual->EffectiveInstallerType() == expected.EffectiveInstallerType());
     REQUIRE(actual->Scope == expected.Scope);
     REQUIRE(actual->MinOSVersion == expected.MinOSVersion);
     REQUIRE(actual->Locale == expected.Locale);

--- a/src/AppInstallerCLITests/RestInterface_1_0.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_0.cpp
@@ -238,7 +238,7 @@ namespace
             REQUIRE(actualInstaller.Platform.size() == 1);
             REQUIRE(actualInstaller.Platform[0] == PlatformEnum::Desktop);
             REQUIRE(actualInstaller.MinOSVersion == "1078");
-            REQUIRE(actualInstaller.InstallerType == InstallerTypeEnum::Msix);
+            REQUIRE(actualInstaller.BaseInstallerType == InstallerTypeEnum::Msix);
             REQUIRE(actualInstaller.Scope == ScopeEnum::User);
             REQUIRE(actualInstaller.SignatureSha256 == AppInstaller::Utility::SHA256::ConvertToBytes("011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6"));
             REQUIRE(actualInstaller.InstallModes.size() == 1);
@@ -425,7 +425,7 @@ TEST_CASE("Search_Optimized_ManifestResponse", "[RestSource][Interface_1_0]")
     REQUIRE(manifest.Installers.size() == 1);
     REQUIRE(manifest.Installers[0].Arch == Architecture::X64);
     REQUIRE(manifest.Installers[0].Sha256 == AppInstaller::Utility::SHA256::ConvertToBytes("011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6"));
-    REQUIRE(manifest.Installers[0].InstallerType == InstallerTypeEnum::Exe);
+    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(manifest.Installers[0].Url == "https://installer.example.com/foobar.exe");
 }
 

--- a/src/AppInstallerCLITests/RestInterface_1_0.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_0.cpp
@@ -520,6 +520,6 @@ TEST_CASE("GetManifests_GoodResponse_UnknownInstaller", "[RestSource][Interface_
     // Verify manifest is populated and manifest validation passed
     Manifest manifest = manifests[0];
     REQUIRE(manifest.Installers.size() == 1);
-    REQUIRE(manifest.Installers.at(0).InstallerType == InstallerTypeEnum::Unknown);
+    REQUIRE(manifest.Installers.at(0).BaseInstallerType == InstallerTypeEnum::Unknown);
     REQUIRE(manifest.Installers.at(0).ProductId.empty());
 }

--- a/src/AppInstallerCLITests/RestInterface_1_1.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_1.cpp
@@ -257,7 +257,7 @@ namespace
             REQUIRE(actualInstaller.Platform.size() == 1);
             REQUIRE(actualInstaller.Platform[0] == PlatformEnum::Desktop);
             REQUIRE(actualInstaller.MinOSVersion == "1078");
-            REQUIRE(actualInstaller.InstallerType == InstallerTypeEnum::Msi);
+            REQUIRE(actualInstaller.BaseInstallerType == InstallerTypeEnum::Msi);
             REQUIRE(actualInstaller.Scope == ScopeEnum::User);
             REQUIRE(actualInstaller.InstallModes.size() == 1);
             REQUIRE(actualInstaller.InstallModes.at(0) == InstallModeEnum::Interactive);

--- a/src/AppInstallerCLITests/RestInterface_1_1.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_1.cpp
@@ -494,7 +494,7 @@ TEST_CASE("GetManifests_GoodRequest_OnlyMarketRequired", "[RestSource][Interface
     REQUIRE(manifest.Installers.size() == 1);
     REQUIRE(manifest.Installers[0].Arch == Architecture::X64);
     REQUIRE(manifest.Installers[0].Sha256 == AppInstaller::Utility::SHA256::ConvertToBytes("011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6"));
-    REQUIRE(manifest.Installers[0].InstallerType == InstallerTypeEnum::Exe);
+    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(manifest.Installers[0].Url == "https://installer.example.com/foobar.exe");
 }
 
@@ -534,7 +534,7 @@ TEST_CASE("GetManifests_GoodResponse_MSStoreType", "[RestSource][Interface_1_1]"
     // Verify manifest is populated and manifest validation passed
     Manifest manifest = manifests[0];
     REQUIRE(manifest.Installers.size() == 1);
-    REQUIRE(manifest.Installers.at(0).InstallerType == InstallerTypeEnum::MSStore);
+    REQUIRE(manifest.Installers.at(0).BaseInstallerType == InstallerTypeEnum::MSStore);
     REQUIRE(manifest.Installers.at(0).ProductId == "9nblggh4nns1");
 }
 

--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -2946,7 +2946,7 @@ TEST_CASE("SQLiteIndex_ManifestArpVersion_Present_Add", "[sqliteindex]")
     manifest.Id = "Foo";
     manifest.Version = "Bar";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
@@ -2987,7 +2987,7 @@ TEST_CASE("SQLiteIndex_ManifestArpVersion_Present_AddThenUpdate", "[sqliteindex]
     manifest.Id = "Foo";
     manifest.Version = "Bar";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
@@ -3066,7 +3066,7 @@ TEST_CASE("SQLiteIndex_RemoveManifestArpVersionKeepUsedDeleteUnused", "[sqlitein
     manifest.Id = "Foo";
     manifest.Version = "10.0";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
@@ -3078,7 +3078,7 @@ TEST_CASE("SQLiteIndex_RemoveManifestArpVersionKeepUsedDeleteUnused", "[sqlitein
     manifest2.Id = "Foo2";
     manifest2.Version = "1.0";
     manifest2.Installers.push_back({});
-    manifest2.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest2.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest2.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest2.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "10.0";
 
@@ -3116,7 +3116,7 @@ TEST_CASE("SQLiteIndex_ManifestArpVersion_CheckConsistency", "[sqliteindex]")
     manifest.DefaultLocalization.Add<Localization::PackageName>("ArpVersionCheckConsistencyTest");
     manifest.Moniker = "testmoniker";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
@@ -3145,7 +3145,7 @@ TEST_CASE("SQLiteIndex_ManifestArpVersion_ValidateManifestAgainstIndex", "[sqlit
     manifest.Id = "Foo";
     manifest.Version = "10.0";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
@@ -3172,7 +3172,7 @@ TEST_CASE("SQLiteIndex_CheckConsistency_FindEmbeddedNull", "[sqliteindex]")
     manifest.Id = "Foo";
     manifest.Version = "10.0";
     manifest.Installers.push_back({});
-    manifest.Installers[0].InstallerType = InstallerTypeEnum::Exe;
+    manifest.Installers[0].BaseInstallerType = InstallerTypeEnum::Exe;
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});
     manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion = "1.0";
     manifest.Installers[0].AppsAndFeaturesEntries.push_back({});

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml
@@ -1,0 +1,21 @@
+PackageIdentifier: AppInstallerCliTest.TestZipInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test Zip Installer
+ShortDescription: AppInstaller Test Zip Installer with exe
+Publisher: Microsoft Corporation
+Moniker: AICLITestZip
+License: Test
+Installers:
+    - Architecture: x86
+      InstallerUrl: https://ThisIsNotUsed
+      InstallerType: zip
+      InstallerSha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+      NestedInstallerType: msstore
+      InstallerSwitches:
+        Custom: /custom /scope=machine
+        SilentWithProgress: /silentwithprogress
+        Silent: /silence
+        Update: /update 
+ManifestType: singleton
+ManifestVersion: 1.3.0

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -191,7 +191,7 @@ namespace
                     ResultMatch(
                         TestPackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Zip" } },
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
                             std::vector<Manifest>{ manifest2, manifest },
                             shared_from_this()
                         ),

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -70,7 +70,7 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(manifest.DefaultInstallerInfo.Commands == MultiValue{ "makemsix", "makeappx" });
     REQUIRE(manifest.DefaultInstallerInfo.Protocols == MultiValue{ "protocol1", "protocol2" });
     REQUIRE(manifest.DefaultInstallerInfo.FileExtensions == MultiValue{ "appx", "appxbundle", "msix", "msixbundle" });
-    REQUIRE(manifest.DefaultInstallerInfo.InstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Zip);
     REQUIRE(manifest.DefaultInstallerInfo.PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
     REQUIRE(manifest.DefaultInstallerInfo.ProductCode == "{Foo}");
     REQUIRE(manifest.DefaultInstallerInfo.UpdateBehavior == UpdateBehaviorEnum::UninstallPrevious);
@@ -93,7 +93,7 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(installer1.Url == "https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip");
     REQUIRE(installer1.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
     REQUIRE(installer1.Locale == "en-US");
-    REQUIRE(installer1.InstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(installer1.BaseInstallerType == InstallerTypeEnum::Zip);
     REQUIRE(installer1.Scope == ScopeEnum::User);
     REQUIRE(installer1.PackageFamilyName == "");
     REQUIRE(installer1.ProductCode == "");
@@ -114,7 +114,7 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(installer2.Url == "https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx64.zip");
     REQUIRE(installer2.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF0000"));
     REQUIRE(installer2.Locale == "en-US");
-    REQUIRE(installer2.InstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(installer2.BaseInstallerType == InstallerTypeEnum::Zip);
     REQUIRE(installer2.Scope == ScopeEnum::User);
     REQUIRE(installer2.PackageFamilyName == "");
     REQUIRE(installer2.ProductCode == "");
@@ -343,30 +343,30 @@ TEST_CASE("ComplexSystemReference", "[ManifestValidation]")
     REQUIRE(manifest.Installers.size() == 5);
 
     // Zip installer does not inherit
-    REQUIRE(manifest.Installers[0].InstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Zip);
     REQUIRE(manifest.Installers[0].PackageFamilyName == "");
     REQUIRE(manifest.Installers[0].ProductCode == "");
 
     // MSIX installer does inherit
-    REQUIRE(manifest.Installers[1].InstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(manifest.Installers[1].BaseInstallerType == InstallerTypeEnum::Msix);
     REQUIRE(manifest.Installers[1].Arch == Architecture::X86);
     REQUIRE(manifest.Installers[1].PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
     REQUIRE(manifest.Installers[1].ProductCode == "");
 
     // MSI installer does inherit
-    REQUIRE(manifest.Installers[2].InstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(manifest.Installers[2].BaseInstallerType == InstallerTypeEnum::Msi);
     REQUIRE(manifest.Installers[2].Arch == Architecture::X86);
     REQUIRE(manifest.Installers[2].PackageFamilyName == "");
     REQUIRE(manifest.Installers[2].ProductCode == "{Foo}");
 
     // MSIX installer with override
-    REQUIRE(manifest.Installers[3].InstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(manifest.Installers[3].BaseInstallerType == InstallerTypeEnum::Msix);
     REQUIRE(manifest.Installers[3].Arch == Architecture::X64);
     REQUIRE(manifest.Installers[3].PackageFamilyName == "Override_8wekyb3d8bbwe");
     REQUIRE(manifest.Installers[3].ProductCode == "");
 
     // MSI installer with override
-    REQUIRE(manifest.Installers[4].InstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(manifest.Installers[4].BaseInstallerType == InstallerTypeEnum::Msi);
     REQUIRE(manifest.Installers[4].Arch == Architecture::X64);
     REQUIRE(manifest.Installers[4].PackageFamilyName == "");
     REQUIRE(manifest.Installers[4].ProductCode == "Override");
@@ -435,7 +435,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
     REQUIRE(manifest.DefaultInstallerInfo.Locale == "en-US");
     REQUIRE(manifest.DefaultInstallerInfo.Platform == std::vector<PlatformEnum>{ PlatformEnum::Desktop, PlatformEnum::Universal });
     REQUIRE(manifest.DefaultInstallerInfo.MinOSVersion == "10.0.0.0");
-    REQUIRE(manifest.DefaultInstallerInfo.InstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Zip);
     REQUIRE(manifest.DefaultInstallerInfo.Scope == ScopeEnum::Machine);
     REQUIRE(manifest.DefaultInstallerInfo.InstallModes == std::vector<InstallModeEnum>{ InstallModeEnum::Interactive, InstallModeEnum::Silent, InstallModeEnum::SilentWithProgress });
 
@@ -534,7 +534,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
     REQUIRE(installer1.Locale == "en-GB");
     REQUIRE(installer1.Platform == std::vector<PlatformEnum>{ PlatformEnum::Desktop });
     REQUIRE(installer1.MinOSVersion == "10.0.1.0");
-    REQUIRE(installer1.InstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(installer1.BaseInstallerType == InstallerTypeEnum::Msix);
     REQUIRE(installer1.Url == "https://www.microsoft.com/msixsdk/msixsdkx86.msix");
     REQUIRE(installer1.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
     REQUIRE(installer1.SignatureSha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
@@ -608,7 +608,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
     if (!isSingleton)
     {
         ManifestInstaller installer2 = manifest.Installers.at(1);
-        REQUIRE(installer2.InstallerType == InstallerTypeEnum::Exe);
+        REQUIRE(installer2.BaseInstallerType == InstallerTypeEnum::Exe);
         REQUIRE(installer2.Arch == Architecture::X64);
         REQUIRE(installer2.Url == "https://www.microsoft.com/msixsdk/msixsdkx64.exe");
         REQUIRE(installer2.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
@@ -639,7 +639,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
         if (manifestVer >= ManifestVer{ s_ManifestVersionV1_2 })
         {
             ManifestInstaller installer3 = manifest.Installers.at(2);
-            REQUIRE(installer3.InstallerType == InstallerTypeEnum::Portable);
+            REQUIRE(installer3.BaseInstallerType == InstallerTypeEnum::Portable);
             REQUIRE(installer3.Arch == Architecture::X86);
             REQUIRE(installer3.Url == "https://www.microsoft.com/msixsdk/msixsdkx86.exe");
             REQUIRE(installer3.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
@@ -655,7 +655,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
         if (manifestVer >= ManifestVer{ s_ManifestVersionV1_3 })
         {
             ManifestInstaller installer4 = manifest.Installers.at(3);
-            REQUIRE(installer4.InstallerType == InstallerTypeEnum::Zip);
+            REQUIRE(installer4.BaseInstallerType == InstallerTypeEnum::Zip);
             REQUIRE(installer4.Arch == Architecture::X64);
             REQUIRE(installer4.Url == "https://www.microsoft.com/msixsdk/msixsdkx64.exe");
             REQUIRE(installer4.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));

--- a/src/AppInstallerCommonCore/Manifest/Manifest.cpp
+++ b/src/AppInstallerCommonCore/Manifest/Manifest.cpp
@@ -94,7 +94,7 @@ namespace AppInstaller::Manifest
 
         for (auto const& installer : Installers)
         {
-            if (DoesInstallerSupportArpVersionRange(installer))
+            if (DoesInstallerTypeSupportArpVersionRange(installer.EffectiveInstallerType()))
             {
                 for (auto const& entry : installer.AppsAndFeaturesEntries)
                 {

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -35,17 +35,6 @@ namespace AppInstaller::Manifest
                 return CompatibilitySet::None;
             }
         }
-
-        InstallerTypeEnum GetInstallerTypeFromInstaller(ManifestInstaller installer)
-        {
-            InstallerTypeEnum installerType = installer.InstallerType;
-            if (IsArchiveType(installerType))
-            {
-                installerType = installer.NestedInstallerType;
-            }
-
-            return installerType;
-        }
     }
 
     ManifestVer::ManifestVer(std::string_view version)
@@ -449,15 +438,13 @@ namespace AppInstaller::Manifest
         return "Unknown"sv;
     }
 
-    bool DoesInstallerUsePackageFamilyName(ManifestInstaller installer)
+    bool DoesInstallerTypeUsePackageFamilyName(InstallerTypeEnum installerType)
     {
-        InstallerTypeEnum installerType = GetInstallerTypeFromInstaller(installer);
         return (installerType == InstallerTypeEnum::Msix || installerType == InstallerTypeEnum::MSStore);
     }
 
-    bool DoesInstallerUseProductCode(ManifestInstaller installer)
+    bool DoesInstallerTypeUseProductCode(InstallerTypeEnum installerType)
     {
-        InstallerTypeEnum installerType = GetInstallerTypeFromInstaller(installer);
         return (
             installerType == InstallerTypeEnum::Exe ||
             installerType == InstallerTypeEnum::Inno ||
@@ -469,9 +456,8 @@ namespace AppInstaller::Manifest
             );
     }
 
-    bool DoesInstallerWriteAppsAndFeaturesEntry(ManifestInstaller installer)
+    bool DoesInstallerTypeWriteAppsAndFeaturesEntry(InstallerTypeEnum installerType)
     {
-        InstallerTypeEnum installerType = GetInstallerTypeFromInstaller(installer);
         return (
             installerType == InstallerTypeEnum::Exe ||
             installerType == InstallerTypeEnum::Inno ||
@@ -481,12 +467,6 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Burn ||
             installerType == InstallerTypeEnum::Portable
             );
-    }
-
-    bool DoesInstallerSupportArpVersionRange(ManifestInstaller installer)
-    {
-        InstallerTypeEnum installerType = GetInstallerTypeFromInstaller(installer);
-        return DoesInstallerTypeSupportArpVersionRange(installerType);
     }
 
     bool DoesInstallerTypeSupportArpVersionRange(InstallerTypeEnum installerType)
@@ -501,9 +481,8 @@ namespace AppInstaller::Manifest
             );
     }
 
-    bool DoesInstallerIgnoreScopeFromManifest(ManifestInstaller installer)
+    bool DoesInstallerIgnoreScopeFromManifest(InstallerTypeEnum installerType)
     {
-        InstallerTypeEnum installerType = GetInstallerTypeFromInstaller(installer);
         return (
             installerType == InstallerTypeEnum::Portable
             );

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -493,6 +493,20 @@ namespace AppInstaller::Manifest
         return (installerType == InstallerTypeEnum::Zip);
     }
 
+    bool IsNestedInstallerTypeSupported(InstallerTypeEnum nestedInstallerType)
+    {
+        return (
+            nestedInstallerType == InstallerTypeEnum::Exe ||
+            nestedInstallerType == InstallerTypeEnum::Inno ||
+            nestedInstallerType == InstallerTypeEnum::Msi ||
+            nestedInstallerType == InstallerTypeEnum::Nullsoft ||
+            nestedInstallerType == InstallerTypeEnum::Wix ||
+            nestedInstallerType == InstallerTypeEnum::Burn ||
+            nestedInstallerType == InstallerTypeEnum::Portable ||
+            nestedInstallerType == InstallerTypeEnum::Msix
+            );
+    }
+
     bool IsInstallerTypeCompatible(InstallerTypeEnum type1, InstallerTypeEnum type2)
     {
         // Unknown type cannot be compatible with any other

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -481,7 +481,7 @@ namespace AppInstaller::Manifest
             );
     }
 
-    bool DoesInstallerIgnoreScopeFromManifest(InstallerTypeEnum installerType)
+    bool DoesInstallerTypeIgnoreScopeFromManifest(InstallerTypeEnum installerType)
     {
         return (
             installerType == InstallerTypeEnum::Portable

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -42,9 +42,9 @@ namespace AppInstaller::Manifest
         // Todo: use the comparator from ManifestComparator when that one is fully implemented.
         auto installerCmp = [](const ManifestInstaller& in1, const ManifestInstaller& in2)
         {
-            if (in1.InstallerType != in2.InstallerType)
+            if (in1.EffectiveInstallerType() != in2.EffectiveInstallerType())
             {
-                return in1.InstallerType < in2.InstallerType;
+                return in1.EffectiveInstallerType() < in2.EffectiveInstallerType();
             }
 
             if (in1.Arch != in2.Arch)
@@ -74,14 +74,14 @@ namespace AppInstaller::Manifest
         for (auto const& installer : manifest.Installers)
         {
             // If not full validation, for future compatibility, skip validating unknown installers.
-            if (installer.InstallerType == InstallerTypeEnum::Unknown && !fullValidation)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Unknown && !fullValidation)
             {
                 continue;
             }
 
             if (!duplicateInstallerFound && !installerSet.insert(installer).second)
             {
-                AICLI_LOG(Core, Error, << "Duplicate installer: Type[" << InstallerTypeToString(installer.InstallerType) <<
+                AICLI_LOG(Core, Error, << "Duplicate installer: Type[" << InstallerTypeToString(installer.EffectiveInstallerType()) <<
                     "] Architecture[" << Utility::ToString(installer.Arch) << "] Locale[" << installer.Locale <<
                     "] Scope[" << ScopeToString(installer.Scope) << "]");
 
@@ -94,7 +94,7 @@ namespace AppInstaller::Manifest
                 resultErrors.emplace_back(ManifestError::InvalidFieldValue, "Architecture");
             }
 
-            if (installer.InstallerType == InstallerTypeEnum::Unknown)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Unknown)
             {
                 resultErrors.emplace_back(ManifestError::InvalidFieldValue, "InstallerType");
             }
@@ -106,29 +106,29 @@ namespace AppInstaller::Manifest
 
             // Validate system reference strings if they are set at the installer level
             // Allow PackageFamilyName to be declared with non msix installers to support nested installer scenarios after manifest version 1.1
-            if (manifest.ManifestVersion <= ManifestVer{ s_ManifestVersionV1_1 } && !installer.PackageFamilyName.empty() && !DoesInstallerUsePackageFamilyName(installer))
+            if (manifest.ManifestVersion <= ManifestVer{ s_ManifestVersionV1_1 } && !installer.PackageFamilyName.empty() && !DoesInstallerTypeUsePackageFamilyName(installer.EffectiveInstallerType()))
             {
-                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotSupportPackageFamilyName, "InstallerType", InstallerTypeToString(installer.InstallerType));
+                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotSupportPackageFamilyName, "InstallerType", InstallerTypeToString(installer.EffectiveInstallerType()));
             }
 
-            if (!installer.ProductCode.empty() && !DoesInstallerUseProductCode(installer))
+            if (!installer.ProductCode.empty() && !DoesInstallerTypeUseProductCode(installer.EffectiveInstallerType()))
             {
-                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotSupportProductCode, "InstallerType", InstallerTypeToString(installer.InstallerType));
+                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotSupportProductCode, "InstallerType", InstallerTypeToString(installer.EffectiveInstallerType()));
             }
 
-            if (!installer.AppsAndFeaturesEntries.empty() && !DoesInstallerWriteAppsAndFeaturesEntry(installer))
+            if (!installer.AppsAndFeaturesEntries.empty() && !DoesInstallerTypeWriteAppsAndFeaturesEntry(installer.EffectiveInstallerType()))
             {
-                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotWriteAppsAndFeaturesEntry, "InstallerType", InstallerTypeToString(installer.InstallerType));
+                resultErrors.emplace_back(ManifestError::InstallerTypeDoesNotWriteAppsAndFeaturesEntry, "InstallerType", InstallerTypeToString(installer.EffectiveInstallerType()));
             }
 
-            if (installer.InstallerType == InstallerTypeEnum::MSStore)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::MSStore)
             {
                 if (fullValidation)
                 {
                     // MSStore type is not supported in community repo
                     resultErrors.emplace_back(
                         ManifestError::FieldValueNotSupported, "InstallerType",
-                        InstallerTypeToString(installer.InstallerType));
+                        InstallerTypeToString(installer.EffectiveInstallerType()));
                 }
 
                 if (installer.ProductId.empty())
@@ -154,14 +154,14 @@ namespace AppInstaller::Manifest
                 }
             }
 
-            if (installer.InstallerType == InstallerTypeEnum::Exe &&
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Exe &&
                 (installer.Switches.find(InstallerSwitchType::SilentWithProgress) == installer.Switches.end() ||
                  installer.Switches.find(InstallerSwitchType::Silent) == installer.Switches.end()))
             {
                 resultErrors.emplace_back(ManifestError::ExeInstallerMissingSilentSwitches, ValidationError::Level::Warning);
             }
 
-            if (installer.InstallerType == InstallerTypeEnum::Portable)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Portable)
             {
                 if (installer.AppsAndFeaturesEntries.size() > 1)
                 {
@@ -177,7 +177,7 @@ namespace AppInstaller::Manifest
                 }
             }
 
-            if (IsArchiveType(installer.InstallerType))
+            if (IsArchiveType(installer.BaseInstallerType))
             {
                 if (installer.NestedInstallerType == InstallerTypeEnum::Unknown)
                 {
@@ -304,7 +304,7 @@ namespace AppInstaller::Manifest
         for (const auto& installer : manifest.Installers)
         {
             // Installer msix or msixbundle
-            if (installer.InstallerType == InstallerTypeEnum::Msix)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Msix)
             {
                 auto installerErrors = msixManifestValidation.Validate(manifest, installer);
                 std::move(installerErrors.begin(), installerErrors.end(), std::inserter(errors, errors.end()));

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -161,15 +161,20 @@ namespace AppInstaller::Manifest
                 resultErrors.emplace_back(ManifestError::ExeInstallerMissingSilentSwitches, ValidationError::Level::Warning);
             }
 
+            // The command field restriction only applies if the base installer type is Portable.
+            if (installer.BaseInstallerType == InstallerTypeEnum::Portable)
+            {
+                if (installer.Commands.size() > 1)
+                {
+                    resultErrors.emplace_back(ManifestError::ExceededCommandsLimit);
+                }
+            }
+
             if (installer.EffectiveInstallerType() == InstallerTypeEnum::Portable)
             {
                 if (installer.AppsAndFeaturesEntries.size() > 1)
                 {
                     resultErrors.emplace_back(ManifestError::ExceededAppsAndFeaturesEntryLimit);
-                }
-                if (installer.Commands.size() > 1)
-                {
-                    resultErrors.emplace_back(ManifestError::ExceededCommandsLimit);
                 }
                 if (installer.Scope != ScopeEnum::Unknown)
                 {

--- a/src/AppInstallerCommonCore/Manifest/ManifestYamlPopulator.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestYamlPopulator.cpp
@@ -187,7 +187,7 @@ namespace AppInstaller::Manifest
         // Common fields across versions
         std::vector<FieldProcessInfo> result =
         {
-            { "InstallerType", [this](const YAML::Node& value)->ValidationErrors { m_p_installer->InstallerType = ConvertToInstallerTypeEnum(value.as<std::string>()); return {}; } },
+            { "InstallerType", [this](const YAML::Node& value)->ValidationErrors { m_p_installer->BaseInstallerType = ConvertToInstallerTypeEnum(value.as<std::string>()); return {}; } },
             { "PackageFamilyName", [this](const YAML::Node& value)->ValidationErrors { m_p_installer->PackageFamilyName = value.as<std::string>(); return {}; } },
             { "ProductCode", [this](const YAML::Node& value)->ValidationErrors { m_p_installer->ProductCode = value.as<std::string>(); return {}; } },
         };
@@ -922,22 +922,22 @@ namespace AppInstaller::Manifest
             std::move(errors.begin(), errors.end(), std::inserter(resultErrors, resultErrors.end()));
 
             // Copy in system reference strings from the root if not set in the installer and appropriate
-            if (installer.PackageFamilyName.empty() && DoesInstallerUsePackageFamilyName(installer))
+            if (installer.PackageFamilyName.empty() && DoesInstallerTypeUsePackageFamilyName(installer.EffectiveInstallerType()))
             {
                 installer.PackageFamilyName = manifest.DefaultInstallerInfo.PackageFamilyName;
             }
 
-            if (installer.ProductCode.empty() && DoesInstallerUseProductCode(installer))
+            if (installer.ProductCode.empty() && DoesInstallerTypeUseProductCode(installer.EffectiveInstallerType()))
             {
                 installer.ProductCode = manifest.DefaultInstallerInfo.ProductCode;
             }
 
-            if (installer.AppsAndFeaturesEntries.empty() && DoesInstallerWriteAppsAndFeaturesEntry(installer))
+            if (installer.AppsAndFeaturesEntries.empty() && DoesInstallerTypeWriteAppsAndFeaturesEntry(installer.EffectiveInstallerType()))
             {
                 installer.AppsAndFeaturesEntries = manifest.DefaultInstallerInfo.AppsAndFeaturesEntries;
             }
 
-            if (IsArchiveType(installer.InstallerType))
+            if (IsArchiveType(installer.BaseInstallerType))
             {
                 if (installer.NestedInstallerFiles.empty())
                 {
@@ -957,7 +957,7 @@ namespace AppInstaller::Manifest
             }
 
             // Populate installer default switches if not exists
-            auto defaultSwitches = GetDefaultKnownSwitches(installer.InstallerType);
+            auto defaultSwitches = GetDefaultKnownSwitches(installer.EffectiveInstallerType());
             for (auto const& defaultSwitch : defaultSwitches)
             {
                 if (installer.Switches.find(defaultSwitch.first) == installer.Switches.end())
@@ -967,7 +967,7 @@ namespace AppInstaller::Manifest
             }
 
             // Populate installer default return codes if not present in ExpectedReturnCodes and InstallerSuccessCodes
-            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.InstallerType);
+            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.EffectiveInstallerType());
             for (auto const& defaultReturnCode : defaultReturnCodes)
             {
                 if (installer.ExpectedReturnCodes.find(defaultReturnCode.first) == installer.ExpectedReturnCodes.end() &&

--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -303,22 +303,19 @@ namespace AppInstaller::Manifest
     std::string_view ScopeToString(ScopeEnum scope);
 
     // Gets a value indicating whether the given installer uses the PackageFamilyName system reference.
-    bool DoesInstallerUsePackageFamilyName(ManifestInstaller installer);
+    bool DoesInstallerTypeUsePackageFamilyName(InstallerTypeEnum installerType);
 
     // Gets a value indicating whether the given installer uses the ProductCode system reference.
-    bool DoesInstallerUseProductCode(ManifestInstaller installer);
+    bool DoesInstallerTypeUseProductCode(InstallerTypeEnum installerType);
 
     // Gets a value indicating whether the given installer writes ARP entry.
-    bool DoesInstallerWriteAppsAndFeaturesEntry(ManifestInstaller installer);
-
-    // Gets a value indicating whether the given installer supports ARP version range.
-    bool DoesInstallerSupportArpVersionRange(ManifestInstaller installer);
+    bool DoesInstallerTypeWriteAppsAndFeaturesEntry(InstallerTypeEnum installerType);
 
     // Gets a value indicating whether the given installer type supports ARP version range.
     bool DoesInstallerTypeSupportArpVersionRange(InstallerTypeEnum installer);
 
     // Gets a value indicating whether the given installer ignores the Scope value from the manifest.
-    bool DoesInstallerIgnoreScopeFromManifest(ManifestInstaller installer);
+    bool DoesInstallerTypeIgnoreScopeFromManifest(InstallerTypeEnum installerType);
 
     // Gets a value indicating whether the given installer type is an archive.
     bool IsArchiveType(InstallerTypeEnum installerType);

--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -320,6 +320,9 @@ namespace AppInstaller::Manifest
     // Gets a value indicating whether the given installer type is an archive.
     bool IsArchiveType(InstallerTypeEnum installerType);
 
+    // Gets a value indicating whether the given nested installer type is supported.
+    bool IsNestedInstallerTypeSupported(InstallerTypeEnum nestedInstallerType);
+
     // Checks whether 2 installer types are compatible. E.g. inno and exe are update compatible
     bool IsInstallerTypeCompatible(InstallerTypeEnum type1, InstallerTypeEnum type2);
 

--- a/src/AppInstallerCommonCore/Public/winget/ManifestInstaller.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestInstaller.h
@@ -40,9 +40,14 @@ namespace AppInstaller::Manifest
         string_t MinOSVersion;
 
         // If present, has more precedence than root
-        InstallerTypeEnum InstallerType = InstallerTypeEnum::Unknown;
+        InstallerTypeEnum BaseInstallerType = InstallerTypeEnum::Unknown;
 
         InstallerTypeEnum NestedInstallerType = InstallerTypeEnum::Unknown;
+
+        InstallerTypeEnum EffectiveInstallerType() const
+        {
+            return IsArchiveType(BaseInstallerType) ? NestedInstallerType : BaseInstallerType;
+        }
 
         std::vector<NestedInstallerFile> NestedInstallerFiles;
 

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/ManifestDeserializer_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/ManifestDeserializer_1_0.cpp
@@ -366,7 +366,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0::Json
         }
 
         // Installer Switches
-        installer.Switches = Manifest::GetDefaultKnownSwitches(installer.BaseInstallerType);
+        installer.Switches = Manifest::GetDefaultKnownSwitches(installer.EffectiveInstallerType());
         std::optional<std::reference_wrapper<const web::json::value>> switches =
             JSON::GetJsonValueFromNode(installerJsonObject, JSON::GetUtilityString(InstallerSwitches));
         if (switches)

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/ManifestDeserializer_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/Json/ManifestDeserializer_1_0.cpp
@@ -321,7 +321,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0::Json
             AICLI_LOG(Repo, Error, << "Missing installer type.");
             return {};
         }
-        installer.InstallerType = ConvertToInstallerType(installerType.value());
+        installer.BaseInstallerType = ConvertToInstallerType(installerType.value());
         installer.Locale = JSON::GetRawStringValueFromJsonNode(installerJsonObject, JSON::GetUtilityString(InstallerLocale)).value_or("");
 
         // platform
@@ -366,7 +366,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0::Json
         }
 
         // Installer Switches
-        installer.Switches = Manifest::GetDefaultKnownSwitches(installer.InstallerType);
+        installer.Switches = Manifest::GetDefaultKnownSwitches(installer.BaseInstallerType);
         std::optional<std::reference_wrapper<const web::json::value>> switches =
             JSON::GetJsonValueFromNode(installerJsonObject, JSON::GetUtilityString(InstallerSwitches));
         if (switches)

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
@@ -158,7 +158,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_1::Json
             }
 
             // Populate installer default return codes if not present in ExpectedReturnCodes and InstallerSuccessCodes
-            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.BaseInstallerType);
+            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.EffectiveInstallerType());
             for (auto const& defaultReturnCode : defaultReturnCodes)
             {
                 if (installer.ExpectedReturnCodes.find(defaultReturnCode.first) == installer.ExpectedReturnCodes.end() &&

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
@@ -158,7 +158,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_1::Json
             }
 
             // Populate installer default return codes if not present in ExpectedReturnCodes and InstallerSuccessCodes
-            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.EffectiveInstallerType());
+            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.BaseInstallerType);
             for (auto const& defaultReturnCode : defaultReturnCodes)
             {
                 if (installer.ExpectedReturnCodes.find(defaultReturnCode.first) == installer.ExpectedReturnCodes.end() &&

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_1/Json/ManifestDeserializer_1_1.cpp
@@ -158,7 +158,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_1::Json
             }
 
             // Populate installer default return codes if not present in ExpectedReturnCodes and InstallerSuccessCodes
-            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.InstallerType);
+            auto defaultReturnCodes = GetDefaultKnownReturnCodes(installer.BaseInstallerType);
             for (auto const& defaultReturnCode : defaultReturnCodes)
             {
                 if (installer.ExpectedReturnCodes.find(defaultReturnCode.first) == installer.ExpectedReturnCodes.end() &&


### PR DESCRIPTION
Fixes #2392 

Changes:
- Changes installer.InstallerType -> installer.BaseInstallerType.
- Created a method called EffectiveInstallerType() that returns the actual installerType that will be executed (i.e. the NestedInstallerType if it is a zip installer)

Tests:
- Reenabled ZipWithMsi test
- All existing tests should pass

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2413)