### PR TITLE
Use INSTALLDIR as install location switch for WiX installers

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -556,6 +556,13 @@ namespace AppInstaller::Manifest
         {
         case InstallerTypeEnum::Burn:
         case InstallerTypeEnum::Wix:
+            return
+            {
+                {InstallerSwitchType::Silent, ManifestInstaller::string_t("/quiet /norestart")},
+                {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/passive /norestart")},
+                {InstallerSwitchType::Log, ManifestInstaller::string_t("/log \"" + std::string(ARG_TOKEN_LOGPATH) + "\"")},
+                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("INSTALLDIR=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
+            };
         case InstallerTypeEnum::Msi:
             return
             {


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  * Related to #1857

-----

MSI installers built by [WiX Toolset](https://wixtoolset.org/) use different switches such as `INSTALLDIR` instead of  `TARGETDIR` as install location parameter. While adding new packages and reworking old packages, I noticed that most WiX installers are using `INSTALLDIR`. I felt that it is necessary to replace the current install location switch with `INSTALLDIR` since some new building toolchains like Tauri Builder are using WiX as the default installer builder, where developers are less likely to modify the WiX template and don't know what switches should be used for WinGet manifest.

However, the custom location switch may vary among WiX installers according to <https://github.com/microsoft/winget-cli/issues/1857#issuecomment-1127011986>. In case of potential conner cases, I will draft this PR and look into the remaining packages in winget-pkgs repo to see the proportion of switches they are using.

---

Some of the conner cases:
- `INSTALLLOCATION`
  - `LiErHeXun.Quicker`