### PR TITLE
Add empty `pin` command

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -266,7 +266,7 @@ Experimental feature with the aim of managing dependencies, as of now it only sh
 
 ### pinning
 
-This feature enables the ability to pin packages to a specific version to prevent the Windows Package Manager from updating them.
+This feature enables the ability to pin packages to prevent the Windows Package Manager from updating them.
 You can enable the feature as shown below.
 
 ```json

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -253,12 +253,24 @@ You can enable the feature as shown below.
        "openLogsArgument": true
    },
 ```
-### Dependencies
+
+### dependencies
 
 Experimental feature with the aim of managing dependencies, as of now it only shows package dependency information. You can enable the feature as shown below.
 
 ```json
    "experimentalFeatures": {
        "dependencies": true
+   },
+```
+
+### pinning
+
+This feature enables the ability to pin packages to a specific version to prevent the Windows Package Manager from updating them.
+You can enable the feature as shown below.
+
+```json
+   "experimentalFeatures": {
+       "openLogsArgument": true
    },
 ```

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -271,6 +271,6 @@ You can enable the feature as shown below.
 
 ```json
    "experimentalFeatures": {
-       "openLogsArgument": true
+       "pinning": true
    },
 ```

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -249,6 +249,7 @@
     <ClInclude Include="Commands\FeaturesCommand.h" />
     <ClInclude Include="Commands\HashCommand.h" />
     <ClInclude Include="Commands\ListCommand.h" />
+    <ClInclude Include="Commands\PinCommand.h" />
     <ClInclude Include="Commands\SearchCommand.h" />
     <ClInclude Include="Commands\ShowCommand.h" />
     <ClInclude Include="Commands\InstallCommand.h" />
@@ -283,6 +284,7 @@
     <ClInclude Include="Workflows\ImportExportFlow.h" />
     <ClInclude Include="Workflows\MsiInstallFlow.h" />
     <ClInclude Include="Workflows\MSStoreInstallerHandler.h" />
+    <ClInclude Include="Workflows\PinFlow.h" />
     <ClInclude Include="Workflows\PortableFlow.h" />
     <ClInclude Include="Workflows\PromptFlow.h" />
     <ClInclude Include="Workflows\SettingsFlow.h" />
@@ -299,6 +301,7 @@
     <ClCompile Include="COMContext.cpp" />
     <ClCompile Include="Commands\COMCommand.cpp" />
     <ClCompile Include="Commands\ImportCommand.cpp" />
+    <ClCompile Include="Commands\PinCommand.cpp" />
     <ClCompile Include="ContextOrchestrator.cpp" />
     <ClCompile Include="Workflows\DependenciesFlow.cpp" />
     <ClCompile Include="PackageCollection.cpp" />

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj.filters
@@ -188,6 +188,12 @@
     <ClInclude Include="PortableInstaller.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Commands\PinCommand.h">
+      <Filter>Commands</Filter>
+    </ClInclude>
+    <ClInclude Include="Workflows\PinFlow.h">
+      <Filter>Workflows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -341,6 +347,9 @@
       <Filter>Workflows</Filter>
     </ClCompile>
     <ClCompile Include="PortableInstaller.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Commands\PinCommand.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -13,7 +13,6 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::Utility::literals;
     using namespace std::string_view_literals;
 
-    // TODO: Create this link with the docs!
     static constexpr std::string_view s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"sv;
 
     std::vector<std::unique_ptr<Command>> PinCommand::GetCommands() const
@@ -123,7 +122,6 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::Exact),
             Argument::ForType(Args::Type::CustomHeader),
             Argument::ForType(Args::Type::AcceptSourceAgreements),
