### PR TITLE
Return localization independent string for help links

### DIFF
--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -246,7 +246,7 @@ namespace AppInstaller::CLI
         }
 
         // Finally, the link to the documentation pages
-        auto helpLink = Utility::LocIndString{ HelpLink() };
+        auto helpLink = HelpLink();
         if (!helpLink.empty())
         {
             infoOut << std::endl << Resource::String::HelpLinkPreamble(helpLink) << std::endl;

--- a/src/AppInstallerCLICore/Command.h
+++ b/src/AppInstallerCLICore/Command.h
@@ -101,7 +101,7 @@ namespace AppInstaller::CLI
 
         virtual void OutputIntroHeader(Execution::Reporter& reporter) const;
         virtual void OutputHelp(Execution::Reporter& reporter, const CommandException* exception = nullptr) const;
-        virtual Utility::LocIndString HelpLink() const { return {}; }
+        virtual Utility::LocIndView HelpLink() const { return {}; }
 
         virtual std::unique_ptr<Command> FindSubCommand(Invocation& inv) const;
         virtual void ParseArguments(Invocation& inv, Execution::Args& execArgs) const;

--- a/src/AppInstallerCLICore/Command.h
+++ b/src/AppInstallerCLICore/Command.h
@@ -101,7 +101,7 @@ namespace AppInstaller::CLI
 
         virtual void OutputIntroHeader(Execution::Reporter& reporter) const;
         virtual void OutputHelp(Execution::Reporter& reporter, const CommandException* exception = nullptr) const;
-        virtual std::string HelpLink() const { return {}; }
+        virtual Utility::LocIndString HelpLink() const { return {}; }
 
         virtual std::unique_ptr<Command> FindSubCommand(Invocation& inv) const;
         virtual void ParseArguments(Invocation& inv, Execution::Args& execArgs) const;

--- a/src/AppInstallerCLICore/Commands/CompleteCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/CompleteCommand.cpp
@@ -29,9 +29,9 @@ namespace AppInstaller::CLI
         return { Resource::String::CompleteCommandLongDescription };
     }
 
-    Utility::LocIndString CompleteCommand::HelpLink() const
+    Utility::LocIndView CompleteCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-complete"_lis;
+        return "https://aka.ms/winget-command-complete"_liv;
     }
 
     void CompleteCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/CompleteCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/CompleteCommand.cpp
@@ -29,9 +29,9 @@ namespace AppInstaller::CLI
         return { Resource::String::CompleteCommandLongDescription };
     }
 
-    std::string CompleteCommand::HelpLink() const
+    Utility::LocIndString CompleteCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-complete";
+        return "https://aka.ms/winget-command-complete"_lis;
     }
 
     void CompleteCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/CompleteCommand.h
+++ b/src/AppInstallerCLICore/Commands/CompleteCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/CompleteCommand.h
+++ b/src/AppInstallerCLICore/Commands/CompleteCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ExperimentalCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ExperimentalCommand.cpp
@@ -29,9 +29,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ExperimentalCommandLongDescription };
     }
 
-    Utility::LocIndString ExperimentalCommand::HelpLink() const
+    Utility::LocIndView ExperimentalCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-settings"_lis;
+        return "https://aka.ms/winget-settings"_liv;
     }
 
     void ExperimentalCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ExperimentalCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ExperimentalCommand.cpp
@@ -29,9 +29,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ExperimentalCommandLongDescription };
     }
 
-    std::string ExperimentalCommand::HelpLink() const
+    Utility::LocIndString ExperimentalCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-settings";
+        return "https://aka.ms/winget-settings"_lis;
     }
 
     void ExperimentalCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ExperimentalCommand.h
+++ b/src/AppInstallerCLICore/Commands/ExperimentalCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ExperimentalCommand.h
+++ b/src/AppInstallerCLICore/Commands/ExperimentalCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ExportCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ExportCommand.cpp
@@ -46,9 +46,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString ExportCommand::HelpLink() const
+    Utility::LocIndView ExportCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-export"_lis;
+        return "https://aka.ms/winget-command-export"_liv;
     }
 
     void ExportCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ExportCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ExportCommand.cpp
