### PR TITLE
Restore nuget.config file for public dependencies

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Related to: #2756

Adds back the nuget.config file for public dependencies. This file was causing an issue in the AppInstaller build pipeline because it points to a public feed. This file will be removed in the AppInstaller repository rather than here since it is needed in the winget-cli repository.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2763)