### PR TITLE
Refactor test workflow source search

### DIFF
--- a/src/AppInstallerCLITests/ExportFlow.cpp
+++ b/src/AppInstallerCLITests/ExportFlow.cpp
@@ -14,7 +14,14 @@ TEST_CASE("ExportFlow_ExportAll", "[ExportFlow][workflow]")
     std::ostringstream exportOutput;
     TestContext context{ exportOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     context.Args.AddArg(Execution::Args::Type::OutputFile, exportResultPath);
 
     ExportCommand exportCommand({});
@@ -61,7 +68,14 @@ TEST_CASE("ExportFlow_ExportAll_WithVersions", "[ExportFlow][workflow]")
     std::ostringstream exportOutput;
     TestContext context{ exportOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     context.Args.AddArg(Execution::Args::Type::OutputFile, exportResultPath);
     context.Args.AddArg(Execution::Args::Type::IncludeVersions);
 

--- a/src/AppInstallerCLITests/ImportFlow.cpp
+++ b/src/AppInstallerCLITests/ImportFlow.cpp
@@ -12,15 +12,24 @@ using namespace AppInstaller::Utility::literals;
 
 void OverrideForImportSource(TestContext& context, bool useTestCompositeSource = false)
 {
+    auto testCompositeSource = CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_Dependencies,
+        TSR::TestInstaller_Exe_LicenseAgreement,
+        TSR::TestInstaller_Exe_NothingInstalled,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_Msix_WFDependency,
+        });
+
     context.Override({ "OpenPredefinedSource", [=](TestContext& context)
     {
-        auto installedSource = useTestCompositeSource ? std::make_shared<WorkflowTestCompositeSource>() : std::make_shared<TestSource>();
+        auto installedSource = useTestCompositeSource ? testCompositeSource : std::make_shared<TestSource>();
         context.Add<Execution::Data::Source>(Source{ installedSource });
     } });
 
-    context.Override({ Workflow::OpenSourcesForImport, [](TestContext& context)
+    context.Override({ Workflow::OpenSourcesForImport, [=](TestContext& context)
     {
-        context.Add<Execution::Data::Sources>(std::vector<Source>{ Source{ std::make_shared<WorkflowTestCompositeSource>() } });
+        context.Add<Execution::Data::Sources>(std::vector<Source>{ Source{ testCompositeSource } });
     } });
 }
 

--- a/src/AppInstallerCLITests/InstallFlow.cpp
+++ b/src/AppInstallerCLITests/InstallFlow.cpp
@@ -846,9 +846,9 @@ TEST_CASE("InstallFlow_SearchAndInstall", "[InstallFlow][workflow]")
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForOpenSource(context, true);
+    OverrideForOpenSource(context, CreateTestSource({ TSR::TestQuery_ReturnOne }), true);
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestQueryReturnOne"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestQuery_ReturnOne.Query);
 
     InstallCommand install({});
     install.Execute(context);
@@ -869,7 +869,7 @@ TEST_CASE("InstallFlow_SearchFoundNoApp", "[InstallFlow][workflow]")
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForOpenSource(context, true);
+    OverrideForOpenSource(context, CreateTestSource({}), true);
     context.Args.AddArg(Execution::Args::Type::Query, "TestQueryReturnZero"sv);
 
     InstallCommand install({});
@@ -885,8 +885,8 @@ TEST_CASE("InstallFlow_SearchFoundMultipleApp", "[InstallFlow][workflow]")
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForOpenSource(context, true);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestQueryReturnTwo"sv);
+    OverrideForOpenSource(context, CreateTestSource({ TSR::TestQuery_ReturnTwo }), true);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestQuery_ReturnTwo.Query);
 
     InstallCommand install({});
     install.Execute(context);

--- a/src/AppInstallerCLITests/ShowFlow.cpp
+++ b/src/AppInstallerCLITests/ShowFlow.cpp
@@ -13,8 +13,8 @@ TEST_CASE("ShowFlow_SearchAndShowAppInfo", "[ShowFlow][workflow]")
     std::ostringstream showOutput;
     TestContext context{ showOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForOpenSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestQueryReturnOne"sv);
+    OverrideForOpenSource(context, CreateTestSource({ TSR::TestQuery_ReturnOne }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestQuery_ReturnOne.Query);
 
     ShowCommand show({});
     show.Execute(context);
@@ -32,8 +32,8 @@ TEST_CASE("ShowFlow_SearchAndShowAppVersion", "[ShowFlow][workflow]")
     std::ostringstream showOutput;
     TestContext context{ showOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForOpenSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestQueryReturnOne"sv);
+    OverrideForOpenSource(context, CreateTestSource({ TSR::TestQuery_ReturnOne }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestQuery_ReturnOne.Query);
     context.Args.AddArg(Execution::Args::Type::ListVersions);
 
     ShowCommand show({});

--- a/src/AppInstallerCLITests/UninstallFlow.cpp
+++ b/src/AppInstallerCLITests/UninstallFlow.cpp
@@ -67,9 +67,9 @@ TEST_CASE("UninstallFlow_UninstallPortable", "[UninstallFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext context{ uninstallOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
     OverrideForPortableUninstall(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestPortableInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Portable.Query);
 
     UninstallCommand uninstall({});
     uninstall.Execute(context);
@@ -84,9 +84,9 @@ TEST_CASE("UninstallFlow_UninstallExe", "[UninstallFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext context{ uninstallOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
     OverrideForExeUninstall(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
     context.Args.AddArg(Execution::Args::Type::Silent);
 
     UninstallCommand uninstall({});
@@ -110,9 +110,9 @@ TEST_CASE("UninstallFlow_UninstallMsix", "[UninstallFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext context{ uninstallOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Msix }));
     OverrideForMSIXUninstall(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestMsixInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Msix.Query);
 
     UninstallCommand uninstall({});
     uninstall.Execute(context);
@@ -134,9 +134,9 @@ TEST_CASE("UninstallFlow_UninstallMSStore", "[UninstallFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext context{ uninstallOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_MSStore }));
     OverrideForMSIXUninstall(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestMSStoreInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_MSStore.Query);
 
     UninstallCommand uninstall({});
     uninstall.Execute(context);
@@ -158,7 +158,7 @@ TEST_CASE("UninstallFlow_UninstallExeNotFound", "[UninstallFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext context{ uninstallOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({}));
     context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.MissingApp"sv);
     context.Args.AddArg(Execution::Args::Type::Silent);
 

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -21,7 +21,7 @@ TEST_CASE("UpdateFlow_UpdateWithManifest", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
     OverrideForShellExecute(context);
     context.Args.AddArg(Execution::Args::Type::Manifest, TestDataFile("UpdateFlowTest_Exe.yaml").GetPath().u8string());
 
@@ -46,7 +46,7 @@ TEST_CASE("UpdateFlow_UpdateWithManifestMSStore", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_MSStore }));
     OverrideForMSStore(context, true);
     context.Args.AddArg(Execution::Args::Type::Manifest, TestDataFile("InstallFlowTest_MSStore.yaml").GetPath().u8string());
 
@@ -70,7 +70,7 @@ TEST_CASE("UpdateFlow_UpdateWithManifestAppNotInstalled", "[UpdateFlow][workflow
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({}));
     context.Args.AddArg(Execution::Args::Type::Manifest, TestDataFile("InstallerArgTest_Inno_NoSwitches.yaml").GetPath().u8string());
 
     UpgradeCommand update({});
@@ -90,7 +90,7 @@ TEST_CASE("UpdateFlow_UpdateWithManifestVersionAlreadyInstalled", "[UpdateFlow][
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
     context.Args.AddArg(Execution::Args::Type::Manifest, TestDataFile("InstallFlowTest_Exe.yaml").GetPath().u8string());
 
     UpgradeCommand update({});
@@ -110,9 +110,9 @@ TEST_CASE("UpdateFlow_UpdateExe", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
     context.Args.AddArg(Execution::Args::Type::Silent);
 
     UpgradeCommand update({});
@@ -137,11 +137,11 @@ TEST_CASE("UpdateFlow_UpdateZip_Exe", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Zip }));
     OverrideForShellExecute(context);
     OverrideForExtractInstallerFromArchive(context);
     OverrideForVerifyAndSetNestedInstaller(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestZipInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Zip.Query);
     context.Args.AddArg(Execution::Args::Type::Silent);
 
     UpgradeCommand update({});
@@ -166,9 +166,9 @@ TEST_CASE("UpdateFlow_UpdatePortable", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
     OverrideForPortableInstallFlow(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestPortableInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Portable.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -185,8 +185,8 @@ TEST_CASE("UpdateFlow_Portable_SymlinkCreationFail", "[UpdateFlow][workflow]")
     bool overrideCreateSymlinkStatus = false;
     AppInstaller::Filesystem::TestHook_SetCreateSymlinkResult_Override(&overrideCreateSymlinkStatus);
     OverridePortableInstaller(context);
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestPortableInstaller"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Portable.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -200,8 +200,8 @@ TEST_CASE("UpdateFlow_Portable_SymlinkCreationFail", "[UpdateFlow][workflow]")
     std::ostringstream uninstallOutput;
     TestContext uninstallContext{ uninstallOutput, std::cin };
     auto previousThreadGlobals = uninstallContext.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(uninstallContext);
-    uninstallContext.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestPortableInstaller"sv);
+    OverrideForCompositeInstalledSource(uninstallContext, CreateTestSource({ TSR::TestInstaller_Portable }));
+    uninstallContext.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Portable.Query);
 
     UninstallCommand uninstall({});
     uninstall.Execute(uninstallContext);
@@ -219,8 +219,8 @@ TEST_CASE("UpdateFlow_UpdateExeWithUnsupportedArgs", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithUnsupportedArguments"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_UnsupportedArguments }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_UnsupportedArguments.Query);
     context.Args.AddArg(Execution::Args::Type::InstallLocation, tempDirectory);
 
     UpgradeCommand update({});
@@ -243,8 +243,8 @@ TEST_CASE("UpdateFlow_UnknownVersion", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithUnknownVersion"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_UnknownVersion }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_UnknownVersion.Query);
     context.Args.AddArg(Execution::Args::Type::InstallLocation, tempDirectory);
 
     UpgradeCommand update({});
@@ -266,9 +266,9 @@ TEST_CASE("UpdateFlow_UnknownVersion_IncludeUnknownArg", "[UpdateFlow][workflow]
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_UnknownVersion }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithUnknownVersion"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_UnknownVersion.Query);
     context.Args.AddArg(Execution::Args::Type::InstallLocation, tempDirectory);
     context.Args.AddArg(Execution::Args::Type::IncludeUnknown);
 
@@ -284,7 +284,14 @@ TEST_CASE("UpdateFlow_NoArgs_UnknownVersion", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
 
     UpgradeCommand update({});
     context.SetExecutingCommand(&update);
@@ -300,7 +307,14 @@ TEST_CASE("UpdateFlow_IncludeUnknown", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     context.Args.AddArg(Execution::Args::Type::IncludeUnknown);
 
     UpgradeCommand update({});
@@ -320,7 +334,7 @@ TEST_CASE("UpdateFlow_UpdatePortableWithManifest", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
     OverrideForPortableInstallFlow(context);
     context.Args.AddArg(Execution::Args::Type::Manifest, TestDataFile("UpdateFlowTest_Portable.yaml").GetPath().u8string());
 
@@ -337,9 +351,9 @@ TEST_CASE("UpdateFlow_UpdateMsix", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Msix }));
     OverrideForMSIX(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestMsixInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Msix.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -356,9 +370,9 @@ TEST_CASE("UpdateFlow_UpdateMSStore", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_MSStore }));
     OverrideForMSStore(context, true);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestMSStoreInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_MSStore.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -380,8 +394,8 @@ TEST_CASE("UpdateFlow_UpdateExeLatestAlreadyInstalled", "[UpdateFlow][workflow]"
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithLatestInstalled"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_LatestInstalled }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_LatestInstalled.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -400,8 +414,8 @@ TEST_CASE("UpdateFlow_UpdateExeInstallerTypeNotApplicable", "[UpdateFlow][workfl
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithIncompatibleInstallerType"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_IncompatibleInstallerType }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_IncompatibleInstallerType.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -420,8 +434,8 @@ TEST_CASE("UpdateFlow_UpdateExeInstallerTypeNotApplicableSpecificVersion", "[Upd
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithIncompatibleInstallerType"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_IncompatibleInstallerType }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_IncompatibleInstallerType.Query);
     context.Args.AddArg(Execution::Args::Type::Version, "2.0.0.0"sv);
 
     UpgradeCommand update({});
@@ -442,9 +456,9 @@ TEST_CASE("UpdateFlow_UpdateExeWithDifferentInstalledType", "[UpdateFlow][workfl
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_DifferentInstallerType }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithDifferentInstalledType"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_DifferentInstallerType.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -462,8 +476,8 @@ TEST_CASE("UpdateFlow_UpdateExeSpecificVersionNotFound", "[UpdateFlow][workflow]
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
     context.Args.AddArg(Execution::Args::Type::Version, "1.2.3.4"sv);
 
     UpgradeCommand update({});
@@ -483,8 +497,8 @@ TEST_CASE("UpdateFlow_UpdateExeSpecificVersionNotApplicable", "[UpdateFlow][work
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithIncompatibleInstallerType"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_IncompatibleInstallerType }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_IncompatibleInstallerType.Query);
     context.Args.AddArg(Execution::Args::Type::Version, "1.0.0.0"sv);
 
     UpgradeCommand update({});
@@ -507,7 +521,14 @@ TEST_CASE("UpdateFlow_UpdateAllApplicable", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     OverrideForShellExecute(context);
     OverrideForMSIX(context);
     OverrideForMSStore(context, true);
@@ -539,7 +560,14 @@ TEST_CASE("UpdateFlow_UpdateAll_IncludeUnknown", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     OverrideForShellExecute(context);
     OverrideForMSIX(context);
     OverrideForMSStore(context, true);
@@ -569,10 +597,10 @@ TEST_CASE("UpdateFlow_UpgradeWithDuplicateUpgradeItemsFound", "[UpdateFlow][work
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_UpgradeAllWithDuplicateUpgradeItems }));
     // Installer should only be run once since the 2 upgrade items are same.
     OverrideForShellExecute(context, 1);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestUpgradeAllWithDuplicateUpgradeItems"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_UpgradeAllWithDuplicateUpgradeItems.Query);
     context.Args.AddArg(Execution::Args::Type::All);
 
     UpgradeCommand update({});
@@ -588,9 +616,9 @@ TEST_CASE("UpdateFlow_Dependencies", "[UpdateFlow][workflow][dependencies]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_Dependencies }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller.Dependencies"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_Dependencies.Query);;
 
     TestUserSettings settings;
     settings.Set<AppInstaller::Settings::Setting::EFDependencies>({ true });
@@ -614,9 +642,9 @@ TEST_CASE("UpdateFlow_LicenseAgreement", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_LicenseAgreement }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestInstallerWithLicenseAgreement"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_LicenseAgreement.Query);
     context.Args.AddArg(Execution::Args::Type::AcceptPackageAgreements);
 
     UpgradeCommand update({});
@@ -641,8 +669,8 @@ TEST_CASE("UpdateFlow_LicenseAgreement_NotAccepted", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, updateInput };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestInstallerWithLicenseAgreement"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_LicenseAgreement }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_LicenseAgreement.Query);
 
     UpgradeCommand update({});
     update.Execute(context);
@@ -668,7 +696,14 @@ TEST_CASE("UpdateFlow_All_LicenseAgreement", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context, TestSourceSearchOptions::UpgradeUsesAgreements);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe_UpgradeUsesAgreements,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix_UpgradeUsesAgreements,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     OverrideForShellExecute(context);
     OverrideForMSIX(context);
     OverrideForMSStore(context, true);
@@ -705,7 +740,14 @@ TEST_CASE("UpdateFlow_All_LicenseAgreement_NotAccepted", "[UpdateFlow][workflow]
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, updateInput };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context, TestSourceSearchOptions::UpgradeUsesAgreements);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe_UpgradeUsesAgreements,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix_UpgradeUsesAgreements,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
     context.Args.AddArg(Execution::Args::Type::All);
 
     UpgradeCommand update({});
@@ -736,7 +778,14 @@ TEST_CASE("UpdateFlow_RequireExplicit", "[UpdateFlow][workflow]")
 
     // Msix package has an update that requires explicit upgrade.
     // Exe, Portable, MSStore, Zip are also listed with an available upgrade.
-    OverrideForCompositeInstalledSource(context, TestSourceSearchOptions::UpgradeRequiresExplicit);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_Msix_UpgradeRequiresExplicit,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Zip,
+        }));
 
     SECTION("List available upgrades")
     {
@@ -780,7 +829,7 @@ TEST_CASE("UpdateFlow_RequireExplicit", "[UpdateFlow][workflow]")
 
     SECTION("Upgrade explicitly")
     {
-        context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestMsixInstaller"sv);
+        context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Msix.Query);
         OverrideForMSIX(context);
 
         UpgradeCommand update({});
@@ -801,9 +850,9 @@ TEST_CASE("InstallFlow_FoundInstalledAndUpgradeAvailable", "[UpdateFlow][workflo
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
     OverrideForShellExecute(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller"sv);
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
     context.Args.AddArg(Execution::Args::Type::Silent);
 
     InstallCommand install({});
@@ -827,8 +876,8 @@ TEST_CASE("InstallFlow_FoundInstalledAndUpgradeAvailable_WithNoUpgrade", "[Updat
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "AppInstallerCliTest.TestExeInstaller"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
     context.Args.AddArg(Execution::Args::Type::NoUpgrade);
 
     InstallCommand install({});
@@ -848,8 +897,8 @@ TEST_CASE("InstallFlow_FoundInstalledAndUpgradeNotAvailable", "[UpdateFlow][work
     std::ostringstream installOutput;
     TestContext context{ installOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
-    context.Args.AddArg(Execution::Args::Type::Query, "TestExeInstallerWithLatestInstalled"sv);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe_LatestInstalled }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe_LatestInstalled.Query);
 
     InstallCommand install({});
     install.Execute(context);

--- a/src/AppInstallerCLITests/WorkflowCommon.cpp
+++ b/src/AppInstallerCLITests/WorkflowCommon.cpp
@@ -17,54 +17,376 @@ using namespace AppInstaller::Utility;
 
 namespace TestCommon
 {
+    namespace TSR
+    {
+        const TestSourceResult TestQuery_ReturnOne(
+            "TestQueryReturnOne"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(std::vector<Manifest>{ manifest }, source),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnOne")));
+            });
+
+        const TestSourceResult TestQuery_ReturnTwo(
+            "TestQueryReturnTwo"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(std::vector<Manifest>{ manifest }, source),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
+
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("Manifest-Good.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(std::vector<Manifest>{ manifest2 }, source),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
+            });
+
+        const TestSourceResult TestInstaller_Exe(
+            "AppInstallerCliTest.TestExeInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
+
+                auto testPackage =
+                    TestPackage::Make(
+                        manifest,
+                        TestPackage::MetadataMap
+                        {
+                            { PackageVersionMetadata::InstalledType, "Exe" },
+                            { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                            { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                        },
+                        std::vector<Manifest>{ manifest3, manifest2, manifest },
+                        source
+                        );
+                testPackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                matches.emplace_back(
+                    ResultMatch(
+                        testPackage,
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_UpgradeUsesAgreements(
+            "AppInstallerCliTest.TestExeInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
+
+                auto testPackage =
+                    TestPackage::Make(
+                        manifest,
+                        TestPackage::MetadataMap
+                        {
+                            { PackageVersionMetadata::InstalledType, "Exe" },
+                            { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                            { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                        },
+                        std::vector<Manifest>{ manifest3, manifest2, manifest },
+                        source
+                        );
+                testPackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
+                matches.emplace_back(
+                    ResultMatch(
+                        testPackage,
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Portable(
+            "AppInstallerCliTest.TestPortableInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Portable.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Portable.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Portable" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestPortableInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Msix(
+            "AppInstallerCliTest.TestMsixInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Msix_StreamingFlow.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Msix.yaml"));
+
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Msix_UpgradeUsesAgreements(
+            "AppInstallerCliTest.TestMsixInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Msix_StreamingFlow.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Msix_LicenseAgreement.yaml"));
+
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Msix_UpgradeRequiresExplicit(
+            "AppInstallerCliTest.TestMsixInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Msix_StreamingFlow.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Msix.yaml"));
+
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap
+                            {
+                                { PackageVersionMetadata::InstalledType, "Msix" },
+                                { PackageVersionMetadata::PinnedState, "PinnedByManifest" },
+                            },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                            ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Zip(
+            "AppInstallerCliTest.TestZipInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Zip_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Zip_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestZipInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_MSStore(
+            "AppInstallerCliTest.TestMSStoreInstaller"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto installed = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_MSStore.yaml"));
+                auto available = installed;
+                // Override the installed version to not be Latest
+                installed.Version = "1.0.0.0";
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            installed,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "MSStore" } },
+                            std::vector<Manifest>{ available },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMSStoreInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_UnknownVersion(
+            "TestExeInstallerWithUnknownVersion"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto installed = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_UnknownVersion.yaml"));
+                auto available = installed;
+                // Override the installed version to be unknown.
+                installed.Version = "unknown";
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            installed,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            std::vector<Manifest>{ available },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeUnknownVersion")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_LatestInstalled(
+            "TestExeInstallerWithLatestInstalled"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest2,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_IncompatibleInstallerType(
+            "TestExeInstallerWithIncompatibleInstallerType"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_DifferentInstallerType(
+            "TestExeInstallerWithDifferentInstalledType"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_ARPInstallerType.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_UnsupportedArguments(
+            "TestExeInstallerWithUnsupportedArguments"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_UnsupportedArgs.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_NothingInstalled(
+            "TestExeInstallerWithNothingInstalled"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            std::vector<Manifest>{ manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_Dependencies(
+            "AppInstallerCliTest.TestExeInstaller.Dependencies"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("Installer_Exe_Dependencies.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_ExeDependencies.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap
+                            {
+                                { PackageVersionMetadata::InstalledType, "Exe" },
+                                { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                                { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                            },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                            ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller.Dependencies")));
+            });
+
+        const TestSourceResult TestInstaller_Msix_WFDependency(
+            "AppInstallerCliTest.TestMsixInstaller.WFDep"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("Installer_Msix_WFDependency.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            std::vector<Manifest>{ manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller.WFDep")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_LicenseAgreement(
+            "TestInstallerWithLicenseAgreement"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_LicenseAgreement.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
+                            std::vector<Manifest>{ manifest2, manifest },
+                            source
+                        ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestInstallerWithLicenseAgreement")));
+            });
+
+        const TestSourceResult TestInstaller_Exe_UpgradeAllWithDuplicateUpgradeItems(
+            "TestUpgradeAllWithDuplicateUpgradeItems"sv,
+            [](std::vector<ResultMatch>& matches, std::weak_ptr<const ISource> source) {
+                auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+                auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
+                auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest,
+                            TestPackage::MetadataMap
+                            {
+                                { PackageVersionMetadata::InstalledType, "Exe" },
+                                { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                                { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                            },
+                            std::vector<Manifest>{ manifest3, manifest2, manifest },
+                            source
+                            ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+                matches.emplace_back(
+                    ResultMatch(
+                        TestPackage::Make(
+                            manifest2,
+                            TestPackage::MetadataMap
+                            {
+                                { PackageVersionMetadata::InstalledType, "Exe" },
+                                { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
+                                { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
+                            },
+                            std::vector<Manifest>{ manifest3, manifest2, manifest },
+                            source
+                            ),
+                        PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
+            });
+    }
 
     SearchResult WorkflowTestSource::Search(const SearchRequest& request) const
     {
-        SearchResult result;
-
         std::string input;
-
-        if (request.Query)
-        {
-            input = request.Query->Value;
-        }
-        else if (!request.Inclusions.empty())
-        {
-            input = request.Inclusions[0].Value;
-        }
-
-        if (input == "TestQueryReturnOne")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(std::vector<Manifest>{ manifest }, shared_from_this()),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnOne")));
-        }
-        else if (input == "TestQueryReturnTwo")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(std::vector<Manifest>{ manifest }, shared_from_this()),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
-
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("Manifest-Good.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(std::vector<Manifest>{ manifest2 }, shared_from_this()),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestQueryReturnTwo")));
-        }
-
-        return result;
-    }
-
-    SearchResult WorkflowTestCompositeSource::Search(const SearchRequest& request) const
-    {
-        SearchResult result;
-
-        std::string input;
-
         if (request.Query)
         {
             input = request.Query->Value;
@@ -78,296 +400,26 @@ namespace TestCommon
             input = request.Filters[0].Value;
         }
 
-        // Empty query should return all exe, msix and msstore installer
-        if (input.empty() || CaseInsensitiveEquals(input, "AppInstallerCliTest.TestExeInstaller"))
+        SearchResult result;
+        for (const auto& testSourceResult : m_testSourceResults)
         {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
-            Manifest manifest3;
-            switch (m_searchOptions)
+            if (input.empty() || CaseInsensitiveEquals(input, testSourceResult.Query))
             {
-            case TestSourceSearchOptions::UpgradeUsesAgreements:
-                manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
-                break;
-            default:
-                manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
-                break;
+                testSourceResult.AddResults(result.Matches, shared_from_this());
             }
-
-            auto testPackage =
-                TestPackage::Make(
-                    manifest,
-                    TestPackage::MetadataMap
-                    {
-                        { PackageVersionMetadata::InstalledType, "Exe" },
-                        { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
-                        { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
-                    },
-                    std::vector<Manifest>{ manifest3, manifest2, manifest },
-                    shared_from_this()
-                    );
-            testPackage->IsSameOverride = [](const IPackage*, const IPackage*) { return true; };
-            result.Matches.emplace_back(
-                ResultMatch(
-                    testPackage,
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input.empty() || input == "AppInstallerCliTest.TestPortableInstaller")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Portable.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Portable.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Portable" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestPortableInstaller")));
-        }
-
-        if (input.empty() || input == "AppInstallerCliTest.TestMsixInstaller")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Msix_StreamingFlow.yaml"));
-            Manifest manifest2;
-            switch (m_searchOptions)
-            {
-            case TestSourceSearchOptions::UpgradeUsesAgreements:
-                manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Msix_LicenseAgreement.yaml"));
-                break;
-            case TestSourceSearchOptions::None:
-            default:
-                manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Msix.yaml"));
-                break;
-            }
-
-            TestPackage::MetadataMap packageMetadata
-            {
-                { PackageVersionMetadata::InstalledType, "Msix" },
-            };
-
-            if (m_searchOptions == TestSourceSearchOptions::UpgradeRequiresExplicit)
-            {
-                packageMetadata[PackageVersionMetadata::PinnedState] = "PinnedByManifest";
-            }
-
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        packageMetadata,
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller")));
-        }
-
-        if (input.empty() || input == "AppInstallerCliTest.TestZipInstaller")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Zip_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Zip_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestZipInstaller")));
-        }
-
-        if (input.empty() || input == "AppInstallerCliTest.TestMSStoreInstaller")
-        {
-            auto installed = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_MSStore.yaml"));
-            auto available = installed;
-            // Override the installed version to not be Latest
-            installed.Version = "1.0.0.0";
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        installed,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "MSStore" } },
-                        std::vector<Manifest>{ available },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMSStoreInstaller")));
-        }
-
-        if (input.empty() || input == "TestExeInstallerWithUnknownVersion")
-        {
-            auto installed = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_UnknownVersion.yaml"));
-            auto available = installed;
-            // Override the installed version to be unknown.
-            installed.Version = "unknown";
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        installed,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
-                        std::vector<Manifest>{ available },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeUnknownVersion")));
-        }
-
-        if (input == "TestExeInstallerWithLatestInstalled")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest2,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input == "TestExeInstallerWithIncompatibleInstallerType")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input == "TestExeInstallerWithDifferentInstalledType")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_ARPInstallerType.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Msix" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input == "TestExeInstallerWithUnsupportedArguments")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_UnsupportedArgs.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input == "TestExeInstallerWithNothingInstalled")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        std::vector<Manifest>{ manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-        }
-
-        if (input == "AppInstallerCliTest.TestExeInstaller.Dependencies")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("Installer_Exe_Dependencies.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_ExeDependencies.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap
-                        {
-                            { PackageVersionMetadata::InstalledType, "Exe" },
-                            { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
-                            { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
-                        },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                        ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller.Dependencies")));
-        }
-
-        if (input == "AppInstallerCliTest.TestMsixInstaller.WFDep")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("Installer_Msix_WFDependency.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        std::vector<Manifest>{ manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestMsixInstaller.WFDep")));
-        }
-
-        if (input == "TestInstallerWithLicenseAgreement")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_LicenseAgreement.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2_LicenseAgreement.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap{ { PackageVersionMetadata::InstalledType, "Exe" } },
-                        std::vector<Manifest>{ manifest2, manifest },
-                        shared_from_this()
-                    ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "TestInstallerWithLicenseAgreement")));
-        }
-
-        if (input == "TestUpgradeAllWithDuplicateUpgradeItems")
-        {
-            auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
-            auto manifest2 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe.yaml"));
-            auto manifest3 = YamlParser::CreateFromPath(TestDataFile("UpdateFlowTest_Exe_2.yaml"));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest,
-                        TestPackage::MetadataMap
-                        {
-                            { PackageVersionMetadata::InstalledType, "Exe" },
-                            { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
-                            { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
-                        },
-                        std::vector<Manifest>{ manifest3, manifest2, manifest },
-                        shared_from_this()
-                        ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
-            result.Matches.emplace_back(
-                ResultMatch(
-                    TestPackage::Make(
-                        manifest2,
-                        TestPackage::MetadataMap
-                        {
-                            { PackageVersionMetadata::InstalledType, "Exe" },
-                            { PackageVersionMetadata::StandardUninstallCommand, "C:\\uninstall.exe" },
-                            { PackageVersionMetadata::SilentUninstallCommand, "C:\\uninstall.exe /silence" },
-                        },
-                        std::vector<Manifest>{ manifest3, manifest2, manifest },
-                        shared_from_this()
-                        ),
-                    PackageMatchFilter(PackageMatchField::Id, MatchType::Exact, "AppInstallerCliTest.TestExeInstaller")));
         }
 
         return result;
+    }
+
+    void WorkflowTestSource::AddResult(const TestSourceResult& testSourceResult)
+    {
+        m_testSourceResults.push_back(testSourceResult);
+    }
+
+    std::shared_ptr<WorkflowTestSource> CreateTestSource(std::vector<TestSourceResult>&& testSourceResults)
+    {
+        return std::make_shared<WorkflowTestSource>(std::move(testSourceResults));
     }
 
     TestContext::TestContext(std::ostream& out, std::istream& in) : TestContext(out, in, false, std::make_shared<std::vector<WorkflowTaskOverride>>())
@@ -434,11 +486,11 @@ namespace TestCommon
         return clone;
     }
 
-    void OverrideForOpenSource(TestContext& context, bool overrideOpenCompositeSource)
+    void OverrideForOpenSource(TestContext& context, std::shared_ptr<WorkflowTestSource> testSource, bool overrideOpenCompositeSource)
     {
-        context.Override({ "OpenSource", [](TestContext& context)
+        context.Override({ "OpenSource", [=](TestContext& context)
         {
-            context.Add<Execution::Data::Source>(Source{ std::make_shared<WorkflowTestSource>() });
+            context.Add<Execution::Data::Source>(Source{ testSource });
         } });
 
         if (overrideOpenCompositeSource)
@@ -449,7 +501,7 @@ namespace TestCommon
         }
     }
 
-    void OverrideForCompositeInstalledSource(TestContext& context, TestSourceSearchOptions searchOptions)
+    void OverrideForCompositeInstalledSource(TestContext& context, std::shared_ptr<WorkflowTestSource> testSource)
     {
         context.Override({ "OpenSource", [](TestContext&)
         {
@@ -457,7 +509,7 @@ namespace TestCommon
 
         context.Override({ "OpenCompositeSource", [=](TestContext& context)
         {
-            context.Add<Execution::Data::Source>(Source{ std::make_shared<WorkflowTestCompositeSource>(searchOptions) });
+            context.Add<Execution::Data::Source>(Source{ testSource });
         } });
     }
 


### PR DESCRIPTION
Another refactor that nobody asked for, for something that has been bothering me for a long time and I couldn't ignore while working on something else... (I swear I am also working on the stuff I'm supposed to!)

This change breaks up the huge `WorkflowTestCompositeSource::Search()` function, which was a long series of "if query is 'package' then add package to search results" (and which had a fun compilation warning about using too much space in the stack). I'm doing this by creating objects containing the matching query string and the modifications made to the search results in case of a match. Then, the search function can just iterate over these objects and modify the results when appropriate.

On each test, we now declare which results we want to get and we can use the query strings from these objects instead of duplicating the strings on each place they are needed.

I couldn't come up with a good name for these objects, so I'm expecting feedback on that if this change is something we want.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2782)