@@ -46,9 +46,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string ExportCommand::HelpLink() const
+    Utility::LocIndString ExportCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-export";
+        return "https://aka.ms/winget-command-export"_lis;
     }
 
     void ExportCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ExportCommand.h
+++ b/src/AppInstallerCLICore/Commands/ExportCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ExportCommand.h
+++ b/src/AppInstallerCLICore/Commands/ExportCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
@@ -20,9 +20,9 @@ namespace AppInstaller::CLI
         return { Resource::String::FeaturesCommandLongDescription };
     }
 
-    std::string FeaturesCommand::HelpLink() const
+    Utility::LocIndString FeaturesCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-experimentalfeatures";
+        return "https://aka.ms/winget-experimentalfeatures"_lis;
     }
 
     void FeaturesCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/FeaturesCommand.cpp
@@ -20,9 +20,9 @@ namespace AppInstaller::CLI
         return { Resource::String::FeaturesCommandLongDescription };
     }
 
-    Utility::LocIndString FeaturesCommand::HelpLink() const
+    Utility::LocIndView FeaturesCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-experimentalfeatures"_lis;
+        return "https://aka.ms/winget-experimentalfeatures"_liv;
     }
 
     void FeaturesCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/FeaturesCommand.h
+++ b/src/AppInstallerCLICore/Commands/FeaturesCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/FeaturesCommand.h
+++ b/src/AppInstallerCLICore/Commands/FeaturesCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/HashCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HashCommand.cpp
@@ -30,9 +30,9 @@ namespace AppInstaller::CLI
         return { Resource::String::HashCommandLongDescription };
     }
 
-    std::string HashCommand::HelpLink() const
+    Utility::LocIndString HashCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-hash";
+        return "https://aka.ms/winget-command-hash"_lis;
     }
 
     void HashCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/HashCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/HashCommand.cpp
@@ -30,9 +30,9 @@ namespace AppInstaller::CLI
         return { Resource::String::HashCommandLongDescription };
     }
 
-    Utility::LocIndString HashCommand::HelpLink() const
+    Utility::LocIndView HashCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-hash"_lis;
+        return "https://aka.ms/winget-command-hash"_liv;
     }
 
     void HashCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/HashCommand.h
+++ b/src/AppInstallerCLICore/Commands/HashCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/HashCommand.h
+++ b/src/AppInstallerCLICore/Commands/HashCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ImportCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ImportCommand.cpp
@@ -33,9 +33,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ImportCommandLongDescription };
     }
 
-    std::string ImportCommand::HelpLink() const
+    Utility::LocIndString ImportCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-import";
+        return "https://aka.ms/winget-command-import"_lis;
     }
 
     void ImportCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ImportCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ImportCommand.cpp
@@ -33,9 +33,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ImportCommandLongDescription };
     }
 
-    Utility::LocIndString ImportCommand::HelpLink() const
+    Utility::LocIndView ImportCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-import"_lis;
+        return "https://aka.ms/winget-command-import"_liv;
     }
 
     void ImportCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ImportCommand.h
+++ b/src/AppInstallerCLICore/Commands/ImportCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ImportCommand.h
+++ b/src/AppInstallerCLICore/Commands/ImportCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -86,9 +86,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString InstallCommand::HelpLink() const
+    Utility::LocIndView InstallCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-install"_lis;
+        return "https://aka.ms/winget-command-install"_liv;
     }
 
     void InstallCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -86,9 +86,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string InstallCommand::HelpLink() const
+    Utility::LocIndString InstallCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-install";
+        return "https://aka.ms/winget-command-install"_lis;
     }
 
     void InstallCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/InstallCommand.h
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/InstallCommand.h
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -64,9 +64,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString ListCommand::HelpLink() const
+    Utility::LocIndView ListCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-list"_lis;
+        return "https://aka.ms/winget-command-list"_liv;
     }
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -64,9 +64,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string ListCommand::HelpLink() const
+    Utility::LocIndString ListCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-list";
+        return "https://aka.ms/winget-command-list"_lis;
     }
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ListCommand.h
+++ b/src/AppInstallerCLICore/Commands/ListCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ListCommand.h
+++ b/src/AppInstallerCLICore/Commands/ListCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -13,7 +13,7 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::Utility::literals;
     using namespace std::string_view_literals;
 
