### PR TITLE
Make entitlement best effort

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -264,10 +264,6 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(MsixArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(MsixSignatureHashFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(MSStoreAppBlocked);
-        WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallGetEntitlementNetworkError);
-        WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallGetEntitlementNoStoreAccount);
-        WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallGetEntitlementServerError);
-        WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallGetEntitlementSuccess);
         WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallOrUpdateFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(MSStoreInstallTryGetEntitlement);
         WINGET_DEFINE_RESOURCE_STRINGID(MSStoreStoreClientBlocked);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -386,18 +386,6 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Failed to install or upgrade Microsoft Store package. Error code: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when a Microsoft Store application package fails to install or upgrade. {0} is a placeholder replaced by an error code.</comment>
   </data>
-  <data name="MSStoreInstallGetEntitlementNetworkError" xml:space="preserve">
-    <value>Verifying/Requesting package acquisition failed: network error</value>
-  </data>
-  <data name="MSStoreInstallGetEntitlementNoStoreAccount" xml:space="preserve">
-    <value>Verifying/Requesting package acquisition failed: no store account found</value>
-  </data>
-  <data name="MSStoreInstallGetEntitlementServerError" xml:space="preserve">
-    <value>Verifying/Requesting package acquisition failed: server error</value>
-  </data>
-  <data name="MSStoreInstallGetEntitlementSuccess" xml:space="preserve">
-    <value>Verifying/Requesting package acquisition success</value>
-  </data>
   <data name="MSStoreStoreClientBlocked" xml:space="preserve">
     <value>Failed to install or upgrade Microsoft Store package because Microsoft Store client is blocked by policy</value>
   </data>


### PR DESCRIPTION
Fixes #2052 

## Change
Make entitlement acquisition best effort rather than required. A recent change caused some issues for us regarding the entitlement process, and since the entitlement isn't actually required to install, just attempt to get it and log if it failed.  Even if the underlying issue is resolved, this change will prevent future issues from having the same level of impact.

This may lead to an issue where the entitlement acquisition fails, the package is installed, but attempting to run it fails because the entitlement cannot be acquired then either (by the OS in the background).  Given the choice between the two failure modes though, it seems far better to remove these false negatives and create the (my gut says fewer) false positives that will result.

## Validation
Manually verified that I can get an error from entitlement acquisition and still have the install succeed (at least for the re-acquisition case).  Also verified independently that not getting an entitlement, installing, and then launching works.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3172)