### PR TITLE
Update link to VS Installer Project extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The client is built around the concept of sources; a set of packages effectively
    * Desktop Development with C++
    * Universal Windows Platform Development
 * The following extensions:
-   * [Microsoft Visual Studio Installer Projects](https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects)
+   * [Microsoft Visual Studio Installer Projects](https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects)
 
 ### Building
 


### PR DESCRIPTION
The link should point to Microsoft Visual Studio Installer Projects 2022 instead of the the older one, as the project now builds with VS2022.

- [x ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----
