### PR TITLE
Add User Setting controlling Path Tokenization

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -31,12 +31,6 @@ To manually update the source use `winget source update`
 
 The `visual` settings involve visual elements that are displayed by WinGet
 
-```json
-    "visual": {
-        "progressBar": "accent"
-    },
-```
-
 ### progressBar
 
 Color of the progress bar that WinGet displays when not specified by arguments. 
@@ -44,6 +38,22 @@ Color of the progress bar that WinGet displays when not specified by arguments.
 - accent (default)
 - retro
 - rainbow
+
+```json
+    "visual": {
+        "progressBar": "accent"
+    },
+```
+
+### anonymizeDisplayedPaths
+
+Replaces some known folder paths with their respective environment variable. Defaults to true.
+
+```json
+    "visual": {
+        "anonymizeDisplayedPaths": true
+    },
+```
 
 ## Install Behavior
 

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -28,6 +28,11 @@
             "rainbow",
             "retro"
           ]
+        },
+        "anonymizeDisplayedPaths": {
+          "description": "Replaces some known folder paths with their respective environment variable",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -235,7 +235,7 @@ TEST_CASE("SettingsAnonymizePathForDisplay", "[settings]")
     }
     SECTION("Invalid Value")
     {
-        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": notBoolean } })";
+        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": "notBoolean" } })";
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -204,6 +204,46 @@ TEST_CASE("SettingProgressBar", "[settings]")
     }
 }
 
+TEST_CASE("SettingsAnonymizePathForDisplay", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Default")
+    {
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::AnonymizePathForDisplay>() == true);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("True")
+    {
+        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": true } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::AnonymizePathForDisplay>() == true);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("False")
+    {
+        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": false } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::AnonymizePathForDisplay>() == false);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Invalid Value")
+    {
+        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": notABool } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::AnonymizePathForDisplay>() == true);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}
+
 TEST_CASE("SettingLoggingLevelPreference", "[settings]")
 {
     auto again = DeleteUserSettingsFiles();

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -235,7 +235,7 @@ TEST_CASE("SettingsAnonymizePathForDisplay", "[settings]")
     }
     SECTION("Invalid Value")
     {
-        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": notABool } })";
+        std::string_view json = R"({ "visual": { "anonymizeDisplayedPaths": notBoolean } })";
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -63,6 +63,7 @@ namespace AppInstaller::Settings
     {
         // Visual
         ProgressBarVisualStyle,
+        AnonymizePathForDisplay,
         // Source
         AutoUpdateTimeInMinutes,
         // Experimental
@@ -135,6 +136,7 @@ namespace AppInstaller::Settings
 
         // Visual
         SETTINGMAPPING_SPECIALIZATION(Setting::ProgressBarVisualStyle, std::string, VisualStyle, VisualStyle::Accent, ".visual.progressBar"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::AnonymizePathForDisplay, bool, bool, true, ".visual.anonymizeDisplayedPaths"sv);
         // Source
         SETTINGMAPPING_SPECIALIZATION_POLICY(Setting::AutoUpdateTimeInMinutes, uint32_t, std::chrono::minutes, 5min, ".source.autoUpdateIntervalInMinutes"sv, ValuePolicy::SourceAutoUpdateIntervalInMinutes);
         // Experimental

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -113,7 +113,7 @@ namespace AppInstaller::Runtime
         // Gets the user's temp path
         std::filesystem::path GetPathToUserTemp(bool forDisplay)
         {
-            if (forDisplay)
+            if (forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>())
             {
                 return "%TEMP%";
             }
@@ -133,7 +133,7 @@ namespace AppInstaller::Runtime
         {
             THROW_HR_IF(E_NOT_VALID_STATE, IsRunningInPackagedContext());
 
-            std::filesystem::path result = forDisplay ? s_LocalAppDataEnvironmentVariable : GetKnownFolderPath(FOLDERID_LocalAppData);
+            std::filesystem::path result = (forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>()) ? s_LocalAppDataEnvironmentVariable : GetKnownFolderPath(FOLDERID_LocalAppData);
             result /= "Microsoft/WinGet";
 
             return result;
@@ -338,7 +338,7 @@ namespace AppInstaller::Runtime
         switch (path)
         {
         case PathName::UserProfile:
-            result.Path = forDisplay ? s_UserProfileEnvironmentVariable : GetKnownFolderPath(FOLDERID_Profile);
+            result.Path = (forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>()) ? s_UserProfileEnvironmentVariable : GetKnownFolderPath(FOLDERID_Profile);
             result.Create = false;
             break;
         case PathName::PortablePackageUserRoot:
@@ -386,7 +386,7 @@ namespace AppInstaller::Runtime
             THROW_HR(E_UNEXPECTED);
         }
 
-        if (mayBeInProfilePath && forDisplay)
+        if (mayBeInProfilePath && forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>())
         {
             ReplaceProfilePathsWithEnvironmentVariable(result.Path);
         }
@@ -462,7 +462,7 @@ namespace AppInstaller::Runtime
             THROW_HR(E_UNEXPECTED);
         }
 
-        if (mayBeInProfilePath && forDisplay)
+        if (mayBeInProfilePath && forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>())
         {
             ReplaceProfilePathsWithEnvironmentVariable(result.Path);
         }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -264,6 +264,7 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFUninstallPreviousArgument)
         WINGET_VALIDATE_PASS_THROUGH(EFConfiguration)
         WINGET_VALIDATE_PASS_THROUGH(EFWindowsFeature)
+        WINGET_VALIDATE_PASS_THROUGH(AnonymizePathForDisplay)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(InteractivityDisable)
         WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
@@ -572,7 +573,7 @@ namespace AppInstaller::Settings
     {
         auto path = Stream{ Stream::PrimaryUserSettings }.GetPath();
 
-        if (forDisplay)
+        if (forDisplay && Settings::User().Get<Setting::AnonymizePathForDisplay>())
         {
             ReplaceCommonPathPrefix(path, GetKnownFolderPath(FOLDERID_LocalAppData), "%LOCALAPPDATA%");
         }


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue. #1977

Some users may not want their paths to be replaced with environment variables when displayed. This PR adds a setting to control whether the paths are tokenized or not. 

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3209)