### PR TITLE
Remove redundant GetInstallerArgs call

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -319,7 +319,6 @@ namespace AppInstaller::CLI::Workflow
             ScanArchiveFromLocalManifest <<
             ExtractFilesFromArchive <<
             VerifyAndSetNestedInstaller <<
-            GetInstallerArgs <<
             ExecuteInstallerForType(context.Get<Execution::Data::Installer>().value().NestedInstallerType);
     }
 

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -311,6 +311,9 @@
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_MultipleNonPortableNestedInstallers.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_Nullsoft.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -558,6 +558,9 @@
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_MultipleNonPortableNestedInstallers.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_Nullsoft.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallFlowTest_Zip_UnsupportedNestedInstaller.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/InstallFlowTest_Zip_Nullsoft.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallFlowTest_Zip_Nullsoft.yaml
@@ -1,0 +1,18 @@
+PackageIdentifier: AppInstallerCliTest.TestZipInstaller.Nullsoft
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test Zip Installer
+ShortDescription: AppInstaller Test Zip Installer with nullsoft
+Publisher: Microsoft Corporation
+Moniker: AICLITestZip
+License: Test
+Installers:
+    - Architecture: x86
+      InstallerUrl: https://ThisIsNotUsed
+      InstallerType: zip
+      InstallerSha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+      NestedInstallerType: nullsoft
+      NestedInstallerFiles:
+        - RelativeFilePath: relativeFilePath
+ManifestType: singleton
+ManifestVersion: 1.4.0


### PR DESCRIPTION
Also added test to verify default args be passed to nested installer

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2662)