### PR TITLE
Stop using `m_summary` in the global globals for telemetry

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -100,7 +100,7 @@ namespace AppInstaller::Logging
         this->IsCOMCall = other.IsCOMCall;
     }
 
-    TelemetryTraceLogger::TelemetryTraceLogger()
+    TelemetryTraceLogger::TelemetryTraceLogger(bool useSummary) : m_useSummary(useSummary)
     {
         std::ignore = CoCreateGuid(&m_activityId);
         m_subExecutionId = s_RootExecutionId;
@@ -219,13 +219,16 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.FailureHResult = failure.hr;
-            m_summary.FailureMessage = anonMessage;
-            m_summary.FailureModule = StringOrEmptyIfNull(failure.pszModule);
-            m_summary.FailureThreadId = failure.threadId;
-            m_summary.FailureType = ConvertWilFailureTypeToFailureType(failure.type);
-            m_summary.FailureFile = StringOrEmptyIfNull(failure.pszFile);
-            m_summary.FailureLine = failure.uLineNumber;
+            if (m_useSummary)
+            {
+                m_summary.FailureHResult = failure.hr;
+                m_summary.FailureMessage = anonMessage;
+                m_summary.FailureModule = StringOrEmptyIfNull(failure.pszModule);
+                m_summary.FailureThreadId = failure.threadId;
+                m_summary.FailureType = ConvertWilFailureTypeToFailureType(failure.type);
+                m_summary.FailureFile = StringOrEmptyIfNull(failure.pszFile);
+                m_summary.FailureLine = failure.uLineNumber;
+            }
         }
 
         // Also send failure to the log
@@ -255,7 +258,10 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.IsCOMCall = isCOMCall;
+            if (m_useSummary)
+            {
+                m_summary.IsCOMCall = isCOMCall;
+            }
         }
 
         AICLI_LOG(Core, Info, << "WinGet, version [" << version << "], activity [" << *GetActivityId() << ']');
@@ -278,7 +284,10 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance | PDT_ProductAndServiceUsage),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.Command = commandName;
+            if (m_useSummary)
+            {
+                m_summary.Command = commandName;
+            }
         }
 
         AICLI_LOG(CLI, Info, << "Leaf command to execute: " << commandName);
@@ -294,7 +303,10 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.CommandSuccess = true;
+            if (m_useSummary)
+            {
+                m_summary.CommandSuccess = true;
+            }
         }
 
         AICLI_LOG(CLI, Info, << "Leaf command succeeded: " << commandName);
@@ -314,10 +326,13 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.FailureHResult = hr;
-            m_summary.FailureType = FailureTypeEnum::CommandTermination;
-            m_summary.FailureFile = file;
-            m_summary.FailureLine = static_cast<UINT32>(line);
+            if (m_useSummary)
+            {
+                m_summary.FailureHResult = hr;
+                m_summary.FailureType = FailureTypeEnum::CommandTermination;
+                m_summary.FailureFile = file;
+                m_summary.FailureLine = static_cast<UINT32>(line);
+            }
         }
 
         AICLI_LOG(CLI, Error, << "Terminating context: 0x" << SetHRFormat << hr << " at " << file << ":" << line);
@@ -340,8 +355,11 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.FailureType = type;
-            m_summary.FailureMessage = anonMessage;
+            if (m_useSummary)
+            {
+                m_summary.FailureType = type;
+                m_summary.FailureMessage = anonMessage;
+            }
         }
 
         AICLI_LOG(CLI, Error, << "Caught " << exceptionTypeString << ": " << message);
@@ -358,7 +376,10 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.IsManifestLocal = isLocalManifest;
+            if (m_useSummary)
+            {
+                m_summary.IsManifestLocal = isLocalManifest;
+            }
         }
     }
 
@@ -375,9 +396,12 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.PackageIdentifier = id;
-            m_summary.PackageName = name;
-            m_summary.PackageVersion = version;
+            if (m_useSummary)
+            {
+                m_summary.PackageIdentifier = id;
+                m_summary.PackageName = name;
+                m_summary.PackageVersion = version;
+            }
         }
 
         AICLI_LOG(CLI, Info, << "Manifest fields: Name [" << name << "], Version [" << version << ']');
