### PR TITLE
Add logging around specific number of matches

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -851,7 +851,6 @@ namespace AppInstaller::CLI::Workflow
         auto& searchResult = context.Get<Execution::Data::SearchResult>();
 
         Logging::Telemetry().LogSearchResultCount(searchResult.Matches.size());
-        AICLI_LOG(Repo, Verbose, << "Search result size: " << searchResult.Matches.size());
 
         if (searchResult.Matches.size() == 0)
         {

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -851,6 +851,7 @@ namespace AppInstaller::CLI::Workflow
         auto& searchResult = context.Get<Execution::Data::SearchResult>();
 
         Logging::Telemetry().LogSearchResultCount(searchResult.Matches.size());
+        AICLI_LOG(Repo, Verbose, << "Search result size: " << searchResult.Matches.size());
 
         if (searchResult.Matches.size() == 0)
         {

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -550,6 +550,8 @@ namespace AppInstaller::Logging
                 m_summary.SearchResultCount = resultCount;
             }
         }
+
+        AICLI_LOG(CLI, Verbose, << "Search result size: " << resultCount);
     }
 
     void TelemetryTraceLogger::LogInstallerHashMismatch(


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

In attempting to diagnose issues with search results, it's helpful to have the number of matches in the search result. This information is sent to telemetry, but is not ever put into the log.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3094)