### PR TITLE
Show Enabled Admin Settings in --info

### DIFF
--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -110,6 +110,30 @@ namespace AppInstaller::CLI
                 }
             }
         }
+
+        void OutputAdminSettings(Execution::Context& context)
+        {
+            std::vector<AdminSetting> adminSettings = Settings::GetAllAdminSettings();
+            std::vector<AdminSetting> enabledSettings;
+            std::copy_if(adminSettings.begin(), adminSettings.end(), std::back_inserter(enabledSettings), [](AdminSetting setting) { return IsAdminSettingEnabled(setting); });
+
+            // Only display the table if there are settings to report
+            if (!enabledSettings.empty())
+            {
+                auto info = context.Reporter.Info();
+                info << std::endl;
+
+                Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, {} } };
+
+                // Output the admin settings.
+                for (const auto& setting : enabledSettings)
+                {
+                    adminSettingsTable.OutputLine({
+                    std::string{ AdminSettingToString(setting), {} } });
+                }
+                adminSettingsTable.Complete();
+            }
+        }
     }
 
     std::vector<std::unique_ptr<Command>> RootCommand::GetCommands() const
@@ -210,6 +234,7 @@ namespace AppInstaller::CLI
             links.Complete();
 
             OutputGroupPolicies(context);
+            OutputAdminSettings(context);
         }
         else if (context.Args.Contains(Execution::Args::Type::ToolVersion))
         {

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -114,25 +114,21 @@ namespace AppInstaller::CLI
         void OutputAdminSettings(Execution::Context& context)
         {
             std::vector<AdminSetting> adminSettings = Settings::GetAllAdminSettings();
-            std::vector<AdminSetting> enabledSettings;
-            std::copy_if(adminSettings.begin(), adminSettings.end(), std::back_inserter(enabledSettings), [](AdminSetting setting) { return IsAdminSettingEnabled(setting); });
 
-            // Only display the table if there are settings to report
-            if (!enabledSettings.empty())
+            auto info = context.Reporter.Info();
+            info << std::endl;
+
+            Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, Resource::String::PoliciesState } };
+
+            // Output the admin settings.
+            for (const auto& setting : adminSettings)
             {
-                auto info = context.Reporter.Info();
-                info << std::endl;
-
-                Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, {} } };
-
-                // Output the admin settings.
-                for (const auto& setting : enabledSettings)
-                {
-                    adminSettingsTable.OutputLine({
-                    std::string{ AdminSettingToString(setting), {} } });
-                }
-                adminSettingsTable.Complete();
+                adminSettingsTable.OutputLine({
+                std::string{ AdminSettingToString(setting)},
+                Resource::LocString{ IsAdminSettingEnabled(setting) ? Resource::String::PoliciesEnabled : Resource::String::PoliciesDisabled }
+                });
             }
+            adminSettingsTable.Complete();
         }
     }
 

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -67,7 +67,7 @@ namespace AppInstaller::CLI
                 auto info = context.Reporter.Info();
                 info << std::endl;
 
-                Execution::TableOutput<2> policiesTable{ context.Reporter, { Resource::String::PoliciesPolicy, Resource::String::PoliciesState } };
+                Execution::TableOutput<2> policiesTable{ context.Reporter, { Resource::String::PoliciesPolicy, Resource::String::StateHeader } };
 
                 // Output the toggle policies.
                 for (const auto& activePolicy : activePolicies)
@@ -75,7 +75,7 @@ namespace AppInstaller::CLI
                     auto policy = Settings::TogglePolicy::GetPolicy(activePolicy.first);
                     policiesTable.OutputLine({
                         Resource::LocString{ policy.PolicyName() }.get(),
-                        Resource::LocString{ activePolicy.second == Settings::PolicyState::Enabled ? Resource::String::PoliciesEnabled : Resource::String::PoliciesDisabled }.get() });
+                        Resource::LocString{ activePolicy.second == Settings::PolicyState::Enabled ? Resource::String::StateEnabled : Resource::String::StateDisabled }.get() });
                 }
 
                 // Output the update interval in the same table if needed.
