### PR TITLE
Suppress reboot by default on Inno Setup based installers

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -561,8 +561,8 @@ namespace AppInstaller::Manifest
         case InstallerTypeEnum::Inno:
             return
             {
-                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/VERYSILENT")},
-                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/SILENT")},
+                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/VERYSILENT /NORESTART")},
+                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/SILENT /NORESTART")},
                 {InstallerSwitchType::Log, ManifestInstaller::string_t("/LOG=\"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
                 {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("/DIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
             };


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Issue:

- https://github.com/microsoft/winget-cli/issues/229

Problem:

- Every WinGet installation for Inno Setup based installers may restart the computer suddenly if any of the affected files are in use.

Solution:

- Add '/NORESTART' flag by default.
  https://jrsoftware.org/ishelp/index.php?topic=setupcmdline

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2536)