### PR TITLE
Print command aliases added on portable install

### DIFF
--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -141,7 +141,7 @@ namespace AppInstaller::CLI::Portable
                 AICLI_LOG(Core, Info, << "Portable install executed in user mode. Adding package directory to PATH.");
                 CommitToARPEntry(PortableValueName::InstallDirectoryAddedToPath, InstallDirectoryAddedToPath = true);
             }
-            m_stream << Resource::String::PortableAliasAdded << filePath.stem() << std::endl;
+            m_stream << Resource::String::PortableAliasAdded << ' ' << filePath.stem() << std::endl;
         }
     }
 

--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -141,6 +141,7 @@ namespace AppInstaller::CLI::Portable
                 AICLI_LOG(Core, Info, << "Portable install executed in user mode. Adding package directory to PATH.");
                 CommitToARPEntry(PortableValueName::InstallDirectoryAddedToPath, InstallDirectoryAddedToPath = true);
             }
+            m_stream << Resource::String::PortableAliasAdded << filePath.stem() << std::endl;
         }
     }
 

--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -110,36 +110,39 @@ namespace AppInstaller::CLI::Portable
             AICLI_LOG(Core, Info, << "Moving directory to: " << filePath);
             Filesystem::RenameFile(entry.CurrentPath, filePath);
         }
-        else if (entry.FileType == PortableFileType::Symlink && !InstallDirectoryAddedToPath)
+        else if (entry.FileType == PortableFileType::Symlink)
         {
-            std::filesystem::file_status status = std::filesystem::status(filePath);
-            if (std::filesystem::is_directory(status))
+            if (!InstallDirectoryAddedToPath)
             {
-                AICLI_LOG(CLI, Info, << "Unable to create symlink. '" << filePath << "points to an existing directory.");
-                THROW_HR(APPINSTALLER_CLI_ERROR_PORTABLE_SYMLINK_PATH_IS_DIRECTORY);
-            }
+                std::filesystem::file_status status = std::filesystem::status(filePath);
+                if (std::filesystem::is_directory(status))
+                {
+                    AICLI_LOG(CLI, Info, << "Unable to create symlink. '" << filePath << "points to an existing directory.");
+                    THROW_HR(APPINSTALLER_CLI_ERROR_PORTABLE_SYMLINK_PATH_IS_DIRECTORY);
+                }
 
-            if (!RecordToIndex)
-            {
-                CommitToARPEntry(PortableValueName::PortableSymlinkFullPath, filePath);
-            }
+                if (!RecordToIndex)
+                {
+                    CommitToARPEntry(PortableValueName::PortableSymlinkFullPath, filePath);
+                }
 
-            if (std::filesystem::remove(filePath))
-            {
-                AICLI_LOG(CLI, Info, << "Removed existing file at " << filePath);
-                m_stream << Resource::String::OverwritingExistingFileAtMessage << ' ' << filePath.u8string() << std::endl;
-            }
+                if (std::filesystem::remove(filePath))
+                {
+                    AICLI_LOG(CLI, Info, << "Removed existing file at " << filePath);
+                    m_stream << Resource::String::OverwritingExistingFileAtMessage << ' ' << filePath.u8string() << std::endl;
+                }
 
-            if (Filesystem::CreateSymlink(entry.SymlinkTarget, filePath))
-            {
-                AICLI_LOG(Core, Info, << "Symlink created at: " << filePath);
-            }
-            else
-            {
-                // Symlink creation should only fail if the user executes without admin rights or developer mode.
-                // Resort to adding install directory to PATH directly.
-                AICLI_LOG(Core, Info, << "Portable install executed in user mode. Adding package directory to PATH.");
-                CommitToARPEntry(PortableValueName::InstallDirectoryAddedToPath, InstallDirectoryAddedToPath = true);
+                if (Filesystem::CreateSymlink(entry.SymlinkTarget, filePath))
+                {
+                    AICLI_LOG(Core, Info, << "Symlink created at: " << filePath);
+                }
+                else
+                {
+                    // Symlink creation should only fail if the user executes without admin rights or developer mode.
+                    // Resort to adding install directory to PATH directly.
+                    AICLI_LOG(Core, Info, << "Portable install executed in user mode. Adding package directory to PATH.");
+                    CommitToARPEntry(PortableValueName::InstallDirectoryAddedToPath, InstallDirectoryAddedToPath = true);
+                }
             }
             m_stream << Resource::String::PortableAliasAdded << ' ' << filePath.stem() << std::endl;
         }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -237,6 +237,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PoliciesState);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableHashMismatchOverridden);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableHashMismatchOverrideRequired);
+        WINGET_DEFINE_RESOURCE_STRINGID(PortableAliasAdded);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableInstallFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(PortablePackageAlreadyExists);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableRegistryCollisionOverridden);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1341,6 +1341,9 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="NoPackageSelectionArgumentProvided" xml:space="preserve">
     <value>No package selection argument was provided; see the help for details about finding a package.</value>
   </data>
+  <data name="PortableAliasAdded" xml:space="preserve">
+    <value>Command line alias added: </value>
+  </data>
   <data name="PortableInstallFailed" xml:space="preserve">
     <value>Portable install failed; Cleaning up...</value>
   </data>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1342,7 +1342,8 @@ Please specify one of them using the `--source` option to proceed.</value>
     <value>No package selection argument was provided; see the help for details about finding a package.</value>
   </data>
   <data name="PortableAliasAdded" xml:space="preserve">
-    <value>Command line alias added: </value>
+    <value>Command line alias added:</value>
+
   </data>
   <data name="PortableInstallFailed" xml:space="preserve">
     <value>Portable install failed; Cleaning up...</value>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- #2516

There is a slight technicality with this in that it prints the alias has been added when the symlink/file is created before the path has been modified. This is because the alias should be printed for each portable package installed. From my perspective, I don't believe this matters since there isn't any case in the code where adding to path would fail. 

![image](https://user-images.githubusercontent.com/12611259/197315301-9497539a-6517-4ac0-ab46-b3cfd2c37668.png)

![image](https://user-images.githubusercontent.com/12611259/197315313-56dab867-551e-4dab-959a-44dd3917e929.png)

-----
