### PR TITLE
Add AdvancedInstaller (exe) type and Default Switches

### DIFF
--- a/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
@@ -65,7 +65,8 @@
         "wix",
         "burn",
         "pwa",
-        "portable"
+        "portable",
+        "advancedinstaller"
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
@@ -80,7 +81,8 @@
         "nullsoft",
         "wix",
         "burn",
-        "portable"
+        "portable",
+        "advancedinstaller"
       ],
       "description": "Enumeration of supported nested installer types contained inside an archive file"
     },

--- a/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
@@ -66,7 +66,7 @@
         "burn",
         "pwa",
         "portable",
-        "advancedinstaller"
+        "advancedInstaller"
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
@@ -82,7 +82,7 @@
         "wix",
         "burn",
         "portable",
-        "advancedinstaller"
+        "advancedInstaller"
       ],
       "description": "Enumeration of supported nested installer types contained inside an archive file"
     },

--- a/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
@@ -107,7 +107,8 @@
         "wix",
         "burn",
         "pwa",
-        "portable"
+        "portable",
+        "advancedinstaller"
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
@@ -122,7 +123,8 @@
         "nullsoft",
         "wix",
         "burn",
-        "portable"
+        "portable",
+        "advancedinstaller"
       ],
       "description": "Enumeration of supported nested installer types contained inside an archive file"
     },

--- a/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
@@ -108,7 +108,7 @@
         "burn",
         "pwa",
         "portable",
-        "advancedinstaller"
+        "advancedInstaller"
       ],
       "description": "Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level"
     },
@@ -124,7 +124,7 @@
         "wix",
         "burn",
         "portable",
-        "advancedinstaller"
+        "advancedInstaller"
       ],
       "description": "Enumeration of supported nested installer types contained inside an archive file"
     },

--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -40,6 +40,7 @@ namespace AppInstaller::CLI::Workflow
             case InstallerTypeEnum::Inno:
             case InstallerTypeEnum::Nullsoft:
             case InstallerTypeEnum::Portable:
+            case InstallerTypeEnum::AdvancedInstaller:
                 return L".exe"sv;
             case InstallerTypeEnum::Msi:
             case InstallerTypeEnum::Wix:
@@ -153,6 +154,7 @@ namespace AppInstaller::CLI::Workflow
             case InstallerTypeEnum::Portable: 
             case InstallerTypeEnum::Wix:
             case InstallerTypeEnum::Zip:
+            case InstallerTypeEnum::AdvancedInstaller:
                 context << DownloadInstallerFile;
                 break;
             case InstallerTypeEnum::Msix:

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -45,6 +45,7 @@ namespace AppInstaller::CLI::Workflow
             case InstallerTypeEnum::Msi:
             case InstallerTypeEnum::Nullsoft:
             case InstallerTypeEnum::Wix:
+            case InstallerTypeEnum::AdvancedInstaller:
                 return true;
             default:
                 return false;
@@ -266,6 +267,7 @@ namespace AppInstaller::CLI::Workflow
         case InstallerTypeEnum::Msi:
         case InstallerTypeEnum::Nullsoft:
         case InstallerTypeEnum::Wix:
