### PR TITLE
Fix a few issues with the single package targeting commands

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/PackageCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/PackageCmdlet.cs
@@ -17,6 +17,15 @@ namespace Microsoft.WinGet.Client.Commands.Common
     public abstract class PackageCmdlet : FinderCmdlet
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PackageCmdlet"/> class.
+        /// </summary>
+        public PackageCmdlet()
+        {
+            // The default match option for single package operations.
+            this.MatchOption = PSObjects.PSPackageFieldMatchOption.EqualsCaseInsensitive;
+        }
+
+        /// <summary>
         /// Gets or sets the package to directly install.
         /// </summary>
         [Alias("InputObject")]

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
@@ -88,7 +88,13 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             return GetMatchResults(catalog, options);
         }
 
-        private static void SetQueryInFindPackagesOptions(
+        /// <summary>
+        /// Sets the find package options for a query input.
+        /// </summary>
+        /// <param name="options">The options object.</param>
+        /// <param name="match">The match type.</param>
+        /// <param name="value">The query value.</param>
+        protected virtual void SetQueryInFindPackagesOptions(
             ref FindPackagesOptions options,
             PackageFieldMatchOption match,
             string value)
@@ -161,7 +167,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         private FindPackagesOptions GetFindPackagesOptions(uint limit)
         {
             var options = ComObjectFactory.Value.CreateFindPackagesOptions();
-            SetQueryInFindPackagesOptions(ref options, this.MatchOption, this.QueryAsJoinedString);
+            this.SetQueryInFindPackagesOptions(ref options, this.MatchOption, this.QueryAsJoinedString);
             this.AddAttributedFiltersToFindPackagesOptions(ref options, this.MatchOption);
             options.ResultLimit = limit;
             return options;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
@@ -63,6 +63,27 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             }
         }
 
+        /// <summary>
+        /// Sets the find package options for a query input that is looking for a specific package.
+        /// </summary>
+        /// <param name="options">The options object.</param>
+        /// <param name="match">The match type.</param>
+        /// <param name="value">The query value.</param>
+        protected override void SetQueryInFindPackagesOptions(
+            ref FindPackagesOptions options,
+            PackageFieldMatchOption match,
+            string value)
+        {
+            foreach (PackageMatchField field in new PackageMatchField[] { PackageMatchField.Id, PackageMatchField.Name, PackageMatchField.Moniker })
+            {
+                var selector = ComObjectFactory.Value.CreatePackageMatchFilter();
+                selector.Field = field;
+                selector.Value = value ?? string.Empty;
+                selector.Option = match;
+                options.Selectors.Add(selector);
+            }
+        }
+
         private CatalogPackage GetCatalogPackage(CompositeSearchBehavior behavior)
         {
             if (this.CatalogPackage != null)


### PR DESCRIPTION
## Change
Change the single package targeting commands in the client PS module to operate like the single package targeting commands in `winget.exe`.  That is to say, use case-insensitive equality and the Id/Name/Moniker fields only for the search.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3196)