### PR TITLE
Allow Version Listing through 'Winget Search'

### DIFF
--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -76,26 +76,22 @@ namespace AppInstaller::CLI
     {
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
 
+        context <<
+            Workflow::OpenSource() <<
+            Workflow::SearchSourceForMany <<
+            Workflow::HandleSearchResultFailures <<
+            Workflow::EnsureOneMatchFromSearchResult(false);
 
-        if (context.Args.Contains(Execution::Args::Type::ListVersions))
-        {
-            context <<
-                Workflow::OpenSource() <<
-                Workflow::SearchSourceForMany <<
-                Workflow::HandleSearchResultFailures <<
-                Workflow::EnsureOneMatchFromSearchResult(false) <<
+            if (context.Args.Contains(Execution::Args::Type::ListVersions))
+            {
+                context <<
                 Workflow::ReportPackageIdentity <<
                 Workflow::ShowAppVersions;
-        }
-        else
-        {
-            context <<
-                Workflow::OpenSource() <<
-                Workflow::SearchSourceForMany <<
-                Workflow::HandleSearchResultFailures <<
-                Workflow::EnsureMatchesFromSearchResult(false) <<
-                Workflow::ReportSearchResult;
-        }
+            }
+            else
+            {
+                context << Workflow::ReportSearchResult;
+            }
         
     }
 }

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -79,18 +79,20 @@ namespace AppInstaller::CLI
         context <<
             Workflow::OpenSource() <<
             Workflow::SearchSourceForMany <<
-            Workflow::HandleSearchResultFailures <<
-            Workflow::EnsureOneMatchFromSearchResult(false);
+            Workflow::HandleSearchResultFailures;
 
             if (context.Args.Contains(Execution::Args::Type::ListVersions))
             {
                 context <<
+                Workflow::EnsureOneMatchFromSearchResult(false) <<
                 Workflow::ReportPackageIdentity <<
                 Workflow::ShowAppVersions;
             }
             else
             {
-                context << Workflow::ReportSearchResult;
+                context << 
+                    Workflow::EnsureMatchesFromSearchResult(false) <<
+                    Workflow::ReportSearchResult;
             }
         
     }

--- a/src/AppInstallerCLICore/Commands/SearchCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/SearchCommand.cpp
@@ -25,6 +25,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Execution::Args::Type::Exact),
             Argument::ForType(Execution::Args::Type::CustomHeader),
             Argument::ForType(Execution::Args::Type::AcceptSourceAgreements),
+            Argument::ForType(Execution::Args::Type::ListVersions),
         };
     }
 
@@ -75,11 +76,26 @@ namespace AppInstaller::CLI
     {
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
 
-        context <<
-            Workflow::OpenSource() <<
-            Workflow::SearchSourceForMany <<
-            Workflow::HandleSearchResultFailures <<
-            Workflow::EnsureMatchesFromSearchResult(false) <<
-            Workflow::ReportSearchResult;
+
+        if (context.Args.Contains(Execution::Args::Type::ListVersions))
+        {
+            context <<
+                Workflow::OpenSource() <<
+                Workflow::SearchSourceForMany <<
+                Workflow::HandleSearchResultFailures <<
+                Workflow::EnsureOneMatchFromSearchResult(false) <<
+                Workflow::ReportPackageIdentity <<
+                Workflow::ShowAppVersions;
+        }
+        else
+        {
+            context <<
+                Workflow::OpenSource() <<
+                Workflow::SearchSourceForMany <<
+                Workflow::HandleSearchResultFailures <<
+                Workflow::EnsureMatchesFromSearchResult(false) <<
+                Workflow::ReportSearchResult;
+        }
+        
     }
 }

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -224,16 +224,4 @@ namespace AppInstaller::CLI::Workflow
         table.OutputLine({ manifest.Version, manifest.Channel });
         table.Complete();
     }
-
-    void ShowAppVersions(Execution::Context& context)
-    {
-        auto versions = context.Get<Execution::Data::Package>()->GetAvailableVersionKeys();
-
-        Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
-        for (const auto& version : versions)
-        {
-            table.OutputLine({ version.Version, version.Channel });
-        }
-        table.Complete();
-    }
 }

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.h
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.h
@@ -28,10 +28,4 @@ namespace AppInstaller::CLI::Workflow
     // Inputs: Manifest
     // Outputs: None
     void ShowManifestVersion(Execution::Context& context);
-
-    // Shows all versions for an application.
-    // Required Args: None
-    // Inputs: SearchResult [only operates on first match]
-    // Outputs: None
-    void ShowAppVersions(Execution::Context& context);
 }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1111,6 +1111,18 @@ namespace AppInstaller::CLI::Workflow
     {
         context.SetExecutionStage(m_stage);
     }
+
+    void ShowAppVersions(Execution::Context& context)
+    {
+        auto versions = context.Get<Execution::Data::Package>()->GetAvailableVersionKeys();
+
+        Execution::TableOutput<2> table(context.Reporter, { Resource::String::ShowVersion, Resource::String::ShowChannel });
+        for (const auto& version : versions)
+        {
+            table.OutputLine({ version.Version, version.Channel });
+        }
+        table.Complete();
+    }
 }
 
 AppInstaller::CLI::Execution::Context& operator<<(AppInstaller::CLI::Execution::Context& context, AppInstaller::CLI::Workflow::WorkflowTask::Func f)

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -368,6 +368,12 @@ namespace AppInstaller::CLI::Workflow
     // Outputs: InstalledPackageVersion
     void GetInstalledPackageVersion(Execution::Context& context);
 
+    // Shows all versions for an application.
+    // Required Args: None
+    // Inputs: SearchResult [only operates on first match]
+    // Outputs: None
+    void ShowAppVersions(Execution::Context& context);
+
     // Reports execution stage in a workflow
     // Required Args: ExecutionStage
     // Inputs: ExecutionStage?


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  - #520
-----

This PR moves the workflow for ShowAppVersions into the workflow base and makes it available to the search command.
Intentionally left the search command as `SearchSourceForMany` to retain the same searching behavior. 

```
PS C:\WINDOWS\system32> wingetdev search 7zip.7zip --versions
Multiple packages found matching input criteria. Please refine the input.
Name              Id                  Source
--------------------------------------------
7-Zip             7zip.7zip           winget
7-Zip Alpha (msi) 7zip.7zip.Alpha.msi winget
7-Zip Alpha (exe) 7zip.7zip.Alpha.exe winget
PS C:\WINDOWS\system32> wingetdev search -e 7zip.7zip --versions
Found 7-Zip [7zip.7zip]
Version
----------
22.01
22.00
21.07
21.06
19.00.00.0
16.04
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2847)