### PR TITLE
Enforce single install across winget processes

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -75,6 +75,7 @@ corecrt
 count'th
 countof
 countryregion
+CPIL
 cplusplus
 createmanifestmetadata
 cswinrt

--- a/src/AppInstallerCLICore/COMContext.cpp
+++ b/src/AppInstallerCLICore/COMContext.cpp
@@ -41,6 +41,11 @@ namespace AppInstaller::CLI::Execution
         FireCallbacks(ReportType::Progressing, current, maximum, progressType, m_executionStage);
     }
 
+    void COMContext::SetProgressMessage(std::string_view)
+    {
+        // TODO: Consider sending message to COM progress
+    }
+
     void COMContext::EndProgress(bool)
     {
         FireCallbacks(ReportType::EndProgress, 0, 0, ProgressType::None, m_executionStage);

--- a/src/AppInstallerCLICore/COMContext.h
+++ b/src/AppInstallerCLICore/COMContext.h
@@ -54,6 +54,7 @@ namespace AppInstaller::CLI::Execution
         // IProgressSink
         void BeginProgress() override;
         void OnProgress(uint64_t current, uint64_t maximum, ProgressType type) override;
+        void SetProgressMessage(std::string_view message) override;
         void EndProgress(bool) override;
 
         //Execution::Context

--- a/src/AppInstallerCLICore/ChannelStreams.cpp
+++ b/src/AppInstallerCLICore/ChannelStreams.cpp
@@ -9,6 +9,19 @@ namespace AppInstaller::CLI::Execution
     using namespace Settings;
     using namespace VirtualTerminal;
 
+    size_t GetConsoleWidth()
+    {
+        CONSOLE_SCREEN_BUFFER_INFO consoleInfo{};
+        if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo))
+        {
+            return static_cast<size_t>(consoleInfo.dwSize.X);
+        }
+        else
+        {
+            return 120;
+        }
+    }
+
     BaseStream::BaseStream(std::ostream& out, bool enabled, bool VTEnabled) :
         m_out(out), m_enabled(enabled), m_VTEnabled(VTEnabled) {}
 

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -11,6 +11,9 @@
 
 namespace AppInstaller::CLI::Execution
 {
+    // Gets the current console width.
+    size_t GetConsoleWidth();
+
     // The base stream for all channels.
     struct BaseStream
     {

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -151,6 +151,24 @@ namespace AppInstaller::CLI::Execution
                 LOG_HR(E_UNEXPECTED);
             }
         }
+
+        void ProgressVisualizerBase::ClearLine()
+        {
+            if (UseVT())
+            {
+                m_out << TextModification::EraseLineEntirely << '\r';
+            }
+            else
+            {
+                // Best effort when no VT (arbitrary number of spaces that seems to work)
+                m_out << "\r                                                              \r";
+            }
+        }
+
+        void ProgressVisualizerBase::SetMessage(std::string_view message)
+        {
+            m_message = message;
+        }
     }
 
     void IndefiniteSpinner::ShowSpinner()
@@ -188,17 +206,19 @@ namespace AppInstaller::CLI::Execution
             }
 
             // Indent two spaces for the spinner, but three here so that we can overwrite it in the loop.
-            m_out << "   ";
+            std::string_view indent = "   ";
 
             for (size_t i = 0; !m_canceled; ++i)
             {
                 constexpr size_t repetitionCount = 20;
                 ApplyStyle(i % repetitionCount, repetitionCount, true);
-                m_out << '\b' << spinnerChars[i % ARRAYSIZE(spinnerChars)] << std::flush;
+                m_out << '\r' << indent << spinnerChars[i % ARRAYSIZE(spinnerChars)];
+                m_out.RestoreDefault();
+                m_out << ' ' << m_message << std::flush;
                 Sleep(250);
             }
 
-            m_out << "\b \r";
+            ClearLine();
 
             if (UseVT())
             {
@@ -217,6 +237,7 @@ namespace AppInstaller::CLI::Execution
             ClearLine();
         }
 
