### PR TITLE
Fix installer metadata collection

### DIFF
--- a/src/AppInstallerRepositoryCore/InstallerMetadataCollectionContext.cpp
+++ b/src/AppInstallerRepositoryCore/InstallerMetadataCollectionContext.cpp
@@ -489,7 +489,11 @@ namespace AppInstaller::Repository::Metadata
         AICLI_LOG(Repo, Info, << "Opening InstallerMetadataCollectionContext input file: " << file);
         std::ifstream fileStream{ file };
 
-        result->InitializePreinstallState(ConvertToUTF16(ReadEntireStream(fileStream)));
+        auto content = ReadEntireStream(fileStream);
+        // CppRestSdk's implementation of json parsing does not work with '\0', so trimming them here
+        content.erase(std::find(content.begin(), content.end(), '\0'), content.end());
+
+        result->InitializePreinstallState(ConvertToUTF16(content));
 
         return result;
     }

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -498,7 +498,7 @@ namespace AppInstaller::Repository
 
         if (!m_source)
         {
-            SourceList sourceList;
+            std::unique_ptr<SourceList> sourceList;
 
             // Check for updates before opening.
             for (auto& sourceReference : m_sourceReferences)
@@ -512,9 +512,14 @@ namespace AppInstaller::Repository
                         // to avoid the progress bar fill up multiple times.
                         if (BackgroundUpdateSourceFromDetails(details, progress))
                         {
-                            auto detailsInternal = sourceList.GetSource(details.Name);
+                            if (sourceList == nullptr)
+                            {
+                                sourceList = std::make_unique<SourceList>();
+                            }
+
+                            auto detailsInternal = sourceList->GetSource(details.Name);
                             detailsInternal->LastUpdateTime = details.LastUpdateTime;
-                            sourceList.SaveMetadata(*detailsInternal);
+                            sourceList->SaveMetadata(*detailsInternal);
                         }
                         else
                         {


### PR DESCRIPTION
- Fixed installer metadata collection crash by delay initializing SourceList
- Fixed issue with parsing input json be removing trailing null characters

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2517)