### PR TITLE
Add --custom argument for passing additional installer arguments

### DIFF
--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -53,6 +53,8 @@ namespace AppInstaller::CLI
             return Argument{ "architecture"_liv, 'a', Args::Type::InstallArchitecture, Resource::String::InstallArchitectureArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help };
         case Args::Type::Log:
             return Argument{ "log"_liv, 'o', Args::Type::Log, Resource::String::LogArgumentDescription, ArgumentType::Standard };
+        case Args::Type::CustomSwitches:
+            return Argument{ "custom"_liv, NoAlias, Args::Type::CustomSwitches, Resource::String::CustomSwitchesArgumentDescription, ArgumentType::Standard};
         case Args::Type::Override:
             return Argument{ "override"_liv, NoAlias, Args::Type::Override, Resource::String::OverrideArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help };
         case Args::Type::InstallLocation:

--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -33,6 +33,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::Silent),
             Argument::ForType(Args::Type::Locale),
             Argument::ForType(Args::Type::Log),
+            Argument::ForType(Args::Type::CustomSwitches),
             Argument::ForType(Args::Type::Override),
             Argument::ForType(Args::Type::InstallLocation),
             Argument::ForType(Args::Type::HashOverride),

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -98,6 +98,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::Silent),          // -h
             Argument::ForType(Args::Type::Purge),
             Argument::ForType(Args::Type::Log),             // -o
+            Argument::ForType(Args::Type::CustomSwitches),
             Argument::ForType(Args::Type::Override),
             Argument::ForType(Args::Type::InstallLocation), // -l
             Argument{ s_ArgumentName_Scope, Argument::NoAlias, Execution::Args::Type::InstallScope, Resource::String::InstalledScopeArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -35,6 +35,7 @@ namespace AppInstaller::CLI::Execution
             Silent,
             Locale,
             Log,
+            CustomSwitches, // CustomSwitches args are args passed to the installer in addition to any defined in the manifest
             Override, // Override args are (and the only args) directly passed to installer
             InstallLocation,
             InstallScope,

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -50,6 +50,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConvertInstallFlowToUpgrade);
         WINGET_DEFINE_RESOURCE_STRINGID(CountArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(CountOutOfBoundsError);
+        WINGET_DEFINE_RESOURCE_STRINGID(CustomSwitchesArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesFlowInstall);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesFlowSourceNotFound);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesFlowSourceTooManyMatches);

--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -117,9 +117,16 @@ namespace AppInstaller::CLI::Workflow
             {
                 installerArgs += ' ' + installerSwitches.at(InstallerSwitchType::Custom);
             }
+
+            // Construct custom arg passed in by cli arg
             if (context.Args.Contains(Execution::Args::Type::CustomSwitches))
             {
-                installerArgs += ' ' + Utility::Normalize(context.Args.GetArg(Execution::Args::Type::CustomSwitches));
+                std::string_view customSwitches = context.Args.GetArg(Execution::Args::Type::CustomSwitches);
+                // Since these arguments are appended to the installer at runtime, it doesn't make sense to append them if empty or whitespace
+                if (!customSwitches.empty() && !std::all_of(customSwitches.begin(), customSwitches.end(), isspace))
+                {
+                    installerArgs += ' ' + Utility::Normalize(customSwitches);
+                }
             }
 
             // Construct update arg if applicable

--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -123,9 +123,9 @@ namespace AppInstaller::CLI::Workflow
             {
                 std::string_view customSwitches = context.Args.GetArg(Execution::Args::Type::CustomSwitches);
                 // Since these arguments are appended to the installer at runtime, it doesn't make sense to append them if empty or whitespace
-                if (!customSwitches.empty() && !std::all_of(customSwitches.begin(), customSwitches.end(), isspace))
+                if (!Utility::IsEmptyOrWhitespace(customSwitches))
                 {
-                    installerArgs += ' ' + Utility::Normalize(customSwitches);
+                    installerArgs += ' ' + std::string{ customSwitches };
                 }
             }
 

--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -117,6 +117,10 @@ namespace AppInstaller::CLI::Workflow
             {
                 installerArgs += ' ' + installerSwitches.at(InstallerSwitchType::Custom);
             }
+            if (context.Args.Contains(Execution::Args::Type::CustomSwitches))
+            {
+                installerArgs += ' ' + Utility::Normalize(context.Args.GetArg(Execution::Args::Type::CustomSwitches));
+            }
 
             // Construct update arg if applicable
             if (isUpdate && installerSwitches.find(InstallerSwitchType::Update) != installerSwitches.end())

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1319,6 +1319,9 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="CountOutOfBoundsError" xml:space="preserve">
     <value>The requested number of results must be between 1 and 1000.</value>
   </data>
+  <data name="CustomSwitchesArgumentDescription" xml:space="preserve">
+    <value>Arguments to be passed on to the installer in addition to the defaults</value>
+  </data>
   <data name="UpgradeDifferentInstallTechnologyInNewerVersions" xml:space="preserve">
     <value>A newer version was found, but the install technology is different from the current version installed. Please uninstall the package and install the newer version.</value>
   </data>