+        // TODO: Progress bar does not currently use message
         if (UseVT())
         {
             ShowProgressWithVT(current, maximum, type);
@@ -252,19 +273,6 @@ namespace AppInstaller::CLI::Execution
             }
 
             m_isVisible = false;
-        }
-    }
-
-    void ProgressBar::ClearLine()
-    {
-        if (UseVT())
-        {
-            m_out << TextModification::EraseLineEntirely << '\r';
-        }
-        else
-        {
-            // Best effort when no VT (arbitrary number of spaces that seems to work)
-            m_out << "\r                                                              \r";
         }
     }
 

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -160,8 +160,7 @@ namespace AppInstaller::CLI::Execution
             }
             else
             {
-                // Best effort when no VT (arbitrary number of spaces that seems to work)
-                m_out << "\r                                                              \r";
+                m_out << '\r' << std::string(GetConsoleWidth(), ' ') << '\r';
             }
         }
 

--- a/src/AppInstallerCLICore/ExecutionProgress.h
+++ b/src/AppInstallerCLICore/ExecutionProgress.h
@@ -27,14 +27,19 @@ namespace AppInstaller::CLI::Execution
 
             void SetStyle(AppInstaller::Settings::VisualStyle style) { m_style = style; }
 
+            void SetMessage(std::string_view message);
+
         protected:
             BaseStream& m_out;
             Settings::VisualStyle m_style = AppInstaller::Settings::VisualStyle::Accent;
+            std::string m_message;
 
             bool UseVT() const { return m_enableVT && m_style != AppInstaller::Settings::VisualStyle::NoVT; }
 
             // Applies the selected visual style.
             void ApplyStyle(size_t i, size_t max, bool foregroundOnly);
+
+            void ClearLine();
 
         private:
             bool m_enableVT = false;
@@ -70,13 +75,9 @@ namespace AppInstaller::CLI::Execution
 
         void EndProgress(bool hideProgressWhenDone);
 
-        void SetStyle(AppInstaller::Settings::VisualStyle style) { m_style = style; }
-
     private:
         std::atomic<bool> m_isVisible = false;
         uint64_t m_lastCurrent = 0;
-
-        void ClearLine();
 
         void ShowProgressNoVT(uint64_t current, uint64_t maximum, ProgressType type);
 

--- a/src/AppInstallerCLICore/ExecutionReporter.cpp
+++ b/src/AppInstallerCLICore/ExecutionReporter.cpp
@@ -216,6 +216,19 @@ namespace AppInstaller::CLI::Execution
         }
     }
 
+    void Reporter::SetProgressMessage(std::string_view message)
+    {
+        if (m_spinner)
+        {
+            m_spinner->SetMessage(message);
+        }
+
+        if (m_progressBar)
+        {
+            m_progressBar->SetMessage(message);
+        }
+    }
+
     void Reporter::BeginProgress()
     {
         GetBasicOutputStream() << VirtualTerminal::Cursor::Visibility::DisableShow;
@@ -229,6 +242,7 @@ namespace AppInstaller::CLI::Execution
         {
             m_progressBar->EndProgress(hideProgressWhenDone);
         }
+        SetProgressMessage({});
         GetBasicOutputStream() << VirtualTerminal::Cursor::Visibility::EnableShow;
     };
 

--- a/src/AppInstallerCLICore/ExecutionReporter.h
+++ b/src/AppInstallerCLICore/ExecutionReporter.h
@@ -113,6 +113,7 @@ namespace AppInstaller::CLI::Execution
         // IProgressSink
         void BeginProgress() override;
         void OnProgress(uint64_t current, uint64_t maximum, ProgressType type) override;
