### PR TITLE
Download MSIX installer during manifest validation (if necessary)

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -14,7 +14,7 @@ namespace AppInstaller::Manifest
     {
         std::vector<ValidationError> errors;
         Msix::PackageVersion packageVersion(manifest.Version);
-        auto msixInfo = GetMsixInfo(installer.Url, errors);
+        auto msixInfo = GetMsixInfo(installer.Url);
         if (msixInfo)
         {
             ValidateMsixManifestSignatureHash(msixInfo, installer.SignatureSha256, errors);
@@ -27,6 +27,10 @@ namespace AppInstaller::Manifest
                 ValidateMsixManifestPackageVersion(msixManifestIdentity.GetVersion(), packageVersion, errors);
                 ValidateMsixManifestMinOSVersion(msixManifest.GetMinimumOSVersionForSupportedPlatforms(), installerMinOSVersion, installer.Url, errors);
             }
+        }
+        else
+        {
+            errors.emplace_back(ManifestError::InstallerFailedToProcess, "InstallerUrl", installer.Url);
         }
 
         return errors;
@@ -81,9 +85,7 @@ namespace AppInstaller::Manifest
         }
     }
 
-    std::shared_ptr<Msix::MsixInfo> MsixManifestValidation::GetMsixInfo(
-        std::string installerUrl,
-        std::vector<ValidationError>& errors)
+    std::shared_ptr<Msix::MsixInfo> MsixManifestValidation::GetMsixInfo(std::string installerUrl)
     {
         std::shared_ptr<Msix::MsixInfo> msixInfo;
         // Cache Msix info for new installer url
@@ -102,7 +104,7 @@ namespace AppInstaller::Manifest
                 }
                 else
                 {
-                    AICLI_LOG(Core, Error, << "Failed to download installer. Msix info could not be obtained.");
+                    AICLI_LOG(Core, Error, << "Failed to download installer.");
                 }
             }
 
@@ -112,7 +114,7 @@ namespace AppInstaller::Manifest
             }
             else
             {
-                errors.emplace_back(ManifestError::InstallerFailedToProcess, "InstallerUrl", installerUrl);
+                AICLI_LOG(Core, Error, << "Msix info could not be obtained.");
             }
         }
         else

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -22,9 +22,7 @@ namespace AppInstaller::Manifest
 
         // Get Msix info from url/local path, or load it from cache.
         // Return null pointer if operation failed.
-        std::shared_ptr<Msix::MsixInfo> GetMsixInfo(
-            std::string installerUrl,
-            std::vector<ValidationError>& errors);
+        std::shared_ptr<Msix::MsixInfo> GetMsixInfo(std::string installerUrl);
 
         // Get Msix info from installer url.
         // Return null pointer if operation failed.

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -28,9 +28,9 @@ namespace AppInstaller::Manifest
         // Return null pointer if operation failed.
         std::shared_ptr<Msix::MsixInfo> GetMsixInfoFromUrl(std::string installerUrl);
 
-        // Get msix info from installer local path.
+        // Download and get msix info from installer local path.
         // Return null pointer if operation failed.
-        std::shared_ptr<Msix::MsixInfo> GetMsixInfoFromLocalPath(std::filesystem::path installerPath);
+        std::shared_ptr<Msix::MsixInfo> GetMsixInfoFromLocalPath(std::string installerUrl);
 
         // Download the installer.
         // If the download was successful, return the destination path.

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -20,11 +20,23 @@ namespace AppInstaller::Manifest
         std::map<std::string, std::shared_ptr<Msix::MsixInfo>> m_msixInfoCache;
         ValidationError::Level m_validationErrorLevel;
 
-        // Get Msix info from installer url, or load it from cache. Return null
-        // pointer if failed to process installer url.
+        // Get Msix info from url/local path, or load it from cache.
+        // Return null pointer if operation failed.
         std::shared_ptr<Msix::MsixInfo> GetMsixInfo(
             std::string installerUrl,
             std::vector<ValidationError>& errors);
+
+        // Get Msix info from installer url.
+        // Return null pointer if operation failed.
+        std::shared_ptr<Msix::MsixInfo> GetMsixInfoFromUrl(std::string installerUrl);
+
+        // Get msix info from installer local path.
+        // Return null pointer if operation failed.
+        std::shared_ptr<Msix::MsixInfo> GetMsixInfoFromLocalPath(std::filesystem::path installerPath);
+
+        // Download the installer.
+        // If the download was successful, return the destination path.
+        std::optional<std::filesystem::path> DownloadInstaller(std::string installerUrl, int retryCount);
 
         // Get manifest installer minimum OS version or nullopt if failed to
         // parse input.


### PR DESCRIPTION
- MSIX manifest validation fails to read information about certain packages from the installer URL
  - https://github.com/microsoft/winget-pkgs/issues/79677 
- Added a step for downloading the installer if reading the information directly from the installer URL failed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2587)