+        case InstallerTypeEnum::AdvancedInstaller:
             if (isUpdate && updateBehavior == UpdateBehaviorEnum::UninstallPrevious)
             {
                 context <<

--- a/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
@@ -78,6 +78,7 @@ namespace AppInstaller::CLI::Workflow
         case InstallerTypeEnum::Burn:
         case InstallerTypeEnum::Inno:
         case InstallerTypeEnum::Nullsoft:
+        case InstallerTypeEnum::AdvancedInstaller:
         {
             IPackageVersion::Metadata packageMetadata = installedPackageVersion->GetMetadata();
 
@@ -162,6 +163,7 @@ namespace AppInstaller::CLI::Workflow
         case InstallerTypeEnum::Burn:
         case InstallerTypeEnum::Inno:
         case InstallerTypeEnum::Nullsoft:
+        case InstallerTypeEnum::AdvancedInstaller:
             context <<
                 Workflow::ShellExecuteUninstallImpl <<
                 ReportUninstallerResult("UninstallString", APPINSTALLER_CLI_ERROR_EXEC_UNINSTALL_COMMAND_FAILED);

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -257,6 +257,9 @@
     <CopyFileToFolders Include="TestData\Manifest-Good.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_AdvancedInstallerExe.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_EncodedUrl.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
@@ -615,6 +618,9 @@
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\Manifest-Bad-Channel-NotSupported.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_AdvancedInstallerExe.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -504,6 +504,9 @@
     <CopyFileToFolders Include="TestData\TestZip.zip">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_AdvancedInstallerExe.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_NoApplicableArchitecture.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
@@ -571,6 +574,9 @@
       <Filter>TestData</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallerArgTest_Inno_NoSwitches.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\UpdateFlowTest_AdvancedInstallerExe.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_AdvancedInstallerExe.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_AdvancedInstallerExe.yaml
@@ -1,0 +1,14 @@
+Id: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
+Version: 1.0.0.0
+Name: AppInstaller Test AdvancedInstaller Exe Installer
+Publisher: Microsoft Corporation
+AppMoniker: AICLITestAdvancedInstallerExe
+License: Test
+ProductCode: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
+Installers: 
+    - Arch: x64
+      Url: https://ThisIsNotUsed
+      InstallerType: advancedInstaller
+      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+      Scope: user
+ManifestVersion: 0.1.0

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_AdvancedInstallerExe.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_AdvancedInstallerExe.yaml
@@ -1,14 +1,17 @@
-Id: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
-Version: 1.0.0.0
-Name: AppInstaller Test AdvancedInstaller Exe Installer
+PackageIdentifier: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test AdvancedInstaller Exe Installer
 Publisher: Microsoft Corporation
-AppMoniker: AICLITestAdvancedInstallerExe
+Moniker: AICLITestAdvancedInstallerExe
+ShortDescription: AppInstaller Test Installer
 License: Test
 ProductCode: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
 Installers: 
-    - Arch: x64
-      Url: https://ThisIsNotUsed
-      InstallerType: advancedInstaller
-      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
-      Scope: user
-ManifestVersion: 0.1.0
+- Architecture: x64
+  InstallerUrl: https://ThisIsNotUsed
+  InstallerType: advancedInstaller
+  InstallerSha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+  Scope: user
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_ExpectedReturnCodes.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_ExpectedReturnCodes.yaml
@@ -43,5 +43,11 @@ Installers:
             ReturnResponse: downgrade
           - InstallerReturnCode: 15
             ReturnResponse: blockedByPolicy
+          - InstallerReturnCode: 16
+            ReturnResponse: packageInUseByApplication
+          - InstallerReturnCode: 17
+            ReturnResponse: invalidParameter
+          - InstallerReturnCode: 18
+            ReturnResponse: systemNotSupported
 ManifestType: singleton
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/TestData/UpdateFlowTest_AdvancedInstallerExe.yaml
+++ b/src/AppInstallerCLITests/TestData/UpdateFlowTest_AdvancedInstallerExe.yaml
@@ -1,15 +1,19 @@
 # Same content with InstallFlowTest_AdvancedInstallerExe.yaml but with higher version
-Id: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
-Version: 2.0.0.0
-Name: AppInstaller Test AdvancedInstaller Exe Installer
+PackageIdentifier: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
+PackageVersion: 2.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test AdvancedInstaller Exe Installer
 Publisher: Microsoft Corporation
-AppMoniker: AICLITestAdvancedInstallerExe
+Moniker: AICLITestAdvancedInstallerExe
+ShortDescription: AppInstaller Test Installer
 License: Test
 Installers: 
-    - Arch: x64
-      Url: https://ThisIsNotUsed
-      InstallerType: advancedInstaller
-      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
-      InstallerSwitches:
-          - Update: /update
-ManifestVersion: 0.1.0
+- Architecture: x64
+  InstallerUrl: https://ThisIsNotUsed
+  InstallerType: advancedInstaller
+  InstallerSha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+  InstallerSwitches:
+    Upgrade: /update
+    Custom: /ver2.0.0.0
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/AppInstallerCLITests/TestData/UpdateFlowTest_AdvancedInstallerExe.yaml
+++ b/src/AppInstallerCLITests/TestData/UpdateFlowTest_AdvancedInstallerExe.yaml
@@ -1,0 +1,15 @@
+# Same content with InstallFlowTest_AdvancedInstallerExe.yaml but with higher version
+Id: AppInstallerCliTest.TestAdvancedInstallerExeInstaller
+Version: 2.0.0.0
+Name: AppInstaller Test AdvancedInstaller Exe Installer
+Publisher: Microsoft Corporation
+AppMoniker: AICLITestAdvancedInstallerExe
+License: Test
+Installers: 
+    - Arch: x64
+      Url: https://ThisIsNotUsed
+      InstallerType: advancedInstaller
+      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+      InstallerSwitches:
+          - Update: /update
+ManifestVersion: 0.1.0

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -178,12 +178,17 @@ namespace
             if (input.empty() || input == "AppInstallerCliTest.TestAdvancedInstallerExeInstaller")
             {
                 auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_AdvancedInstallerExe.yaml"));
-                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Portable.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_AdvancedInstallerExe.yaml"));
                 result.Matches.emplace_back(
                     ResultMatch(
                         TestPackage::Make(
                             manifest,
-                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "AdvancedInstaller" } },
+                            TestPackage::MetadataMap
+                            {
+                                { PackageVersionMetadata::InstalledType, "AdvancedInstaller" },
+                                { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                                { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                            },
                             std::vector<Manifest>{ manifest2, manifest },
                             shared_from_this()
                         ),
@@ -2090,7 +2095,7 @@ TEST_CASE("UpdateFlow_UpdateExe", "[UpdateFlow][workflow]")
     REQUIRE(updateResultStr.find("/ver3.0.0.0") != std::string::npos);
 }
 
-TEST_CASE("UpdateFlow_UpdateAdvanced_Installer_Exe", "[UpdateFlow][workflow]")
+TEST_CASE("UpdateFlow_UpdateAdvancedInstaller_Exe", "[UpdateFlow][workflow]")
 {
     TestCommon::TempFile updateResultPath("TestExeInstalled.txt");
 
@@ -2113,7 +2118,7 @@ TEST_CASE("UpdateFlow_UpdateAdvanced_Installer_Exe", "[UpdateFlow][workflow]")
     std::string updateResultStr;
     std::getline(updateResultFile, updateResultStr);
     REQUIRE(updateResultStr.find("/update") != std::string::npos); // This should be passed in from the Manifest
-    REQUIRE(updateResultStr.find("/exenoui /passive /norestart") != std::string::npos); // These should be the default passed in from the CLI
+    REQUIRE(updateResultStr.find("/exenoui /quiet /norestart") != std::string::npos); // These should be the default passed in from the CLI
     REQUIRE(updateResultStr.find("/ver2.0.0.0") != std::string::npos);
 }
 
@@ -2826,7 +2831,7 @@ TEST_CASE("ExportFlow_ExportAll", "[ExportFlow][workflow]")
     REQUIRE(exportedCollection.Sources[0].Details.Identifier == "*TestSource");
 
     const auto& exportedPackages = exportedCollection.Sources[0].Packages;
-    REQUIRE(exportedPackages.size() == 5);
+    REQUIRE(exportedPackages.size() == 6);
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestExeInstaller" && p.VersionAndChannel.GetVersion().ToString().empty();
@@ -2846,6 +2851,10 @@ TEST_CASE("ExportFlow_ExportAll", "[ExportFlow][workflow]")
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestZipInstaller" && p.VersionAndChannel.GetVersion().ToString().empty();
+        }));
+    REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
+        {
+            return p.Id == "AppInstallerCliTest.TestAdvancedInstallerExeInstaller" && p.VersionAndChannel.GetVersion().ToString().empty();
         }));
 }
 