-    Utility::LocIndString s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"_lis;
+    Utility::LocIndView s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"_liv;
 
     std::vector<std::unique_ptr<Command>> PinCommand::GetCommands() const
     {
@@ -35,7 +35,7 @@ namespace AppInstaller::CLI
         return { Resource::String::PinCommandLongDescription };
     }
 
-    Utility::LocIndString PinCommand::HelpLink() const
+    Utility::LocIndView PinCommand::HelpLink() const
     {
         return s_PinCommand_HelpLink;
     }
@@ -89,7 +89,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString PinAddCommand::HelpLink() const
+    Utility::LocIndView PinAddCommand::HelpLink() const
     {
         return s_PinCommand_HelpLink;
     }
@@ -150,7 +150,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString PinRemoveCommand::HelpLink() const
+    Utility::LocIndView PinRemoveCommand::HelpLink() const
     {
         return s_PinCommand_HelpLink;
     }
@@ -202,7 +202,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString PinListCommand::HelpLink() const
+    Utility::LocIndView PinListCommand::HelpLink() const
     {
         return s_PinCommand_HelpLink;
     }
@@ -230,7 +230,7 @@ namespace AppInstaller::CLI
         return { Resource::String::PinResetCommandLongDescription };
     }
 
-    Utility::LocIndString PinResetCommand::HelpLink() const
+    Utility::LocIndView PinResetCommand::HelpLink() const
     {
         return s_PinCommand_HelpLink;
     }

--- a/src/AppInstallerCLICore/Commands/PinCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/PinCommand.cpp
@@ -13,7 +13,7 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::Utility::literals;
     using namespace std::string_view_literals;
 
-    static constexpr std::string_view s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"sv;
+    Utility::LocIndString s_PinCommand_HelpLink = "https://aka.ms/winget-command-pin"_lis;
 
     std::vector<std::unique_ptr<Command>> PinCommand::GetCommands() const
     {
@@ -35,9 +35,9 @@ namespace AppInstaller::CLI
         return { Resource::String::PinCommandLongDescription };
     }
 
-    std::string PinCommand::HelpLink() const
+    Utility::LocIndString PinCommand::HelpLink() const
     {
-        return std::string{ s_PinCommand_HelpLink };
+        return s_PinCommand_HelpLink;
     }
 
     void PinCommand::ExecuteInternal(Execution::Context& context) const
@@ -89,9 +89,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string PinAddCommand::HelpLink() const
+    Utility::LocIndString PinAddCommand::HelpLink() const
     {
-        return std::string{ s_PinCommand_HelpLink };
+        return s_PinCommand_HelpLink;
     }
 
     void PinAddCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const
@@ -150,9 +150,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string PinRemoveCommand::HelpLink() const
+    Utility::LocIndString PinRemoveCommand::HelpLink() const
     {
-        return std::string{ s_PinCommand_HelpLink };
+        return s_PinCommand_HelpLink;
     }
 
     void PinRemoveCommand::ExecuteInternal(Execution::Context& context) const
@@ -202,9 +202,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string PinListCommand::HelpLink() const
+    Utility::LocIndString PinListCommand::HelpLink() const
     {
-        return std::string{ s_PinCommand_HelpLink };
+        return s_PinCommand_HelpLink;
     }
 
     void PinListCommand::ExecuteInternal(Execution::Context& context) const
@@ -230,9 +230,9 @@ namespace AppInstaller::CLI
         return { Resource::String::PinResetCommandLongDescription };
     }
 
-    std::string PinResetCommand::HelpLink() const
+    Utility::LocIndString PinResetCommand::HelpLink() const
     {
-        return std::string{ s_PinCommand_HelpLink };
+        return s_PinCommand_HelpLink;
     }
 
     void PinResetCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/PinCommand.h
+++ b/src/AppInstallerCLICore/Commands/PinCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -32,7 +32,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
@@ -50,7 +50,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -67,7 +67,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -82,7 +82,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/PinCommand.h
+++ b/src/AppInstallerCLICore/Commands/PinCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -32,7 +32,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
@@ -50,7 +50,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -67,7 +67,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -82,7 +82,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -148,9 +148,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ToolDescription };
     }
 