-            Argument::ForType(Args::Type::Force),
         };
     }
 

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "PinCommand.h"
+#include "Workflows/CompletionFlow.h"
+#include "Workflows/PinFlow.h"
+#include "Workflows/WorkflowBase.h"
+#include "Resources.h"
+
+namespace AppInstaller::CLI
+{
+    using namespace AppInstaller::CLI::Execution;
+    using namespace std::string_view_literals;
+
+    // TODO: Create this link with the docs!
+    static constexpr std::string_view s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"sv;
+
+    std::vector<std::unique_ptr<Command>> PinCommand::GetCommands() const
+    {
+        return InitializeFromMoveOnly<std::vector<std::unique_ptr<Command>>>({
+            std::make_unique<PinAddCommand>(FullName()),
+            std::make_unique<PinRemoveCommand>(FullName()),
+            std::make_unique<PinListCommand>(FullName()),
+        });
+    }
+
+    Resource::LocString PinCommand::ShortDescription() const
+    {
+        return { Resource::String::PinCommandShortDescription };
+    }
+
+    Resource::LocString PinCommand::LongDescription() const
+    {
+        return { Resource::String::PinCommandLongDescription };
+    }
+
+    std::string PinCommand::HelpLink() const
+    {
+        return std::string{ s_PinCommand_HelpLink };
+    }
+
+    void PinCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        OutputHelp(context.Reporter);
+    }
+
+    std::vector<Argument> PinAddCommand::GetArguments() const
+    {
+        // TODO
+    }
+
+    Resource::LocString PinAddCommand::ShortDescription() const
+    {
+        return { Resource::String::PinAddCommandShortDescription };
+    }
+
+    Resource::LocString PinAddCommand::LongDescription() const
+    {
+        return { Resource::String::PinAddCommandLongDescription };
+    }
+
+    void PinAddCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    {
+        // TODO
+    }
+
+    std::string PinAddCommand::HelpLink() const
+    {
+        return std::string{ s_PinCommand_HelpLink };
+    }
+
+    void PinAddCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        // TODO
+    }
+
+    std::vector<Argument> PinRemoveCommand::GetArguments() const
+    {
+        // TODO
+    }
+
+    Resource::LocString PinRemoveCommand::ShortDescription() const
+    {
+        return { Resource::String::PinRemoveCommandShortDescription };
+    }
+
+    Resource::LocString PinRemoveCommand::LongDescription() const
+    {
+        return { Resource::String::PinRemoveCommandLongDescription };
+    }
+
+    void PinRemoveCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    {
+        // TODO
+    }
+
+    std::string PinRemoveCommand::HelpLink() const
+    {
+        return std::string{ s_PinCommand_HelpLink };
+    }
+
+    void PinRemoveCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        // TODO
+    }
+
+    std::vector<Argument> PinListCommand::GetArguments() const
+    {
+        // TODO
+    }
+
+    Resource::LocString PinListCommand::ShortDescription() const
+    {
+        return { Resource::String::PinListCommandShortDescription };
+    }
+
+    Resource::LocString PinListCommand::LongDescription() const
+    {
+        return { Resource::String::PinListCommandLongDescription };
+    }
+
+    void PinListCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    {
+        // TODO
+    }
+
+    std::string PinListCommand::HelpLink() const
+    {
+        return std::string{ s_PinCommand_HelpLink };
+    }
+
+    void PinListCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        // TODO
+    }
+
+    std::vector<Argument> PinResetCommand::GetArguments() const
+    {
+        // TODO
+    }
+
+    Resource::LocString PinResetCommand::ShortDescription() const
+    {
+        return { Resource::String::PinResetCommandShortDescription };
+    }
+
+    Resource::LocString PinResetCommand::LongDescription() const
+    {
+        return { Resource::String::PinResetCommandLongDescription };
+    }
+
+    void PinResetCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    {
+        // TODO
+    }
+
+    std::string PinResetCommand::HelpLink() const
+    {
+        return std::string{ s_PinCommand_HelpLink };
+    }
+
+    void PinResetCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        // TODO
+    }
+}

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -10,6 +10,7 @@
 namespace AppInstaller::CLI
 {
     using namespace AppInstaller::CLI::Execution;
+    using namespace AppInstaller::Utility::literals;
     using namespace std::string_view_literals;
 
     // TODO: Create this link with the docs!
@@ -46,7 +47,21 @@ namespace AppInstaller::CLI
 
     std::vector<Argument> PinAddCommand::GetArguments() const
     {
-        // TODO
+        return {
+            Argument::ForType(Args::Type::Query),
+            Argument::ForType(Args::Type::Id),
+            Argument::ForType(Args::Type::Name),
+            Argument::ForType(Args::Type::Moniker),
+            Argument::ForType(Args::Type::Tag),
+            Argument::ForType(Args::Type::Command),
+            Argument::ForType(Args::Type::Exact),
+            Argument{ "version"_liv, 'v', Args::Type::GatedVersion, Resource::String::GatedVersionArgumentDescription, ArgumentType::Standard },
+            Argument::ForType(Args::Type::Source),
+            Argument::ForType(Args::Type::CustomHeader),
+            Argument::ForType(Args::Type::AcceptSourceAgreements),
+            Argument::ForType(Args::Type::Force),
+            Argument{ "blocking"_liv, Argument::NoAlias, Args::Type::BlockingPin, Resource::String::PinAddBlockingArgumentDescription, ArgumentType::Flag },
+        };
     }
 
     Resource::LocString PinAddCommand::ShortDescription() const
@@ -59,9 +74,19 @@ namespace AppInstaller::CLI
         return { Resource::String::PinAddCommandLongDescription };
     }
 