@@ -2870,7 +2879,7 @@ TEST_CASE("ExportFlow_ExportAll_WithVersions", "[ExportFlow][workflow]")
     REQUIRE(exportedCollection.Sources[0].Details.Identifier == "*TestSource");
 
     const auto& exportedPackages = exportedCollection.Sources[0].Packages;
-    REQUIRE(exportedPackages.size() == 5);
+    REQUIRE(exportedPackages.size() == 6);
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestExeInstaller" && p.VersionAndChannel.GetVersion().ToString() == "1.0.0.0";
@@ -2890,6 +2899,10 @@ TEST_CASE("ExportFlow_ExportAll_WithVersions", "[ExportFlow][workflow]")
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestZipInstaller" && p.VersionAndChannel.GetVersion().ToString() == "1.0.0.0";
+        }));
+    REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
+        {
+            return p.Id == "AppInstallerCliTest.TestAdvancedInstallerExeInstaller" && p.VersionAndChannel.GetVersion().ToString() == "1.0.0.0";
         }));
 }
 

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -608,7 +608,6 @@ namespace AppInstaller::Manifest
         switch (installerType)
         {
         case InstallerTypeEnum::Burn:
-        case InstallerTypeEnum::AdvancedInstaller:
         case InstallerTypeEnum::Wix:
         case InstallerTypeEnum::Msi:
             // See https://docs.microsoft.com/windows/win32/msi/error-codes
@@ -620,6 +619,9 @@ namespace AppInstaller::Manifest
                 { ERROR_SUCCESS_REBOOT_REQUIRED, ExpectedReturnCodeEnum::RebootRequiredToFinish },
                 { ERROR_SUCCESS_REBOOT_INITIATED, ExpectedReturnCodeEnum::RebootInitiated },
                 { ERROR_INSTALL_USEREXIT, ExpectedReturnCodeEnum::CancelledByUser },
+                { ERROR_BAD_CONFIGURATION, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_INSTALL_UI_FAILURE, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_CREATE_FAILED, ExpectedReturnCodeEnum::ContactSupport },
                 { ERROR_PRODUCT_VERSION, ExpectedReturnCodeEnum::AlreadyInstalled },
                 { ERROR_INSTALL_REJECTED, ExpectedReturnCodeEnum::SystemNotSupported },
                 { ERROR_INSTALL_PACKAGE_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
@@ -633,6 +635,24 @@ namespace AppInstaller::Manifest
                 { ERROR_INVALID_PATCH_XML, ExpectedReturnCodeEnum::InvalidParameter },
                 { ERROR_INSTALL_LANGUAGE_UNSUPPORTED, ExpectedReturnCodeEnum::SystemNotSupported },
                 { ERROR_INSTALL_PLATFORM_UNSUPPORTED, ExpectedReturnCodeEnum::SystemNotSupported },
+            };
+        case InstallerTypeEnum::AdvancedInstaller:
+            // See https://www.advancedinstaller.com/user-guide/exe-setup-file.html
+            return
+            {
+                { ERROR_INSTALL_ALREADY_RUNNING, ExpectedReturnCodeEnum::InstallInProgress },
+                { ERROR_DISK_FULL, ExpectedReturnCodeEnum::DiskFull },
+                { ERROR_INSTALL_SERVICE_FAILURE, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_SUCCESS_REBOOT_REQUIRED, ExpectedReturnCodeEnum::RebootRequiredToFinish },
+                { ERROR_SUCCESS_REBOOT_INITIATED, ExpectedReturnCodeEnum::RebootInitiated },
+                { ERROR_INSTALL_USEREXIT, ExpectedReturnCodeEnum::CancelledByUser },
+                { ERROR_BAD_CONFIGURATION, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_INSTALL_UI_FAILURE, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_CREATE_FAILED, ExpectedReturnCodeEnum::ContactSupport },
+                { ERROR_PRODUCT_VERSION, ExpectedReturnCodeEnum::AlreadyInstalled },
+                { ERROR_INSTALL_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { -1, ExpectedReturnCodeEnum::CancelledByUser },
+                // 1 when EXE bootstrapper is launched with wrong value for /aespassword parameter
             };
         case InstallerTypeEnum::Inno:
             // See https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -650,9 +650,20 @@ namespace AppInstaller::Manifest
                 { ERROR_INSTALL_UI_FAILURE, ExpectedReturnCodeEnum::ContactSupport },
                 { ERROR_CREATE_FAILED, ExpectedReturnCodeEnum::ContactSupport },
                 { ERROR_PRODUCT_VERSION, ExpectedReturnCodeEnum::AlreadyInstalled },
-                { ERROR_INSTALL_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_INSTALL_REJECTED, ExpectedReturnCodeEnum::SystemNotSupported },
+                { ERROR_INSTALL_PACKAGE_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_INSTALL_TRANSFORM_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_PATCH_PACKAGE_REJECTED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_PATCH_REMOVAL_DISALLOWED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_INSTALL_REMOTE_DISALLOWED, ExpectedReturnCodeEnum::BlockedByPolicy },
+                { ERROR_INVALID_PARAMETER, ExpectedReturnCodeEnum::InvalidParameter },
+                { ERROR_INVALID_TABLE, ExpectedReturnCodeEnum::InvalidParameter },
+                { ERROR_INVALID_COMMAND_LINE, ExpectedReturnCodeEnum::InvalidParameter },
+                { ERROR_INVALID_PATCH_XML, ExpectedReturnCodeEnum::InvalidParameter },
+                { ERROR_INSTALL_LANGUAGE_UNSUPPORTED, ExpectedReturnCodeEnum::SystemNotSupported },
+                { ERROR_INSTALL_PLATFORM_UNSUPPORTED, ExpectedReturnCodeEnum::SystemNotSupported },
                 { -1, ExpectedReturnCodeEnum::CancelledByUser },
-                // 1 when EXE bootstrapper is launched with wrong value for /aespassword parameter
+                { 1, ExpectedReturnCodeEnum::InvalidParameter },
             };
         case InstallerTypeEnum::Inno:
             // See https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -24,6 +24,7 @@ namespace AppInstaller::Manifest
             case InstallerTypeEnum::Nullsoft:
             case InstallerTypeEnum::Exe:
             case InstallerTypeEnum::Burn:
+            case InstallerTypeEnum::AdvancedInstaller:
                 return CompatibilitySet::Exe;
             case InstallerTypeEnum::Wix:
             case InstallerTypeEnum::Msi:
@@ -161,6 +162,10 @@ namespace AppInstaller::Manifest
         else if (inStrLower == "portable") 
         {
             result = InstallerTypeEnum::Portable;
+        }
+        else if (inStrLower == "advancedinstaller")
+        {
+            result = InstallerTypeEnum::AdvancedInstaller;
         }
 
         return result;
@@ -432,6 +437,8 @@ namespace AppInstaller::Manifest
             return "msstore"sv;
         case InstallerTypeEnum::Portable:
             return "portable"sv;
+        case InstallerTypeEnum::AdvancedInstaller:
+            return "advancedinstaller"sv;
         }
 
         return "unknown"sv;
