### PR TITLE
Define properties object in configuration schema

### DIFF
--- a/schemas/JSON/configuration/configuration.schema.0.1.json
+++ b/schemas/JSON/configuration/configuration.schema.0.1.json
@@ -4,28 +4,33 @@
     "description": "A representation of a configuration used by an orchestrator for WinDSC.",
     "type": "object",
     "properties": {
-        "assertions": {
-            "type": "array",
-            "items": { "$ref": "#/$defs/resource" }
-        },
-        "resources": {
-            "type": "array",
-            "items": { "$ref": "#/$defs/resource" }
-        },
-        "parameters": {
-            "type": "array",
-            "items": { "$ref": "#/$defs/resource" },
-            "description": "Resources that retrieve information via a 'get' operation."
-        },
-        "configurationVersion": {
-            "type": "string",
-            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-            "maxLength": 128,
-            "default": "0.1",
-            "description": "The configuration syntax version"
+        "properties": {
+            "type": "object",
+            "properties": {
+                "assertions": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/resource" }
+                },
+                "resources": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/resource" }
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/resource" },
+                    "description": "Resources that retrieve information via a 'get' operation."
+                },
+                "configurationVersion": {
+                    "type": "string",
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                    "maxLength": 128,
+                    "default": "0.1.0",
+                    "description": "The configuration syntax version"
+                }
+            },
+            "required": ["configurationVersion"]
         }
     },
-    "required": ["configurationVersion"],
 
     "$defs": {
         "resource": {


### PR DESCRIPTION
Changes:
- Defines an enclosing `properties` object that contains all of the fields, which is what is expected based on the configuration implementation. 
- Changes the default value of `configurationVersion` to `0.1.0` to align with semantic versioning.

Validated test yamls with these schema changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3081)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3081)