### PR TITLE
Copy winget unpackaged logs in E2E tests

### DIFF
--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -52,7 +52,8 @@ namespace AppInstallerCLIE2ETests
         public const string SignTool = "signtool.exe";
         public const string IndexCreationTool = "IndexCreationTool";
         public const string WinGetUtil = "WinGetUtil";
-        public const string E2ETestLogsPath = @"Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir";
+        public const string E2ETestLogsPathPackaged = @"Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir";
+        public const string E2ETestLogsPathUnpackaged = @"WinGet\defaultState";
 
         // Installer filename
         public const string TestCommandExe = "testCommand.exe";

--- a/src/AppInstallerCLIE2ETests/ListCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ListCommand.cs
@@ -23,7 +23,7 @@ namespace AppInstallerCLIE2ETests
             var installDir = TestCommon.GetRandomTestDir();
 
             string localAppDataPath = System.Environment.GetEnvironmentVariable(Constants.LocalAppData);
-            string logFilePath = System.IO.Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
+            string logFilePath = System.IO.Path.Combine(localAppDataPath, Constants.E2ETestLogsPathPackaged);
             logFilePath = System.IO.Path.Combine(logFilePath, "ListAfterInstall-" + System.IO.Path.GetRandomFileName() + ".log");
 
             var result = TestCommon.RunAICLICommand("list", productCode);

--- a/src/AppInstallerCLIE2ETests/README.md
+++ b/src/AppInstallerCLIE2ETests/README.md
@@ -95,7 +95,8 @@ Make sure to replace **MSFT** with your own user name. Modifying this example wi
 
 
 #### Log Files
-After running the E2E Tests, the logs can be found in either the following two paths:
+After running the E2E Tests, the logs can be found in the following paths:
 
 - **%LOCALAPPDATA%\Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir**
 - **%LOCALAPPDATA%\E2ETestLogs**
+- **%TEMP%\WinGet\defaultState**

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -367,7 +367,7 @@ namespace AppInstallerCLIE2ETests
             string tempPath = Path.GetTempPath();
             string localAppDataPath = Environment.GetEnvironmentVariable("LocalAppData");
             string testLogsPackagedSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPathPackaged);
-            string testLogsUnpackagedSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPathUnpackaged);
+            string testLogsUnpackagedSourcePath = Path.Combine(tempPath, Constants.E2ETestLogsPathUnpackaged);
             string testLogsDestPath = Path.Combine(tempPath, "E2ETestLogs");
             string testLogsPackagedDestPath = Path.Combine(testLogsDestPath, "Packaged");
             string testLogsUnpackagedDestPath = Path.Combine(testLogsDestPath, "Unpackaged");

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -366,8 +366,11 @@ namespace AppInstallerCLIE2ETests
         {
             string tempPath = Path.GetTempPath();
             string localAppDataPath = Environment.GetEnvironmentVariable("LocalAppData");
-            string testLogsSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPath);
+            string testLogsPackagedSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPathPackaged);
+            string testLogsUnpackagedSourcePath = Path.Combine(localAppDataPath, Constants.E2ETestLogsPathUnpackaged);
             string testLogsDestPath = Path.Combine(tempPath, "E2ETestLogs");
+            string testLogsPackagedDestPath = Path.Combine(testLogsDestPath, "Packaged");
+            string testLogsUnpackagedDestPath = Path.Combine(testLogsDestPath, "Unpackaged");
 
             if (Directory.Exists(testLogsDestPath))
             {
@@ -375,9 +378,14 @@ namespace AppInstallerCLIE2ETests
                 Directory.Delete(testLogsDestPath);
             }
 
-            if (Directory.Exists(testLogsSourcePath))
+            if (Directory.Exists(testLogsPackagedSourcePath))
             {
-                TestIndexSetup.CopyDirectory(testLogsSourcePath, testLogsDestPath);
+                TestIndexSetup.CopyDirectory(testLogsPackagedSourcePath, testLogsPackagedDestPath);
+            }
+
+            if (Directory.Exists(testLogsUnpackagedSourcePath))
+            {
+                TestIndexSetup.CopyDirectory(testLogsUnpackagedSourcePath, testLogsUnpackagedDestPath);
             }
         }
 


### PR DESCRIPTION
E2E tests copy the winget logs to a location that is published as artifacts in the pipeline, but only for when winget runs packaged. When winget runs unpackaged, the logs are placed in a different location and are not copied.
This PR changes to also copy the logs from unpackaged runs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2441)