-    void PinAddCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    void PinAddCommand::Complete(Execution::Context& context, Args::Type valueType) const
     {
-        // TODO
+        switch (valueType)
+        {
+        case Args::Type::Query:
+        case Args::Type::Id:
+        case Args::Type::Name:
+        case Args::Type::Moniker:
+        case Args::Type::Source:
+            context <<
+                Workflow::CompleteWithSingleSemanticsForValue(valueType);
+            break;
+        }
     }
 
     std::string PinAddCommand::HelpLink() const
@@ -69,14 +94,36 @@ namespace AppInstaller::CLI
         return std::string{ s_PinCommand_HelpLink };
     }
 
+    void PinAddCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const
+    {
+        if (execArgs.Contains(Execution::Args::Type::GatedVersion) && execArgs.Contains(Execution::Args::Type::BlockingPin))
+        {
+            throw CommandException(Resource::String::BothGatedVersionAndBlockingFlagProvided);
+        }
+
+    }
+
     void PinAddCommand::ExecuteInternal(Execution::Context& context) const
     {
         // TODO
+        Command::ExecuteInternal(context);
     }
 
     std::vector<Argument> PinRemoveCommand::GetArguments() const
     {
-        // TODO
+        return {
+            Argument::ForType(Args::Type::Query),
+            Argument::ForType(Args::Type::Id),
+            Argument::ForType(Args::Type::Name),
+            Argument::ForType(Args::Type::Moniker),
+            Argument::ForType(Args::Type::Source),
+            Argument::ForType(Args::Type::Tag),
+            Argument::ForType(Args::Type::Command),
+            Argument::ForType(Args::Type::Exact),
+            Argument::ForType(Args::Type::CustomHeader),
+            Argument::ForType(Args::Type::AcceptSourceAgreements),
+            Argument::ForType(Args::Type::Force),
+        };
     }
 
     Resource::LocString PinRemoveCommand::ShortDescription() const
@@ -89,9 +136,19 @@ namespace AppInstaller::CLI
         return { Resource::String::PinRemoveCommandLongDescription };
     }
 
-    void PinRemoveCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    void PinRemoveCommand::Complete(Execution::Context& context, Args::Type valueType) const
     {
-        // TODO
+        switch (valueType)
+        {
+        case Args::Type::Query:
+        case Args::Type::Id:
+        case Args::Type::Name:
+        case Args::Type::Moniker:
+        case Args::Type::Source:
+            context <<
+                Workflow::CompleteWithSingleSemanticsForValue(valueType);
+            break;
+        }
     }
 
     std::string PinRemoveCommand::HelpLink() const
