### PR TITLE
Remove zip installer type from 1.0 and 1.1 manifests

### DIFF
--- a/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.installer.1.0.0.json
@@ -53,7 +53,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",

--- a/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
+++ b/schemas/JSON/manifests/v1.0.0/manifest.singleton.1.0.0.json
@@ -65,7 +65,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",

--- a/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.installer.1.1.0.json
@@ -53,7 +53,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",

--- a/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
+++ b/schemas/JSON/manifests/v1.1.0/manifest.singleton.1.1.0.json
@@ -86,7 +86,6 @@
         "msi",
         "appx",
         "exe",
-        "zip",
         "inno",
         "nullsoft",
         "wix",

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-SystemReferenceComplex.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-SystemReferenceComplex.yaml
@@ -4,24 +4,24 @@ Version: 1.7.32
 Publisher: Microsoft
 License: MIT License
 Description: A complex system reference test file.
-InstallerType: EXE
+InstallerType: exe
 PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
 ProductCode: "{Foo}"
 Installers:
-  - InstallerType: MSIX
+  - InstallerType: msix
     Arch: x86
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
-  - InstallerType: MSI
+  - InstallerType: msi
     Arch: x86
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
-  - InstallerType: MSIX
+  - InstallerType: msix
     Arch: x64
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
     PackageFamilyName: Override_8wekyb3d8bbwe
-  - InstallerType: MSI
+  - InstallerType: msi
     Arch: x64
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-SystemReferenceComplex.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-SystemReferenceComplex.yaml
@@ -4,14 +4,10 @@ Version: 1.7.32
 Publisher: Microsoft
 License: MIT License
 Description: A complex system reference test file.
-InstallerType: Zip
+InstallerType: EXE
 PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
 ProductCode: "{Foo}"
 Installers:
-  - InstallerType: Zip
-    Arch: x86
-    Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
-    Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
   - InstallerType: MSIX
     Arch: x86
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip

--- a/src/AppInstallerCLITests/TestData/Manifest-Good.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good.yaml
@@ -16,7 +16,7 @@ Protocols: "protocol1,protocol2"
 FileExtensions: "appx,appxbundle,msix,msixbundle"
 # InstallerType and Switches CAN have a "default" value
 # on the root. An installer can override them.
-InstallerType: Zip
+InstallerType: exe
 PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
 ProductCode: "{Foo}"
 UpdateBehavior: UninstallPrevious
@@ -34,7 +34,7 @@ Installers:
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
     Language: en-US
-    InstallerType: Zip
+    InstallerType: exe
     Scope: user
     UpdateBehavior: Install
     Switches:
@@ -50,7 +50,7 @@ Installers:
     Url: https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx64.zip
     Sha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF0000
     Language: en-US
-    InstallerType: Zip
+    InstallerType: exe
     Scope: user
 Localization:
   - Language: es-MX

--- a/src/AppInstallerCLITests/TestData/ManifestV1-Singleton.yaml
+++ b/src/AppInstallerCLITests/TestData/ManifestV1-Singleton.yaml
@@ -23,7 +23,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/ManifestV1_1-Singleton.yaml
+++ b/src/AppInstallerCLITests/TestData/ManifestV1_1-Singleton.yaml
@@ -29,7 +29,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/ManifestV1_2-Singleton.yaml
+++ b/src/AppInstallerCLITests/TestData/ManifestV1_2-Singleton.yaml
@@ -34,7 +34,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/ManifestV1_4-Singleton.yaml
+++ b/src/AppInstallerCLITests/TestData/ManifestV1_4-Singleton.yaml
@@ -34,7 +34,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1/ManifestV1-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1/ManifestV1-MultiFile-Installer.yaml
@@ -5,7 +5,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1_1/ManifestV1_1-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1_1/ManifestV1_1-MultiFile-Installer.yaml
@@ -5,7 +5,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1_2/ManifestV1_2-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1_2/ManifestV1_2-MultiFile-Installer.yaml
@@ -5,7 +5,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/TestData/MultiFileManifestV1_4/ManifestV1_4-MultiFile-Installer.yaml
+++ b/src/AppInstallerCLITests/TestData/MultiFileManifestV1_4/ManifestV1_4-MultiFile-Installer.yaml
@@ -5,7 +5,7 @@ Platform:
   - Windows.Desktop
   - Windows.Universal
 MinimumOSVersion: 10.0.0.0
-InstallerType: zip
+InstallerType: exe
 Scope: machine
 InstallModes:
   - interactive

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -70,7 +70,7 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(manifest.DefaultInstallerInfo.Commands == MultiValue{ "makemsix", "makeappx" });
     REQUIRE(manifest.DefaultInstallerInfo.Protocols == MultiValue{ "protocol1", "protocol2" });
     REQUIRE(manifest.DefaultInstallerInfo.FileExtensions == MultiValue{ "appx", "appxbundle", "msix", "msixbundle" });