@@ -464,7 +471,8 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Nullsoft ||
             installerType == InstallerTypeEnum::Wix ||
             installerType == InstallerTypeEnum::Burn ||
-            installerType == InstallerTypeEnum::Portable
+            installerType == InstallerTypeEnum::Portable ||
+            installerType == InstallerTypeEnum::AdvancedInstaller
             );
     }
 
@@ -477,7 +485,8 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Nullsoft ||
             installerType == InstallerTypeEnum::Wix ||
             installerType == InstallerTypeEnum::Burn ||
-            installerType == InstallerTypeEnum::Portable
+            installerType == InstallerTypeEnum::Portable ||
+            installerType == InstallerTypeEnum::AdvancedInstaller
             );
     }
 
@@ -489,7 +498,8 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Msi ||
             installerType == InstallerTypeEnum::Nullsoft ||
             installerType == InstallerTypeEnum::Wix ||
-            installerType == InstallerTypeEnum::Burn
+            installerType == InstallerTypeEnum::Burn ||
+            installerType == InstallerTypeEnum::AdvancedInstaller
             );
     }
 
@@ -520,7 +530,8 @@ namespace AppInstaller::Manifest
             nestedInstallerType == InstallerTypeEnum::Wix ||
             nestedInstallerType == InstallerTypeEnum::Burn ||
             nestedInstallerType == InstallerTypeEnum::Portable ||
