### PR TITLE
Repair-WinGetPackage download VCLibs if needed

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -176,17 +176,20 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
         private bool DownloadAndInstall(string versionTag, bool downgrade)
         {
+            using var tempFile = new TempFile();
+
             // Download and install.
             var gitHubRelease = new GitHubRelease();
-            var downloadedMsixBundlePath = gitHubRelease.DownloadRelease(versionTag);
+            gitHubRelease.DownloadRelease(versionTag, tempFile.FullFileName);
 
             var appxModule = new AppxModuleHelper(this.PsCmdlet);
-            appxModule.AddAppInstallerBundle(downloadedMsixBundlePath, downgrade);
+            appxModule.AddAppInstallerBundle(tempFile.FullFileName, downgrade);
 
             // Verify that is installed
             var integrityCategory = WinGetIntegrity.GetIntegrityCategory(this.PsCmdlet, versionTag);
             if (integrityCategory != IntegrityCategory.Installed)
             {
+                this.PsCmdlet.WriteDebug($"Failed installing {versionTag}. IntegrityCategory after attempt: '{integrityCategory}'");
                 return false;
             }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -180,10 +180,10 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
             // Download and install.
             var gitHubRelease = new GitHubRelease();
-            gitHubRelease.DownloadRelease(versionTag, tempFile.FullFileName);
+            gitHubRelease.DownloadRelease(versionTag, tempFile.FullPath);
 
             var appxModule = new AppxModuleHelper(this.PsCmdlet);
-            appxModule.AddAppInstallerBundle(tempFile.FullFileName, downgrade);
+            appxModule.AddAppInstallerBundle(tempFile.FullPath, downgrade);
 
             // Verify that is installed
             var integrityCategory = WinGetIntegrity.GetIntegrityCategory(this.PsCmdlet, versionTag);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
@@ -48,17 +48,17 @@ namespace Microsoft.WinGet.Client.Engine.Common
             }
             catch (Win32Exception e)
             {
-                psCmdlet.WriteDebug($"'winget.exe --version' Win32Exception {e}");
+                psCmdlet.WriteDebug($"'winget.exe' Win32Exception {e.Message}");
                 throw new WinGetIntegrityException(GetReason(psCmdlet));
             }
             catch (Exception e) when (e is WinGetCLIException || e is WinGetCLITimeoutException)
             {
-                psCmdlet.WriteDebug($"'winget.exe --version' WinGetCLIException {e}");
+                psCmdlet.WriteDebug($"'winget.exe' WinGetCLIException {e.Message}");
                 throw new WinGetIntegrityException(IntegrityCategory.Failure, e);
             }
             catch (Exception e)
             {
-                psCmdlet.WriteDebug($"'winget.exe --version' Exception {e}");
+                psCmdlet.WriteDebug($"'winget.exe' Exception {e.Message}");
                 throw new WinGetIntegrityException(IntegrityCategory.Unknown, e);
             }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
@@ -46,16 +46,19 @@ namespace Microsoft.WinGet.Client.Engine.Common
                 var result = wingetCliWrapper.RunCommand("--version");
                 result.VerifyExitCode();
             }
-            catch (Win32Exception)
+            catch (Win32Exception e)
             {
+                psCmdlet.WriteDebug($"'winget.exe --version' Win32Exception {e}");
                 throw new WinGetIntegrityException(GetReason(psCmdlet));
             }
             catch (Exception e) when (e is WinGetCLIException || e is WinGetCLITimeoutException)
             {
+                psCmdlet.WriteDebug($"'winget.exe --version' WinGetCLIException {e}");
                 throw new WinGetIntegrityException(IntegrityCategory.Failure, e);
             }
             catch (Exception e)
             {
+                psCmdlet.WriteDebug($"'winget.exe --version' Exception {e}");
                 throw new WinGetIntegrityException(IntegrityCategory.Unknown, e);
             }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/GitHubRelease.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/GitHubRelease.cs
@@ -39,10 +39,10 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// Download a release from winget-cli.
         /// </summary>
         /// <param name="releaseTag">Optional release name. If null, gets latest.</param>
-        /// <returns>Path where the msix bundle is downloaded.</returns>
-        public string DownloadRelease(string releaseTag)
+        /// <param name="outputFile">Output file.</param>
+        public void DownloadRelease(string releaseTag, string outputFile)
         {
-            return this.DownloadReleaseAsync(releaseTag).GetAwaiter().GetResult();
+            this.DownloadReleaseAsync(releaseTag, outputFile).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -69,17 +69,16 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// Download asynchronously a release from winget-cli.
         /// </summary>
         /// <param name="releaseTag">Optional release name. If null, gets latest.</param>
-        /// <returns>Path where the msix bundle is downloaded.</returns>
-        public async Task<string> DownloadReleaseAsync(string releaseTag)
+        /// <param name="outputFile">Output file.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task DownloadReleaseAsync(string releaseTag, string outputFile)
         {
             Release release = await this.gitHubClient.Repository.Release.Get(Owner, Repo, releaseTag);
 
             // Get asset and download.
             var msixBundleAsset = release.Assets.Where(a => a.Name == MsixBundleName).First();
 
-            var tmpFile = Path.GetTempFileName();
-            await this.DownloadUrlAsync(msixBundleAsset.Url, tmpFile);
-            return tmpFile;
+            await this.DownloadUrlAsync(msixBundleAsset.Url, outputFile);
         }
 
         /// <summary>
@@ -96,7 +95,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
                 ContentType);
 
             using var memoryStream = new MemoryStream((byte[])response.Body);