@@ -423,8 +447,11 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.PackageIdentifier = id;
-            m_summary.PackageName = name;
+            if (m_useSummary)
+            {
+                m_summary.PackageIdentifier = id;
+                m_summary.PackageName = name;
+            }
         }
 
         AICLI_LOG(CLI, Info, << "Found one app. App id: " << id << " App name: " << name);
@@ -445,11 +472,14 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.InstallerArchitecture = arch;
-            m_summary.InstallerUrl = url;
-            m_summary.InstallerType = installerType;
-            m_summary.InstallerScope = scope;
-            m_summary.InstallerLocale = language;
+            if (m_useSummary)
+            {
+                m_summary.InstallerArchitecture = arch;
+                m_summary.InstallerUrl = url;
+                m_summary.InstallerType = installerType;
+                m_summary.InstallerScope = scope;
+                m_summary.InstallerLocale = language;
+            }
         }
 
         AICLI_LOG(CLI, Info, << "Completed installer selection.");
@@ -488,15 +518,18 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.SearchType = type;
-            m_summary.SearchQuery = query;
-            m_summary.SearchId = id;
-            m_summary.SearchName = name;
-            m_summary.SearchMoniker = moniker;
-            m_summary.SearchTag = tag;
-            m_summary.SearchCommand = command;
-            m_summary.SearchMaximum = static_cast<UINT64>(maximum);
-            m_summary.SearchRequest = request;
+            if (m_useSummary)
+            {
+                m_summary.SearchType = type;
+                m_summary.SearchQuery = query;
+                m_summary.SearchId = id;
+                m_summary.SearchName = name;
+                m_summary.SearchMoniker = moniker;
+                m_summary.SearchTag = tag;
+                m_summary.SearchCommand = command;
+                m_summary.SearchMaximum = static_cast<UINT64>(maximum);
+                m_summary.SearchRequest = request;
+            }
         }
     }
 
@@ -511,7 +544,10 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.SearchResultCount = resultCount;
+            if (m_useSummary)
+            {
+                m_summary.SearchResultCount = resultCount;
+            }
         }
     }
 
@@ -537,12 +573,15 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.PackageIdentifier = id;
-            m_summary.PackageVersion = version;
-            m_summary.Channel = channel;
-            m_summary.HashMismatchExpected = expected;
-            m_summary.HashMismatchActual = actual;
-            m_summary.HashMismatchOverride = overrideHashMismatch;
+            if (m_useSummary)
+            {
+                m_summary.PackageIdentifier = id;
+                m_summary.PackageVersion = version;
+                m_summary.Channel = channel;
+                m_summary.HashMismatchExpected = expected;
+                m_summary.HashMismatchActual = actual;
+                m_summary.HashMismatchOverride = overrideHashMismatch;
+            }
         }
 
         AICLI_LOG(CLI, Error,
@@ -568,11 +607,14 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.PackageIdentifier = id;
-            m_summary.PackageVersion = version;
-            m_summary.Channel = channel;
-            m_summary.InstallerExecutionType = type;
-            m_summary.InstallerErrorCode = errorCode;
+            if (m_useSummary)
+            {
+                m_summary.PackageIdentifier = id;
+                m_summary.PackageVersion = version;
+                m_summary.Channel = channel;
+                m_summary.InstallerExecutionType = type;
+                m_summary.InstallerErrorCode = errorCode;
+            }
         }
 
         AICLI_LOG(CLI, Error, << type << " installer failed: " << errorCode);
@@ -592,10 +634,13 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.PackageIdentifier = id;
-            m_summary.PackageVersion = version;
-            m_summary.UninstallerExecutionType = type;
-            m_summary.UninstallerErrorCode = errorCode;
+            if (m_useSummary)
+            {
+                m_summary.PackageIdentifier = id;
+                m_summary.PackageVersion = version;
+                m_summary.UninstallerExecutionType = type;
+                m_summary.UninstallerErrorCode = errorCode;
+            }
         }
 
         AICLI_LOG(CLI, Error, << type << " uninstaller failed: " << errorCode);
