### PR TITLE
Add PowerShell cmdlet help text and examples

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_AddRemoveSource.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_AddRemoveSource.ps1
@@ -1,0 +1,26 @@
+<#
+    .SYNOPSIS
+        Imports the Microsoft.WinGet.Client powershell module and demonstrates how to add, remove, and reset the sources.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+Get-WinGetSource
+
+Remove-WinGetSource -Name winget
+
+Add-WinGetSource -Name 'winget' -Argument 'https://cdn.winget.microsoft.com/cache'
+
+Remove-WinGetSource -Name winget
+
+Reset-WinGetSource
+
+$sources = Get-WinGetSource
+
+Write-Host($sources)

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_AddRemoveSource.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_AddRemoveSource.ps1
@@ -1,6 +1,7 @@
 <#
     .SYNOPSIS
-        Imports the Microsoft.WinGet.Client powershell module and demonstrates how to add, remove, and reset the sources.
+        Example for 'Get-WinGetSource', 'Add-WinGetSource', 'Remove-WinGetSource', and 'Reset-WinGetSource' cmdlet.
+        Cmdlets to allow you to manage sources for the Windows Package Manager.
 #>
 
 # TODO: Replace parameter with actual module name from PSGallery once module is released. 
@@ -11,16 +12,14 @@ Param (
 
 Import-Module -Name $ModulePath
 
+# List current sources.
 Get-WinGetSource
 
-Remove-WinGetSource -Name winget
+# Add REST source
+Add-WinGetSource -Name 'Contoso' -Argument 'https://www.contoso.com/cache' -Type 'Microsoft.Rest'
 
-Add-WinGetSource -Name 'winget' -Argument 'https://cdn.winget.microsoft.com/cache'
+# Remove source by name
+Remove-WinGetSource -Name 'Contoso'
 
-Remove-WinGetSource -Name winget
-
+# Reset to default sources
 Reset-WinGetSource
-
-$sources = Get-WinGetSource
-
-Write-Host($sources)

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_EnableSettings.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_EnableSettings.ps1
@@ -1,0 +1,19 @@
+<#
+    .SYNOPSIS
+        Example for 'Enable-WinGetSetting' and 'Disable-WinGetSetting' cmdlets.
+        Cmdlet for enabling/disabling a specified WinGet setting. May require elevation.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# Enables the 'LocalManifestFiles' setting.
+Enable-WinGetSetting -Name LocalManifestFiles
+
+# Disables the 'LocalManifestFiles' setting.
+Disable-WinGetSetting -Name LocalManifestFiles 

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_FindPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_FindPackage.ps1
@@ -1,0 +1,28 @@
+<#
+    .SYNOPSIS
+        Example for 'Find-WinGetPackage' cmdlet.
+        Displays all applications available for instasllation.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# Find all available packages
+Find-WinGetPackage
+
+# Find package by name
+Find-WinGetPackage -Name git
+
+# Find 10 packages by name
+Find-WinGetPackage -Name git -Count 10
+
+# Find package by package identifier
+Find-WinGetPackage -Id git.git
+
+# Find exact package from a specific source.
+Find-WinGetPackage -Id Git.Git -Source winget -Exact

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_GetPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_GetPackage.ps1
@@ -1,0 +1,28 @@
+<#
+    .SYNOPSIS
+        Example for 'Get-WinGetPackage' cmdlet.
+        Displays a list of the applications currently installed on your computer.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# List all installed packages
+Get-WinGetPackage
+
+# List installed package by name
+Get-WinGetPackage -Name git
+
+# List 10 packages by name
+Get-WinGetPackage -Name git -Count 10
+
+# List package by package identifier
+Get-WinGetPackage -Id git.git
+
+# List exact package from a specific source.
+Get-WinGetPackage -Id Git.Git -Source winget -Exact

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_GetVersion.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_GetVersion.ps1
@@ -1,0 +1,17 @@
+<#
+    .SYNOPSIS
+        Example for 'Get-WinGetVersion' cmdlet.
+        Prints the current client version.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+$version = Get-WinGetVersion
+
+Write-Host($version);

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_InstallPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_InstallPackage.ps1
@@ -1,0 +1,25 @@
+<#
+    .SYNOPSIS
+        Example for 'Install-WinGetPackage' cmdlet.
+        Installs the specified application based on the provided arguments.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# Install a package by name
+Install-WinGetPackage -Name powertoys
+
+# Install a package by version and package identifier.
+Install-WinGetPackage -Id Microsoft.PowerToys -Version 0.15.2
+
+# Install a package from a specific source
+Install-WinGetPackage -Id Microsoft.PowerToys -Source winget
+
+# Install a package with a specific architecture and scope.
+Install-WinGetPAckage -Id Microsoft.PowerToys -Architecture X64 -Scope User

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_InstallPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_InstallPackage.ps1
@@ -22,4 +22,4 @@ Install-WinGetPackage -Id Microsoft.PowerToys -Version 0.15.2
 Install-WinGetPackage -Id Microsoft.PowerToys -Source winget
 
 # Install a package with a specific architecture and scope.
-Install-WinGetPAckage -Id Microsoft.PowerToys -Architecture X64 -Scope User
+Install-WinGetPackage -Id Microsoft.PowerToys -Architecture X64 -Scope User

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_UninstallPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_UninstallPackage.ps1
@@ -1,0 +1,22 @@
+<#
+    .SYNOPSIS
+        Example for 'Uninstall-WinGetPackage' cmdlet.
+        Uninstalls the specified application.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# Uninstall a package by name
+Uninstall-WinGetPackage -Name powertoys
+
+# Uninstall a package by version and package identifier.
+Uninstall-WinGetPackage -Id Microsoft.PowerToys -Version 0.15.2
+
+# Uninstall a package from a specific source
+Uninstall-WinGetPackage -Id Microsoft.PowerToys -Source winget

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_UpdatePackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_UpdatePackage.ps1
@@ -1,0 +1,25 @@
+<#
+    .SYNOPSIS
+        Example for 'Update-WinGetPackage' cmdlet.
+        Updates the specified application.
+#>
+
+# TODO: Replace parameter with actual module name from PSGallery once module is released. 
+Param (
+    [Parameter(Mandatory)]
+    $ModulePath
+)
+
+Import-Module -Name $ModulePath
+
+# Update a package by name
+Update-WinGetPackage -Name powertoys
+
+# Update a package by version and package identifier.
+Update-WinGetPackage -Id Microsoft.PowerToys -Version 0.15.2
+
+# Update a package with silent mode
+Update-WinGetPackage -Id Microsoft.PowerToys -Mode Silent
+
+# Force update a package
+Update-WinGetPackage -Id Microsoft.PowerToys -Force

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psd1
@@ -120,7 +120,7 @@ PrivateData = @{
             'PSEdition_Core',
             'Windows',
             'WindowsPackageManager',
-		'WinGet'
+            'WinGet'
         )
 
         # A URL to the license for this module.

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psd1
@@ -76,7 +76,6 @@ else {
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
     'Get-WinGetVersion'
-    'Get-WinGetVersion',
     'Enable-WinGetSetting',
     'Disable-WinGetSetting',
     'Add-WinGetSource',
@@ -120,7 +119,8 @@ PrivateData = @{
             'PSEdition_Desktop',
             'PSEdition_Core',
             'Windows',
-            'WindowsPackageManager'
+            'WindowsPackageManager',
+		'WinGet'
         )
 
         # A URL to the license for this module.

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psm1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.psm1
@@ -14,7 +14,7 @@ class PowerShellCustomFunctionAttribute : System.Attribute {
 function Get-WinGetVersion
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(    )
 
@@ -81,49 +81,27 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Displays the version of the tool.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Displays the version of the winget.exe tool.
 
-usage: winget [<command>] [<options>]
+  .INPUTS
+  None.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .OUTPUTS
+  None
 
-For more details on a specific command, pass it the help argument. [-?]
-
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
-
-More help can be found at: https://aka.ms/winget-command-help
-
-.DESCRIPTION See help for winget.exe
-
+  .EXAMPLE
+  PS> Get-WinGetVersion
 #>
 }
-
-
-
 
 function Enable-WinGetSetting
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(
 [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,Mandatory=$true)]
@@ -204,44 +182,24 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Enables the WinGet setting specified by the `Name` parameter.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Enables the WinGet setting specified by the `Name` parameter.
+  Supported settings: `LocalManifestFiles`
 
-usage: winget [<command>] [<options>]
+  .PARAMETER Name
+  Specifies the name of the setting to be enabled.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .INPUTS
+  None.
 
-For more details on a specific command, pass it the help argument. [-?]
+  .OUTPUTS
+  None
 
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
-
-More help can be found at: https://aka.ms/winget-command-help
-
-.DESCRIPTION See help for winget.exe
-
-.PARAMETER Name
-
-
-
-
+  .EXAMPLE
+  PS> Enable-WinGetSetting -name LocalManifestFiles 
 #>
 }
 
@@ -251,7 +209,7 @@ More help can be found at: https://aka.ms/winget-command-help
 function Disable-WinGetSetting
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(
 [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,Mandatory=$true)]
@@ -332,54 +290,31 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Disables the WinGet setting specified by the `Name` parameter.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Disables the WinGet setting specified by the `Name` parameter.
+  Supported settings: `LocalManifestFiles`
 
-usage: winget [<command>] [<options>]
+  .PARAMETER Name
+  Specifies the name of the setting to be disabled.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .INPUTS
+  None.
 
-For more details on a specific command, pass it the help argument. [-?]
+  .OUTPUTS
+  None
 
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
-
-More help can be found at: https://aka.ms/winget-command-help
-
-.DESCRIPTION See help for winget.exe
-
-.PARAMETER Name
-
-
-
-
+  .EXAMPLE
+  PS> Disable-WinGetSetting -name LocalManifestFiles 
 #>
 }