-    Utility::LocIndString RootCommand::HelpLink() const
+    Utility::LocIndView RootCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-help"_lis;
+        return "https://aka.ms/winget-command-help"_liv;
     }
 
     void RootCommand::Execute(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -148,9 +148,9 @@ namespace AppInstaller::CLI
         return { Resource::String::ToolDescription };
     }
 
-    std::string RootCommand::HelpLink() const
+    Utility::LocIndString RootCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-help";
+        return "https://aka.ms/winget-command-help"_lis;
     }
 
     void RootCommand::Execute(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/RootCommand.h
+++ b/src/AppInstallerCLICore/Commands/RootCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
         void Execute(Execution::Context& context) const override;
 

--- a/src/AppInstallerCLICore/Commands/RootCommand.h
+++ b/src/AppInstallerCLICore/Commands/RootCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
         void Execute(Execution::Context& context) const override;
 

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -61,9 +61,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SearchCommand::HelpLink() const
+    Utility::LocIndView SearchCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-search"_lis;
+        return "https://aka.ms/winget-command-search"_liv;
     }
 
     void SearchCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -61,9 +61,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SearchCommand::HelpLink() const
+    Utility::LocIndString SearchCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-search";
+        return "https://aka.ms/winget-command-search"_lis;
     }
 
     void SearchCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/SearchCommand.h
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/SearchCommand.h
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.h
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
         constexpr Utility::LocIndView s_ArgumentName_Enable = "enable"_liv;
         constexpr Utility::LocIndView s_ArgumentName_Disable = "disable"_liv;
         constexpr Utility::LocIndView s_ArgName_EnableAndDisable = "enable|disable"_liv;
-        static constexpr std::string_view s_SettingsCommand_HelpLink = "https://aka.ms/winget-settings"sv;
+        Utility::LocIndString s_SettingsCommand_HelpLink = "https://aka.ms/winget-settings"_lis;
     }
 
     std::vector<std::unique_ptr<Command>> SettingsCommand::GetCommands() const
@@ -44,9 +44,9 @@ namespace AppInstaller::CLI
         return { Resource::String::SettingsCommandLongDescription };
     }
 
-    std::string SettingsCommand::HelpLink() const
+    Utility::LocIndString SettingsCommand::HelpLink() const
     {
-        return std::string{ s_SettingsCommand_HelpLink };
+        return s_SettingsCommand_HelpLink;
     }
 
     void SettingsCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const
@@ -108,9 +108,9 @@ namespace AppInstaller::CLI
         return { Resource::String::SettingsExportCommandLongDescription };
     }
 
-    std::string SettingsExportCommand::HelpLink() const
+    Utility::LocIndString SettingsExportCommand::HelpLink() const
     {
-        return std::string{ s_SettingsCommand_HelpLink };
+        return s_SettingsCommand_HelpLink;
     }
 
     void SettingsExportCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SettingsCommand.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
         constexpr Utility::LocIndView s_ArgumentName_Enable = "enable"_liv;
         constexpr Utility::LocIndView s_ArgumentName_Disable = "disable"_liv;
         constexpr Utility::LocIndView s_ArgName_EnableAndDisable = "enable|disable"_liv;
-        Utility::LocIndString s_SettingsCommand_HelpLink = "https://aka.ms/winget-settings"_lis;
+        Utility::LocIndView s_SettingsCommand_HelpLink = "https://aka.ms/winget-settings"_liv;
     }
 
     std::vector<std::unique_ptr<Command>> SettingsCommand::GetCommands() const
@@ -44,7 +44,7 @@ namespace AppInstaller::CLI
         return { Resource::String::SettingsCommandLongDescription };
     }
 
-    Utility::LocIndString SettingsCommand::HelpLink() const
+    Utility::LocIndView SettingsCommand::HelpLink() const
     {
         return s_SettingsCommand_HelpLink;
     }
@@ -108,7 +108,7 @@ namespace AppInstaller::CLI
         return { Resource::String::SettingsExportCommandLongDescription };
     }
 
