### PR TITLE
Update the privacy statement link in README to link to correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ The winget.exe client respects machine wide privacy settings and users can opt-o
 
 In short to opt-out, go to `Start`, then select `Settings` > `Privacy` > `Diagnostics & feedback`, and select `Basic`. 
 
-See the [privacy statement](privacy.md) for more details.
+See the [privacy statement](PRIVACY.md) for more details.


### PR DESCRIPTION
This PR fixes the link for the privacy statement in the README currently it directs to a page that does not exists this PR fixes that.
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3116)