-            using var fileStream = File.Open(fileName, FileMode.Open);
+            using var fileStream = File.Open(fileName, FileMode.OpenOrCreate);
             memoryStream.Position = 0;
             await memoryStream.CopyToAsync(fileStream);
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/TempFile.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/TempFile.cs
@@ -1,0 +1,110 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="TempFile.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Client.Engine.Helpers
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Creates a temporary file in the user's temporary directory.
+    /// </summary>
+    internal class TempFile : IDisposable
+    {
+        private readonly bool cleanup;
+
+        private bool disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TempFile"/> class.
+        /// </summary>
+        /// <param name="fileName">Optional file name. If null, creates a random file name.</param>
+        /// <param name="deleteIfExists">Delete file if already exists. Default true.</param>
+        /// <param name="content">Optional content. If not null or empty, creates file and writes to it.</param>
+        /// <param name="cleanup">Deletes file at disposing time. Default true.</param>
+        public TempFile(
+            string fileName = null,
+            bool deleteIfExists = true,
+            string content = null,
+            bool cleanup = true)
+        {
+            if (fileName is null)
+            {
+                this.FileName = Path.GetRandomFileName();
+            }
+            else
+            {
+                this.FileName = fileName;
+            }
+
+            this.FullFileName = Path.Combine(Path.GetTempPath(), this.FileName);
+
+            if (deleteIfExists && File.Exists(this.FullFileName))
+            {
+                File.Delete(this.FullFileName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                this.CreateFile(content);
+            }
+
+            this.cleanup = cleanup;
+        }
+
+        /// <summary>
+        /// Gets the file name.
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Gets the full file name.
+        /// </summary>
+        public string FullFileName { get; }
+
+        /// <summary>
+        /// IDisposable.Dispose .
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Creates the file.
+        /// </summary>
+        /// <param name="content">Content.</param>
+        public void CreateFile(string content = null)
+        {
+            if (content is null)
+            {
+                using var fs = File.Create(this.FullFileName);
+            }
+            else
+            {
+                File.WriteAllText(this.FullFileName, content);
+            }
+        }
+
+        /// <summary>
+        /// Protected disposed.
+        /// </summary>
+        /// <param name="disposing">Disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (this.cleanup && File.Exists(this.FullFileName))
+                {
+                    File.Delete(this.FullFileName);
+                }
+
+                this.disposed = true;
+            }
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/TempFile.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/TempFile.cs
@@ -40,11 +40,11 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
                 this.FileName = fileName;
             }
 
-            this.FullFileName = Path.Combine(Path.GetTempPath(), this.FileName);
+            this.FullPath = Path.Combine(Path.GetTempPath(), this.FileName);
 
-            if (deleteIfExists && File.Exists(this.FullFileName))
+            if (deleteIfExists && File.Exists(this.FullPath))
             {
-                File.Delete(this.FullFileName);
+                File.Delete(this.FullPath);
             }
 
             if (!string.IsNullOrWhiteSpace(content))
@@ -61,12 +61,12 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         public string FileName { get; }
 
         /// <summary>
-        /// Gets the full file name.
+        /// Gets the full path.
         /// </summary>
-        public string FullFileName { get; }
+        public string FullPath { get; }
 
         /// <summary>
-        /// IDisposable.Dispose .
+        /// IDisposable.Dispose.
         /// </summary>
         public void Dispose()
         {
@@ -82,11 +82,11 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         {
             if (content is null)
             {
-                using var fs = File.Create(this.FullFileName);
+                using var fs = File.Create(this.FullPath);
             }
             else
             {
-                File.WriteAllText(this.FullFileName, content);
+                File.WriteAllText(this.FullPath, content);
             }
         }
 
@@ -98,9 +98,9 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         {
             if (!this.disposed)
             {
-                if (this.cleanup && File.Exists(this.FullFileName))
+                if (this.cleanup && File.Exists(this.FullPath))
                 {
-                    File.Delete(this.FullFileName);
+                    File.Delete(this.FullPath);
                 }
 
                 this.disposed = true;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -35,6 +35,7 @@
     </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == '$(DesktopFramework)'"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`Add-AppxPackage -Path <vclibs urls>` fails in Windows Sandbox. This change detects it and download the package and installs is from a file path. 

Add more debug information to Repair and Assert cmdlets.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3180)