### PR TITLE
Fix PowerShell module for release configuration

### DIFF
--- a/src/IndexCreationTool/IndexCreationTool.csproj
+++ b/src/IndexCreationTool/IndexCreationTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\IndexCreationTool\</OutDir>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>

--- a/src/LocalhostWebServer/LocalhostWebServer.csproj
+++ b/src/LocalhostWebServer/LocalhostWebServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<OutDir>$(SolutionDir)$(Platform)\$(Configuration)\LocalhostWebServer\</OutDir>
 	<Platforms>x64;x86</Platforms>
   </PropertyGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client/Common/BaseClientCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Common/BaseClientCommand.cs
@@ -69,7 +69,7 @@ namespace Microsoft.WinGet.Client.Common
             }
         }
 
-        [DllImport("winrtact.dll", EntryPoint = "winrtact_Initialize", ExactSpelling = true, PreserveSig = false)]
+        [DllImport("winrtact.dll", EntryPoint = "winrtact_Initialize", ExactSpelling = true, PreserveSig = true)]
         private static extern void InitializeUndockedRegFreeWinRT();
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client/Copy-PlatformBinaries.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Copy-PlatformBinaries.ps1
@@ -31,12 +31,12 @@ param (
 )
 
 # src\x64\Release\Project\net461\Library.Desktop.dll
-# src\x64\Release\Project\net5.0-windows10.0.22000.0\Library.Core.dll
+# src\x64\Release\Project\net6.0-windows10.0.22000.0\Library.Core.dll
 
 # build\Module\x64\Desktop\Library.Desktop.dll
 # build\Module\x64\Core\Library.Core.dll
 
-$CoreFramework = 'net5.0-windows10.0.22000.0'
+$CoreFramework = 'net6.0-windows10.0.22000.0'
 $CoreFolderName = 'Core'
 $DesktopFramework = 'net461'
 $DesktopFolderName = 'Desktop'

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
@@ -2,14 +2,16 @@
 
   <PropertyGroup>
     <TargetWindowsVersion>10.0.22000.0</TargetWindowsVersion>
-    <CoreFramework>net5.0-windows$(TargetWindowsVersion)</CoreFramework>
+    <CoreFramework>net6.0-windows$(TargetWindowsVersion)</CoreFramework>
     <DesktopFramework>net461</DesktopFramework>
   </PropertyGroup>
   
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>9</LangVersion>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
+    <OutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</OutputDirectory>
+    <OutputPath>$(OutputDirectory)\$(MSBuildProjectName)\</OutputPath>
+    <PowerShellModuleOutputDirectory>$(OutputPath)\PowerShell</PowerShellModuleOutputDirectory>
     <Platforms>x64;x86</Platforms>
     <TargetFrameworks>$(CoreFramework);$(DesktopFramework)</TargetFrameworks>
   </PropertyGroup>
@@ -76,5 +78,29 @@
 		<Message Importance="high" Text="Copying '@(WinRTActDll)' to '$(OutputPath)'" />
 		<Copy SourceFiles="@(WinRTActDll)" DestinationFolder="$(OutputPath)" />
 	</Target>