--- a/src/AppInstallerCLITests/InstallFlow.cpp
+++ b/src/AppInstallerCLITests/InstallFlow.cpp
@@ -825,6 +825,27 @@ TEST_CASE("ShellExecuteHandlerInstallerArgs", "[InstallFlow][workflow]")
         std::ostringstream installOutput;
         TestContext context{ installOutput, std::cin };
         auto previousThreadGlobals = context.SetForCurrentThread();
+        // Inno type with /silent and /log and /custom and /installlocation, switches specified in manifest
+        auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Inno_WithSwitches.yaml"));
+        context.Args.AddArg(Execution::Args::Type::Silent);
+        context.Args.AddArg(Execution::Args::Type::Log, "MyLog.log"sv);
+        context.Args.AddArg(Execution::Args::Type::InstallLocation, "MyDir"sv);
+        context.Args.AddArg(Execution::Args::Type::CustomSwitches, "/MyAppendedSwitch"sv);
+        context.Add<Data::Manifest>(manifest);
+        context.Add<Data::Installer>(manifest.Installers.at(0));
+        context << GetInstallerArgs;
+        std::string installerArgs = context.Get<Data::InstallerArgs>();
+        REQUIRE(installerArgs.find("/mysilent") != std::string::npos); // Use declaration in manifest
+        REQUIRE(installerArgs.find("/mylog=\"MyLog.log\"") != std::string::npos); // Use declaration in manifest
+        REQUIRE(installerArgs.find("/mycustom") != std::string::npos); // Use declaration in manifest
+        REQUIRE(installerArgs.find("/myinstalldir=\"MyDir\"") != std::string::npos); // Use declaration in manifest
+        REQUIRE(installerArgs.find("/MyAppendedSwitch") != std::string::npos); // Use declaration from argument
+    }
+
+    {
+        std::ostringstream installOutput;
+        TestContext context{ installOutput, std::cin };
+        auto previousThreadGlobals = context.SetForCurrentThread();
         // Override switch specified. The whole arg passed to installer is overridden.
         auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Inno_WithSwitches.yaml"));
         context.Args.AddArg(Execution::Args::Type::Silent);

--- a/src/AppInstallerCLITests/InstallFlow.cpp
+++ b/src/AppInstallerCLITests/InstallFlow.cpp
@@ -825,7 +825,7 @@ TEST_CASE("ShellExecuteHandlerInstallerArgs", "[InstallFlow][workflow]")
         std::ostringstream installOutput;
         TestContext context{ installOutput, std::cin };
         auto previousThreadGlobals = context.SetForCurrentThread();
-        // Inno type with /silent and /log and /custom and /installlocation, switches specified in manifest
+        // Inno type with /silent and /log and /custom and /installlocation, switches specified in manifest and --custom argument used in cli
         auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Inno_WithSwitches.yaml"));
         context.Args.AddArg(Execution::Args::Type::Silent);
         context.Args.AddArg(Execution::Args::Type::Log, "MyLog.log"sv);
@@ -840,6 +840,22 @@ TEST_CASE("ShellExecuteHandlerInstallerArgs", "[InstallFlow][workflow]")
         REQUIRE(installerArgs.find("/mycustom") != std::string::npos); // Use declaration in manifest
         REQUIRE(installerArgs.find("/myinstalldir=\"MyDir\"") != std::string::npos); // Use declaration in manifest
         REQUIRE(installerArgs.find("/MyAppendedSwitch") != std::string::npos); // Use declaration from argument
+    }
+
+    {
+        std::ostringstream installOutput;
+        TestContext context{ installOutput, std::cin };
+        auto previousThreadGlobals = context.SetForCurrentThread();
+        // Inno type with /silent and /log and /custom and /installlocation, switches specified in manifest and whitespace-only --custom argument used in cli
+        auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Inno_WithSwitches.yaml"));
+        context.Args.AddArg(Execution::Args::Type::Silent);
+        context.Args.AddArg(Execution::Args::Type::CustomSwitches, "\t"sv);
+        context.Add<Data::Manifest>(manifest);
+        context.Add<Data::Installer>(manifest.Installers.at(0));
+        context << GetInstallerArgs;
+        std::string installerArgs = context.Get<Data::InstallerArgs>();
+        REQUIRE(installerArgs.find("/mysilent") != std::string::npos); // Use declaration in manifest
+        REQUIRE(installerArgs.find("\t") == std::string::npos); // Whitespace only Custom switches should not be appended
     }
 
     {

--- a/src/Microsoft.Management.Deployment/InstallOptions.cpp
+++ b/src/Microsoft.Management.Deployment/InstallOptions.cpp
@@ -84,6 +84,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         m_replacementInstallerArguments = value;
     }
