### PR TITLE
Manifest (Msix) installer validation - Try parsing package version

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -776,6 +776,9 @@
     <CopyFileToFolders Include="TestData\Manifest-Bad-InconsistentSignedMsixBundleInstallerFields.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-MsixInstaller-PackageVersion.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLICore\AppInstallerCLICore.vcxproj">

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -726,6 +726,9 @@
     <CopyFileToFolders Include="TestData\Manifest-Bad-MissingMsixInstallerFields.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-MsixInstaller-PackageVersion.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\Manifest-Bad-NoSupportedPlatforms.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-PackageVersion.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-MsixInstaller-PackageVersion.yaml
@@ -1,0 +1,13 @@
+PackageIdentifier: AppInstallerCliTest.BadMsixInstaller-PackageVersion
+PackageVersion: test.version # Version cannot be parsed to UINT64
+PackageLocale: es-MX
+PackageName: es-MX package name
+Publisher: es-MX publisher
+PackageFamilyName: FakeInstallerForTesting_125rzkzqaqjwj
+MinimumOSVersion: 10.0.0.0
+InstallerType: msix
+Installers: 
+    - Architecture: x64
+      InstallerUrl: Installer-Good.msix
+ManifestType: merged
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -1000,9 +1000,7 @@ TEST_CASE("ReadManifestAndValidateMsixInstallers_NoSupportedPlatforms", "[Manife
 
 TEST_CASE("ReadManifestAndValidateMsixInstallers_PackageVersionNotUINT64", "[ManifestValidation]")
 {
-    auto testFileName = "Manifest-Bad-MsixInstaller-PackageVersion.yaml";
-    TestDataFile testFile(testFileName);
-    Manifest manifest = YamlParser::CreateFromPath(testFile);
+    Manifest manifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Bad-MsixInstaller-PackageVersion.yaml"));
 
     // Update the installer path for testing
     REQUIRE(1 == manifest.Installers.size());

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -998,6 +998,23 @@ TEST_CASE("ReadManifestAndValidateMsixInstallers_NoSupportedPlatforms", "[Manife
     ValidateError(errors[0], ValidationError::Level::Error, ManifestError::NoSupportedPlatforms, "InstallerUrl", manifest.Installers.front().Url);
 }
 
+TEST_CASE("ReadManifestAndValidateMsixInstallers_PackageVersionNotUINT64", "[ManifestValidation]")
+{
+    auto testFileName = "Manifest-Bad-MsixInstaller-PackageVersion.yaml";
+    TestDataFile testFile(testFileName);
+    Manifest manifest = YamlParser::CreateFromPath(testFile);
+
+    // Update the installer path for testing
+    REQUIRE(1 == manifest.Installers.size());
+    TestDataFile msixFile(manifest.Installers[0].Url.c_str());
+    manifest.Installers[0].Url = msixFile.GetPath().u8string();
+
+    auto errors = ValidateManifestInstallers(manifest);
+    REQUIRE(1 == errors.size());
+
+    ValidateError(errors[0], ValidationError::Level::Error, ManifestError::InstallerMsixInconsistencies, "PackageVersion", "43690.48059.52428.56797");
+}
+
 TEST_CASE("ReadManifestAndValidateMsixInstallers_MissingFields", "[ManifestValidation]")
 {
     TestDataFile testFile("Manifest-Bad-MissingMsixInstallerFields.yaml");

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -9,8 +9,8 @@
 namespace AppInstaller::Manifest
 {
     std::vector<ValidationError> MsixManifestValidation::Validate(
-        const Manifest &manifest,
-        const ManifestInstaller &installer)
+        const Manifest& manifest,
+        const ManifestInstaller& installer)
     {
         std::vector<ValidationError> errors;
         auto msixInfo = GetMsixInfo(installer.Url);
@@ -146,7 +146,7 @@ namespace AppInstaller::Manifest
 
     std::optional<Msix::OSVersion> MsixManifestValidation::GetManifestInstallerMinOSVersion(
         std::string minOSVersion,
-        std::vector<ValidationError> &errors)
+        std::vector<ValidationError>& errors)
     {
         try
         {
@@ -165,7 +165,7 @@ namespace AppInstaller::Manifest
     void MsixManifestValidation::ValidateMsixManifestPackageFamilyName(
         Utility::NormalizedString msixPackageFamilyName,
         Utility::NormalizedString manifestPackageFamilyName,
-        std::vector<ValidationError> &errors)
+        std::vector<ValidationError>& errors)
     {
         if (!manifestPackageFamilyName.empty())
         {
@@ -181,9 +181,9 @@ namespace AppInstaller::Manifest
     }
 
     void MsixManifestValidation::ValidateMsixManifestPackageVersion(
-        const Msix::PackageVersion &msixPackageVersion,
-        const string_t &manifestPackageVersionStr,
-        std::vector<ValidationError> &errors)
+        const Msix::PackageVersion& msixPackageVersion,
+        const string_t& manifestPackageVersionStr,
+        std::vector<ValidationError>& errors)
     {
         std::optional<Msix::PackageVersion> manifestPackageVersion;
         try
@@ -205,7 +205,7 @@ namespace AppInstaller::Manifest
         const std::optional<Msix::OSVersion>& msixMinOSVersion,
         const std::optional<Msix::OSVersion>& manifestMinOSVersion,
         std::string installerUrl,
-        std::vector<ValidationError> &errors)
+        std::vector<ValidationError>& errors)
     {
         if (!msixMinOSVersion.has_value())
         {

--- a/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/MsixManifestValidation.cpp
@@ -13,7 +13,6 @@ namespace AppInstaller::Manifest
         const ManifestInstaller &installer)
     {
         std::vector<ValidationError> errors;
-        Msix::PackageVersion packageVersion(manifest.Version);
         auto msixInfo = GetMsixInfo(installer.Url);
         if (msixInfo)
         {
@@ -24,7 +23,7 @@ namespace AppInstaller::Manifest
             {
                 auto msixManifestIdentity = msixManifest.GetIdentity();
                 ValidateMsixManifestPackageFamilyName(msixManifestIdentity.GetPackageFamilyName(), installer.PackageFamilyName, errors);
-                ValidateMsixManifestPackageVersion(msixManifestIdentity.GetVersion(), packageVersion, errors);
+                ValidateMsixManifestPackageVersion(msixManifestIdentity.GetVersion(), manifest.Version, errors);
                 ValidateMsixManifestMinOSVersion(msixManifest.GetMinimumOSVersionForSupportedPlatforms(), installerMinOSVersion, installer.Url, errors);
             }
         }
@@ -183,10 +182,20 @@ namespace AppInstaller::Manifest
 
     void MsixManifestValidation::ValidateMsixManifestPackageVersion(
         const Msix::PackageVersion &msixPackageVersion,
-        const Msix::PackageVersion &manifestPackageVersion,
+        const string_t &manifestPackageVersionStr,
         std::vector<ValidationError> &errors)
     {
-        if (msixPackageVersion != manifestPackageVersion)
+        std::optional<Msix::PackageVersion> manifestPackageVersion;
+        try
+        {
+            manifestPackageVersion = { manifestPackageVersionStr };
+        }
+        catch (...)
+        {
+            AICLI_LOG(Core, Error, << "Failed to parse package version to UINT64");
+        }
+
+        if (!manifestPackageVersion.has_value() || msixPackageVersion != manifestPackageVersion.value())
         {
             errors.emplace_back(ManifestError::InstallerMsixInconsistencies, "PackageVersion", msixPackageVersion.ToString());
         }

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -16,8 +16,8 @@ namespace AppInstaller::Manifest
 
         // Validate manifest for Msix packages and Msix bundles.
         std::vector<ValidationError> Validate(
-            const Manifest &manifest,
-            const ManifestInstaller &installer);
+            const Manifest& manifest,
+            const ManifestInstaller& installer);
     private:
         std::map<std::string, std::shared_ptr<Msix::MsixInfo>> m_msixInfoCache;
         std::vector<std::filesystem::path> m_downloadedInstallers;

--- a/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsixManifestValidation.h
@@ -54,7 +54,7 @@ namespace AppInstaller::Manifest
         // Validate Msix package version.
         void ValidateMsixManifestPackageVersion(
             const Msix::PackageVersion& msixPackageVersion,
-            const Msix::PackageVersion& manifestPackageVersion,
+            const string_t& manifestPackageVersionStr,
             std::vector<ValidationError>& errors);
 
         // Validate Msix minimum OS version for supported platforms.


### PR DESCRIPTION
## What was done?
- Report an error message if the package version could not be parsed to UINT64 during the manifest (Msix) installer validation, instead of throwing an exception.

## Test
- Added unit test

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2692)