@@ -102,11 +159,23 @@ namespace AppInstaller::CLI
     void PinRemoveCommand::ExecuteInternal(Execution::Context& context) const
     {
         // TODO
+        Command::ExecuteInternal(context);
     }
 
     std::vector<Argument> PinListCommand::GetArguments() const
     {
-        // TODO
+        return {
+            Argument::ForType(Args::Type::Query),
+            Argument::ForType(Args::Type::Id),
+            Argument::ForType(Args::Type::Name),
+            Argument::ForType(Args::Type::Moniker),
+            Argument::ForType(Args::Type::Source),
+            Argument::ForType(Args::Type::Tag),
+            Argument::ForType(Args::Type::Command),
+            Argument::ForType(Args::Type::Exact),
+            Argument::ForType(Args::Type::CustomHeader),
+            Argument::ForType(Args::Type::AcceptSourceAgreements),
+        };
     }
 
     Resource::LocString PinListCommand::ShortDescription() const
@@ -119,9 +188,19 @@ namespace AppInstaller::CLI
         return { Resource::String::PinListCommandLongDescription };
     }
 
-    void PinListCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
+    void PinListCommand::Complete(Execution::Context& context, Args::Type valueType) const
     {
-        // TODO
+        switch (valueType)
+        {
+        case Args::Type::Query:
+        case Args::Type::Id:
+        case Args::Type::Name:
+        case Args::Type::Moniker:
+        case Args::Type::Source:
+            context <<
+                Workflow::CompleteWithSingleSemanticsForValue(valueType);
+            break;
+        }
     }
 
     std::string PinListCommand::HelpLink() const
@@ -132,11 +211,14 @@ namespace AppInstaller::CLI
     void PinListCommand::ExecuteInternal(Execution::Context& context) const
     {
         // TODO
+        Command::ExecuteInternal(context);
     }
 
     std::vector<Argument> PinResetCommand::GetArguments() const
     {
-        // TODO
+        return {
+            Argument::ForType(Args::Type::Force),
+        };
     }
 
     Resource::LocString PinResetCommand::ShortDescription() const
@@ -149,11 +231,6 @@ namespace AppInstaller::CLI
         return { Resource::String::PinResetCommandLongDescription };
     }
 
-    void PinResetCommand::Complete(Execution::Context& context, Execution::Args::Type valueType) const
-    {
-        // TODO
-    }
-
     std::string PinResetCommand::HelpLink() const
     {
         return std::string{ s_PinCommand_HelpLink };
@@ -162,5 +239,6 @@ namespace AppInstaller::CLI
     void PinResetCommand::ExecuteInternal(Execution::Context& context) const
     {
         // TODO
+        Command::ExecuteInternal(context);
     }
 }

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -22,6 +22,7 @@ namespace AppInstaller::CLI
             std::make_unique<PinAddCommand>(FullName()),
             std::make_unique<PinRemoveCommand>(FullName()),
             std::make_unique<PinListCommand>(FullName()),
+            std::make_unique<PinResetCommand>(FullName()),
         });
     }
 

--- a/src/AppInstallerCLICore/Commands/PinCommand.h
+++ b/src/AppInstallerCLICore/Commands/PinCommand.h
@@ -35,6 +35,7 @@ namespace AppInstaller::CLI
         std::string HelpLink() const override;
 
     protected:
+        void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
         void ExecuteInternal(Execution::Context& context) const override;
     };
 
@@ -80,8 +81,6 @@ namespace AppInstaller::CLI
 
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
-
-        void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
         std::string HelpLink() const override;
 

