### PR TITLE
Use DisplayVersion when validating Msix installer

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -776,6 +776,12 @@
     <CopyFileToFolders Include="TestData\Manifest-Bad-InconsistentSignedMsixBundleInstallerFields.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Good-MsixInstaller-DisplayVersion.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-MsixInstaller-InconsistentVersion.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLICore\AppInstallerCLICore.vcxproj">

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -726,6 +726,12 @@
     <CopyFileToFolders Include="TestData\Manifest-Bad-MissingMsixInstallerFields.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Good-MsixInstaller-DisplayVersion.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-MsixInstaller-InconsistentVersion.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\Manifest-Bad-NoSupportedPlatforms.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-InconsistentVersion.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-InconsistentVersion.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller-DisplayVersion
-PackageVersion: test.version.1 # Version not compatibe with UINT64 msix version
+PackageVersion: 43690.48059.52428.56797
 PackageLocale: es-MX
 PackageName: es-MX package name
 Publisher: es-MX publisher
@@ -10,6 +10,6 @@ Installers:
     - Architecture: x64
       InstallerUrl: Installer-Good.msix
       AppsAndFeaturesEntries:
-      - DisplayVersion: test.version.2 # Version not compatibe with UINT64 msix version
+      - DisplayVersion: test.version # Version not compatibe with UINT64 msix version
 ManifestType: merged
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-InconsistentVersion.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-InconsistentVersion.yaml
@@ -1,5 +1,5 @@
-PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller
-PackageVersion: 43690.48059.52428.56797
+PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller-DisplayVersion
+PackageVersion: test.version.1 # Version not compatibe with UINT64 msix version
 PackageLocale: es-MX
 PackageName: es-MX package name
 Publisher: es-MX publisher
@@ -10,6 +10,6 @@ Installers:
     - Architecture: x64
       InstallerUrl: Installer-Good.msix
       AppsAndFeaturesEntries:
-      - DisplayVersion: 1.0.0.0 # Ignored
+      - DisplayVersion: test.version.2 # Version not compatibe with UINT64 msix version
 ManifestType: merged
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller-DisplayVersion.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller-DisplayVersion.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller-DisplayVersion
-PackageVersion: test.version # Version not compatibe with UINT64 msix version
+PackageVersion: 1.0.0.0 # Version ignored in favor of DisplayVersion
 PackageLocale: es-MX
 PackageName: es-MX package name
 Publisher: es-MX publisher

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller-DisplayVersion.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller-DisplayVersion.yaml
@@ -1,5 +1,5 @@
-PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller
-PackageVersion: 43690.48059.52428.56797
+PackageIdentifier: AppInstallerCliTest.GoodMsixInstaller-DisplayVersion
+PackageVersion: test.version # Version not compatibe with UINT64 msix version
 PackageLocale: es-MX
 PackageName: es-MX package name
 Publisher: es-MX publisher
@@ -10,6 +10,6 @@ Installers:
     - Architecture: x64
       InstallerUrl: Installer-Good.msix
       AppsAndFeaturesEntries:
-      - DisplayVersion: 1.0.0.0 # Ignored
+      - DisplayVersion: 43690.48059.52428.56797
 ManifestType: merged
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller.yaml
@@ -10,4 +10,4 @@ Installers:
     - Architecture: x64
       InstallerUrl: Installer-Good.msix
 ManifestType: merged
-ManifestVersion: 1.2.0
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-MsixInstaller.yaml
@@ -9,7 +9,5 @@ InstallerType: msix
 Installers: 
     - Architecture: x64
       InstallerUrl: Installer-Good.msix
-      AppsAndFeaturesEntries:
-      - DisplayVersion: 1.0.0.0 # Ignored
 ManifestType: merged
 ManifestVersion: 1.2.0

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -1157,8 +1157,6 @@ TEST_CASE("MsixManifestValidation_UseDisplayVersion", "[ManifestValidation]")
     TestDataFile msixFile(manifest.Installers[0].Url.c_str());
     manifest.Installers[0].Url = msixFile.GetPath().u8string();
 
