### PR TITLE
Remove zip from 1.2 schema

### DIFF
--- a/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.installer.1.2.0.json
@@ -59,7 +59,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",

--- a/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
+++ b/schemas/JSON/manifests/v1.2.0/manifest.singleton.1.2.0.json
@@ -101,7 +101,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - Resolves #2532

-----

I've checked and don't believe that zip is implemented in any of the 1.2 interfaces, meaning it is safe to remove here.
If a 1.2 manifest does contain installer type zip, it will throw a validation warning but should not error
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/2996)