@@ -108,22 +108,20 @@ namespace AppInstaller::CLI
                         OutputGroupPolicySourceList(context, sources->get(), Resource::String::SourceListAllowedSource);
                     }
                 }
+                info << std::endl;
             }
         }
 
         void OutputAdminSettings(Execution::Context& context)
         {
-            auto info = context.Reporter.Info();
-            info << std::endl;
-
-            Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, Resource::String::PoliciesState } };
+            Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, Resource::String::StateHeader } };
 
             // Output the admin settings.
             for (const auto& setting : Settings::GetAllAdminSettings())
             {
                 adminSettingsTable.OutputLine({
-                std::string{ AdminSettingToString(setting)},
-                Resource::LocString{ IsAdminSettingEnabled(setting) ? Resource::String::PoliciesEnabled : Resource::String::PoliciesDisabled }
+                    std::string{ AdminSettingToString(setting)},
+                    Resource::LocString{ IsAdminSettingEnabled(setting) ? Resource::String::StateEnabled : Resource::String::StateDisabled }
                 });
             }
             adminSettingsTable.Complete();
@@ -226,6 +224,7 @@ namespace AppInstaller::CLI
             links.OutputLine({ Resource::LocString(Resource::String::WindowsStoreTerms).get(), "https://www.microsoft.com/en-us/storedocs/terms-of-sale" });
 
             links.Complete();
+            info << std::endl;
 
             OutputGroupPolicies(context);
             OutputAdminSettings(context);

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -113,15 +113,13 @@ namespace AppInstaller::CLI
 
         void OutputAdminSettings(Execution::Context& context)
         {
-            std::vector<AdminSetting> adminSettings = Settings::GetAllAdminSettings();
-
             auto info = context.Reporter.Info();
             info << std::endl;
 
             Execution::TableOutput<2> adminSettingsTable{ context.Reporter, { Resource::String::AdminSettingHeader, Resource::String::PoliciesState } };
 
             // Output the admin settings.
-            for (const auto& setting : adminSettings)
+            for (const auto& setting : Settings::GetAllAdminSettings())
             {
                 adminSettingsTable.OutputLine({
                 std::string{ AdminSettingToString(setting)},

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -27,6 +27,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(AdminSettingDisableDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(AdminSettingEnabled);
         WINGET_DEFINE_RESOURCE_STRINGID(AdminSettingEnableDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(AdminSettingHeader);
         WINGET_DEFINE_RESOURCE_STRINGID(ArchiveFailedMalwareScan);
         WINGET_DEFINE_RESOURCE_STRINGID(ArchiveFailedMalwareScanOverridden);
         WINGET_DEFINE_RESOURCE_STRINGID(ArgumentForSinglePackageProvidedWithMultipleQueries);

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -265,10 +265,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PinResettingAll);
         WINGET_DEFINE_RESOURCE_STRINGID(PinResetUseForceArg);
         WINGET_DEFINE_RESOURCE_STRINGID(PinType);
-        WINGET_DEFINE_RESOURCE_STRINGID(PoliciesDisabled);
-        WINGET_DEFINE_RESOURCE_STRINGID(PoliciesEnabled);
         WINGET_DEFINE_RESOURCE_STRINGID(PoliciesPolicy);
-        WINGET_DEFINE_RESOURCE_STRINGID(PoliciesState);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableHashMismatchOverridden);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableHashMismatchOverrideRequired);
         WINGET_DEFINE_RESOURCE_STRINGID(PortableAliasAdded);
@@ -406,6 +403,9 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SourceUpdateCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceUpdateCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SourceUpdateOne);
+        WINGET_DEFINE_RESOURCE_STRINGID(StateDisabled);
+        WINGET_DEFINE_RESOURCE_STRINGID(StateEnabled);
+        WINGET_DEFINE_RESOURCE_STRINGID(StateHeader);
         WINGET_DEFINE_RESOURCE_STRINGID(SystemArchitecture);
         WINGET_DEFINE_RESOURCE_STRINGID(TagArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ThankYou);

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -128,14 +128,13 @@ namespace AppInstaller::CLI::Workflow
     void ExportSettings(Execution::Context& context)
     {
         ExportSettingsJson exportSettingsJson;
-        using AdminSetting_t = std::underlying_type_t<AdminSetting>;
-
-        // Skip Unknown.
-        for (AdminSetting_t i = 1 + static_cast<AdminSetting_t>(AdminSetting::Unknown); i < static_cast<AdminSetting_t>(AdminSetting::Max); ++i)
+        auto adminSettings = GetAllAdminSettings();
+        
+        for (const auto& setting : adminSettings)
         {
-            exportSettingsJson.AddAdminSetting(static_cast<AdminSetting>(i));
+            exportSettingsJson.AddAdminSetting(setting);
         }
-
+        
         context.Reporter.Info() << exportSettingsJson.ToJsonString() << std::endl;
     }
 }

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -134,7 +134,7 @@ namespace AppInstaller::CLI::Workflow
         {
             exportSettingsJson.AddAdminSetting(setting);
         }
-        
+
         context.Reporter.Info() << exportSettingsJson.ToJsonString() << std::endl;
     }
 }