-    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(manifest.DefaultInstallerInfo.PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
     REQUIRE(manifest.DefaultInstallerInfo.ProductCode == "{Foo}");
     REQUIRE(manifest.DefaultInstallerInfo.UpdateBehavior == UpdateBehaviorEnum::UninstallPrevious);
@@ -93,10 +93,10 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(installer1.Url == "https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx86.zip");
     REQUIRE(installer1.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
     REQUIRE(installer1.Locale == "en-US");
-    REQUIRE(installer1.BaseInstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(installer1.BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(installer1.Scope == ScopeEnum::User);
     REQUIRE(installer1.PackageFamilyName == "");
-    REQUIRE(installer1.ProductCode == "");
+    REQUIRE(installer1.ProductCode == "{Foo}");
     REQUIRE(installer1.UpdateBehavior == UpdateBehaviorEnum::Install);
 
     auto installer1Switches = installer1.Switches;
@@ -114,10 +114,10 @@ TEST_CASE("ReadPreviewGoodManifestAndVerifyContents", "[ManifestValidation]")
     REQUIRE(installer2.Url == "https://rubengustorage.blob.core.windows.net/publiccontainer/msixsdkx64.zip");
     REQUIRE(installer2.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF0000"));
     REQUIRE(installer2.Locale == "en-US");
-    REQUIRE(installer2.BaseInstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(installer2.BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(installer2.Scope == ScopeEnum::User);
     REQUIRE(installer2.PackageFamilyName == "");
-    REQUIRE(installer2.ProductCode == "");
+    REQUIRE(installer2.ProductCode == "{Foo}");
     REQUIRE(installer2.UpdateBehavior == UpdateBehaviorEnum::UninstallPrevious);
 
     // Installer2 does not declare switches, it inherits switches from package default.
@@ -342,36 +342,31 @@ TEST_CASE("ComplexSystemReference", "[ManifestValidation]")
 {
     Manifest manifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Good-SystemReferenceComplex.yaml"));
 
-    REQUIRE(manifest.Installers.size() == 5);
-
-    // Zip installer does not inherit
-    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Zip);
-    REQUIRE(manifest.Installers[0].PackageFamilyName == "");
-    REQUIRE(manifest.Installers[0].ProductCode == "");
+    REQUIRE(manifest.Installers.size() == 4);
 
     // MSIX installer does inherit
-    REQUIRE(manifest.Installers[1].BaseInstallerType == InstallerTypeEnum::Msix);
-    REQUIRE(manifest.Installers[1].Arch == Architecture::X86);
-    REQUIRE(manifest.Installers[1].PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
-    REQUIRE(manifest.Installers[1].ProductCode == "");
+    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(manifest.Installers[0].Arch == Architecture::X86);
+    REQUIRE(manifest.Installers[0].PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
+    REQUIRE(manifest.Installers[0].ProductCode == "");
 
     // MSI installer does inherit
-    REQUIRE(manifest.Installers[2].BaseInstallerType == InstallerTypeEnum::Msi);
-    REQUIRE(manifest.Installers[2].Arch == Architecture::X86);
-    REQUIRE(manifest.Installers[2].PackageFamilyName == "");
-    REQUIRE(manifest.Installers[2].ProductCode == "{Foo}");
+    REQUIRE(manifest.Installers[1].BaseInstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(manifest.Installers[1].Arch == Architecture::X86);
+    REQUIRE(manifest.Installers[1].PackageFamilyName == "");
+    REQUIRE(manifest.Installers[1].ProductCode == "{Foo}");
 
     // MSIX installer with override
-    REQUIRE(manifest.Installers[3].BaseInstallerType == InstallerTypeEnum::Msix);
-    REQUIRE(manifest.Installers[3].Arch == Architecture::X64);
-    REQUIRE(manifest.Installers[3].PackageFamilyName == "Override_8wekyb3d8bbwe");
-    REQUIRE(manifest.Installers[3].ProductCode == "");
+    REQUIRE(manifest.Installers[2].BaseInstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(manifest.Installers[2].Arch == Architecture::X64);
+    REQUIRE(manifest.Installers[2].PackageFamilyName == "Override_8wekyb3d8bbwe");
+    REQUIRE(manifest.Installers[2].ProductCode == "");
 
     // MSI installer with override
-    REQUIRE(manifest.Installers[4].BaseInstallerType == InstallerTypeEnum::Msi);
-    REQUIRE(manifest.Installers[4].Arch == Architecture::X64);
-    REQUIRE(manifest.Installers[4].PackageFamilyName == "");
-    REQUIRE(manifest.Installers[4].ProductCode == "Override");
+    REQUIRE(manifest.Installers[3].BaseInstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(manifest.Installers[3].Arch == Architecture::X64);
+    REQUIRE(manifest.Installers[3].PackageFamilyName == "");
+    REQUIRE(manifest.Installers[3].ProductCode == "Override");
 }
 
 TEST_CASE("ManifestVersionExtensions", "[ManifestValidation]")
@@ -437,7 +432,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
     REQUIRE(manifest.DefaultInstallerInfo.Locale == "en-US");
     REQUIRE(manifest.DefaultInstallerInfo.Platform == std::vector<PlatformEnum>{ PlatformEnum::Desktop, PlatformEnum::Universal });
     REQUIRE(manifest.DefaultInstallerInfo.MinOSVersion == "10.0.0.0");
-    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Zip);
+    REQUIRE(manifest.DefaultInstallerInfo.BaseInstallerType == InstallerTypeEnum::Exe);
     REQUIRE(manifest.DefaultInstallerInfo.Scope == ScopeEnum::Machine);
     REQUIRE(manifest.DefaultInstallerInfo.InstallModes == std::vector<InstallModeEnum>{ InstallModeEnum::Interactive, InstallModeEnum::Silent, InstallModeEnum::SilentWithProgress });
 

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -345,28 +345,32 @@ TEST_CASE("ComplexSystemReference", "[ManifestValidation]")
     REQUIRE(manifest.Installers.size() == 4);
 
     // MSIX installer does inherit
-    REQUIRE(manifest.Installers[0].BaseInstallerType == InstallerTypeEnum::Msix);
-    REQUIRE(manifest.Installers[0].Arch == Architecture::X86);
-    REQUIRE(manifest.Installers[0].PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
-    REQUIRE(manifest.Installers[0].ProductCode == "");
+    auto& installer = manifest.Installers[0];
+    REQUIRE(installer.BaseInstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(installer.Arch == Architecture::X86);
+    REQUIRE(installer.PackageFamilyName == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe");
+    REQUIRE(installer.ProductCode == "");
 
     // MSI installer does inherit
-    REQUIRE(manifest.Installers[1].BaseInstallerType == InstallerTypeEnum::Msi);
-    REQUIRE(manifest.Installers[1].Arch == Architecture::X86);
-    REQUIRE(manifest.Installers[1].PackageFamilyName == "");
-    REQUIRE(manifest.Installers[1].ProductCode == "{Foo}");
+    auto& installer1 = manifest.Installers[1];
+    REQUIRE(installer1.BaseInstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(installer1.Arch == Architecture::X86);
+    REQUIRE(installer1.PackageFamilyName == "");
+    REQUIRE(installer1.ProductCode == "{Foo}");
 
     // MSIX installer with override
-    REQUIRE(manifest.Installers[2].BaseInstallerType == InstallerTypeEnum::Msix);
-    REQUIRE(manifest.Installers[2].Arch == Architecture::X64);
-    REQUIRE(manifest.Installers[2].PackageFamilyName == "Override_8wekyb3d8bbwe");
-    REQUIRE(manifest.Installers[2].ProductCode == "");
+    auto& installer2 = manifest.Installers[2];
+    REQUIRE(installer2.BaseInstallerType == InstallerTypeEnum::Msix);
+    REQUIRE(installer2.Arch == Architecture::X64);
+    REQUIRE(installer2.PackageFamilyName == "Override_8wekyb3d8bbwe");
+    REQUIRE(installer2.ProductCode == "");
 
     // MSI installer with override
-    REQUIRE(manifest.Installers[3].BaseInstallerType == InstallerTypeEnum::Msi);
-    REQUIRE(manifest.Installers[3].Arch == Architecture::X64);
-    REQUIRE(manifest.Installers[3].PackageFamilyName == "");
-    REQUIRE(manifest.Installers[3].ProductCode == "Override");
+    auto& installer3 = manifest.Installers[3];
+    REQUIRE(installer3.BaseInstallerType == InstallerTypeEnum::Msi);
+    REQUIRE(installer3.Arch == Architecture::X64);
+    REQUIRE(installer3.PackageFamilyName == "");
+    REQUIRE(installer3.ProductCode == "Override");
 }
 
 TEST_CASE("ManifestVersionExtensions", "[ManifestValidation]")
@@ -657,6 +661,7 @@ void VerifyV1ManifestContent(const Manifest& manifest, bool isSingleton, Manifes
             REQUIRE(installer4.Arch == Architecture::X64);
             REQUIRE(installer4.Url == "https://www.microsoft.com/msixsdk/msixsdkx64.exe");
             REQUIRE(installer4.Sha256 == SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"));
+            REQUIRE(installer4.ProductCode == "{Foo}");
             REQUIRE(installer4.NestedInstallerType == InstallerTypeEnum::Portable);
             REQUIRE(installer4.NestedInstallerFiles.size() == 2);
             REQUIRE(installer4.NestedInstallerFiles.at(0).RelativeFilePath == "relativeFilePath1");


### PR DESCRIPTION
Continuation of #2996

Removes zip installer type from 1.0 and 1.1 manifests as zip is not supported until 1.4 client.
Also fixes the unit tests accordingly so that they do not rely on the zip installertype.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3006)