-    REQUIRE("test.version" == manifest.Version);
-
     auto errors = ValidateManifestInstallers(manifest);
     REQUIRE(0 == errors.size());
 }
@@ -1172,9 +1170,8 @@ TEST_CASE("MsixManifestValidation_InconsistentVersion", "[ManifestValidation]")
     TestDataFile msixFile(manifest.Installers[0].Url.c_str());
     manifest.Installers[0].Url = msixFile.GetPath().u8string();
 
-    REQUIRE("test.version.1" == manifest.Version);
     REQUIRE(1 == manifest.Installers[0].AppsAndFeaturesEntries.size());
-    REQUIRE("test.version.2" == manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion);
+    REQUIRE("test.version" == manifest.Installers[0].AppsAndFeaturesEntries[0].DisplayVersion);
 
     auto errors = ValidateManifestInstallers(manifest);
     REQUIRE(1 == errors.size());

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -477,7 +477,8 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Nullsoft ||
             installerType == InstallerTypeEnum::Wix ||
             installerType == InstallerTypeEnum::Burn ||
-            installerType == InstallerTypeEnum::Portable
+            installerType == InstallerTypeEnum::Portable ||
+            installerType == InstallerTypeEnum::Msix
             );
     }
 

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -188,9 +188,9 @@ namespace AppInstaller::Manifest
     {
         // Manifest package version:
         // 1. If DisplayVersion is defined, then use it as the manifest package
-        //    version if it can be parse to UINT64, otherwsie report an error
+        //    version if it can be parsed to UINT64, otherwise report an error
         // 2. If DisplayVersion is not defined, then use PackageVersion as the
-        //    manifest package version if it can be parse to UINT64, otherwise
+        //    manifest package version if it can be parsed to UINT64, otherwise
         //    report an error
         std::optional<Msix::PackageVersion> manifestPackageVersion;
 

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -186,7 +186,14 @@ namespace AppInstaller::Manifest
         const std::vector<AppsAndFeaturesEntry>& appsAndFeaturesEntries,
         std::vector<ValidationError>& errors)
     {
+        // Manifest package version:
+        // 1. If DisplayVersion is defined, then use it as the manifest package
+        //    version if it can be parse to UINT64, otherwsie report an error
+        // 2. If DisplayVersion is not defined, then use PackageVersion as the
+        //    manifest package version if it can be parse to UINT64, otherwise
+        //    report an error
         std::optional<Msix::PackageVersion> manifestPackageVersion;
+
         try
         {
             // Parse package version to UINT64 version
@@ -198,13 +205,15 @@ namespace AppInstaller::Manifest
         }
 
         // Find the first parsable UINT64 display version in AppsAndFeaturesEntries
-        for (int eId = 0; !manifestPackageVersion.has_value() && eId < appsAndFeaturesEntries.size(); ++eId)
+        for (int eId = 0; eId < appsAndFeaturesEntries.size(); ++eId)
         {
             const auto& entry = appsAndFeaturesEntries[eId];
             if (!entry.DisplayVersion.empty())
             {
                 try
                 {
+                    // Reset package version to prioritize DisplayVersion
+                    manifestPackageVersion.reset();
                     manifestPackageVersion = { entry.DisplayVersion };
                 }
                 catch (...)

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -54,7 +54,8 @@ namespace AppInstaller::Manifest
         // Validate Msix package version.
         void ValidateMsixManifestPackageVersion(
             const Msix::PackageVersion& msixPackageVersion,
-            const Msix::PackageVersion& manifestPackageVersion,
+            const string_t& manifestPackageVersionStr,
+            const std::vector<AppsAndFeaturesEntry>& appsAndFeaturesEntries,
             std::vector<ValidationError>& errors);
 
         // Validate Msix minimum OS version for supported platforms.


### PR DESCRIPTION
## What was done?
When validating the manifest Msix installers:
- If `DisplayVersion` is defined, then use it as the manifest package version if it can be parsed to `UINT64`, otherwise report an error
- If `DisplayVersion` is not defined, then use `PackageVersion` as the manifest package version if it can be parsed to `UINT64`, otherwise report an error

## Test
- Added unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2687)