-            nestedInstallerType == InstallerTypeEnum::Msix
+            nestedInstallerType == InstallerTypeEnum::Msix ||
+            nestedInstallerType == InstallerTypeEnum::AdvancedInstaller
             );
     }
 
@@ -579,6 +590,14 @@ namespace AppInstaller::Manifest
                 {InstallerSwitchType::Log, ManifestInstaller::string_t("/LOG=\"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
                 {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("/DIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
             };
+        case InstallerTypeEnum::AdvancedInstaller:
+            return
+            {
+                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/exenoui /quiet /norestart")},
+                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/exenoui /passive /norestart")},
+                {InstallerSwitchType::Log, ManifestInstaller::string_t("/log \"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
+                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("APPDIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
+            };
         default:
             return {};
         }
@@ -589,6 +608,7 @@ namespace AppInstaller::Manifest
         switch (installerType)
         {
         case InstallerTypeEnum::Burn:
+        case InstallerTypeEnum::AdvancedInstaller:
         case InstallerTypeEnum::Wix:
         case InstallerTypeEnum::Msi:
             // See https://docs.microsoft.com/windows/win32/msi/error-codes

--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -83,6 +83,7 @@ namespace AppInstaller::Manifest
         Burn,
         MSStore,
         Portable,
+        AdvancedInstaller,
     };
 
     enum class UpdateBehaviorEnum

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_4/Json/ManifestDeserializer_1_4.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_4/Json/ManifestDeserializer_1_4.cpp
@@ -43,6 +43,10 @@ namespace AppInstaller::Repository::Rest::Schema::V1_4::Json
         {
             return InstallerTypeEnum::Portable;
         }
+        else if (inStrLower == "advancedinstaller")
+        {
+            return InstallerTypeEnum::AdvancedInstaller;
+        }
 
         return V1_1::Json::ManifestDeserializer::ConvertToInstallerType(inStrLower);
     }

--- a/src/Microsoft.Management.Deployment/Converters.cpp
+++ b/src/Microsoft.Management.Deployment/Converters.cpp
@@ -286,6 +286,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             return Microsoft::Management::Deployment::PackageInstallerType::Wix;
         case ::AppInstaller::Manifest::InstallerTypeEnum::Zip:
             return Microsoft::Management::Deployment::PackageInstallerType::Zip;
+        case ::AppInstaller::Manifest::InstallerTypeEnum::AdvancedInstaller:
+            return Microsoft::Management::Deployment::PackageInstallerType::AdvancedInstaller;
         case ::AppInstaller::Manifest::InstallerTypeEnum::Unknown:
             return Microsoft::Management::Deployment::PackageInstallerType::Unknown;
         }

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -321,6 +321,8 @@ namespace Microsoft.Management.Deployment
         MSStore,
         /// Portable type.
         Portable,
+        /// AdvancedInstaller type.
+        AdvancedInstaller,
     };
 
     /// The package installer scope.


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?
  - No. I noticed that several (~100+) packages use exe's built with Advanced Installer and that they all had the same switches. I felt that having a dedicated installer type for this would save contributors from having to add installer switches and expected return codes for this type of executable. Additionally, it would show good faith and reciprocity towards Advanced Installer as they mention winget on their page about [Finding Silent Install Switches](https://www.advancedinstaller.com/find-exe-silent-install-switches.html)

* This PR does not consider all changes required for REST support
* This PR does not consider any learn.microsoft.com documentation that would need to be added. For example - https://www.advancedinstaller.com/silent-install-exe-msi-applications.html being linked in [Installer Switches](https://www.advancedinstaller.com/silent-install-exe-msi-applications.html)
* This PR does not consider wingetcreate support for the installer type
-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2617)