-
-
-
 
 function Add-WinGetSource
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(
 [Parameter(Position=0,ValueFromPipelineByPropertyName=$true,Mandatory=$true)]
@@ -480,62 +415,39 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Add a new source.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Add a new source. A source provides the data for you to discover and install packages.
+  Only add a new source if you trust it as a secure location.
 
-usage: winget [<command>] [<options>]
+  .PARAMETER Name
+  Name of the source.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .PARAMETER Argument
+  Argument to be given to the source.
 
-For more details on a specific command, pass it the help argument. [-?]
+  .PARAMETER Type
+  Type of the source.
 
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
+  .INPUTS
+  None.
 
-More help can be found at: https://aka.ms/winget-command-help
+  .OUTPUTS
+  None.
 
-.DESCRIPTION See help for winget.exe
-
-.PARAMETER Name
-
-
-
-.PARAMETER Argument
-
-
-
-.PARAMETER Type
-
-
-
+  .EXAMPLE
+  PS> Add-WinGetSource -Name Contoso -Argument https://www.contoso.com/cache
 
 #>
 }
 
 
-
-
 function Remove-WinGetSource
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(
 [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,Mandatory=$true)]
@@ -616,54 +528,31 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Remove a specific source.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Remove a specific source. The source must already exist to be removed.
 
