### PR TITLE
Don't enable/disable admin settings if group policy prevents it

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -61,8 +61,10 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesManagementError);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesManagementExitMessage);
         WINGET_DEFINE_RESOURCE_STRINGID(DisabledByGroupPolicy);
+        WINGET_DEFINE_RESOURCE_STRINGID(DisableAdminSettingFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(DisableInteractivityArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(Done);
+        WINGET_DEFINE_RESOURCE_STRINGID(EnableAdminSettingFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(ExactArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ExperimentalArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ExperimentalCommandLongDescription);

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
+#include "AppInstallerStrings.h"
 #include "SettingsFlow.h"
 #include <winget/UserSettings.h>
 #include <winget/AdminSettings.h>
@@ -9,30 +10,37 @@
 namespace AppInstaller::CLI::Workflow
 {
     using namespace AppInstaller::Settings;
+    using namespace AppInstaller::Utility;
 
     void EnableAdminSetting(Execution::Context& context)
     {
-        AdminSetting adminSetting = Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingEnable));
+        std::string_view adminSettingString = context.Args.GetArg(Execution::Args::Type::AdminSettingEnable);
+        AdminSetting adminSetting = Settings::StringToAdminSetting(adminSettingString);
         if (Settings::EnableAdminSetting(adminSetting))
         {
             context.Reporter.Info() << Resource::String::AdminSettingEnabled;
         }
         else
         {
-            // TODO context.Reporter.Error() << ;
+            std::string adminSettingErrorMessage = Resource::LocString{ Resource::String::EnableAdminSettingFailed };
+            context.Reporter.Error() <<
+                Utility::LocIndString{ FindAndReplaceMessageToken(adminSettingErrorMessage, adminSettingString) };
         }
     }
 
     void DisableAdminSetting(Execution::Context& context)
     {
-        AdminSetting adminSetting = Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingDisable));
+        std::string_view adminSettingString = context.Args.GetArg(Execution::Args::Type::AdminSettingDisable);
+        AdminSetting adminSetting = Settings::StringToAdminSetting(adminSettingString);
         if (Settings::DisableAdminSetting(adminSetting))
         {
             context.Reporter.Info() << Resource::String::AdminSettingDisabled;
         }
         else
         {
-            // TODO context.Reporter.Error() << ;
+            std::string adminSettingErrorMessage = Resource::LocString{ Resource::String::DisableAdminSettingFailed };
+            context.Reporter.Error() <<
+                Utility::LocIndString{ FindAndReplaceMessageToken(adminSettingErrorMessage, adminSettingString) };
         }
     }
 

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "AppInstallerStrings.h"
+#include "Resources.h"
 #include "SettingsFlow.h"
+#include <AppInstallerStrings.h>
 #include <winget/UserSettings.h>
 #include <winget/AdminSettings.h>
-#include "Resources.h"
 
 namespace AppInstaller::CLI::Workflow
 {

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -12,14 +12,28 @@ namespace AppInstaller::CLI::Workflow
 
     void EnableAdminSetting(Execution::Context& context)
     {
-        Settings::EnableAdminSetting(Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingEnable)));
-        context.Reporter.Info() << Resource::String::AdminSettingEnabled;
+        AdminSetting adminSetting = Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingEnable));
+        if (Settings::EnableAdminSetting(adminSetting))
+        {
+            context.Reporter.Info() << Resource::String::AdminSettingEnabled;
+        }
+        else
+        {
+            // TODO context.Reporter.Error() << ;
+        }
     }
 
     void DisableAdminSetting(Execution::Context& context)
     {
-        Settings::DisableAdminSetting(Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingDisable)));
-        context.Reporter.Info() << Resource::String::AdminSettingDisabled;
+        AdminSetting adminSetting = Settings::StringToAdminSetting(context.Args.GetArg(Execution::Args::Type::AdminSettingDisable));
+        if (Settings::DisableAdminSetting(adminSetting))
+        {
+            context.Reporter.Info() << Resource::String::AdminSettingDisabled;
+        }
+        else
+        {
+            // TODO context.Reporter.Error() << ;
+        }
     }
 
     void OpenUserSetting(Execution::Context& context)

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1475,4 +1475,12 @@ Please specify one of them using the `--source` option to proceed.</value>
   <data name="PackageAlreadyInstalled" xml:space="preserve">
     <value>A package version is already installed. Installation cancelled.</value>
   </data>
