### PR TITLE
Remove MSIX installers after validation is done

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -397,6 +397,7 @@ namespace AppInstaller::Manifest
                 std::move(installerErrors.begin(), installerErrors.end(), std::inserter(errors, errors.end()));
             }
         }
+        msixManifestValidation.Cleanup();
 
         return errors;
     }

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -397,7 +397,6 @@ namespace AppInstaller::Manifest
                 std::move(installerErrors.begin(), installerErrors.end(), std::inserter(errors, errors.end()));
             }
         }
-        msixManifestValidation.Cleanup();
 
         return errors;
     }

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -36,6 +36,23 @@ namespace AppInstaller::Manifest
         return errors;
     }
 
+    void MsixManifestValidation::Cleanup()
+    {
+        // Remove all downloaded files (if any)
+        AICLI_LOG(Core, Info, << "Removing downloaded installers");
+        for (const auto& installerPath : m_downloadedInstallers)
+        {
+            try
+            {
+                std::filesystem::remove(installerPath);
+            }
+            catch (...)
+            {
+                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer");
+            }
+        }
+    }
+
     std::optional<std::filesystem::path> MsixManifestValidation::DownloadInstaller(std::string installerUrl, int retryCount)
     {
         while (retryCount-- > 0)
@@ -81,17 +98,12 @@ namespace AppInstaller::Manifest
             try
             {
                 AICLI_LOG(Core, Info, << "Fetching Msix info from installer local path");
+                m_downloadedInstallers.push_back(installerPath.value());
                 msixInfo = std::make_shared<Msix::MsixInfo>(installerPath.value());
             }
             catch (...)
             {
                 AICLI_LOG(Core, Error, << "Error fetching Msix info from the installer local path.");
-            }
-
-            AICLI_LOG(Core, Info, << "Removing downloaded installer");
-            if (!std::filesystem::remove(installerPath.value()))
-            {
-                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer");
             }
         }
         else

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -38,6 +38,10 @@ namespace AppInstaller::Manifest
 
     void MsixManifestValidation::Cleanup()
     {
+        // Clean cache
+        AICLI_LOG(Core, Info, << "Clearing Msix info cache");
+        m_msixInfoCache.clear();
+
         // Remove all downloaded files (if any)
         AICLI_LOG(Core, Info, << "Removing downloaded installers");
         for (const auto& installerPath : m_downloadedInstallers)

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -38,7 +38,7 @@ namespace AppInstaller::Manifest
 
     void MsixManifestValidation::Cleanup()
     {
-        // Clean cache
+        // Clear cache
         AICLI_LOG(Core, Info, << "Clearing Msix info cache");
         m_msixInfoCache.clear();
 
@@ -55,6 +55,7 @@ namespace AppInstaller::Manifest
                 AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer");
             }
         }
+        m_downloadedInstallers.clear();
     }
 
     std::optional<std::filesystem::path> MsixManifestValidation::DownloadInstaller(std::string installerUrl, int retryCount)

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -47,7 +47,7 @@ namespace AppInstaller::Manifest
             }
             catch (...)
             {
-                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer: " << installerPath.u8string());
+                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer: " << installerPath);
             }
         }
     }

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -63,6 +63,7 @@ namespace AppInstaller::Manifest
                 auto tempFile = Runtime::GetNewTempFilePath();
                 ProgressCallback callback;
                 Utility::Download(installerUrl, tempFile, Utility::DownloadType::Installer, callback);
+                m_downloadedInstallers.push_back(tempFile);
                 return tempFile;
             }
             catch (...)
@@ -98,7 +99,6 @@ namespace AppInstaller::Manifest
             try
             {
                 AICLI_LOG(Core, Info, << "Fetching Msix info from installer local path");
-                m_downloadedInstallers.push_back(installerPath.value());
                 msixInfo = std::make_shared<Msix::MsixInfo>(installerPath.value());
             }
             catch (...)

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -36,13 +36,8 @@ namespace AppInstaller::Manifest
         return errors;
     }
 
-    void MsixManifestValidation::Cleanup()
+    MsixManifestValidation::~MsixManifestValidation()
     {
-        // Clear cache
-        AICLI_LOG(Core, Info, << "Clearing Msix info cache");
-        m_msixInfoCache.clear();
-
-        // Remove all downloaded files (if any)
         AICLI_LOG(Core, Info, << "Removing downloaded installers");
         for (const auto& installerPath : m_downloadedInstallers)
         {
@@ -52,10 +47,9 @@ namespace AppInstaller::Manifest
             }
             catch (...)
             {
-                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer");
+                AICLI_LOG(Core, Warning, << "Failed to remove downloaded installer: " << installerPath.u8string());
             }
         }
-        m_downloadedInstallers.clear();
     }
 
     std::optional<std::filesystem::path> MsixManifestValidation::DownloadInstaller(std::string installerUrl, int retryCount)

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -12,13 +12,12 @@ namespace AppInstaller::Manifest
     {
         MsixManifestValidation(ValidationError::Level validationErrorLevel) : m_validationErrorLevel(validationErrorLevel) {}
 
+        ~MsixManifestValidation();
+
         // Validate manifest for Msix packages and Msix bundles.
         std::vector<ValidationError> Validate(
             const Manifest &manifest,
             const ManifestInstaller &installer);
-
-        // Cleanup after validation
-        void Cleanup();
     private:
         std::map<std::string, std::shared_ptr<Msix::MsixInfo>> m_msixInfoCache;
         std::vector<std::filesystem::path> m_downloadedInstallers;

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -16,8 +16,12 @@ namespace AppInstaller::Manifest
         std::vector<ValidationError> Validate(
             const Manifest &manifest,
             const ManifestInstaller &installer);
+
+        // Cleanup after validation
+        void Cleanup();
     private:
         std::map<std::string, std::shared_ptr<Msix::MsixInfo>> m_msixInfoCache;
+        std::vector<std::filesystem::path> m_downloadedInstallers;
         ValidationError::Level m_validationErrorLevel;
 
         // Get Msix info from url/local path, or load it from cache.


### PR DESCRIPTION
Remove MSIX installers _after validation is done_ in order to ensure that the information used during validation is available when needed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2591)