### PR TITLE
Suppress warnings for CA1416 in PowerShell module

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client/Commands/InstallPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Commands/InstallPackageCommand.cs
@@ -69,6 +69,7 @@ namespace Microsoft.WinGet.Client.Commands
         }
 
         /// <inheritdoc />
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Targets Windows 10.0.17763.0")]
         protected override InstallOptions GetInstallOptions(PackageVersionId version)
         {
             InstallOptions options = base.GetInstallOptions(version);

--- a/src/PowerShell/Microsoft.WinGet.Client/Common/Utilities.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Common/Utilities.cs
@@ -28,6 +28,7 @@ namespace Microsoft.WinGet.Client.Common
         /// <summary>
         /// Gets a value indicating whether the current assembly is executing in an administrative context.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Windows only API")]
         public static bool ExecutingAsAdministrator
         {
             get
@@ -41,6 +42,7 @@ namespace Microsoft.WinGet.Client.Common
         /// <summary>
         /// Gets a value indicating whether the current assembly is executing as a SYSTEM user.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Windows only API")]
         public static bool ExecutingAsSystem
         {
             get

--- a/src/PowerShell/Microsoft.WinGet.Client/Helpers/ComObjectFactory.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Helpers/ComObjectFactory.cs
@@ -35,12 +35,17 @@ namespace Microsoft.WinGet.Client.Factories
         private static readonly Guid UninstallOptionsClsid = Guid.Parse("AA2A5C04-1AD9-46C4-B74F-6B334AD7EB8C");
         private static readonly Guid PackageMatchFilterClsid = Guid.Parse("3F85B9F4-487A-4C48-9035-2903F8A6D9E8");
 #endif
-
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type PackageManagerType = Type.GetTypeFromCLSID(PackageManagerClsid);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type FindPackagesOptionsType = Type.GetTypeFromCLSID(FindPackagesOptionsClsid);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type CreateCompositePackageCatalogOptionsType = Type.GetTypeFromCLSID(CreateCompositePackageCatalogOptionsClsid);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type InstallOptionsType = Type.GetTypeFromCLSID(InstallOptionsClsid);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type UninstallOptionsType = Type.GetTypeFromCLSID(UninstallOptionsClsid);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "COM only usage.")]
         private static readonly Type PackageMatchFilterType = Type.GetTypeFromCLSID(PackageMatchFilterClsid);
 
         private static readonly Guid PackageManagerIid = Guid.Parse("B375E3B9-F2E0-5C93-87A7-B67497F7E593");


### PR DESCRIPTION
Suppresses CA1416 warnings that require windows-only apis to be identified in the AppInstaller build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2762)