### PR TITLE
Remove use of Invoke-Expression in test script

### DIFF
--- a/tools/CorrelationTestbed/InSandboxScript.ps1
+++ b/tools/CorrelationTestbed/InSandboxScript.ps1
@@ -75,21 +75,21 @@ Write-Host @"
 
 $installAndCorrelateOutPath = Join-Path $OutputPath "install_and_correlate.json"
 
-$installAndCorrelationExpression = Join-Path $desktopPath "InstallAndCheckCorrelation\InstallAndCheckCorrelation.exe"
-$installAndCorrelationExpression = -join($installAndCorrelationExpression, ' -id "', $PackageIdentifier, '" -src "', $SourceName, '" -out "', $installAndCorrelateOutPath, '"')
+$installAndCheckCorrelationExe = Join-Path $desktopPath "InstallAndCheckCorrelation\InstallAndCheckCorrelation.exe"
+$installAndCheckCorrelationArgs = @('-id', $PackageIdentifier, '-src', $SourceName, '-out', $installAndCorrelateOutPath)
 
 if ($UseDev)
 {
-  $installAndCorrelationExpression = -join($installAndCorrelationExpression, ' -dev')
+  $installAndCheckCorrelationArgs += '-dev'
 }
 
 if ($MetadataCollection)
 {
   $wingetUtilPath = Join-Path $PSScriptRoot "WinGetUtil.dll"
-  $installAndCorrelationExpression = -join($installAndCorrelationExpression, ' -meta "', $wingetUtilPath, '" -sys32 "', $System32Path,'"')
+  $installAndCheckCorrelationArgs += ('-meta', $wingetUtilPath, '-sys32', $System32Path)
 }
 
-Invoke-Expression $installAndCorrelationExpression
+& $installAndCheckCorrelationExe $installAndCheckCorrelationArgs
 
 Write-Host @"
 


### PR DESCRIPTION
We have a test script that uses Invoke-Expression to execute a command from a string we make up with string concatenation. This isn't good because the string gets parsed as Powershell code and it's easy to get it to inject other commands on it. This change replaces the use of Invoke-Expression by the use of the call operator & and passing the arguments as an array of strings, instead of a single string to be parsed. This script is only used on an internal pipeline where we supply all the input.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/winget-cli/pulls/2921)