### PR TITLE
Update protocols max items to 64

### DIFF
--- a/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.installer.1.4.0.json
@@ -274,7 +274,7 @@
         "type": "string",
         "maxLength": 2048
       },
-      "maxItems": 16,
+      "maxItems": 64,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },

--- a/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
+++ b/schemas/JSON/manifests/v1.4.0/manifest.singleton.1.4.0.json
@@ -316,7 +316,7 @@
         "type": "string",
         "maxLength": 2048
       },
-      "maxItems": 16,
+      "maxItems": 64,
       "uniqueItems": true,
       "description": "List of protocols the package provides a handler for"
     },


### PR DESCRIPTION
Related to: #2600 

Updates the max item number of protocols from 16 to 64.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2620)