-    Utility::LocIndString SettingsExportCommand::HelpLink() const
+    Utility::LocIndView SettingsExportCommand::HelpLink() const
     {
         return s_SettingsCommand_HelpLink;
     }

--- a/src/AppInstallerCLICore/Commands/SettingsCommand.h
+++ b/src/AppInstallerCLICore/Commands/SettingsCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
@@ -29,7 +29,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/SettingsCommand.h
+++ b/src/AppInstallerCLICore/Commands/SettingsCommand.h
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
@@ -29,7 +29,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -49,9 +49,9 @@ namespace AppInstaller::CLI
             Workflow::CompleteWithSingleSemanticsForValue(valueType);
     }
 
-    std::string ShowCommand::HelpLink() const
+    Utility::LocIndString ShowCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-show";
+        return "https://aka.ms/winget-command-show"_lis;
     }
 
     void ShowCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -49,9 +49,9 @@ namespace AppInstaller::CLI
             Workflow::CompleteWithSingleSemanticsForValue(valueType);
     }
 
-    Utility::LocIndString ShowCommand::HelpLink() const
+    Utility::LocIndView ShowCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-show"_lis;
+        return "https://aka.ms/winget-command-show"_liv;
     }
 
     void ShowCommand::ValidateArgumentsInternal(Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/ShowCommand.h
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/ShowCommand.h
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/SourceCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.cpp
@@ -12,7 +12,7 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::CLI::Execution;
     using namespace std::string_view_literals;
 
-    Utility::LocIndString s_SourceCommand_HelpLink = "https://aka.ms/winget-command-source"_lis;
+    Utility::LocIndView s_SourceCommand_HelpLink = "https://aka.ms/winget-command-source"_liv;
 
     std::vector<std::unique_ptr<Command>> SourceCommand::GetCommands() const
     {
@@ -36,7 +36,7 @@ namespace AppInstaller::CLI
         return { Resource::String::SourceCommandLongDescription };
     }
 
-    Utility::LocIndString SourceCommand::HelpLink() const
+    Utility::LocIndView SourceCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -67,7 +67,7 @@ namespace AppInstaller::CLI
         return { Resource::String::SourceAddCommandLongDescription };
     }
 
-    Utility::LocIndString SourceAddCommand::HelpLink() const
+    Utility::LocIndView SourceAddCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -110,7 +110,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SourceListCommand::HelpLink() const
+    Utility::LocIndView SourceListCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -148,7 +148,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SourceUpdateCommand::HelpLink() const
+    Utility::LocIndView SourceUpdateCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -186,7 +186,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SourceRemoveCommand::HelpLink() const
+    Utility::LocIndView SourceRemoveCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -227,7 +227,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SourceResetCommand::HelpLink() const
+    Utility::LocIndView SourceResetCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }
@@ -276,7 +276,7 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString SourceExportCommand::HelpLink() const
+    Utility::LocIndView SourceExportCommand::HelpLink() const
     {
         return s_SourceCommand_HelpLink;
     }

--- a/src/AppInstallerCLICore/Commands/SourceCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.cpp
@@ -12,7 +12,7 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::CLI::Execution;
     using namespace std::string_view_literals;
 
-    static constexpr std::string_view s_SourceCommand_HelpLink = "https://aka.ms/winget-command-source"sv;
+    Utility::LocIndString s_SourceCommand_HelpLink = "https://aka.ms/winget-command-source"_lis;
 
     std::vector<std::unique_ptr<Command>> SourceCommand::GetCommands() const
     {
@@ -36,9 +36,9 @@ namespace AppInstaller::CLI
         return { Resource::String::SourceCommandLongDescription };
     }
 
-    std::string SourceCommand::HelpLink() const
+    Utility::LocIndString SourceCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceCommand::ExecuteInternal(Context& context) const
@@ -67,9 +67,9 @@ namespace AppInstaller::CLI
         return { Resource::String::SourceAddCommandLongDescription };
     }
 