+        void SetProgressMessage(std::string_view message) override;
         void EndProgress(bool hideProgressWhenDone) override;
 
         // Runs the given callable of type: auto(IProgressCallback&)

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -209,6 +209,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(InstallFlowStartingPackageInstall);
         WINGET_DEFINE_RESOURCE_STRINGID(InstallLocationNotProvided);
         WINGET_DEFINE_RESOURCE_STRINGID(InstallScopeDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(InstallWaitingOnAnother);
         WINGET_DEFINE_RESOURCE_STRINGID(InteractiveArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidAliasError);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidArgumentSpecifierError);

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -12,23 +12,6 @@
 
 namespace AppInstaller::CLI::Execution
 {
-    namespace details
-    {
-        // Gets the column width of the console.
-        inline size_t GetConsoleWidth()
-        {
-            CONSOLE_SCREEN_BUFFER_INFO consoleInfo{};
-            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo))
-            {
-                return static_cast<size_t>(consoleInfo.dwSize.X);
-            }
-            else
-            {
-                return 120;
-            }
-        }
-    }
-
     // Enables output data in a table format.
     // TODO: Improve for use with sparse data.
     template <size_t FieldCount>
@@ -144,7 +127,7 @@ namespace AppInstaller::CLI::Execution
                 totalRequired += m_columns[i].MaxLength + (m_columns[i].SpaceAfter ? 1 : 0);
             }
 
-            size_t consoleWidth = details::GetConsoleWidth();
+            size_t consoleWidth = GetConsoleWidth();
 
             // If the total space would be too big, shrink them.
             // We don't want to use the last column, lest we auto-wrap

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.h
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "ExecutionContext.h"
+#include <winget/Manifest.h>
 
 namespace AppInstaller::CLI::Workflow
 {
@@ -10,6 +11,45 @@ namespace AppInstaller::CLI::Workflow
     // Token specified in installer args will be replaced by proper value.
     static constexpr std::string_view ARG_TOKEN_LOGPATH = "<LOGPATH>"sv;
     static constexpr std::string_view ARG_TOKEN_INSTALLPATH = "<INSTALLPATH>"sv;
+
+    // Determines if an installer type is allowed to install/uninstall in parallel.
+    bool ExemptFromSingleInstallLocking(AppInstaller::Manifest::InstallerTypeEnum type);
+
+    namespace details
+    {
+        // These single type install flows should remain "internal" and only ExecuteInstallerForType should be used externally
+        // so that all installs can properly handle single install locking.
+
+        // Runs the installer via ShellExecute.
+        // Required Args: None
+        // Inputs: Installer, InstallerPath
+        // Outputs: None
+        void ShellExecuteInstall(Execution::Context& context);
+
+        // Runs an MSI installer directly via MSI APIs.
+        // Required Args: None
+        // Inputs: Installer, InstallerPath
+        // Outputs: None
+        void DirectMSIInstall(Execution::Context& context);
+
+        // Deploys the MSIX.
+        // Required Args: None
+        // Inputs: Manifest?, Installer || InstallerPath
+        // Outputs: None
+        void MsixInstall(Execution::Context& context);
+
+        // Runs the flow for installing a Portable package.
+        // Required Args: None
+        // Inputs: Installer, InstallerPath
+        // Outputs: None
+        void PortableInstall(Execution::Context& context);
+
+        // Runs the flow for installing a package from an archive.
+        // Required Args: None
+        // Inputs: Installer, InstallerPath, Manifest
+        // Outputs: None
+        void ArchiveInstall(Execution::Context& context);
+    }
 
     // Ensures that there is an applicable installer.
     // Required Args: None
@@ -60,36 +100,6 @@ namespace AppInstaller::CLI::Workflow
     private:
         Manifest::InstallerTypeEnum m_installerType;
     };
