### PR TITLE
Add an issue option to guide users to winget-pkgs for package issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:  
+  - name: Package issues
+    url: https://github.com/microsoft/winget-pkgs/issues
+    about: Please create issues related to the packages here.
   - name: General Question
     url: https://github.com/microsoft/winget-cli/discussions/new
     about: Have a question on something? Start a new discussion thread.


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

Add an issue option so that people who encountered package-related issues would post them to winget-pkgs instead of winget-cli, just like "WinGet Client issues" in <https://github.com/microsoft/winget-pkgs/issues/new/choose>.

-----

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2658)