### PR TITLE
Fix bugs with display paths

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -227,9 +227,6 @@
     <ClCompile Include="Archive.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
-    <ClCompile Include="Filesystem.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="FolderFileWatcher.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
@@ -241,9 +238,6 @@
     </ClCompile>
     <ClCompile Include="PackageDependenciesValidationUtil.cpp">
       <Filter>Source Files\Repository</Filter>
-    </ClCompile>
-    <ClCompile Include="RestInterface_1_4.cpp">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="AdminSettings.cpp">
       <Filter>Source Files\Common</Filter>
@@ -292,6 +286,12 @@
     </ClCompile>
     <ClCompile Include="WindowsFeature.cpp">
       <Filter>Source Files\CLI</Filter>
+    </ClCompile>
+    <ClCompile Include="Filesystem.cpp">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
+    <ClCompile Include="RestInterface_1_4.cpp">
+      <Filter>Source Files\Repository</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerCLITests/Filesystem.cpp
+++ b/src/AppInstallerCLITests/Filesystem.cpp
@@ -87,3 +87,17 @@ TEST_CASE("VerifyIsSameVolume", "[filesystem]")
     REQUIRE_FALSE(IsSameVolume(path4, path6));
     REQUIRE_FALSE(IsSameVolume(path6, path8));
 }
+
+TEST_CASE("ReplaceCommonPathPrefix", "[filesystem]")
+{
+    std::filesystem::path prefix = "C:\\test1\\test2";
+    std::string replacement = "%TEST%";
+
+    std::filesystem::path shouldReplace = "C:\\test1\\test2\\subdir1\\subdir2";
+    REQUIRE(ReplaceCommonPathPrefix(shouldReplace, prefix, replacement));
+    REQUIRE(shouldReplace.u8string() == (replacement + "\\subdir1\\subdir2"));
+
+    std::filesystem::path shouldNotReplace = "C:\\test1\\test3\\subdir1\\subdir2";
+    REQUIRE(!ReplaceCommonPathPrefix(shouldNotReplace, prefix, replacement));
+    REQUIRE(shouldNotReplace.u8string() == "C:\\test1\\test3\\subdir1\\subdir2");
+}

--- a/src/AppInstallerCLITests/TestCommon.cpp
+++ b/src/AppInstallerCLITests/TestCommon.cpp
@@ -8,6 +8,8 @@
 #include <AppInstallerMsixInfo.h>
 #include <AppInstallerDownloader.h>
 
+using namespace AppInstaller;
+
 namespace TestCommon
 {
     namespace
@@ -362,5 +364,16 @@ namespace TestCommon
         }
 
         return root;
+    }
+
+    void SetTestPathOverrides()
+    {
+        // Force all tests to run against settings inside this container.
+        // This prevents test runs from trashing the users actual settings.
+        Runtime::TestHook_SetPathOverride(Runtime::PathName::LocalState, Runtime::GetPathTo(Runtime::PathName::LocalState) / "Tests");
+        Runtime::TestHook_SetPathOverride(Runtime::PathName::UserFileSettings, Runtime::GetPathTo(Runtime::PathName::UserFileSettings) / "Tests");
+        Runtime::TestHook_SetPathOverride(Runtime::PathName::StandardSettings, Runtime::GetPathTo(Runtime::PathName::StandardSettings) / "Tests");
+        Runtime::TestHook_SetPathOverride(Runtime::PathName::SecureSettingsForRead, Runtime::GetPathTo(Runtime::PathName::StandardSettings) / "WinGet_SecureSettings_Tests");
+        Runtime::TestHook_SetPathOverride(Runtime::PathName::SecureSettingsForWrite, Runtime::GetPathDetailsFor(Runtime::PathName::SecureSettingsForRead));
     }
 }