@@ -642,17 +687,20 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance | PDT_ProductAndServiceUsage | PDT_SoftwareSetupAndInventory),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
-            m_summary.SourceIdentifier = sourceIdentifier;
-            m_summary.PackageIdentifier = packageIdentifier;
-            m_summary.PackageVersion = packageVersion;
-            m_summary.Channel = packageChannel;
-            m_summary.ChangesToARP = static_cast<UINT64>(changesToARP);
-            m_summary.MatchesInARP = static_cast<UINT64>(matchesInARP);
-            m_summary.ChangesThatMatch = static_cast<UINT64>(countOfIntersectionOfChangesAndMatches);
-            m_summary.ARPName = arpName;
-            m_summary.ARPVersion = arpVersion;
-            m_summary.ARPPublisher = arpPublisher;
-            m_summary.ARPLanguage = static_cast<UINT64>(languageNumber);
+            if (m_useSummary)
+            {
+                m_summary.SourceIdentifier = sourceIdentifier;
+                m_summary.PackageIdentifier = packageIdentifier;
+                m_summary.PackageVersion = packageVersion;
+                m_summary.Channel = packageChannel;
+                m_summary.ChangesToARP = static_cast<UINT64>(changesToARP);
+                m_summary.MatchesInARP = static_cast<UINT64>(matchesInARP);
+                m_summary.ChangesThatMatch = static_cast<UINT64>(countOfIntersectionOfChangesAndMatches);
+                m_summary.ARPName = arpName;
+                m_summary.ARPVersion = arpVersion;
+                m_summary.ARPPublisher = arpPublisher;
+                m_summary.ARPLanguage = static_cast<UINT64>(languageNumber);
+            }
         }
 
         AICLI_LOG(CLI, Info, << "During package install, " << changesToARP << " changes to ARP were observed, "
@@ -680,8 +728,11 @@ namespace AppInstaller::Logging
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
 
-            m_summary.DOUrl = url;
-            m_summary.DOHResult = hr;
+            if (m_useSummary)
+            {
+                m_summary.DOUrl = url;
+                m_summary.DOHResult = hr;
+            }
         }
     }
 
@@ -696,68 +747,71 @@ namespace AppInstaller::Logging
                 packageVersion = Runtime::GetPackageVersion();
             }
 
