### PR TITLE
Make correlation test script work on powershell.exe

### DIFF
--- a/tools/CorrelationTestbed/Process-CorrelationResults.ps1
+++ b/tools/CorrelationTestbed/Process-CorrelationResults.ps1
@@ -73,12 +73,12 @@ foreach ($result in (Get-ChildItem $ResultsPath -Directory))
                 $stats.CorrelationDisagreement += 1
             }
         }
-        Export-Csv -InputObject ($resultObj | Select-Object -Property * -ExcludeProperty @("Error", "Phase", "Action", "HRESULT") ) -Path $resultFile -Append -Encoding UTF8BOM
+        Export-Csv -InputObject ($resultObj | Select-Object -Property * -ExcludeProperty @("Error", "Phase", "Action", "HRESULT") ) -Path $resultFile -Append -Encoding utf8
     }
     else
     {
         $stats.Failed++
-        Export-Csv -InputObject $resultObj -Path $failedFile -Append -Encoding UTF8BOM
+        Export-Csv -InputObject $resultObj -Path $failedFile -Append -Encoding utf8
     }
 }
 


### PR DESCRIPTION
One of the correlation test scripts includes a line that makes a cmdlet use utf8BOM encoding, which doesn't exist in powershell.exe, only on pwsh.exe. Change this encoding to utf8 which is supported in both.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2834)