### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,50 +1,51 @@
 {
-"Registrations":[
-  {
-    "component": {
-      "type": "git",
-      "git": {
-        "repositoryUrl": "https://github.com/catchorg/Catch2.git",
-        "commitHash": "e1c9d5569dc4135babb9c81891d70a8ba8ed938c"
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/catchorg/Catch2.git",
+          "commitHash": "e1c9d5569dc4135babb9c81891d70a8ba8ed938c"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/yaml/libyaml.git",
+          "commitHash": "2c891fc7a770e8ba2fec34fc6b545c672beb37e6"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/open-source-parsers/jsoncpp.git",
+          "commitHash": "9be589598595963f94ba264d7b416d0533421106"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/tristanpenman/valijson.git",
+          "commitHash": "2dfc7499a31b84edef71189f4247919268ebc74e"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/cpprestsdk.git",
+          "commitHash": "122d09549201da5383321d870bed45ecb9e168c5"
+        }
       }
     }
-  },
-  {
-    "component": {
-      "type": "git",
-      "git": {
-        "repositoryUrl": "https://github.com/yaml/libyaml.git",
-        "commitHash": "2c891fc7a770e8ba2fec34fc6b545c672beb37e6"
-      }
-    }
-  },
-  {
-    "component": {
-      "type": "git",
-      "git": {
-        "repositoryUrl": "https://github.com/open-source-parsers/jsoncpp.git",
-        "commitHash": "9be589598595963f94ba264d7b416d0533421106"
-      }
-    }
-  },
-  {
-    "component": {
-      "type": "git",
-      "git": {
-        "repositoryUrl": "https://github.com/tristanpenman/valijson.git",
-        "commitHash": "2dfc7499a31b84edef71189f4247919268ebc74e"
-      }
-    }
-  },
-  {
-    "component": {
-      "type": "git",
-      "git": {
-        "repositoryUrl": "https://github.com/microsoft/cpprestsdk.git",
-        "commitHash": "122d09549201da5383321d870bed45ecb9e168c5"
-      }
-    }
-  }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2487)