### PR TITLE
Copy install behavior flags on upgrade --all

### DIFF
--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -31,6 +31,7 @@ namespace AppInstaller::CLI::Execution
             Channel,
 
             // Install behavior
+            // When adding a new flag, we may need to copy it in Context::CreateSubContext()
             Interactive,
             Silent,
             Locale,

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -135,12 +135,13 @@ namespace AppInstaller::CLI::Execution
     void Context::CopyArgsToSubContext(Context* subContext)
     {
         // Copy over install behavior flags from the parent context.
-        // Arguments not copied: Override, Log
         for (auto flag : {
             Args::Type::Interactive,
             Args::Type::Silent,
             Args::Type::HashOverride,
             Args::Type::IgnoreLocalArchiveMalwareScan,
+            Args::Type::NoUpgrade,
+            Args::Type::Force,
             })
         {
             if (Args.Contains(flag))
@@ -151,7 +152,6 @@ namespace AppInstaller::CLI::Execution
 
         for (auto arg : {
             Args::Type::Locale,
-            Args::Type::InstallLocation,
             Args::Type::InstallScope,
             Args::Type::InstallArchitecture,
             })

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -128,7 +128,39 @@ namespace AppInstaller::CLI::Execution
         {
             clone->EnableCtrlHandler();
         }
+        CopyArgsToSubContext(clone.get());
         return clone;
+    }
+
+    void Context::CopyArgsToSubContext(Context* subContext)
+    {
+        // Copy over install behavior flags from the parent context.
+        // Arguments not copied: Override, Log
+        for (auto flag : {
+            Args::Type::Interactive,
+            Args::Type::Silent,
+            Args::Type::HashOverride,
+            Args::Type::IgnoreLocalArchiveMalwareScan,
+            })
+        {
+            if (Args.Contains(flag))
+            {
+                subContext->Args.AddArg(flag);
+            }
+        }
+
+        for (auto arg : {
+            Args::Type::Locale,
+            Args::Type::InstallLocation,
+            Args::Type::InstallScope,
+            Args::Type::InstallArchitecture,
+            })
+        {
+            if (Args.Contains(arg))
+            {
+                subContext->Args.AddArg(arg, Args.GetArg(arg));
+            }
+        }
     }
 
     void Context::EnableCtrlHandler(bool enabled)

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -155,6 +155,9 @@ namespace AppInstaller::CLI::Execution
 #endif
 
     protected:
+        // Copies the args that are also needed in a sub-context. E.g., silent
+        void CopyArgsToSubContext(Context* subContext);
+
         // Neither virtual functions nor member fields can be inside AICLI_DISABLE_TEST_HOOKS
         // or we could have ODR violations that lead to nasty bugs. So we will simply never
         // use this if AICLI_DISABLE_TEST_HOOKS is defined.

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -920,7 +920,12 @@ TEST_CASE("UpdateFlow_UpdateAll_ForwardArgs", "[UpdateFlow][workflow]")
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
-    OverrideForCompositeInstalledSource(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Portable,
+        }));
     OverrideForShellExecute(context);
     OverrideForMSIX(context);
     OverrideForMSStore(context, true);

--- a/src/AppInstallerCLITests/WorkflowCommon.cpp
+++ b/src/AppInstallerCLITests/WorkflowCommon.cpp
@@ -431,6 +431,7 @@ namespace TestCommon
     {
         auto clone = std::make_unique<TestContext>(m_out, m_in, true, m_overrides);
         clone->SetFlags(this->GetFlags());
+        CopyArgsToSubContext(clone.get());
         return clone;
     }
 


### PR DESCRIPTION
*Issue:*
When we install multiple packages in the same execution (`upgrade --all` and `import`), we create a sub-context to install each individual package but this sub-context does not respect the parent's install behavior flags, like `--silent`.

*Change:*
Added a step to the creation of a sub-context to copy the relevant flags from the parent context, so that the same behavior is used for all packages. Added a test to verify the new behavior.

---

This came from a user running `winget upgrade --all --silent` and expecting all the upgrades to be done silently. We need to either respect those flags (this PR) or change the argument validation to forbid that combination.

I figure the most contentious issue with this PR will be which args we should forward. I added basically everything that made sense to me, but we can trim the list as much as needed.

Fixes #2008 and #2793

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2794)