### PR TITLE
Add std::endl after enabling/disabling Admin Setting

### DIFF
--- a/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SettingsFlow.cpp
@@ -47,11 +47,11 @@ namespace AppInstaller::CLI::Workflow
         AdminSetting adminSetting = Settings::StringToAdminSetting(adminSettingString);
         if (Settings::EnableAdminSetting(adminSetting))
         {
-            context.Reporter.Info() << Resource::String::AdminSettingEnabled(AdminSettingToString(adminSetting));
+            context.Reporter.Info() << Resource::String::AdminSettingEnabled(AdminSettingToString(adminSetting)) << std::endl;
         }
         else
         {
-            context.Reporter.Error() << Resource::String::EnableAdminSettingFailed(AdminSettingToString(adminSetting));
+            context.Reporter.Error() << Resource::String::EnableAdminSettingFailed(AdminSettingToString(adminSetting)) << std::endl;
         }
     }
 
@@ -61,11 +61,11 @@ namespace AppInstaller::CLI::Workflow
         AdminSetting adminSetting = Settings::StringToAdminSetting(adminSettingString);
         if (Settings::DisableAdminSetting(adminSetting))
         {
-            context.Reporter.Info() << Resource::String::AdminSettingDisabled(AdminSettingToString(adminSetting));
+            context.Reporter.Info() << Resource::String::AdminSettingDisabled(AdminSettingToString(adminSetting)) << std::endl;
         }
         else
         {
-            context.Reporter.Error() << Resource::String::DisableAdminSettingFailed(AdminSettingToString(adminSetting));
+            context.Reporter.Error() << Resource::String::DisableAdminSettingFailed(AdminSettingToString(adminSetting)) << std::endl;
         }
     }
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

Fixes:
```
--> Installing WinGet
Tip: you can type 'Update-EnvironmentVariables' to update your environment variables, such as after installing a new software.

--> Configuring Winget
Admin setting enabled.Admin setting enabled.

--> Installing the Manifest 7.1.0.62
```

-----
