### PR TITLE
Removed en-US in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The winget.exe client is instrumented to collect usage and diagnostic (error) da
 
 If you build the client yourself the instrumentation will not be enabled and no data will be sent to Microsoft.
 
-The winget.exe client respects machine wide privacy settings and users can opt-out on their device, as documented in the Microsoft Windows privacy statement [here](https://support.microsoft.com/help/4468236/diagnostics-feedback-and-privacy-in-windows-10-microsoft-privacy). In addition, you may also explicitly block telemetry using [settings](https://docs.microsoft.com/en-us/windows/package-manager/winget/settings)
+The winget.exe client respects machine wide privacy settings and users can opt-out on their device, as documented in the Microsoft Windows privacy statement [here](https://support.microsoft.com/help/4468236/diagnostics-feedback-and-privacy-in-windows-10-microsoft-privacy). In addition, you may also explicitly block telemetry using [settings](https://docs.microsoft.com/windows/package-manager/winget/settings)
 
 In short to opt-out, go to `Start`, then select `Settings` > `Privacy` > `Diagnostics & feedback`, and select `Basic`. 
 

--- a/doc/specs/#140 - ZIP Support.md
+++ b/doc/specs/#140 - ZIP Support.md
@@ -45,13 +45,13 @@ The initial implementation of this feature will only support the following insta
 - Single or multiple portable exes bundled as a suite inside an archive file.
 
 ## ZIP Extraction
-The extraction of ZIPs will be done using Windows Shell APIs. ZIP files can be represented as a [ShellFolder](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishellfolder) object that can be used to manage the contents of the ZIP file. File contents are represented as [ShellItems](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishellitem), which can be handled using the methods exposed by the [IFileOperation interface](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ifileoperation). 
+The extraction of ZIPs will be done using Windows Shell APIs. ZIP files can be represented as a [ShellFolder](https://docs.microsoft.com/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishellfolder) object that can be used to manage the contents of the ZIP file. File contents are represented as [ShellItems](https://docs.microsoft.com/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishellitem), which can be handled using the methods exposed by the [IFileOperation interface](https://docs.microsoft.com/windows/win32/api/shobjidl_core/nn-shobjidl_core-ifileoperation). 
 
 In our initial implementation, we will only support extracting the top level archive to a temporary location. This means that the `NestedInstallerFile` must not be contained in any nested archives. The appropriate install flow will proceed based on the specified `NestedInstallerType`. 
 
 > If the community presents enough use cases that require decompressing additional layers, then we will consider extending this functionality and adding a separate manifest entry to override the default behavior of only unzipping the top level archive.
 
-> Since we are utilizing Windows Shell APIs, we need to ensure that we are not invoking a UI during the extraction. This can be done by [setting the operation flag to not display any UI](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifileoperation-setoperationflags). 
+> Since we are utilizing Windows Shell APIs, we need to ensure that we are not invoking a UI during the extraction. This can be done by [setting the operation flag to not display any UI](https://docs.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifileoperation-setoperationflags). 
 
 > During implementation, we will also need to ensure that this process can work under SYSTEM context.
 

--- a/doc/specs/#182 - Support for installation of portable standalone apps.md
+++ b/doc/specs/#182 - Support for installation of portable standalone apps.md
@@ -214,5 +214,5 @@ Support for channels has not yet been implemented. Some portable applications ma
 
 [Portable / Standalone Executables · Discussion #44183 · microsoft/winget-pkgs (github.com)](https://github.com/microsoft/winget-pkgs/discussions/44183)
 
-[Application Registration - Win32 Apps](https://docs.microsoft.com/en-us/windows/win32/shell/app-registration)
+[Application Registration - Win32 Apps](https://docs.microsoft.com/windows/win32/shell/app-registration)
 

--- a/doc/specs/#888 - Com Api.md
+++ b/doc/specs/#888 - Com Api.md
@@ -6,7 +6,7 @@ make use of that functionality. The API will be preferred by callers that want t
 and completion events, and UWP packages that do not have permission to launch command line processes.
 The goal for this api is to provide the full set of install functionality possible using the Windows
 Package Manager command line. The command line is documented at
-https://docs.microsoft.com/en-us/windows/package-manager/winget/
+https://docs.microsoft.com/windows/package-manager/winget/
 
 # 2. Description
 
@@ -323,13 +323,13 @@ Notes have been added inline throughout the api details.
 For this api there are multiple similar apis that are
 relevant with regard to naming and consistency. There is the Windows Package Manager command line which uses
 "source" to describe the various repositories that can host packages and "search" to describe looking up an app.
-https://docs.microsoft.com/en-us/windows/package-manager/winget/
+https://docs.microsoft.com/windows/package-manager/winget/
 There is the Windows::ApplicationModel::PackageCatalog which exists as a Windows API for installing packages
 and monitoring their installation progress.
-https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.packagecatalog?view=winrt-19041
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.packagecatalog?view=winrt-19041
 And there is Windows.Management.Deployment.PackageManager which allows packages with the packageManagement
 capability to install msix apps and uses "Find" to describe looking up an app
-https://docs.microsoft.com/en-us/uwp/api/windows.management.deployment.packagemanager?view=winrt-19041
+https://docs.microsoft.com/uwp/api/windows.management.deployment.packagemanager?view=winrt-19041
 
 This API has aligned with those Windows APIs in using \*Catalog and Find.
 

--- a/doc/troubleshooting/README.md
+++ b/doc/troubleshooting/README.md
@@ -34,7 +34,7 @@ Only the Windows Insider DEV channel will continue receiving pre-release builds 
 
 ### Machine-wide Provisioning
 
-The Windows Package Manager can be provisioned machine-wide or for each new user. The following PowerShell cmdlet can be used to provision the package machine-wide. The latest Windows Package Manager release and license can be downloaded directly from the GitHub repository. It is dependent on the [Microsoft.VCLibs](https://docs.microsoft.com/en-us/troubleshoot/cpp/c-runtime-packages-desktop-bridge) desktop framework package, which needs to be downloaded and specified in the dependency path option in the cmdlet.
+The Windows Package Manager can be provisioned machine-wide or for each new user. The following PowerShell cmdlet can be used to provision the package machine-wide. The latest Windows Package Manager release and license can be downloaded directly from the GitHub repository. It is dependent on the [Microsoft.VCLibs](https://docs.microsoft.com/troubleshoot/cpp/c-runtime-packages-desktop-bridge) desktop framework package, which needs to be downloaded and specified in the dependency path option in the cmdlet.
 
   >`Add-AppxProvisionedPackage -online -PackagePath <desktop AppInstaller msixbundle package path> -LicensePath <license path> -DependencyPackagePath <Microsoft.VCLibs package path>`
 
@@ -124,7 +124,7 @@ Install failed: error 0x80070490: Opening the package from location appxbundle_N
 0x80070490 : Element not found.
 ```
 
-A possible troubleshooting step is to install the [KB5005565](https://support.microsoft.com/en-us/topic/september-14-2021-kb5005565-os-builds-19041-1237-19042-1237-and-19043-1237-292cf8ed-f97b-4cd8-9883-32b71e3e6b44) update, reboot your machine and try installing the appxbundle again.
+A possible troubleshooting step is to install the [KB5005565](https://support.microsoft.com/topic/september-14-2021-kb5005565-os-builds-19041-1237-19042-1237-and-19043-1237-292cf8ed-f97b-4cd8-9883-32b71e3e6b44) update, reboot your machine and try installing the appxbundle again.
 
 #### Updating Microsoft.DesktopAppInstaller from version 1.0.42251.0 doesn't render package name on Windows 11 Pro image in Azure
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

Removed `en-US/` in all links excluding the `/src` folder. I know not every link has different languages, but some do, so it's better to have the standard use of Microsoft links to not force English if another language is previously selected. If the user selected language is not available for that page, it will just display it in English.

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2494)