-	
+
+    <!-- Build Microsoft.Winget.Client PowerShell Module -->
+    <Target Name="Create Powershell module" AfterTargets="AfterBuild">
+        <Message Importance="high" Text="Copying PS1XMl file to to '$(OutputDirectory)/PowerShell'" />
+        <Copy SourceFiles="Format.ps1xml" DestinationFolder="$(OutputDirectory)/PowerShell" />
+        <Copy SourceFiles="Microsoft.WinGet.Client.psd1" DestinationFolder="$(OutputDirectory)/PowerShell" />
+        <Copy SourceFiles="Microsoft.WinGet.Client.psm1" DestinationFolder="$(OutputDirectory)/PowerShell" />
+    </Target>
+    
+    <Target Name="CopyCoreBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(CoreFramework)'">
+        <ItemGroup>
+            <CoreBinaries Include="$(OutputPath)*" />
+        </ItemGroup>
+        <Message Importance="high" Text="Copying @(CoreBinaries) to to '$(OutputDirectory)/PowerShell/$(Platform)/Core'" />
+        <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(OutputDirectory)/PowerShell/$(Platform)/Core" />
+    </Target>
+
+    <Target Name="CopyDesktopBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(DesktopFramework)'">
+        <ItemGroup>
+            <DesktopBinaries Include="$(OutputPath)*" />
+        </ItemGroup>
+        <Message Importance="high" Text="Copying @(CoreBinaries) to to '$(OutputDirectory)/PowerShell/$(Platform)/Desktop'" />
+        <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(OutputDirectory)/PowerShell/$(Platform)/Desktop" />
+    </Target>
+    
 </Project>

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
@@ -9,9 +9,9 @@
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>9</LangVersion>
-    <OutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</OutputDirectory>
-    <OutputPath>$(OutputDirectory)\$(MSBuildProjectName)\</OutputPath>
-    <PowerShellModuleOutputDirectory>$(OutputPath)\PowerShell</PowerShellModuleOutputDirectory>
+    <BuildOutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</BuildOutputDirectory>
+    <OutputPath>$(BuildOutputDirectory)$(MSBuildProjectName)</OutputPath>
+    <PowerShellModuleOutputDirectory>$(BuildOutputDirectory)PowerShell</PowerShellModuleOutputDirectory>
     <Platforms>x64;x86</Platforms>
     <TargetFrameworks>$(CoreFramework);$(DesktopFramework)</TargetFrameworks>
   </PropertyGroup>
@@ -80,27 +80,27 @@
 	</Target>
 
     <!-- Build Microsoft.Winget.Client PowerShell Module -->
-    <Target Name="Create Powershell module" AfterTargets="AfterBuild">
-        <Message Importance="high" Text="Copying PS1XMl file to to '$(OutputDirectory)/PowerShell'" />
-        <Copy SourceFiles="Format.ps1xml" DestinationFolder="$(OutputDirectory)/PowerShell" />
-        <Copy SourceFiles="Microsoft.WinGet.Client.psd1" DestinationFolder="$(OutputDirectory)/PowerShell" />
-        <Copy SourceFiles="Microsoft.WinGet.Client.psm1" DestinationFolder="$(OutputDirectory)/PowerShell" />
+    <Target Name="CopyModuleFiles" AfterTargets="AfterBuild">
+        <Message Importance="high" Text="Copying PowerShell module files to '$(PowerShellModuleOutputDirectory)'" />
+        <Copy SourceFiles="Format.ps1xml" DestinationFolder="$(PowerShellModuleOutputDirectory)" />
+        <Copy SourceFiles="Microsoft.WinGet.Client.psd1" DestinationFolder="$(PowerShellModuleOutputDirectory)" />
+        <Copy SourceFiles="Microsoft.WinGet.Client.psm1" DestinationFolder="$(PowerShellModuleOutputDirectory)" />
     </Target>
     
     <Target Name="CopyCoreBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(CoreFramework)'">
         <ItemGroup>
             <CoreBinaries Include="$(OutputPath)*" />
         </ItemGroup>
-        <Message Importance="high" Text="Copying @(CoreBinaries) to to '$(OutputDirectory)/PowerShell/$(Platform)/Core'" />
-        <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(OutputDirectory)/PowerShell/$(Platform)/Core" />
+        <Message Importance="high" Text="Copying @(CoreBinaries) to '$(PowerShellModuleOutputDirectory)\$(Platform)\Core'" />
+        <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(PowerShellModuleOutputDirectory)\$(Platform)\Core" />
     </Target>
 
     <Target Name="CopyDesktopBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(DesktopFramework)'">
         <ItemGroup>
             <DesktopBinaries Include="$(OutputPath)*" />
         </ItemGroup>
-        <Message Importance="high" Text="Copying @(CoreBinaries) to to '$(OutputDirectory)/PowerShell/$(Platform)/Desktop'" />
-        <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(OutputDirectory)/PowerShell/$(Platform)/Desktop" />
+        <Message Importance="high" Text="Copying @(DesktopBinaries) to '$(PowerShellModuleOutputDirectory)\$(Platform)\Desktop'" />
+        <Copy SourceFiles="@(DesktopBinaries)" DestinationFolder="$(PowerShellModuleOutputDirectory)\$(Platform)\Desktop" />
     </Target>
     
 </Project>