-
-    // Runs the installer via ShellExecute.
-    // Required Args: None
-    // Inputs: Installer, InstallerPath
-    // Outputs: None
-    void ShellExecuteInstall(Execution::Context& context);
-
-    // Runs an MSI installer directly via MSI APIs.
-    // Required Args: None
-    // Inputs: Installer, InstallerPath
-    // Outputs: None
-    void DirectMSIInstall(Execution::Context& context);
-
-    // Deploys the MSIX.
-    // Required Args: None
-    // Inputs: Manifest?, Installer || InstallerPath
-    // Outputs: None
-    void MsixInstall(Execution::Context& context);
-
-    // Runs the flow for installing a Portable package.
-    // Required Args: None
-    // Inputs: Installer, InstallerPath
-    // Outputs: None
-    void PortableInstall(Execution::Context& context);
-
-    // Runs the flow for installing a package from an archive.
-    // Required Args: None
-    // Inputs: Installer, InstallerPath, Manifest
-    // Outputs: None
-    void ArchiveInstall(Execution::Context& context);
 
     // Verifies parameters for install to ensure success.
     // Required Args: None

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1822,6 +1822,6 @@ Please specify one of them using the --source option to proceed.</value>
     <comment>"Windows Feature(s)" is the name of the options Windows features setting.</comment>
   </data>
   <data name="InstallWaitingOnAnother" xml:space="preserve">
-    <value>Waiting on another install or uninstall to complete...</value>
+    <value>Waiting for another install/uninstall to complete...</value>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1821,4 +1821,7 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Reboot required to fully enable the Windows Feature(s); proceeding due to --force</value>
     <comment>"Windows Feature(s)" is the name of the options Windows features setting.</comment>
   </data>
+  <data name="InstallWaitingOnAnother" xml:space="preserve">
+    <value>Waiting on another install or uninstall to complete...</value>
+  </data>
 </root>

--- a/src/AppInstallerCLITests/Synchronization.cpp
+++ b/src/AppInstallerCLITests/Synchronization.cpp
@@ -24,7 +24,7 @@ TEST_CASE("CPRWL_MultipleReaders", "[CrossProcessReaderWriteLock]")
     otherThread.detach();
 
     // Wait up to a second for the other thread to do one thing...
-    REQUIRE(signal.wait(1000));
+    REQUIRE(signal.wait(500));
 }
 
 TEST_CASE("CPRWL_WriterBlocksReader", "[CrossProcessReaderWriteLock]")
@@ -44,11 +44,11 @@ TEST_CASE("CPRWL_WriterBlocksReader", "[CrossProcessReaderWriteLock]")
         // In the event of bugs, we don't want to block the test waiting forever
         otherThread.detach();
 
-        REQUIRE(!signal.wait(1000));
+        REQUIRE(!signal.wait(500));
     }
 
     // Upon release of the writer, the other thread should signal
-    REQUIRE(signal.wait(1000));
+    REQUIRE(signal.wait(500));
 }
 
 TEST_CASE("CPRWL_ReaderBlocksWriter", "[CrossProcessReaderWriteLock]")
@@ -68,11 +68,11 @@ TEST_CASE("CPRWL_ReaderBlocksWriter", "[CrossProcessReaderWriteLock]")
         // In the event of bugs, we don't want to block the test waiting forever
         otherThread.detach();
 
-        REQUIRE(!signal.wait(1000));
+        REQUIRE(!signal.wait(500));
     }
 
     // Upon release of the writer, the other thread should signal
-    REQUIRE(signal.wait(1000));
+    REQUIRE(signal.wait(500));
 }
 
 TEST_CASE("CPRWL_WriterBlocksWriter", "[CrossProcessReaderWriteLock]")
@@ -92,11 +92,11 @@ TEST_CASE("CPRWL_WriterBlocksWriter", "[CrossProcessReaderWriteLock]")
         // In the event of bugs, we don't want to block the test waiting forever
         otherThread.detach();
 
-        REQUIRE(!signal.wait(1000));
+        REQUIRE(!signal.wait(500));
     }
 
     // Upon release of the writer, the other thread should signal
-    REQUIRE(signal.wait(1000));
+    REQUIRE(signal.wait(500));
 }
 
 TEST_CASE("CPRWL_CancelEndsWait", "[CrossProcessReaderWriteLock]")
@@ -116,10 +116,60 @@ TEST_CASE("CPRWL_CancelEndsWait", "[CrossProcessReaderWriteLock]")
     // In the event of bugs, we don't want to block the test waiting forever
     otherThread.detach();
 
