### PR TITLE
Mark events as critical for now

### DIFF
--- a/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
+++ b/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
@@ -230,7 +230,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                 TraceLoggingInt32(static_cast<int32_t>(failurePoint), "FailurePoint"),
                 AICLI_TraceLoggingWStringView(settingNames, "SettingsProvided"),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
             // Keep in sync with above event!
             WinGet_WriteEventToDiagnostics(
@@ -309,7 +309,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                 AICLI_TraceLoggingProcessingSummaryForIntent(informSummary, "Inform", "Informs"),
                 AICLI_TraceLoggingProcessingSummaryForIntent(applySummary, "Apply", "Applies"),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
-                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_CRITICAL_DATA));
 
             // Keep in sync with above event!
             WinGet_WriteEventToDiagnostics(


### PR DESCRIPTION
## Change
Mark the configuration system telemetry events as critical for now, as this increases the sampling rate.  This is only needed in the short term to help collect more data on how well the experimental feature is doing and can be changed back once the usage is high enough to not be concerned about the sampling rate any more.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3171)