### PR TITLE
Fix PSInstalledCatalogPackage being piped to Upgrade-WinGetPackage

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSCatalogPackage.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSCatalogPackage.cs
@@ -80,11 +80,6 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         }
 
         /// <summary>
-        /// Gets the version of the catalog package.
-        /// </summary>
-        public abstract string Version { get; }
-
-        /// <summary>
         /// Gets the catalog package COM object.
         /// </summary>
         internal CatalogPackage CatalogPackageCOM { get; private set; }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSFoundCatalogPackage.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSFoundCatalogPackage.cs
@@ -22,8 +22,10 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
         }
 
-        /// <inheritdoc/>
-        public override string Version
+        /// <summary>
+        /// Gets the default install version of the catalog package.
+        /// </summary>
+        public string Version
         {
             get { return this.CatalogPackageCOM.DefaultInstallVersion.Version; }
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
@@ -23,7 +23,8 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         }
 
         /// <summary>
-        /// Gets or the installed version of the catalog package.
+        /// Gets the installed version of the catalog package.
+
         /// </summary>
         public string InstalledVersion
         {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
@@ -22,8 +22,10 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
         }
 
-        /// <inheritdoc/>
-        public override string Version
+        /// <summary>
+        /// Gets or the installed version of the catalog package.
+        /// </summary>
+        public string InstalledVersion
         {
             get { return this.CatalogPackageCOM.InstalledVersion.Version; }
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstalledCatalogPackage.cs
@@ -24,7 +24,6 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
 
         /// <summary>
         /// Gets the installed version of the catalog package.
-
         /// </summary>
         public string InstalledVersion
         {

--- a/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
+++ b/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
@@ -74,7 +74,7 @@
                 <ScriptBlock>$_.Id</ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
-                <ScriptBlock>$_.Version</ScriptBlock>
+                <ScriptBlock>$_.InstalledVersion</ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>if ($_.IsUpdateAvailable) { $_.AvailableVersions[0] }</ScriptBlock>


### PR DESCRIPTION
In `Update-WinGetPackage`, the pipeline can set the `PSCatalogPackage` can be set by value or property name and the `Version` by property name.

The result of `Get-WinGetPackage` piped to `Update-WinGetPackage` results in both properties being set. In this case, the version is not the desired version to update but the installed version. Internally, when we iterate through all the available versions of the catalog package object we will throw InvalidVersionException because well the version is not available...

To fix it, I renamed the `Version` property of the `PSInstalledCatalogPackage` to `InstalledVersion` to mimic what the underlying catalog package property actually is. This way the version will not be piped into `Update-WinGetPackage` but the caller can also specify which one it wants to update giving a better experience.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3174)