-            TraceLoggingWriteActivity(
-                g_hTraceProvider,
-                "Summary",
-                GetActivityId(),
-                GetParentActivityId(),
-                // From member fields or program info.
-                AICLI_TraceLoggingStringView(m_caller, "Caller"),
-                TraceLoggingPackedFieldEx(m_telemetryCorrelationJsonW.c_str(), static_cast<ULONG>((m_telemetryCorrelationJsonW.size() + 1) * sizeof(wchar_t)), TlgInUNICODESTRING, TlgOutJSON, "CvJson"),
-                TraceLoggingCountedString(version->c_str(), static_cast<ULONG>(version->size()), "ClientVersion"),
-                TraceLoggingCountedString(packageVersion->c_str(), static_cast<ULONG>(packageVersion->size()), "PackageVersion"),
-                TraceLoggingBool(Runtime::IsReleaseBuild(), "IsReleaseBuild"),
-                TraceLoggingUInt32(m_executionStage, "ExecutionStage"),
-                // From TelemetrySummary
-                TraceLoggingHResult(m_summary.FailureHResult, "FailureHResult"),
-                AICLI_TraceLoggingWStringView(m_summary.FailureMessage, "FailureMessage"),
-                AICLI_TraceLoggingStringView(m_summary.FailureModule, "FailureModule"),
-                TraceLoggingUInt32(m_summary.FailureThreadId, "FailureThreadId"),
-                TraceLoggingUInt32(static_cast<UINT32>(m_summary.FailureType), "FailureType"),
-                AICLI_TraceLoggingStringView(m_summary.FailureFile, "FailureFile"),
-                TraceLoggingUInt32(m_summary.FailureLine, "FailureLine"),
-                TraceLoggingBool(m_summary.IsCOMCall, "IsCOMCall"),
-                AICLI_TraceLoggingStringView(m_summary.Command, "Command"),
-                TraceLoggingBool(m_summary.CommandSuccess, "CommandSuccess"),
-                TraceLoggingBool(m_summary.IsManifestLocal, "IsManifestLocal"),
-                AICLI_TraceLoggingStringView(m_summary.PackageIdentifier, "PackageIdentifier"),
-                AICLI_TraceLoggingStringView(m_summary.PackageName, "PackageName"),
-                AICLI_TraceLoggingStringView(m_summary.PackageVersion, "PackageVersion"),
-                AICLI_TraceLoggingStringView(m_summary.Channel, "Channel"),
-                AICLI_TraceLoggingStringView(m_summary.SourceIdentifier, "SourceIdentifier"),
-                TraceLoggingInt32(m_summary.InstallerArchitecture, "InstallerArchitecture"),
-                AICLI_TraceLoggingStringView(m_summary.InstallerUrl, "InstallerUrl"),
-                AICLI_TraceLoggingStringView(m_summary.InstallerType, "InstallerType"),
-                AICLI_TraceLoggingStringView(m_summary.InstallerScope, "InstallerScope"),
-                AICLI_TraceLoggingStringView(m_summary.InstallerLocale, "InstallerLocale"),
-                AICLI_TraceLoggingStringView(m_summary.SearchType, "SearchType"),
-                AICLI_TraceLoggingStringView(m_summary.SearchQuery, "SearchQuery"),
-                AICLI_TraceLoggingStringView(m_summary.SearchId, "SearchId"),
-                AICLI_TraceLoggingStringView(m_summary.SearchName, "SearchName"),
-                AICLI_TraceLoggingStringView(m_summary.SearchMoniker, "SearchMoniker"),
-                AICLI_TraceLoggingStringView(m_summary.SearchTag, "SearchTag"),
-                AICLI_TraceLoggingStringView(m_summary.SearchCommand, "SearchCommand"),
-                TraceLoggingUInt64(m_summary.SearchMaximum, "SearchMaximum"),
-                AICLI_TraceLoggingStringView(m_summary.SearchRequest, "SearchRequest"),
-                TraceLoggingUInt64(m_summary.SearchResultCount, "SearchResultCount"),
-                TraceLoggingBinary(m_summary.HashMismatchExpected.data(), static_cast<ULONG>(m_summary.HashMismatchExpected.size()), "HashMismatchExpected"),
-                TraceLoggingBinary(m_summary.HashMismatchActual.data(), static_cast<ULONG>(m_summary.HashMismatchActual.size()), "HashMismatchActual"),
-                TraceLoggingBool(m_summary.HashMismatchOverride, "HashMismatchOverride"),
-                AICLI_TraceLoggingStringView(m_summary.InstallerExecutionType, "InstallerExecutionType"),
-                TraceLoggingUInt32(m_summary.InstallerErrorCode, "InstallerErrorCode"),
-                AICLI_TraceLoggingStringView(m_summary.UninstallerExecutionType, "UninstallerExecutionType"),
-                TraceLoggingUInt32(m_summary.UninstallerErrorCode, "UninstallerErrorCode"),
-                TraceLoggingUInt64(m_summary.ChangesToARP, "ChangesToARP"),
-                TraceLoggingUInt64(m_summary.MatchesInARP, "MatchesInARP"),
-                TraceLoggingUInt64(m_summary.ChangesThatMatch, "ChangesThatMatch"),
-                TraceLoggingUInt64(m_summary.ARPLanguage, "ARPLanguage"),
-                AICLI_TraceLoggingStringView(m_summary.ARPName, "ARPName"),
-                AICLI_TraceLoggingStringView(m_summary.ARPVersion, "ARPVersion"),
-                AICLI_TraceLoggingStringView(m_summary.ARPPublisher, "ARPPublisher"),
-                AICLI_TraceLoggingStringView(m_summary.DOUrl, "DOUrl"),
-                TraceLoggingHResult(m_summary.DOHResult, "DOHResult"),
-                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance | PDT_ProductAndServiceUsage | PDT_SoftwareSetupAndInventory),
-                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+            if (m_useSummary)
+            {
+                TraceLoggingWriteActivity(
+                    g_hTraceProvider,
+                    "Summary",
+                    GetActivityId(),
+                    GetParentActivityId(),
+                    // From member fields or program info.
+                    AICLI_TraceLoggingStringView(m_caller, "Caller"),
+                    TraceLoggingPackedFieldEx(m_telemetryCorrelationJsonW.c_str(), static_cast<ULONG>((m_telemetryCorrelationJsonW.size() + 1) * sizeof(wchar_t)), TlgInUNICODESTRING, TlgOutJSON, "CvJson"),
+                    TraceLoggingCountedString(version->c_str(), static_cast<ULONG>(version->size()), "ClientVersion"),
+                    TraceLoggingCountedString(packageVersion->c_str(), static_cast<ULONG>(packageVersion->size()), "PackageVersion"),
+                    TraceLoggingBool(Runtime::IsReleaseBuild(), "IsReleaseBuild"),
+                    TraceLoggingUInt32(m_executionStage, "ExecutionStage"),
+                    // From TelemetrySummary
+                    TraceLoggingHResult(m_summary.FailureHResult, "FailureHResult"),
+                    AICLI_TraceLoggingWStringView(m_summary.FailureMessage, "FailureMessage"),
+                    AICLI_TraceLoggingStringView(m_summary.FailureModule, "FailureModule"),
+                    TraceLoggingUInt32(m_summary.FailureThreadId, "FailureThreadId"),
+                    TraceLoggingUInt32(static_cast<UINT32>(m_summary.FailureType), "FailureType"),
+                    AICLI_TraceLoggingStringView(m_summary.FailureFile, "FailureFile"),
+                    TraceLoggingUInt32(m_summary.FailureLine, "FailureLine"),
+                    TraceLoggingBool(m_summary.IsCOMCall, "IsCOMCall"),
+                    AICLI_TraceLoggingStringView(m_summary.Command, "Command"),
+                    TraceLoggingBool(m_summary.CommandSuccess, "CommandSuccess"),
+                    TraceLoggingBool(m_summary.IsManifestLocal, "IsManifestLocal"),
+                    AICLI_TraceLoggingStringView(m_summary.PackageIdentifier, "PackageIdentifier"),
+                    AICLI_TraceLoggingStringView(m_summary.PackageName, "PackageName"),
+                    AICLI_TraceLoggingStringView(m_summary.PackageVersion, "PackageVersion"),
+                    AICLI_TraceLoggingStringView(m_summary.Channel, "Channel"),
+                    AICLI_TraceLoggingStringView(m_summary.SourceIdentifier, "SourceIdentifier"),
+                    TraceLoggingInt32(m_summary.InstallerArchitecture, "InstallerArchitecture"),
+                    AICLI_TraceLoggingStringView(m_summary.InstallerUrl, "InstallerUrl"),
+                    AICLI_TraceLoggingStringView(m_summary.InstallerType, "InstallerType"),
+                    AICLI_TraceLoggingStringView(m_summary.InstallerScope, "InstallerScope"),
+                    AICLI_TraceLoggingStringView(m_summary.InstallerLocale, "InstallerLocale"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchType, "SearchType"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchQuery, "SearchQuery"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchId, "SearchId"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchName, "SearchName"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchMoniker, "SearchMoniker"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchTag, "SearchTag"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchCommand, "SearchCommand"),
+                    TraceLoggingUInt64(m_summary.SearchMaximum, "SearchMaximum"),
+                    AICLI_TraceLoggingStringView(m_summary.SearchRequest, "SearchRequest"),
+                    TraceLoggingUInt64(m_summary.SearchResultCount, "SearchResultCount"),
+                    TraceLoggingBinary(m_summary.HashMismatchExpected.data(), static_cast<ULONG>(m_summary.HashMismatchExpected.size()), "HashMismatchExpected"),
+                    TraceLoggingBinary(m_summary.HashMismatchActual.data(), static_cast<ULONG>(m_summary.HashMismatchActual.size()), "HashMismatchActual"),
+                    TraceLoggingBool(m_summary.HashMismatchOverride, "HashMismatchOverride"),
+                    AICLI_TraceLoggingStringView(m_summary.InstallerExecutionType, "InstallerExecutionType"),
+                    TraceLoggingUInt32(m_summary.InstallerErrorCode, "InstallerErrorCode"),
+                    AICLI_TraceLoggingStringView(m_summary.UninstallerExecutionType, "UninstallerExecutionType"),
+                    TraceLoggingUInt32(m_summary.UninstallerErrorCode, "UninstallerErrorCode"),
+                    TraceLoggingUInt64(m_summary.ChangesToARP, "ChangesToARP"),
+                    TraceLoggingUInt64(m_summary.MatchesInARP, "MatchesInARP"),
+                    TraceLoggingUInt64(m_summary.ChangesThatMatch, "ChangesThatMatch"),
+                    TraceLoggingUInt64(m_summary.ARPLanguage, "ARPLanguage"),
+                    AICLI_TraceLoggingStringView(m_summary.ARPName, "ARPName"),
+                    AICLI_TraceLoggingStringView(m_summary.ARPVersion, "ARPVersion"),
+                    AICLI_TraceLoggingStringView(m_summary.ARPPublisher, "ARPPublisher"),
+                    AICLI_TraceLoggingStringView(m_summary.DOUrl, "DOUrl"),
+                    TraceLoggingHResult(m_summary.DOHResult, "DOHResult"),
+                    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance | PDT_ProductAndServiceUsage | PDT_SoftwareSetupAndInventory),
+                    TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+            }
         }
     }
 
