### PR TITLE
Add table with pinned packages when doing `upgrade --include-pinned` 

### DIFF
--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1685,8 +1685,8 @@ Please specify one of them using the --source option to proceed.</value>
     <comment>{Locked="{0}"} Error message displayed when the user attempts to search for multiple application packages and one of the searches fails. This message is for generic failures, we have more specific messages for when the search returns no results, or when it returns more than one result. {0} is a placeholder replaced by the package name or query.</comment>
   </data>
   <data name="UpgradeBlockingPinCount" xml:space="preserve">
-    <value>{0} package(s) have a blocking pin that needs to be removed before upgrade</value>
-    <comment>{Locked="{0}"} {0} is a placeholder that is replaced by an integer number of packages with blocking pins</comment>
+    <value>{0} package(s) have a pin that needs to be removed before upgrade</value>
+    <comment>{Locked="{0}"} {0} is a placeholder that is replaced by an integer number of packages with pins that prevent upgrade</comment>
   </data>
   <data name="IncludePinnedArgumentDescription" xml:space="preserve">
     <value>Upgrade packages even if they have a non-blocking pin</value>


### PR DESCRIPTION
This change adds a table with the packages that have a blocking or gating pin that prevents upgrade when showing the available upgrades with `upgrade --include-pinned`.

Closes #2975