### PR TITLE
Fix typo in Settings.md

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -141,7 +141,7 @@ The `defaultInstallRoot` affects the install location when a package requires on
 
 ```json
     "installBehavior": {
-        "defaultInstallRoot": "C:\installRoot"
+        "defaultInstallRoot": "C:/installRoot"
     },
 ```
 


### PR DESCRIPTION
Fix typo in "installBehavior.defaultInstallRoot" value, in the "Settings.md" file.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2830)