### PR TITLE
Get arguments when using archive type package

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -319,6 +319,7 @@ namespace AppInstaller::CLI::Workflow
             ScanArchiveFromLocalManifest <<
             ExtractFilesFromArchive <<
             VerifyAndSetNestedInstaller <<
+            GetInstallerArgs <<
             ExecuteInstallerForType(context.Get<Execution::Data::Installer>().value().NestedInstallerType);
     }
 


### PR DESCRIPTION
This fixes an issue where default arguments are not being passed to nested installers

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2660)