--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -128,9 +128,8 @@ namespace AppInstaller::CLI::Workflow
     void ExportSettings(Execution::Context& context)
     {
         ExportSettingsJson exportSettingsJson;
-        auto adminSettings = GetAllAdminSettings();
-        
-        for (const auto& setting : adminSettings)
+
+        for (const auto& setting : GetAllAdminSettings())
         {
             exportSettingsJson.AddAdminSetting(setting);
         }

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1232,6 +1232,10 @@ Do you agree to the terms?</value>
     <value>Disabled admin setting '{0}'.</value>
     <comment>{Locked="{0}"} Message displayed when the user disables an admin setting. {0} is a placeholder replaced by the setting name.</comment>
   </data>
+  <data name="AdminSettingHeader" xml:space="preserve">
+    <value>Enabled Admin Settings</value>
+    <comment>Header for a table displaying admin settings.</comment>
+  </data>
   <data name="InstallFlowReturnCodePackageInUse" xml:space="preserve">
     <value>Application is currently running. Exit the application then try again.</value>
   </data>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -909,21 +909,9 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="PolicySourceAutoUpdateInterval" xml:space="preserve">
     <value>Set Windows Package Manager Source Auto Update Interval In Minutes</value>
   </data>
-  <data name="PoliciesDisabled" xml:space="preserve">
-    <value>Disabled</value>
-    <comment>As in enabled/disabled</comment>
-  </data>
-  <data name="PoliciesEnabled" xml:space="preserve">
-    <value>Enabled</value>
-    <comment>As in enabled/disabled</comment>
-  </data>
   <data name="PoliciesPolicy" xml:space="preserve">
     <value>Group Policy</value>
     <comment>Header for a table listing active Group Policies</comment>
-  </data>
-  <data name="PoliciesState" xml:space="preserve">
-    <value>State</value>
-    <comment>Header for a table listing the state (enabled/disabled) of Group Policies</comment>
   </data>
   <data name="PolicyEnableLocalManifests" xml:space="preserve">
     <value>Enable Windows App Installer Local Manifest Files</value>
@@ -1647,10 +1635,21 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="ArgumentForSinglePackageProvidedWithMultipleQueries" xml:space="preserve">
     <value>An argument was provided that can only be used for single package</value>
-
   </data>
   <data name="MultipleExclusiveArgumentsProvided" xml:space="preserve">
     <value>Multiple mutually exclusive arguments provided: {0}</value>
     <comment>{Locked="{0}"} Error message shown when mutually incompatible command line arguments are used. {0} is a placeholder replaced by the arguments that cannot be specified together</comment>
+  </data>
+  <data name="StateDisabled" xml:space="preserve">
+    <value>Disabled</value>
+    <comment>As in enabled/disabled</comment>
+  </data>
+  <data name="StateEnabled" xml:space="preserve">
+    <value>Enabled</value>
+    <comment>As in enabled/disabled</comment>
+  </data>
+  <data name="StateHeader" xml:space="preserve">
+    <value>State</value>
+    <comment>Header for a table listing the state (enabled/disabled) of Group Policies and Settings</comment>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1233,7 +1233,7 @@ Do you agree to the terms?</value>
     <comment>{Locked="{0}"} Message displayed when the user disables an admin setting. {0} is a placeholder replaced by the setting name.</comment>
   </data>
   <data name="AdminSettingHeader" xml:space="preserve">
-    <value>Enabled Admin Settings</value>
+    <value>Admin Setting</value>
     <comment>Header for a table displaying admin settings.</comment>
   </data>
   <data name="InstallFlowReturnCodePackageInUse" xml:space="preserve">

--- a/src/AppInstallerCommonCore/AdminSettings.cpp
+++ b/src/AppInstallerCommonCore/AdminSettings.cpp
@@ -268,11 +268,9 @@ namespace AppInstaller::Settings
         return adminSettingsInternal.GetAdminSettingBoolValue(setting);
     }
 
