### PR TITLE
Suppress reboot by default on msiexec based installers

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -542,8 +542,8 @@ namespace AppInstaller::Manifest
         case InstallerTypeEnum::Msi:
             return
             {
-                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/quiet")},
-                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/passive")},
+                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/quiet /norestart")},
+                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/passive /norestart")},
                 {InstallerSwitchType::Log, ManifestInstaller::string_t("/log \"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
                 {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("TARGETDIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
             };


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
 -----

Issue: 
 - #229 

Problem: 
- Every WinGet installation using `msiexec` may restart the computer suddenly if any of the affected files are in use.

Solution: 
- Add '/norestart' flag by default.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2499)