-    std::string SourceAddCommand::HelpLink() const
+    Utility::LocIndString SourceAddCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceAddCommand::ExecuteInternal(Context& context) const
@@ -110,9 +110,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SourceListCommand::HelpLink() const
+    Utility::LocIndString SourceListCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceListCommand::ExecuteInternal(Context& context) const
@@ -148,9 +148,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SourceUpdateCommand::HelpLink() const
+    Utility::LocIndString SourceUpdateCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceUpdateCommand::ExecuteInternal(Context& context) const
@@ -186,9 +186,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SourceRemoveCommand::HelpLink() const
+    Utility::LocIndString SourceRemoveCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceRemoveCommand::ExecuteInternal(Context& context) const
@@ -227,9 +227,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SourceResetCommand::HelpLink() const
+    Utility::LocIndString SourceResetCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceResetCommand::ExecuteInternal(Context& context) const
@@ -276,9 +276,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string SourceExportCommand::HelpLink() const
+    Utility::LocIndString SourceExportCommand::HelpLink() const
     {
-        return std::string{ s_SourceCommand_HelpLink };
+        return s_SourceCommand_HelpLink;
     }
 
     void SourceExportCommand::ExecuteInternal(Context& context) const

--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -29,7 +29,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -46,7 +46,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -63,7 +63,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -81,7 +81,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -98,7 +98,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -115,7 +115,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/SourceCommand.h
+++ b/src/AppInstallerCLICore/Commands/SourceCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -29,7 +29,7 @@ namespace AppInstaller::CLI
         Resource::LocString ShortDescription() const override;
         Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -46,7 +46,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -63,7 +63,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -81,7 +81,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -98,7 +98,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
@@ -115,7 +115,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/UninstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UninstallCommand.cpp
@@ -82,9 +82,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string UninstallCommand::HelpLink() const
+    Utility::LocIndString UninstallCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-uninstall";
+        return "https://aka.ms/winget-command-uninstall"_lis;
     }
 
     void UninstallCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/UninstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UninstallCommand.cpp
@@ -82,9 +82,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString UninstallCommand::HelpLink() const
+    Utility::LocIndView UninstallCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-uninstall"_lis;
+        return "https://aka.ms/winget-command-uninstall"_liv;
     }
 
     void UninstallCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/UninstallCommand.h
+++ b/src/AppInstallerCLICore/Commands/UninstallCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/UninstallCommand.h
+++ b/src/AppInstallerCLICore/Commands/UninstallCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -166,9 +166,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    std::string UpgradeCommand::HelpLink() const
+    Utility::LocIndString UpgradeCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-upgrade";
+        return "https://aka.ms/winget-command-upgrade"_lis;
     }
 
     void UpgradeCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -166,9 +166,9 @@ namespace AppInstaller::CLI
         }
     }
 
-    Utility::LocIndString UpgradeCommand::HelpLink() const
+    Utility::LocIndView UpgradeCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-upgrade"_lis;
+        return "https://aka.ms/winget-command-upgrade"_liv;
     }
 
     void UpgradeCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.h
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.h
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.h
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
 
         void Complete(Execution::Context& context, Execution::Args::Type valueType) const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ValidateArgumentsInternal(Execution::Args& execArgs) const override;

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
@@ -28,9 +28,9 @@ namespace AppInstaller::CLI
         return Resource::LocString{ Resource::String::ValidateCommandLongDescription };
     }
 
-    std::string ValidateCommand::HelpLink() const
+    Utility::LocIndString ValidateCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-validate";
+        return "https://aka.ms/winget-command-validate"_lis;
     }
 
     void ValidateCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
@@ -28,9 +28,9 @@ namespace AppInstaller::CLI
         return Resource::LocString{ Resource::String::ValidateCommandLongDescription };
     }
 
-    Utility::LocIndString ValidateCommand::HelpLink() const
+    Utility::LocIndView ValidateCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-command-validate"_lis;
+        return "https://aka.ms/winget-command-validate"_liv;
     }
 
     void ValidateCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.h
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        std::string HelpLink() const override;
+        Utility::LocIndString HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.h
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.h
@@ -14,7 +14,7 @@ namespace AppInstaller::CLI
         virtual Resource::LocString ShortDescription() const override;
         virtual Resource::LocString LongDescription() const override;
 
-        Utility::LocIndString HelpLink() const override;
+        Utility::LocIndView HelpLink() const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;


### PR DESCRIPTION
- Updated `HelpLink` return type to a localization independent string.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2786)