-    REQUIRE(!signal.wait(1000));
+    REQUIRE(!signal.wait(500));
 
     progress.Cancel();
 
     // Upon release of the writer, the other thread should signal
-    REQUIRE(signal.wait(1000));
+    REQUIRE(signal.wait(500));
+}
+
+TEST_CASE("CPIL_BlocksOthers", "[CrossProcessInstallLock]")
+{
+    wil::unique_event signal;
+    signal.create();
+    AppInstaller::ProgressCallback progress;
+
+    CrossProcessInstallLock mainThreadLock;
+    mainThreadLock.Acquire(progress);
+
+    std::thread otherThread([&signal, &progress]() {
+        CrossProcessInstallLock otherThreadLock;
+        otherThreadLock.Acquire(progress);
+        signal.SetEvent();
+        });
+    // In the event of bugs, we don't want to block the test waiting forever
+    otherThread.detach();
+
+    REQUIRE(!signal.wait(500));
+
+    progress.Cancel();
+
+    // Upon release of the writer, the other thread should signal
+    REQUIRE(signal.wait(500));
+}
+
+TEST_CASE("CPIL_CancelEndsWait", "[CrossProcessInstallLock]")
+{
+    wil::unique_event signal;
+    signal.create();
+    AppInstaller::ProgressCallback progress;
+
+    CrossProcessInstallLock mainThreadLock;
+    mainThreadLock.Acquire(progress);
+
+    std::thread otherThread([&signal, &progress]() {
+        CrossProcessInstallLock otherThreadLock;
+        otherThreadLock.Acquire(progress);
+        signal.SetEvent();
+        });
+    // In the event of bugs, we don't want to block the test waiting forever
+    otherThread.detach();
+
+    REQUIRE(!signal.wait(500));
+
+    progress.Cancel();
+
+    // Upon release of the writer, the other thread should signal
+    REQUIRE(signal.wait(500));
 }

--- a/src/AppInstallerCLITests/Synchronization.cpp
+++ b/src/AppInstallerCLITests/Synchronization.cpp
@@ -130,20 +130,20 @@ TEST_CASE("CPIL_BlocksOthers", "[CrossProcessInstallLock]")
     signal.create();
     AppInstaller::ProgressCallback progress;
 
-    CrossProcessInstallLock mainThreadLock;
-    mainThreadLock.Acquire(progress);
+    {
+        CrossProcessInstallLock mainThreadLock;
+        mainThreadLock.Acquire(progress);
 
-    std::thread otherThread([&signal, &progress]() {
-        CrossProcessInstallLock otherThreadLock;
-        otherThreadLock.Acquire(progress);
-        signal.SetEvent();
-        });
-    // In the event of bugs, we don't want to block the test waiting forever
-    otherThread.detach();
+        std::thread otherThread([&signal, &progress]() {
+            CrossProcessInstallLock otherThreadLock;
+            otherThreadLock.Acquire(progress);
+            signal.SetEvent();
+            });
+        // In the event of bugs, we don't want to block the test waiting forever
+        otherThread.detach();
 
-    REQUIRE(!signal.wait(500));
-
-    progress.Cancel();
+        REQUIRE(!signal.wait(500));
+    }
 
     // Upon release of the writer, the other thread should signal
     REQUIRE(signal.wait(500));

--- a/src/AppInstallerCLITests/TestCommon.cpp
+++ b/src/AppInstallerCLITests/TestCommon.cpp
@@ -162,6 +162,10 @@ namespace TestCommon
         }
     }
 
+    void TestProgress::SetProgressMessage(std::string_view)
+    {
+    }
+
     void TestProgress::BeginProgress()
     {
     }

--- a/src/AppInstallerCLITests/TestCommon.h
+++ b/src/AppInstallerCLITests/TestCommon.h
@@ -100,7 +100,9 @@ namespace TestCommon
         void BeginProgress() override;
         
         void OnProgress(uint64_t current, uint64_t maximum, AppInstaller::ProgressType type) override;
-        
+
+        void SetProgressMessage(std::string_view message) override;
+
         void EndProgress(bool) override;
 
         bool IsCancelled() override;