--- a/src/PowerShell/Microsoft.WinGet.Client/README.md
+++ b/src/PowerShell/Microsoft.WinGet.Client/README.md
@@ -4,7 +4,7 @@ This project contains the source code for building the Windows Package Manager P
 
 ## Running the PowerShell Module Locally
 
-After building the project solution, the `Microsoft.WinGet.Client` PowerShell module can be found in the output directory in the `PowerShell` folder. For example if you built the project as x64 release, you should expect to find the module files in `$(ProjectDirectory)/src/x64/Release/PowerShell`.
+After building the project solution, the `Microsoft.WinGet.Client` PowerShell module can be found in the output directory in the `PowerShell` folder. For example if you built the project as x64 release, you should expect to find the module files in `$(SolutionDirectory)/src/x64/Release/PowerShell`.
 
 To run the module, make sure you are using the latest version of PowerShell (not Windows PowerShell), then import the module manifest (Microsoft.WinGet.Client.psd1).
 

--- a/src/PowerShell/Microsoft.WinGet.Client/README.md
+++ b/src/PowerShell/Microsoft.WinGet.Client/README.md
@@ -1,0 +1,28 @@
+﻿# Windows Package Manager PowerShell Module
+
+This project contains the source code for building the Windows Package Manager PowerShell Module.
+
+## Running the PowerShell Module Locally
+
+After building the project solution, the `Microsoft.WinGet.Client` PowerShell module can be found in the output directory in the `PowerShell` folder. For example if you built the project as x64 release, you should expect to find the module files in `$(ProjectDirectory)/src/x64/Release/PowerShell`.
+
+To run the module, make sure you are using the latest version of PowerShell (not Windows PowerShell), then import the module manifest (Microsoft.WinGet.Client.psd1).
+
+```
+Import-Module <Path to Microsoft.WinGet.Client.psd1">
+```
+
+The following cmdlets and functions are available for you to try:
+
+    Get-WinGetVersion
+    Enable-WinGetSetting
+    Disable-WinGetSetting
+    Add-WinGetSource
+    Remove-WinGetSource
+    Reset-WinGetSource
+    Find-WinGetPackage
+    Get-WinGetPackage
+    Get-WinGetSource
+    Install-WinGetPackage
+    Uninstall-WinGetPackage
+    Update-WinGetPackage

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -73,26 +73,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -73,26 +73,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(BuildOutDir)</OutDir>
-    <IntDir>$(OutDir)$(ProjectName)</IntDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(BuildOutDir)</OutDir>
-    <IntDir>$(OutDir)$(ProjectName)</IntDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(BuildOutDir)</OutDir>
-    <IntDir>$(OutDir)$(ProjectName)</IntDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -91,8 +91,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>winrtact</TargetName>
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(BuildOutDir)</OutDir>
-    <IntDir>$(OutDir)$(ProjectName)</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/UndockedRegFreeWinRT/detours/detours.vcxproj
+++ b/src/UndockedRegFreeWinRT/detours/detours.vcxproj
@@ -89,23 +89,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>      
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>     
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>      
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/UndockedRegFreeWinRT/detours/detours.vcxproj
+++ b/src/UndockedRegFreeWinRT/detours/detours.vcxproj
@@ -89,21 +89,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IntDir>$(OutDir)$(ProjectName)\</IntDir>
-    <OutDir>$(BuildOutDir)</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>      
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IntDir>$(OutDir)$(ProjectName)\</IntDir>
-    <OutDir>$(BuildOutDir)</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>      
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/UndockedRegFreeWinRT/detours/detours.vcxproj
+++ b/src/UndockedRegFreeWinRT/detours/detours.vcxproj
@@ -102,6 +102,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
Changes:
- Fixes a bug where the release configuration build for the PowerShell module was throwing a type initialization error. 
- Updates the build output for Detours and UndockedRegFreeWinRT to the appropriate location
- Added an post-build event to copy the modules files into its own directory so that it can be run directly
- Added a README with instructions on how to run the powershell module locally.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2599)