--- a/src/AppInstallerCLICore/Commands/PinCommand.h
+++ b/src/AppInstallerCLICore/Commands/PinCommand.h
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Command.h"
+#include <winget/UserSettings.h>
+
+namespace AppInstaller::CLI
+{
+    struct PinCommand final : public Command
+    {
+        PinCommand(std::string_view parent) : Command("pin", {} /* aliases */, parent, Settings::ExperimentalFeature::Feature::Pinning) {}
+
+        std::vector<std::unique_ptr<Command>> GetCommands() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+        std::string HelpLink() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+
+    struct PinAddCommand final : public Command
+    {
+        PinAddCommand(std::string_view parent) : Command("add", parent) {}
+
+        std::vector<Argument> GetArguments() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+        void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
+
+        std::string HelpLink() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+
+    struct PinRemoveCommand final : public Command
+    {
+        PinRemoveCommand(std::string_view parent) : Command("remove", parent) {}
+
+        std::vector<Argument> GetArguments() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+        void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
+
+        std::string HelpLink() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+
+    struct PinListCommand final : public Command
+    {
+        PinListCommand(std::string_view parent) : Command("list", parent) {}
+
+        std::vector<Argument> GetArguments() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+        void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
+
+        std::string HelpLink() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+
+    struct PinResetCommand final : public Command
+    {
+        PinResetCommand(std::string_view parent) : Command("reset", parent) {}
+
+        std::vector<Argument> GetArguments() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+        void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
+
+        std::string HelpLink() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
+}

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -18,6 +18,7 @@
 #include "CompleteCommand.h"
 #include "ExportCommand.h"
 #include "ImportCommand.h"
+#include "PinCommand.h"
 
 #include "Resources.h"
 #include "TableOutput.h"
@@ -127,6 +128,7 @@ namespace AppInstaller::CLI
             std::make_unique<CompleteCommand>(FullName()),
             std::make_unique<ExportCommand>(FullName()),
             std::make_unique<ImportCommand>(FullName()),
+            std::make_unique<PinCommand>(FullName()),
         });
     }
 

--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -37,7 +37,7 @@ namespace AppInstaller::CLI
 
     struct SourceListCommand final : public Command
     {
-        SourceListCommand(std::string_view parent) : Command("list", parent) {}
+        SourceListCommand(std::string_view parent) : Command("list", { "ls" }, parent) {}
 
         std::vector<Argument> GetArguments() const override;
 

--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -37,7 +37,7 @@ namespace AppInstaller::CLI
 
     struct SourceListCommand final : public Command
     {
-        SourceListCommand(std::string_view parent) : Command("list", { "ls" }, parent) {}
+        SourceListCommand(std::string_view parent) : Command("list", parent) {}
 
         std::vector<Argument> GetArguments() const override;
 

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -87,6 +87,10 @@ namespace AppInstaller::CLI::Execution
             // Show command
             ListVersions, // Used in Show command to list all available versions of an app
 
+            // Pin command
+            GatedVersion, // Differs from Version in that this supports wildcards
+            BlockingPin,
+
             // Common arguments
             NoVT, // Disable VirtualTerminal outputs
             RetroStyle, // Makes progress display as retro

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -237,6 +237,16 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PackageAlreadyInstalled);
         WINGET_DEFINE_RESOURCE_STRINGID(PackageDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(PendingWorkError);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinAddCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinAddCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinListCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinListCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinRemoveCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinRemoveCommandShortDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinResetCommandLongDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinResetCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PoliciesDisabled);
         WINGET_DEFINE_RESOURCE_STRINGID(PoliciesEnabled);
         WINGET_DEFINE_RESOURCE_STRINGID(PoliciesPolicy);

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -36,6 +36,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(AvailableOptions);
         WINGET_DEFINE_RESOURCE_STRINGID(AvailableSubcommands);
         WINGET_DEFINE_RESOURCE_STRINGID(AvailableUpgrades);
+        WINGET_DEFINE_RESOURCE_STRINGID(BothGatedVersionAndBlockingFlagProvided);
         WINGET_DEFINE_RESOURCE_STRINGID(BothManifestAndSearchQueryProvided);
         WINGET_DEFINE_RESOURCE_STRINGID(BothPurgeAndPreserveFlagsProvided);
         WINGET_DEFINE_RESOURCE_STRINGID(Cancelled);
@@ -96,6 +97,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(FilesRemainInInstallDirectory);
         WINGET_DEFINE_RESOURCE_STRINGID(FlagContainAdjoinedError);
         WINGET_DEFINE_RESOURCE_STRINGID(ForceArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(GatedVersionArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(GetManifestResultVersionNotFound);
         WINGET_DEFINE_RESOURCE_STRINGID(HashCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(HashCommandShortDescription);
@@ -237,6 +239,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PackageAlreadyInstalled);
         WINGET_DEFINE_RESOURCE_STRINGID(PackageDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(PendingWorkError);
+        WINGET_DEFINE_RESOURCE_STRINGID(PinAddBlockingArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PinAddCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PinAddCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PinCommandLongDescription);

--- a/src/AppInstallerCLICore/Workflows/PinFlow.h
+++ b/src/AppInstallerCLICore/Workflows/PinFlow.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "ExecutionContext.h"
+
+namespace AppInstaller::CLI::Workflow
+{
+}

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1496,7 +1496,6 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Manage package pins with the sub-commands. A pin can limit the Windows Package Manager from updating a package to specific ranges of versions, or it can prevent it from updating the package altogether. A pinned package may still update on its own and be updated from outside the Windows Package Manager.</value>
   </data>
   <data name="PinCommandShortDescription" xml:space="preserve">
-    <!-- TODO: We need to add "package pin[ning]" to the dictionary of terms for the loc team to know before sending this for localization -->
     <value>Manage package pins</value>
   </data>
   <data name="PinListCommandLongDescription" xml:space="preserve">

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1525,4 +1525,16 @@ Please specify one of them using the --source option to proceed.</value>
     <value />
     <comment>TODO</comment>
   </data>
+  <data name="BothGatedVersionAndBlockingFlagProvided" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="GatedVersionArgumentDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinAddBlockingArgumentDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1503,8 +1503,7 @@ Please specify one of them using the --source option to proceed.</value>
     <value>List all current pins, or full details of a specific pin.</value>
   </data>
   <data name="PinListCommandShortDescription" xml:space="preserve">
-    <value></value>
-    <comment>List current pins</comment>
+    <value>List current pins</value>
   </data>
   <data name="PinRemoveCommandLongDescription" xml:space="preserve">
     <value>Remove a specific package pin.</value>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1486,55 +1486,46 @@ Please specify one of them using the --source option to proceed.</value>
     <comment>{Locked="%1"} The value will be replaced with the feature name</comment>
   </data>
   <data name="PinAddCommandLongDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Add a new pin. A pin can limit the Windows Package Manager from updating a package to specific ranges of versions, or it can prevent it from updating the package altogether. A pinned package may still update on its own and be updated from outside the Windows Package Manager. By default, a pinned package can be updated by mentioning it explicitly in the 'upgrade' command or by adding the '--include-pinned' flag to 'winget upgrade --all'.</value>
+    <comment>{Locked{"'upgrade'"} Locked{"--include-pinned"} Locked{"winget upgrade --all"}</comment>
   </data>
   <data name="PinAddCommandShortDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Add a new pin</value>
   </data>
   <data name="PinCommandLongDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Manage package pins with the sub-commands. A pin can limit the Windows Package Manager from updating a package to specific ranges of versions, or it can prevent it from updating the package altogether. A pinned package may still update on its own and be updated from outside the Windows Package Manager.</value>
   </data>
   <data name="PinCommandShortDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <!-- TODO: We need to add "package pin[ning]" to the dictionary of terms for the loc team to know before sending this for localization -->
+    <value>Manage package pins</value>
   </data>
   <data name="PinListCommandLongDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>List all current pins, or full details of a specific pin.</value>
   </data>
   <data name="PinListCommandShortDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value></value>
+    <comment>List current pins</comment>
   </data>
   <data name="PinRemoveCommandLongDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Remove a specific package pin.</value>
   </data>
   <data name="PinRemoveCommandShortDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Remove a package pin</value>
   </data>
   <data name="PinResetCommandLongDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Reset all existing pins.</value>
   </data>
   <data name="PinResetCommandShortDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Reset pins</value>
   </data>
   <data name="BothGatedVersionAndBlockingFlagProvided" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Both version and '--blocking' arguments provided</value>
+    <comment>{Locked="--blocking"}</comment>
   </data>
   <data name="GatedVersionArgumentDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Version to which to pin the package. The wildcard '*' can be used as the last version part</value>
   </data>
   <data name="PinAddBlockingArgumentDescription" xml:space="preserve">
-    <value />
-    <comment>TODO</comment>
+    <value>Block from updating until the pin is removed, preventing override arguments</value>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1485,4 +1485,44 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Cannot disable %1. This setting is controlled by policy. For more information contact your system administrator.</value>
     <comment>{Locked="%1"} The value will be replaced with the feature name</comment>
   </data>
+  <data name="PinAddCommandLongDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinAddCommandShortDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinCommandLongDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinCommandShortDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinListCommandLongDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinListCommandShortDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinRemoveCommandLongDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinRemoveCommandShortDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinResetCommandLongDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
+  <data name="PinResetCommandShortDescription" xml:space="preserve">
+    <value />
+    <comment>TODO</comment>
+  </data>
 </root>

--- a/src/AppInstallerCommonCore/ExperimentalFeature.cpp
+++ b/src/AppInstallerCommonCore/ExperimentalFeature.cpp
@@ -46,6 +46,8 @@ namespace AppInstaller::Settings
                 return userSettings.Get<Setting::EFZipInstall>();
             case ExperimentalFeature::Feature::OpenLogsArgument:
                 return userSettings.Get<Setting::EFOpenLogsArgument>();
+            case ExperimentalFeature::Feature::Pinning:
+                return userSettings.Get<Setting::EFPinning>();
             default:
                 THROW_HR(E_UNEXPECTED);
             }
@@ -81,6 +83,8 @@ namespace AppInstaller::Settings
             return ExperimentalFeature{ "Zip Installation", "zipInstall", "https://aka.ms/winget-settings", Feature::ZipInstall };
         case Feature::OpenLogsArgument:
             return ExperimentalFeature{ "Open Logs Argument", "openLogsArgument", "https://aka.ms/winget-settings", Feature::OpenLogsArgument };
+        case Feature::Pinning:
+            return ExperimentalFeature{ "Package Pinning", "pinning", "https://aka.ms/winget-settings", Feature::Pinning};
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -25,6 +25,7 @@ namespace AppInstaller::Settings
             DirectMSI = 0x2,
             ZipInstall = 0x4,
             OpenLogsArgument = 0x8,
+            Pinning = 0xA,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -25,7 +25,7 @@ namespace AppInstaller::Settings
             DirectMSI = 0x2,
             ZipInstall = 0x4,
             OpenLogsArgument = 0x8,
-            Pinning = 0xA,
+            Pinning = 0x1,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -25,7 +25,7 @@ namespace AppInstaller::Settings
             DirectMSI = 0x2,
             ZipInstall = 0x4,
             OpenLogsArgument = 0x8,
-            Pinning = 0x1,
+            Pinning = 0x10,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -79,6 +79,7 @@ namespace AppInstaller::Settings
         EFDirectMSI,
         EFZipInstall,
         EFOpenLogsArgument,
+        EFPinning,
         // Telemetry
         TelemetryDisable,
         // Install behavior
@@ -148,6 +149,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFZipInstall, bool, bool, false, ".experimentalFeatures.zipInstall"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFOpenLogsArgument, bool, bool, false, ".experimentalFeatures.openLogsArgument"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::EFPinning, bool, bool, false, ".experimentalFeatures.pinning"sv);
         // Telemetry
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);
         // Install behavior

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -249,6 +249,7 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EFZipInstall)
         WINGET_VALIDATE_PASS_THROUGH(EFOpenLogsArgument)
+        WINGET_VALIDATE_PASS_THROUGH(EFPinning)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(InteractivityDisable)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)


### PR DESCRIPTION
This change adds an empty `pin` command. Actual implementation of the command will come as a separate PR. This change includes:
* Definition of the `pin` command and its sub-commands `add`, `remove`, `list`, `reset`. These definitions contain only the definition of arguments but are missing the actual execution code.
* A new experimental feature flag to hide this command.
* All the help resource strings for the command. Still pending all the resources that will be shown during actual execution.
* Adds a `source ls` alias for the `source list` command.
* Changes an existing string to make it consistent with the rest.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2733)