-usage: winget [<command>] [<options>]
+  .PARAMETER Name
+  Name of the source.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .INPUTS
+  None.
 
-For more details on a specific command, pass it the help argument. [-?]
+  .OUTPUTS
+  None.
 
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
-
-More help can be found at: https://aka.ms/winget-command-help
-
-.DESCRIPTION See help for winget.exe
-
-.PARAMETER Name
-
-
-
+  .EXAMPLE
+  PS> Remove-WinGetSource -Name Contoso
 
 #>
 }
 
-
-
-
 function Reset-WinGetSource
 {
 [PowerShellCustomFunctionAttribute(RequiresElevation=$False)]
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 
 param(
 [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
@@ -745,43 +634,27 @@ PROCESS {
   } # end PROCESS
 
 <#
-.SYNOPSIS
-Windows Package Manager (Preview) v1.3.1391-preview
-Copyright (c) Microsoft Corporation. All rights reserved.
+  .SYNOPSIS
+  Drops existing sources. Without any argument, this command will drop all sources and add the defaults.
 
-The winget command line utility enables installing applications and other packages from the command line.
+  .DESCRIPTION
+  Drops existing sources, potentially leaving any local data behind. Without any argument, it will drop all sources and add the defaults.
+  If a named source is provided, only that source will be dropped.
 
-usage: winget [<command>] [<options>]
+  .PARAMETER Name
+  Name of the source.
 
-The following commands are available:
-  install    Installs the given package
-  show       Shows information about a package
-  source     Manage sources of packages
-  search     Find and show basic info of packages
-  list       Display installed packages
-  upgrade    Shows and performs available upgrades
-  uninstall  Uninstalls the given package
-  hash       Helper to hash installer files
-  validate   Validates a manifest file
-  settings   Open settings or set administrator settings
-  features   Shows the status of experimental features
-  export     Exports a list of the installed packages
-  import     Installs all the packages in a file
+  .INPUTS
+  None.
 
-For more details on a specific command, pass it the help argument. [-?]
+  .OUTPUTS
+  None.
 
-The following options are available:
-  -v,--version  Display the version of the tool
-  --info        Display general info of the tool
+  .EXAMPLE
+  PS> Reset-WinGetSource
 
-More help can be found at: https://aka.ms/winget-command-help
-
-.DESCRIPTION See help for winget.exe
-
-.PARAMETER Name
-
-
-
+  .EXAMPLE
+  PS> Reset-WinGetSource -Name Contoso
 
 #>
 }


### PR DESCRIPTION
- Updates the help text with the proper information.
- Add example scripts for each supported cmdlet.
- Adds [CmdletBinding(SupportsShouldProcess)] to pass PSScriptAnalyzer checks

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2732)