-
     std::vector<AdminSetting> GetAllAdminSettings()
     {
         std::vector<AdminSetting> result;
-
         using AdminSetting_t = std::underlying_type_t<AdminSetting>;
 
         // Skip Unknown.
@@ -282,19 +280,5 @@ namespace AppInstaller::Settings
         }
 
         return result;
-    }
-
-    std::map<std::string, bool> GetAdminSettingsForOutput()
-    {
-        std::map<std::string, bool> adminSettingStatus;
-        using AdminSetting_t = std::underlying_type_t<AdminSetting>;
-
-        // Skip Unknown.
-        for (AdminSetting_t i = 1 + static_cast<AdminSetting_t>(AdminSetting::Unknown); i < static_cast<AdminSetting_t>(AdminSetting::Max); ++i)
-        {
-            AdminSetting setting = static_cast<AdminSetting>(i);
-            adminSettingStatus.emplace(AdminSettingToString(setting), IsAdminSettingEnabled(setting));
-        }
-        return adminSettingStatus;
     }
 }

--- a/src/AppInstallerCommonCore/AdminSettings.cpp
+++ b/src/AppInstallerCommonCore/AdminSettings.cpp
@@ -267,4 +267,34 @@ namespace AppInstaller::Settings
         AdminSettingsInternal adminSettingsInternal;
         return adminSettingsInternal.GetAdminSettingBoolValue(setting);
     }
+
+
+    std::vector<AdminSetting> GetAllAdminSettings()
+    {
+        std::vector<AdminSetting> result;
+
+        using AdminSetting_t = std::underlying_type_t<AdminSetting>;
+
+        // Skip Unknown.
+        for (AdminSetting_t i = 1 + static_cast<AdminSetting_t>(AdminSetting::Unknown); i < static_cast<AdminSetting_t>(AdminSetting::Max); ++i)
+        {
+            result.emplace_back(static_cast<AdminSetting>(i));;
+        }
+
+        return result;
+    }
+
+    std::map<std::string, bool> GetAdminSettingsForOutput()
+    {
+        std::map<std::string, bool> adminSettingStatus;
+        using AdminSetting_t = std::underlying_type_t<AdminSetting>;
+
+        // Skip Unknown.
+        for (AdminSetting_t i = 1 + static_cast<AdminSetting_t>(AdminSetting::Unknown); i < static_cast<AdminSetting_t>(AdminSetting::Max); ++i)
+        {
+            AdminSetting setting = static_cast<AdminSetting>(i);
+            adminSettingStatus.emplace(AdminSettingToString(setting), IsAdminSettingEnabled(setting));
+        }
+        return adminSettingStatus;
+    }
 }

--- a/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
@@ -26,4 +26,6 @@ namespace AppInstaller::Settings
     bool DisableAdminSetting(AdminSetting setting);
 
     bool IsAdminSettingEnabled(AdminSetting setting);
+
+    std::vector<AdminSetting> GetAllAdminSettings();
 }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  - #2898
-----

This is only a partial implementation, as the user settings are much more complicated. The table is only output if there are AdminSettings enabled, and only shows the admin settings that are enabled

![image](https://user-images.githubusercontent.com/12611259/216061443-419260e1-812b-4e42-843e-4735b989f458.png)