--- a/src/AppInstallerCLITests/WorkflowCommon.cpp
+++ b/src/AppInstallerCLITests/WorkflowCommon.cpp
@@ -565,7 +565,7 @@ namespace TestCommon
 
     void OverrideForPortableInstall(TestContext& context)
     {
-        context.Override({ PortableInstall, [](TestContext&)
+        context.Override({ Workflow::details::PortableInstall, [](TestContext&)
         {
             std::filesystem::path temp = std::filesystem::temp_directory_path();
             temp /= "TestPortableInstalled.txt";
@@ -628,7 +628,7 @@ namespace TestCommon
 
     void OverrideForMSIX(TestContext& context)
     {
-        context.Override({ MsixInstall, [](TestContext& context)
+        context.Override({ Workflow::details::MsixInstall, [](TestContext& context)
         {
             std::filesystem::path temp = std::filesystem::temp_directory_path();
             temp /= "TestMsixInstalled.txt";

--- a/src/AppInstallerCommonCore/Progress.cpp
+++ b/src/AppInstallerCommonCore/Progress.cpp
@@ -27,6 +27,15 @@ namespace AppInstaller
         }
     }
 
+    void ProgressCallback::SetProgressMessage(std::string_view message)
+    {
+        IProgressSink* sink = GetSink();
+        if (sink)
+        {
+            sink->SetProgressMessage(message);
+        }
+    }
+
     void ProgressCallback::EndProgress(bool hideProgressWhenDone)
     {
         IProgressSink* sink = GetSink();
@@ -83,6 +92,11 @@ namespace AppInstaller
         THROW_HR_IF(E_UNEXPECTED, ProgressType::Percent != type);
 
         m_baseCallback.OnProgress(m_rangeMin + (m_rangeMax - m_rangeMin) * current / maximum, m_globalMax, type);
+    }
+
+    void PartialPercentProgressCallback::SetProgressMessage(std::string_view message)
+    {
+        m_baseCallback.SetProgressMessage(message);
     }
 
     void PartialPercentProgressCallback::EndProgress(bool)

--- a/src/AppInstallerCommonCore/Public/AppInstallerProgress.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerProgress.h
@@ -4,6 +4,7 @@
 #include <wil/resource.h>
 #include <atomic>
 #include <functional>
+#include <string_view>
 
 namespace AppInstaller
 {
@@ -35,6 +36,9 @@ namespace AppInstaller
         // If maximum is 0, the maximum is unknown.
         virtual void OnProgress(uint64_t current, uint64_t maximum, ProgressType type) = 0;
 
+        // Sets a message for the current progress state.
+        virtual void SetProgressMessage(std::string_view message) = 0;
+
         // Called as progress begins.
         virtual void BeginProgress() = 0;
 
@@ -65,6 +69,8 @@ namespace AppInstaller
 
         void OnProgress(uint64_t current, uint64_t maximum, ProgressType type) override;
 
+        void SetProgressMessage(std::string_view message) override;
+
         void EndProgress(bool hideProgressWhenDone) override;
 
         bool IsCancelled() override;
@@ -89,6 +95,8 @@ namespace AppInstaller
         void BeginProgress() override;
 
         void OnProgress(uint64_t current, uint64_t maximum, ProgressType type) override;
+
+        void SetProgressMessage(std::string_view message) override;
 
         void EndProgress(bool hideProgressWhenDone) override;
 

--- a/src/AppInstallerCommonCore/Public/AppInstallerSynchronization.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerSynchronization.h
@@ -68,6 +68,13 @@ namespace AppInstaller::Synchronization
         // Optionally release the lock before destroying the object.
         void Release();
 
+        // Attempts to acquire the mutex without a wait.
+        // Returns true if it was able, false if not.
+        bool TryAcquireNoWait();
+
+        // Indicates whether the lock is held.
+        operator bool() const;
+
     private:
         wil::unique_mutex m_mutex;
         wil::mutex_release_scope_exit m_lock;

--- a/src/AppInstallerCommonCore/Public/AppInstallerSynchronization.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerSynchronization.h
@@ -55,4 +55,21 @@ namespace AppInstaller::Synchronization
 
         std::vector<wil::unique_mutex> m_mutexesHeld;
     };
+
+    // This lock is used to prevent multiple winget related processes from attempting to install (or uninstall) at the same time.
+    struct CrossProcessInstallLock
+    {
+        CrossProcessInstallLock();
+
+        // Acquires the lock; cancellation is enabled via the progress object.
+        // Returns true when the lock is acquired and false if the wait is cancelled.
+        bool Acquire(IProgressCallback& progress);
+
+        // Optionally release the lock before destroying the object.
+        void Release();
+
+    private:
+        wil::unique_mutex m_mutex;
+        wil::mutex_release_scope_exit m_lock;
+    };
 }

--- a/src/AppInstallerCommonCore/Synchronization.cpp
+++ b/src/AppInstallerCommonCore/Synchronization.cpp
@@ -20,6 +20,9 @@ namespace AppInstaller::Synchronization
     // Arbitrary limit that should not ever cause a problem (theoretically 1 per process)
     constexpr size_t s_CrossProcessReaderWriteLock_MaxReaders = 8;
 
+    // The amount of time that we wait in between checking for cancellation
+    constexpr std::chrono::milliseconds s_CrossProcessInstallLock_WaitLoopTime = 250ms;
+
     namespace
     {
         wil::unique_mutex OpenControlMutex(const std::wstring& name)
@@ -258,5 +261,31 @@ namespace AppInstaller::Synchronization
         }
 
         return result;
+    }
+
+    CrossProcessInstallLock::CrossProcessInstallLock()
+    {
+        m_mutex.create(L"WinGetCrossProcessInstallLock", 0, SYNCHRONIZE);
+    }
+
+    bool CrossProcessInstallLock::Acquire(IProgressCallback& progress)
+    {
+        while (!progress.IsCancelled())
+        {
+            auto lock = m_mutex.acquire(nullptr, static_cast<DWORD>(std::chrono::duration_cast<std::chrono::milliseconds>(s_CrossProcessInstallLock_WaitLoopTime).count()));
+
+            if (lock)
+            {
+                m_lock = std::move(lock);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void CrossProcessInstallLock::Release()
+    {
+        m_lock.reset();
     }
 }

--- a/src/AppInstallerCommonCore/Synchronization.cpp
+++ b/src/AppInstallerCommonCore/Synchronization.cpp
@@ -288,4 +288,22 @@ namespace AppInstaller::Synchronization
     {
         m_lock.reset();
     }
+
+    bool CrossProcessInstallLock::TryAcquireNoWait()
+    {
+        auto lock = m_mutex.acquire(nullptr, 0);
+
+        if (lock)
+        {
+            m_lock = std::move(lock);
+            return true;
+        }
+
+        return false;
+    }
+
+    CrossProcessInstallLock::operator bool() const
+    {
+        return static_cast<bool>(m_lock);
+    }
 }


### PR DESCRIPTION
## Change
This change uses a named mutex to enforce a single install/uninstall operation is occurring for the entire session.  The current behavior is that every process was able to install a single thing at a time, but as we have more usage this could lead to a potential issue.

The mutex is acquired and held for the workflow task that routes out to the installer type specific tasks.  Some installer types are explicitly excluded, as they are known to contain their own synchronization internally.

In addition to the mutex, the ability to set a message to show with the indefinite progress (spinner) was added.  This allows for the message to be removed when the wait is over.  The message was not implemented into the progress bar, nor is it being sent to COM progress.

The COM scheduling was not made aware of the mutex, and so it will execute as it has in the past, blocking on the mutex when appropriate.  This could be improved in the future to enable the parallel capable installer types to operate.  One potential option would be a second installer processing thread that only operated on the excluded types, and thus would never block.

## Validation
Manually validated the user experience with an interactive install.
Automated tests are added to ensure that the lock is held during the installation workflow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3118)