### PR TITLE
Add isPublic to IConfigurationUnitProcessorDetails

### DIFF
--- a/src/AppInstallerCLITests/TestConfiguration.h
+++ b/src/AppInstallerCLITests/TestConfiguration.h
@@ -98,6 +98,9 @@ namespace TestCommon
 
         winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Configuration::IConfigurationUnitSettingDetails> SettingsValue;
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Management::Configuration::IConfigurationUnitSettingDetails> Settings() const { return (SettingsValue ? SettingsValue.GetView() : nullptr); }
+
+        bool IsPublicValue;
+        bool IsPublic() const { return IsPublicValue; }
     };
 
     struct TestConfigurationUnitProcessor : winrt::implements<TestConfigurationUnitProcessor, winrt::Microsoft::Management::Configuration::IConfigurationUnitProcessor>

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessorDetails.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessorDetails.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         public string? UnitName { get; internal set; }
 
         public string? Version { get; internal set; }
+
+        public bool IsPublic { get; internal set; }
 #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationDetailsTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationDetailsTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
     using Microsoft.Management.Configuration.Processor.Helpers;
     using Microsoft.Management.Configuration.Processor.Unit;
     using Microsoft.Management.Configuration.UnitTests.Fixtures;
-    using Microsoft.Management.Configuration.UnitTests.Helpers;
     using Windows.Security.Cryptography.Certificates;
     using Xunit;
     using Xunit.Abstractions;
@@ -31,6 +30,8 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationDetailsTests"/> class.
         /// </summary>
+        /// <param name="fixture">Fixture.</param>
+        /// <param name="log">log.</param>
         public ConfigurationDetailsTests(UnitTestFixture fixture, ITestOutputHelper log)
         {
             this.fixture = fixture;
@@ -163,6 +164,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
                     Assert.Equal("0.0.0.1", details.Version);
                     Assert.Equal("Luffytaro", details.Author);
                     Assert.Equal("Microsoft Corporation", details.Publisher);
+                    Assert.True(details.IsPublic);
                 }
 
                 if (hasCerts)
@@ -207,7 +209,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
                 IconUri = "https://www.contoso.com/icons/icon.png",
                 Name = "xSimpleTestResource",
                 Description = "PowerShell module with DSC resources for unit tests",
-                RepositorySourceLocation = "https://github.com/microsoft/winget-cli",
+                RepositorySourceLocation = "https://www.powershellgallery.com/api/v2",
                 Version = "0.0.0.1",
                 Author = "Luffytaro",
                 CompanyName = "Microsoft Corporation",

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -122,6 +122,9 @@ namespace Microsoft.Management.Configuration
         Windows.Foundation.Collections.IVectorView<IInspectable> SigningInformation{ get; };
         // The settings information for the unit of configuration.
         Windows.Foundation.Collections.IVectorView<IConfigurationUnitSettingDetails> Settings{ get; };
+        // Does it comes from a public repository
+        Boolean IsPublic{ get; };
+
     }
 
     // Defines how the configuration unit is to be used within the configuration system.


### PR DESCRIPTION
Add a new property IsPublic to IConfigurationUnitProcessorDetails.

Set it to true if the repository source location is one of the public repositories. For now, it's only the PSGallery source.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3145)