@@ -803,7 +857,7 @@ namespace AppInstaller::Logging
         }
         else
         {
-            static TelemetryTraceLogger processGlobalTelemetry;
+            static TelemetryTraceLogger processGlobalTelemetry(/* useSummary */ false);
             processGlobalTelemetry.TryInitialize();
             return processGlobalTelemetry;
         }

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -130,7 +130,7 @@ namespace AppInstaller::Logging
     // this should not become a burden.
     struct TelemetryTraceLogger
     {
-        TelemetryTraceLogger();
+        TelemetryTraceLogger(bool useSummary = true);
 
         ~TelemetryTraceLogger();
 
@@ -276,6 +276,7 @@ namespace AppInstaller::Logging
         // Data that is needed by AnonymizeString
         std::wstring m_userProfile;
 
+        bool m_useSummary = true;
         mutable TelemetrySummary m_summary;
 
         // TODO: This and all related code could be removed after transition to summary event in back end.


### PR DESCRIPTION
We were observing crashes in `TelemetryTraceLogger::LogFailure()` due to heap corruption. The root cause of this is that for many types of COM calls we don't have a thread local telemetry trace logger, but instead use a process global. If there are multiple simultaneous calls, there is a possibility for a race condition, specifically around writing to the `TelemetryTraceLogger`'s `m_summary`.

The long term solution would be to stop using a process globals there, but that is tricky. As a band-aid to prevent these crashes, disable the use of `m_summary` in the process globals.

Tested by creating a local repro of the crash and verifying it didn't crash after the change. Repro'd by adding an artificial `THROW_HR_MSG` to force going to `LogFailure()` and then using the sample COM caller project to generate many simultaneous calls that would hit it.

Credit to @JohnMcPMS for figuring out the issue and the fix :)

Related to #1880

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2820)