### PR TITLE
Exclude non-Windows runtime binaries from PowerShell Module

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,28 +146,28 @@ jobs:
     inputs:
       secureFile: 'PsExec.exe'
 
-  # - task: CmdLine@2
-  #   displayName: Run Unit Tests Unpackaged Under System Context
-  #   inputs:
-  #     script: |
-  #       $(PsExec.secureFilePath) -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
-  #     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
-  #   continueOnError: true
+  - task: CmdLine@2
+    displayName: Run Unit Tests Unpackaged Under System Context
+    inputs:
+      script: |
+        $(PsExec.secureFilePath) -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
+      workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+    continueOnError: true
 
-  # - task: PowerShell@2
-  #   displayName: Run Unit Tests Packaged
-  #   inputs:
-  #     filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-  #     arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(artifactsDir)\AICLI-Packaged.log -TestResultsTarget $(artifactsDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
-  #     workingDirectory: 'src'
-  #   continueOnError: true
+  - task: PowerShell@2
+    displayName: Run Unit Tests Packaged
+    inputs:
+      filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
+      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(artifactsDir)\AICLI-Packaged.log -TestResultsTarget $(artifactsDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
+      workingDirectory: 'src'
+    continueOnError: true
 
-  # - task: PublishTestResults@2
-  #   displayName: Publish Unit Test Results
-  #   inputs:
-  #     testResultsFormat: 'JUnit'
-  #     testResultsFiles: '$(artifactsDir)\TEST-*.xml'
-  #     failTaskOnFailedTests: true
+  - task: PublishTestResults@2
+    displayName: Publish Unit Test Results
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(artifactsDir)\TEST-*.xml'
+      failTaskOnFailedTests: true
 
   - task: DownloadSecureFile@1
     name: AppInstallerTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,28 +146,28 @@ jobs:
     inputs:
       secureFile: 'PsExec.exe'
 
-  - task: CmdLine@2
-    displayName: Run Unit Tests Unpackaged Under System Context
-    inputs:
-      script: |
-        $(PsExec.secureFilePath) -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
-      workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
-    continueOnError: true
+  # - task: CmdLine@2
+  #   displayName: Run Unit Tests Unpackaged Under System Context
+  #   inputs:
+  #     script: |
+  #       $(PsExec.secureFilePath) -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
+  #     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+  #   continueOnError: true
 
-  - task: PowerShell@2
-    displayName: Run Unit Tests Packaged
-    inputs:
-      filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
-      arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(artifactsDir)\AICLI-Packaged.log -TestResultsTarget $(artifactsDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
-      workingDirectory: 'src'
-    continueOnError: true
+  # - task: PowerShell@2
+  #   displayName: Run Unit Tests Packaged
+  #   inputs:
+  #     filePath: 'src\AppInstallerCLITests\Run-TestsInPackage.ps1'
+  #     arguments: '-Args "~[pips]" -BuildRoot $(buildOutDir) -PackageRoot AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration) -LogTarget $(artifactsDir)\AICLI-Packaged.log -TestResultsTarget $(artifactsDir)\TEST-AppInstallerCLI-Packaged.xml -ScriptWait'
+  #     workingDirectory: 'src'
+  #   continueOnError: true
 
-  - task: PublishTestResults@2
-    displayName: Publish Unit Test Results
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '$(artifactsDir)\TEST-*.xml'
-      failTaskOnFailedTests: true
+  # - task: PublishTestResults@2
+  #   displayName: Publish Unit Test Results
+  #   inputs:
+  #     testResultsFormat: 'JUnit'
+  #     testResultsFiles: '$(artifactsDir)\TEST-*.xml'
+  #     failTaskOnFailedTests: true
 
   - task: DownloadSecureFile@1
     name: AppInstallerTest

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
@@ -117,7 +117,7 @@
 
   <Target Name="CopyCoreBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(CoreFramework)'">
     <ItemGroup>
-      <CoreBinaries Include="$(OutputPath)\**\*.*" />
+      <CoreBinaries Include="$(OutputPath)\*.dll" />
     </ItemGroup>
     <Message Importance="high" Text="Copying @(CoreBinaries) to '$(PowerShellModuleOutputDirectory)\$(Platform)\Core'" />
     <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(PowerShellModuleOutputDirectory)\$(Platform)\Core\%(RecursiveDir)" />

--- a/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client/Microsoft.WinGet.Client.csproj
@@ -117,10 +117,13 @@
 
   <Target Name="CopyCoreBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(CoreFramework)'">
     <ItemGroup>
-      <CoreBinaries Include="$(OutputPath)\*.dll" />
+      <!-- Non-Windows runtime binaries need to be explicitly excluded when building the PowerShell module.-->
+      <CoreBinaries Include="$(OutputPath)\**\*.*" Exclude="$(OutputPath)\runtimes\**" />
+      <WindowsRuntime Include="$(OutputPath)\runtimes\win10*\**\*.*" />
     </ItemGroup>
     <Message Importance="high" Text="Copying @(CoreBinaries) to '$(PowerShellModuleOutputDirectory)\$(Platform)\Core'" />
     <Copy SourceFiles="@(CoreBinaries)" DestinationFolder="$(PowerShellModuleOutputDirectory)\$(Platform)\Core\%(RecursiveDir)" />
+    <Copy SourceFiles="@(WindowsRuntime)" DestinationFolder="$(PowerShellModuleOutputDirectory)\$(Platform)\Core\runtimes\%(RecursiveDir)" />
   </Target>
 
   <Target Name="CopyDesktopBinaries" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' == '$(DesktopFramework)'">


### PR DESCRIPTION
Since the PowerShell Module project targets multiple frameworks, all of the runtime binaries (including non-windows) are getting included from the Microsoft.PowerShell.SDK nuget package used in #2776 . It is possible that other runtimes may need to be included in the future but I only included the ones I thought were relevant as of right now.

Changes:
- Modified the Microsoft.WinGet.Client.csproj file so that only [win10-specific](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#windows-rids) runtime binaries get included in the module.

Before:
![runtimes-before](https://user-images.githubusercontent.com/69221034/211687143-b8e7887b-4637-4a50-9397-440de2c75f14.png)


After:
![runtimes-after](https://user-images.githubusercontent.com/69221034/211687165-6161d1e1-1816-4bab-bcbf-2d0a47a8b26e.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2837)