+    hstring InstallOptions::AdditionalInstallerArguments()
+    {
+        return hstring(m_additionalInstallerArguments);
+    }
+    void InstallOptions::AdditionalInstallerArguments(hstring const& value)
+    {
+        m_additionalInstallerArguments = value;
+    }
     hstring InstallOptions::CorrelationData()
     {
         return hstring(m_correlationData);

--- a/src/Microsoft.Management.Deployment/InstallOptions.h
+++ b/src/Microsoft.Management.Deployment/InstallOptions.h
@@ -25,6 +25,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         void AllowHashMismatch(bool value);
         hstring ReplacementInstallerArguments();
         void ReplacementInstallerArguments(hstring const& value);
+        hstring AdditionalInstallerArguments();
+        void AdditionalInstallerArguments(hstring const& value);
         hstring CorrelationData();
         void CorrelationData(hstring const& value);
         hstring AdditionalPackageCatalogArguments();
@@ -44,6 +46,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         std::wstring m_logOutputPath = L"";
         bool m_allowHashMismatch = false;
         std::wstring m_replacementInstallerArguments = L"";
+        std::wstring m_additionalInstallerArguments = L"";
         std::wstring m_correlationData = L"";
         std::wstring m_additionalPackageCatalogArguments = L"";
         Windows::Foundation::Collections::IVector<Windows::System::ProcessorArchitecture> m_allowedArchitectures{

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -381,6 +381,11 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 context->Args.AddArg(Execution::Args::Type::Override, ::AppInstaller::Utility::ConvertToUTF8(options.ReplacementInstallerArguments()));
             }
 
+            if (!options.AdditionalInstallerArguments().empty())
+            {
+                context->Args.AddArg(Execution::Args::Type::CustomSwitches, ::AppInstaller::Utility::ConvertToUTF8(options.AdditionalInstallerArguments()));
+            }
+
             if (options.AllowedArchitectures().Size() != 0)
             {
                 std::vector<AppInstaller::Utility::Architecture> allowedArchitectures;

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Management.Deployment
 {
-    [contractversion(5)]
+    [contractversion(6)]
     apicontract WindowsPackageManagerContract{};
 
     /// State of the install
@@ -764,6 +764,13 @@ namespace Microsoft.Management.Deployment
         {
             /// Force the operation to continue upon non security related failures.
             Boolean Force;
+        }
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 6)]
+        {
+            /// A string that will be passed to the installer
+            /// IMPLEMENTATION NOTE: maps to "--custom" in the winget cmd line
+            String AdditionalInstallerArguments;
         }
     }
 

--- a/src/PowerShell/Microsoft.WinGet.Client/Commands/Common/BaseInstallCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Commands/Common/BaseInstallCommand.cs
@@ -33,6 +33,12 @@ namespace Microsoft.WinGet.Client.Commands.Common
         public string Override { get; set; }
 
         /// <summary>
+        /// Gets or sets the arguments to be passed on to the installer in addition to the defaults.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public string Custom { get; set; }
+
+        /// <summary>
         /// Gets or sets the installation location.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
@@ -89,6 +95,11 @@ namespace Microsoft.WinGet.Client.Commands.Common
             if (this.Override != null)
             {
                 options.ReplacementInstallerArguments = this.Override;
+            }
+
+            if (this.Custom != null)
+            {
+                options.AdditionalInstallerArguments = this.Custom;
             }
 
             if (this.Location != null)

--- a/src/PowerShell/Microsoft.WinGet.Client/Commands/Common/BaseInstallCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client/Commands/Common/BaseInstallCommand.cs
@@ -97,7 +97,8 @@ namespace Microsoft.WinGet.Client.Commands.Common
                 options.ReplacementInstallerArguments = this.Override;
             }
 
-            if (this.Custom != null)
+            // Since these arguments are appended to the installer at runtime, it doesn't make sense to append them if they are whitespace
+            if (!string.IsNullOrWhiteSpace(this.Custom))
             {
                 options.AdditionalInstallerArguments = this.Custom;
             }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  - #239
  - #1403
-----

- I chose the argument based on what made sense to me and what was in the referenced issues. If a different name is desired, I'm open to suggestions. 
- Decided to name the arg type CustomSwitches to avoid future confusion; again, if there's a better name, feel free to suggest.

```raw
// Installation failure was expected as the '/?' argument brings up the MSI help menu

PS D:\Git\winget-pkgs> wingetdev install --manifest D:\Git\winget-pkgs\manifests\7\7zip\7zip\22.01 --custom /? --verbose --open-logs
Found 7-Zip [7zip.7zip] Version 22.01
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://www.7-zip.org/a/7z2201-x64.msi
  ██████████████████████████████  1.82 MB / 1.82 MB
Successfully verified installer hash
Starting package install...
Installer failed with exit code: 1639
One of the installation parameters is invalid. The package installation log may have additional details.
```

```
2023-01-09 22:29:04.465 [CLI ] Installer args: /passive /norestart /log "C:\Users\Trenly\AppData\Local\Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir\WinGet-7zip.7zip.22.01-2023-01-09-22-29-04.465.log" /?
2023-01-09 22:29:04.466 [CLI ] Starting: 'C:\Users\Trenly\AppData\Local\Temp\WinGet\7zip.7zip.22.01\7z2201-x64.msi' with arguments '/passive /norestart /log "C:\Users\Trenly\AppData\Local\Packages\WinGetDevCLI_8wekyb3d8bbwe\LocalState\DiagOutputDir\WinGet-7zip.7zip.22.01-2023-01-09-22-29-04.465.log" /?'
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2832)