+  <data name="EnableAdminSettingFailed" xml:space="preserve">
+    <value>Cannot enable %1. This setting is controlled by policy. For more information contact your system administrator.</value>
+    <comment>{Locked="%1"} The value will be replaced with the feature name</comment>
+  </data>
+  <data name="DisableAdminSettingFailed" xml:space="preserve">
+    <value>Cannot disable %1. This setting is controlled by policy. For more information contact your system administrator.</value>
+    <comment>{Locked="%1"} The value will be replaced with the feature name</comment>
+  </data>
 </root>

--- a/src/AppInstallerCLITests/AdminSettings.cpp
+++ b/src/AppInstallerCLITests/AdminSettings.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "TestCommon.h"
+#include "TestSettings.h"
+#include <winget/AdminSettings.h>
+
+using namespace AppInstaller::Settings;
+using namespace TestCommon;
+
+TEST_CASE("AdminSetting_Enable", "[adminSettings]")
+{
+    WHEN("Group policy")
+    {
+        SECTION("Not configured")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::NotConfigured);
+            REQUIRE(EnableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+
+        SECTION("Enabled")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::Enabled);
+            REQUIRE(EnableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+
+        SECTION("Disabled")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::Disabled);
+            REQUIRE_FALSE(EnableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+    }
+}
+
+TEST_CASE("AdminSetting_Disable", "[adminSettings]")
+{
+    WHEN("Group policy")
+    {
+        SECTION("Not configured")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::NotConfigured);
+            REQUIRE(DisableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+
+        SECTION("Enabled")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::Enabled);
+            REQUIRE_FALSE(DisableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+
+        SECTION("Disabled")
+        {
+            GroupPolicyTestOverride policies;
+            policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::Disabled);
+            REQUIRE(DisableAdminSetting(AdminSetting::LocalManifestFiles));
+        }
+    }
+}

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="TestSource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AdminSettings.cpp" />
     <ClCompile Include="Archive.cpp" />
     <ClCompile Include="ARPChanges.cpp" />
     <ClCompile Include="Certificates.cpp" />

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClCompile Include="RestInterface_1_4.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="AdminSettings.cpp">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="PropertySheet.props" />

--- a/src/AppInstallerCommonCore/AdminSettings.cpp
+++ b/src/AppInstallerCommonCore/AdminSettings.cpp
@@ -181,18 +181,6 @@ namespace AppInstaller::Settings
         }
     }
 
-    void EnableAdminSetting(AdminSetting setting)
-    {
-        AdminSettingsInternal adminSettingsInternal;
-        adminSettingsInternal.SetAdminSetting(setting, true);
-    }
-
-    void DisableAdminSetting(AdminSetting setting)
-    {
-        AdminSettingsInternal adminSettingsInternal;
-        adminSettingsInternal.SetAdminSetting(setting, false);
-    }
-
     TogglePolicy::Policy GetAdminSettingPolicy(AdminSetting setting)
     {
         switch (setting)
@@ -204,6 +192,32 @@ namespace AppInstaller::Settings
         default:
             return TogglePolicy::Policy::None;
         }
+    }
+
+    bool EnableAdminSetting(AdminSetting setting)
+    {
+        auto policy = GetAdminSettingPolicy(setting);
+        if (GroupPolicies().GetState(policy) == PolicyState::Disabled)
+        {
+            return false;
+        }
+
+        AdminSettingsInternal adminSettingsInternal;
+        adminSettingsInternal.SetAdminSetting(setting, true);
+        return true;
+    }
+
+    bool DisableAdminSetting(AdminSetting setting)
+    {
+        auto policy = GetAdminSettingPolicy(setting);
+        if (GroupPolicies().GetState(policy) == PolicyState::Enabled)
+        {
+            return false;
+        }
+
+        AdminSettingsInternal adminSettingsInternal;
+        adminSettingsInternal.SetAdminSetting(setting, false);
+        return true;
     }
 
     bool IsAdminSettingEnabled(AdminSetting setting)

--- a/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
@@ -18,9 +18,9 @@ namespace AppInstaller::Settings
 
     std::string_view AdminSettingToString(AdminSetting setting);
 
-    void EnableAdminSetting(AdminSetting setting);
+    bool EnableAdminSetting(AdminSetting setting);
 
-    void DisableAdminSetting(AdminSetting setting);
+    bool DisableAdminSetting(AdminSetting setting);
 
     bool IsAdminSettingEnabled(AdminSetting setting);
 }


### PR DESCRIPTION
## What was done?
- If an admin setting was disabled by a group policy, and user attempts to enable it using `winget settings --enable`, then report an error message.
- Similarly, if an admin setting was enabled by group policy, and user attempts to disable it using `winget settings --disable`, then report an error message.

## Test?
- Added tests covering the various state combinations.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2683)