### PR TITLE
Add `source ls` alias for `source list`

### DIFF
--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -37,7 +37,7 @@ namespace AppInstaller::CLI
 
     struct SourceListCommand final : public Command
     {
-        SourceListCommand(std::string_view parent) : Command("list", parent) {}
+        SourceListCommand(std::string_view parent) : Command("list", { "ls" }, parent) {}
 
         std::vector<Argument> GetArguments() const override;
 


### PR DESCRIPTION
Adding alias for consistency with the `ls` alias for the `list` command.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2736)