--- a/src/AppInstallerCLITests/TestCommon.h
+++ b/src/AppInstallerCLITests/TestCommon.h
@@ -153,4 +153,7 @@ namespace TestCommon
 
     // Convert to Json::Value
     Json::Value ConvertToJson(const std::string& content);
+
+    // Sets up the test path overrides.
+    void SetTestPathOverrides();
 }

--- a/src/AppInstallerCLITests/main.cpp
+++ b/src/AppInstallerCLITests/main.cpp
@@ -13,7 +13,6 @@
 #include <Telemetry/TraceLogging.h>
 
 #include "TestCommon.h"
-#include "TestHooks.h"
 #include "TestSettings.h"
 
 using namespace winrt;
@@ -151,13 +150,7 @@ int main(int argc, char** argv)
     // Forcibly enable event writing to catch bugs in that code
     g_IsTelemetryProviderEnabled = true;
 
-    // Force all tests to run against settings inside this container.
-    // This prevents test runs from trashing the users actual settings.
-    Runtime::TestHook_SetPathOverride(Runtime::PathName::LocalState, Runtime::GetPathTo(Runtime::PathName::LocalState) / "Tests");
-    Runtime::TestHook_SetPathOverride(Runtime::PathName::UserFileSettings, Runtime::GetPathTo(Runtime::PathName::UserFileSettings) / "Tests");
-    Runtime::TestHook_SetPathOverride(Runtime::PathName::StandardSettings, Runtime::GetPathTo(Runtime::PathName::StandardSettings) / "Tests");
-    Runtime::TestHook_SetPathOverride(Runtime::PathName::SecureSettingsForRead, Runtime::GetPathTo(Runtime::PathName::StandardSettings) / "WinGet_SecureSettings_Tests");
-    Runtime::TestHook_SetPathOverride(Runtime::PathName::SecureSettingsForWrite, Runtime::GetPathDetailsFor(Runtime::PathName::SecureSettingsForRead));
+    TestCommon::SetTestPathOverrides();
 
     // Remove any existing settings files in the new tests path
     TestCommon::UserSettingsFileGuard settingsGuard;

--- a/src/AppInstallerCLITests/pch.h
+++ b/src/AppInstallerCLITests/pch.h
@@ -9,6 +9,7 @@
 #include <objbase.h>
 #include <urlmon.h>
 #include <Msi.h>
+#include <KnownFolders.h>
 
 #include <catch.hpp>
 

--- a/src/AppInstallerCommonCore/Filesystem.cpp
+++ b/src/AppInstallerCommonCore/Filesystem.cpp
@@ -209,7 +209,7 @@ namespace AppInstaller::Filesystem
 
         while (prefixItr != prefix.end() && sourceItr != source.end())
         {
-            if (Utility::ICUCaseInsensitiveEquals(prefixItr->u8string(), sourceItr->u8string()))
+            if (!Utility::ICUCaseInsensitiveEquals(prefixItr->u8string(), sourceItr->u8string()))
             {
                 break;
             }

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -62,6 +62,8 @@ namespace AppInstaller::Runtime
         PortableLinksMachineLocation,
         // The root location for the package containing the winget application.
         SelfPackageRoot,
+        // Always one more than the last path; for being able to iterate paths in tests.
+        Max
     };
 
     // The principal that an ACE applies to.


### PR DESCRIPTION
## Change
This change fixes two bugs with display paths:
1. The recent change to use case insensitive ICU for directory name equality inverted the comparison, making the replacement not happen correctly.
2. The recent change to enable display paths generically left them marked for creation, resulting in errors if directories that required administrator privileges to create did not exist and were requested from an unelevated context (ex. run `winget --info` from medium IL process when the portable machine links location(s) did not exist).

In addition, I tried to generally make `forDisplay` apply broadly since it is now allowed to be requested on any path.

## Validation
`winget --info` now contains the expected output instead of an error (2) or the full paths containing the user's account name (1).
A few unit tests that were being hit by the error are also working now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3157)