### PR TITLE
Add Windows10SDK 19041 Workload Component to VSConfig File

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -49,6 +49,7 @@
     "Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest",
     "Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest",
     "Microsoft.VisualStudio.Component.VC.ASAN",
+    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Component.Windows11SDK.22000",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.Component.NetFX.Native",


### PR DESCRIPTION
Tested importing the .vsconfig file to the VSinstaller on a clean vm and when I tried building winget, the `Microsoft.Management.Configuration` project failed due to this missing component. I added the component and retried it and I was able to build successfully. 

Changes:
Added: `Microsoft.VisualStudio.Component.Windows10SDK.19041` to .vsconfig file.