### PR TITLE
Update powershell module target framework to 4.8

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client/Copy-PlatformBinaries.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Copy-PlatformBinaries.ps1
@@ -30,7 +30,7 @@ param (
     $OutDir
 )
 
-# src\x64\Release\Project\net461\Library.Desktop.dll
+# src\x64\Release\Project\net48\Library.Desktop.dll
 # src\x64\Release\Project\net6.0-windows10.0.22000.0\Library.Core.dll
 
 # build\Module\x64\Desktop\Library.Desktop.dll
@@ -38,7 +38,7 @@ param (
 
 $CoreFramework = 'net6.0-windows10.0.22000.0'
 $CoreFolderName = 'Core'
-$DesktopFramework = 'net461'
+$DesktopFramework = 'net48'
 $DesktopFolderName = 'Desktop'
 $ProjectName = 'Microsoft.WinGet.Client'
 

--- a/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_FindPackage.ps1
+++ b/src/PowerShell/Microsoft.WinGet.Client/Examples/Sample_FindPackage.ps1
@@ -1,7 +1,7 @@
 <#
     .SYNOPSIS
         Example for 'Find-WinGetPackage' cmdlet.
-        Displays all applications available for instasllation.
+        Displays all applications available for installation.
 #>
 
 # TODO: Replace parameter with actual module name from PSGallery once module is released. 

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetWindowsVersion>10.0.22000.0</TargetWindowsVersion>
     <CoreFramework>net6.0-windows$(TargetWindowsVersion)</CoreFramework>
-    <DesktopFramework>net461</DesktopFramework>
+    <DesktopFramework>net48</DesktopFramework>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Updates the target desktop .NET framework for the powershell module project from 4.6 to 4.8 since version 4.6 is no longer supported.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2741)