### PR TITLE
Use copy instead of rename for moving extracted archive directories

### DIFF
--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -107,7 +107,7 @@ namespace AppInstaller::CLI::Portable
         }
         else if (fileType == PortableFileType::Directory)
         {
-            // Copy directory instead of renaming as there is a known issue with renaming across filesystems.
+            // Copy directory instead of renaming as there is a known issue with renaming across drives.
             AICLI_LOG(Core, Info, << "Copying directory to: " << filePath);
             std::filesystem::copy(entry.CurrentPath, filePath, std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive);
         }

--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -107,8 +107,9 @@ namespace AppInstaller::CLI::Portable
         }
         else if (fileType == PortableFileType::Directory)
         {
-            AICLI_LOG(Core, Info, << "Moving directory to: " << filePath);
-            Filesystem::RenameFile(entry.CurrentPath, filePath);
+            // Copy directory instead of renaming as there is a known issue with renaming across filesystems.
+            AICLI_LOG(Core, Info, << "Copying directory to: " << filePath);
+            std::filesystem::copy(entry.CurrentPath, filePath, std::filesystem::copy_options::overwrite_existing | std::filesystem::copy_options::recursive);
         }
         else if (entry.FileType == PortableFileType::Symlink)
         {


### PR DESCRIPTION
Fixes #2931 

Special thanks to @farag2 for the extremely thorough investigation on this one. 😄 

Issue:
When specifying a specific `--location` that points to a different drive, the installation fails with an access denied error. The issue is caused when trying to rename a directory across a different drive which isn't supported as `rename` is not a "move/copy" operation. The correct way to handle moving directories is to explicitly copy the directory recursively over to the intended install location. 

Changes:
Replaced `Rename` with `Copy` operation for directory file types during archiveinstallation. 

Tests:
Verified that the following command identified from the issue bug successfully installed. All existing tests should continue to pass. 
```winget install --id=TeamSophia.SophiApp --exact --accept-source-agreements --location "D:\test"```