### PR TITLE
Fix spelling from pinning spec

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -136,6 +136,7 @@ HINSTANCE
 hkey
 hlocal
 hmodule
+Howto
 hre
 hresults
 IARP
@@ -228,6 +229,7 @@ normer
 NOSEPARATOR
 NOTAPROPERTY
 notmatch
+npmjs
 nsis
 nuffing
 objbase


### PR DESCRIPTION
When pinning spec pr was created, the spelling check was disabled.

I will send a follow up pr to update the pinning spec to match what is actually implemented in the end.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2946)