### PR TITLE
Queue write operations for Start-* cmdlets and hook up diagnostics

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -266,6 +266,7 @@ objbase
 objidl
 ofile
 osfhandle
+OPTOUT
 Outptr
 packageinuse
 packageinusebyapplication

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/CompleteWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/CompleteWinGetConfigurationCmdlet.cs
@@ -33,9 +33,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            CancellationTokenSource source = new ();
-
-            var configCommand = new ConfigurationCommand(this, source.Token);
+            var configCommand = new ConfigurationCommand(this);
             configCommand.Continue(this.ConfigurationJob);
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationCmdlet.cs
@@ -20,6 +20,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     public sealed class GetWinGetConfigurationCmdlet : PSCmdlet
     {
         private ExecutionPolicy executionPolicy = ExecutionPolicy.Undefined;
+        private bool canUseTelemetry = true;
 
         /// <summary>
         /// Gets or sets the configuration file.
@@ -35,6 +36,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         protected override void BeginProcessing()
         {
             this.executionPolicy = Utilities.GetExecutionPolicy();
+            this.canUseTelemetry = Utilities.CanUseTelemetry();
         }
 
         /// <summary>
@@ -42,10 +44,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            CancellationTokenSource source = new ();
-
             var configCommand = new ConfigurationCommand(this);
-            configCommand.Get(this.File, this.executionPolicy);
+            configCommand.Get(this.File, this.executionPolicy, this.canUseTelemetry);
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationCmdlet.cs
@@ -44,7 +44,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             CancellationTokenSource source = new ();
 
-            var configCommand = new ConfigurationCommand(this, source.Token);
+            var configCommand = new ConfigurationCommand(this);
             configCommand.Get(this.File, this.executionPolicy);
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
@@ -34,7 +34,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             CancellationTokenSource source = new ();
 
-            var configCommand = new ConfigurationCommand(this, source.Token);
+            var configCommand = new ConfigurationCommand(this);
             configCommand.GetDetails(this.Set);
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
@@ -32,8 +32,6 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            CancellationTokenSource source = new ();
-
             var configCommand = new ConfigurationCommand(this);
             configCommand.GetDetails(this.Set);
         }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
@@ -46,8 +46,6 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            CancellationTokenSource source = new ();
-
             var configCommand = new ConfigurationCommand(this);
             configCommand.Apply(this.Set);
         }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
@@ -48,7 +48,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             CancellationTokenSource source = new ();
 
-            var configCommand = new ConfigurationCommand(this, source.Token, false);
+            var configCommand = new ConfigurationCommand(this);
             configCommand.Apply(this.Set);
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/StartWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/StartWinGetConfigurationCmdlet.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.WinGet.Configuration.Cmdlets
 {
     using System.Management.Automation;
-    using System.Threading;
     using Microsoft.WinGet.Configuration.Engine.Commands;
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
@@ -46,9 +45,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            CancellationTokenSource source = new ();
-
-            var configCommand = new ConfigurationCommand(this, source.Token, false);
+            var configCommand = new ConfigurationCommand(this, canWriteToStream: false);
             configCommand.StartApply(this.Set);
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Helpers/Utilities.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Helpers/Utilities.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.WinGet.Configuration.Helpers
 {
+    using System;
     using System.Linq;
     using System.Management.Automation;
     using Microsoft.PowerShell;
@@ -23,6 +24,72 @@ namespace Microsoft.WinGet.Configuration.Helpers
         {
             var ps = PowerShell.Create(RunspaceMode.CurrentRunspace);
             return ps.AddCommand("Get-ExecutionPolicy").Invoke<ExecutionPolicy>().First();
+        }
+
+        /// <summary>
+        /// Determine if telemetry can be used. It follows the same telemetry rules as PowerShell.
+        /// To opt-out of this telemetry, set the environment variable $env:POWERSHELL_TELEMETRY_OPTOUT to true, yes, or 1.
+        /// This method is the same as GetEnvironmentVariableAsBool from PowerShell but only for POWERSHELL_TELEMETRY_OPTOUT.
+        /// </summary>
+        /// <returns>If telemetry can be used.</returns>
+        public static bool CanUseTelemetry()
+        {
+            var str = Environment.GetEnvironmentVariable("POWERSHELL_TELEMETRY_OPTOUT");
+            if (string.IsNullOrEmpty(str))
+            {
+                return true;
+            }
+
+            var boolStr = str.AsSpan();
+
+            if (boolStr.Length == 1)
+            {
+                if (boolStr[0] == '1')
+                {
+                    return false;
+                }
+
+                if (boolStr[0] == '0')
+                {
+                    return true;
+                }
+            }
+
+            if (boolStr.Length == 3 &&
+                (boolStr[0] == 'y' || boolStr[0] == 'Y') &&
+                (boolStr[1] == 'e' || boolStr[1] == 'E') &&
+                (boolStr[2] == 's' || boolStr[2] == 'S'))
+            {
+                return false;
+            }
+
+            if (boolStr.Length == 2 &&
+                (boolStr[0] == 'n' || boolStr[0] == 'N') &&
+                (boolStr[1] == 'o' || boolStr[1] == 'O'))
+            {
+                return true;
+            }
+
+            if (boolStr.Length == 4 &&
+                (boolStr[0] == 't' || boolStr[0] == 'T') &&
+                (boolStr[1] == 'r' || boolStr[1] == 'R') &&
+                (boolStr[2] == 'u' || boolStr[2] == 'U') &&
+                (boolStr[3] == 'e' || boolStr[3] == 'E'))
+            {
+                return false;
+            }
+
+            if (boolStr.Length == 5 &&
+                (boolStr[0] == 'f' || boolStr[0] == 'F') &&
+                (boolStr[1] == 'a' || boolStr[1] == 'A') &&
+                (boolStr[2] == 'l' || boolStr[2] == 'L') &&
+                (boolStr[3] == 's' || boolStr[3] == 'S') &&
+                (boolStr[4] == 'e' || boolStr[4] == 'E'))
+            {
+                return true;
+            }
+
+            return true;
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Helpers/Utilities.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Helpers/Utilities.cs
@@ -48,11 +48,6 @@ namespace Microsoft.WinGet.Configuration.Helpers
                 {
                     return false;
                 }
-
-                if (boolStr[0] == '0')
-                {
-                    return true;
-                }
             }
 
             if (boolStr.Length == 3 &&
@@ -63,13 +58,6 @@ namespace Microsoft.WinGet.Configuration.Helpers
                 return false;
             }
 
-            if (boolStr.Length == 2 &&
-                (boolStr[0] == 'n' || boolStr[0] == 'N') &&
-                (boolStr[1] == 'o' || boolStr[1] == 'O'))
-            {
-                return true;
-            }
-
             if (boolStr.Length == 4 &&
                 (boolStr[0] == 't' || boolStr[0] == 'T') &&
                 (boolStr[1] == 'r' || boolStr[1] == 'R') &&
@@ -77,16 +65,6 @@ namespace Microsoft.WinGet.Configuration.Helpers
                 (boolStr[3] == 'e' || boolStr[3] == 'E'))
             {
                 return false;
-            }
-
-            if (boolStr.Length == 5 &&
-                (boolStr[0] == 'f' || boolStr[0] == 'F') &&
-                (boolStr[1] == 'a' || boolStr[1] == 'A') &&
-                (boolStr[2] == 'l' || boolStr[2] == 'L') &&
-                (boolStr[3] == 's' || boolStr[3] == 'S') &&
-                (boolStr[4] == 'e' || boolStr[4] == 'E'))
-            {
-                return true;
             }
 
             return true;

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/AsyncCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/AsyncCommand.cs
@@ -44,6 +44,9 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         private CancellationToken cancellationToken;
         private ConcurrentQueue<QueuedOutputStream> queuedOutputStreams = new ();
 
+        private int progressActivityId = 0;
+        private ConcurrentDictionary<int, ProgressRecordType> progressRecords = new ();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncCommand"/> class.
         /// </summary>
@@ -64,6 +67,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             Verbose,
             Warning,
             Error,
+            Progress,
         }
 
         /// <summary>
@@ -98,11 +102,19 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         }
 
         /// <summary>
+        /// Cancel this operation.
+        /// </summary>
+        public virtual void Cancel()
+        {
+            this.source.Cancel();
+        }
+
+        /// <summary>
         /// Execute the delegate in a MTA thread.
         /// </summary>
         /// <param name="func">Function to execute.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task RunOnMTA(Func<Task> func)
+        internal Task RunOnMTA(Func<Task> func)
         {
             // This must be called in the main thread.
             if (this.originalThread != Thread.CurrentThread)
@@ -142,7 +154,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// <param name="func">Function to execute.</param>
         /// <typeparam name="TResult">Return type of function.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task<TResult> RunOnMTA<TResult>(Func<Task<TResult>> func)
+        internal Task<TResult> RunOnMTA<TResult>(Func<Task<TResult>> func)
         {
             // This must be called in the main thread.
             if (this.originalThread != Thread.CurrentThread)
@@ -180,7 +192,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// Waits for the task to be completed. This MUST be called from the main thread.
         /// </summary>
         /// <param name="runningTask">Task to wait for.</param>
-        public void Wait(Task runningTask)
+        internal void Wait(Task runningTask)
         {
             // This must be called in the main thread.
             if (this.originalThread != Thread.CurrentThread)
@@ -230,7 +242,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// sets it to the main thread action and wait for it to be executed.
         /// </summary>
         /// <param name="text">Debug text.</param>
-        public void WriteDebug(string text)
+        internal void WriteDebug(string text)
         {
             // Don't do context switch if no need.
             if (!this.isDebugBounded)
@@ -270,7 +282,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// sets it to the main thread action and wait for it to be executed.
         /// </summary>
         /// <param name="text">Warning text.</param>
-        public void WriteWarning(string text)
+        internal void WriteWarning(string text)
         {
             if (!this.CanWriteToStream)
             {
@@ -304,7 +316,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// sets it to the main thread action and wait for it to be executed.
         /// </summary>
         /// <param name="errorRecord">Error record.</param>
-        public void WriteError(ErrorRecord errorRecord)
+        internal void WriteError(ErrorRecord errorRecord)
         {
             if (!this.CanWriteToStream)
             {
@@ -333,10 +345,48 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         }
 
         /// <summary>
+        /// Calls cmdlet WriteProgress.
+        /// </summary>
+        /// <param name="progressRecord">Progress record.</param>
+        internal void WriteProgress(ProgressRecord progressRecord)
+        {
+            // Keep track of all progress activity.
+            if (!this.progressRecords.TryAdd(progressRecord.ActivityId, progressRecord.RecordType))
+            {
+                _ = this.progressRecords.TryUpdate(progressRecord.ActivityId, progressRecord.RecordType, ProgressRecordType.Completed);
+            }
+
+            if (!this.CanWriteToStream)
+            {
+                this.queuedOutputStreams.Enqueue(
+                    new QueuedOutputStream(OutputStreamType.Progress, progressRecord));
+                return;
+            }
+
+            if (this.originalThread == Thread.CurrentThread)
+            {
+                this.PsCmdlet.WriteProgress(progressRecord);
+                return;
+            }
+
+            try
+            {
+                this.WaitForOurTurn();
+                this.mainThreadAction = () => this.PsCmdlet.WriteProgress(progressRecord);
+                this.mainThreadActionReady.Set();
+                this.WaitMainThreadActionCompletion();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Calls cmdlet WriteObject.
         /// </summary>
         /// <param name="obj">Object to write.</param>
-        public void WriteObject(object obj)
+        internal void WriteObject(object obj)
         {
             if (this.originalThread == Thread.CurrentThread)
             {
@@ -355,14 +405,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             {
                 throw;
             }
-        }
-
-        /// <summary>
-        /// Cancel this operation.
-        /// </summary>
-        public virtual void Cancel()
-        {
-            this.source.Cancel();
         }
 
         /// <summary>
@@ -387,17 +429,29 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             {
                 while (this.queuedOutputStreams.TryDequeue(out var queuedOutput))
                 {
-                    switch (queuedOutput.Type)
+                    if (queuedOutput != null)
                     {
-                        case OutputStreamType.Debug:
-                            this.WriteDebug((string)queuedOutput.Data);
-                            break;
-                        case OutputStreamType.Warning:
-                            this.WriteWarning((string)queuedOutput.Data);
-                            break;
-                        case OutputStreamType.Error:
-                            this.WriteError((ErrorRecord)queuedOutput.Data);
-                            break;
+                        switch (queuedOutput.Type)
+                        {
+                            case OutputStreamType.Debug:
+                                this.WriteDebug((string)queuedOutput.Data);
+                                break;
+                            case OutputStreamType.Warning:
+                                this.WriteWarning((string)queuedOutput.Data);
+                                break;
+                            case OutputStreamType.Error:
+                                this.WriteError((ErrorRecord)queuedOutput.Data);
+                                break;
+                            case OutputStreamType.Progress:
+                                // If the activity is already completed don't write progress.
+                                var progressRecord = (ProgressRecord)queuedOutput.Data;
+                                if (this.progressRecords[progressRecord.ActivityId] == ProgressRecordType.Processing)
+                                {
+                                    this.WriteProgress(progressRecord);
+                                }
+
+                                break;
+                        }
                     }
                 }
             }
@@ -405,6 +459,15 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             {
                 this.Cancel();
             }
+        }
+
+        /// <summary>
+        /// Gets a new progress activity id.
+        /// </summary>
+        /// <returns>The new progress record id.</returns>
+        internal int GetNewProgressActivityId()
+        {
+            return Interlocked.Increment(ref this.progressActivityId);
         }
 
         private void WaitForOurTurn()

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
@@ -9,7 +9,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
     using System;
     using System.IO;
     using System.Management.Automation;
-    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Management.Configuration;
     using Microsoft.Management.Configuration.Processor;
@@ -27,10 +26,9 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// Initializes a new instance of the <see cref="ConfigurationCommand"/> class.
         /// </summary>
         /// <param name="psCmdlet">PSCmdlet.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         /// <param name="canWriteToStream">If the command can write to stream.</param>
-        public ConfigurationCommand(PSCmdlet psCmdlet, CancellationToken cancellationToken, bool canWriteToStream = true)
-            : base(psCmdlet, cancellationToken, canWriteToStream)
+        public ConfigurationCommand(PSCmdlet psCmdlet, bool canWriteToStream = true)
+            : base(psCmdlet, canWriteToStream)
         {
         }
 
@@ -138,6 +136,9 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         {
             if (psConfigurationJob.ConfigurationTask.IsCompleted)
             {
+                // It is safe to print all output.
+                psConfigurationJob.StartCommand.Flush();
+
                 this.WriteDebug("The task was completed before waiting");
                 if (psConfigurationJob.ConfigurationTask.IsCompletedSuccessfully)
                 {

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
@@ -31,19 +31,14 @@ namespace Microsoft.WinGet.Configuration.Engine.PSObjects
         /// </summary>
         /// <param name="factory">Factory.</param>
         /// <param name="diagnosticCommand">AsyncCommand to use for diagnostics.</param>
-        internal PSConfigurationProcessor(IConfigurationSetProcessorFactory factory, AsyncCommand diagnosticCommand)
+        /// <param name="canUseTelemetry">If telemetry can be used.</param>
+        internal PSConfigurationProcessor(IConfigurationSetProcessorFactory factory, AsyncCommand diagnosticCommand, bool canUseTelemetry)
         {
             this.Processor = new ConfigurationProcessor(factory);
             this.Processor.MinimumLevel = DiagnosticLevel.Verbose;
             this.Processor.Caller = "Microsoft.WinGet.Configuration";
             this.Processor.Diagnostics += (sender, args) => this.LogConfigurationDiagnostics(args);
-
-            // TODO: see if there's a PowerShell thing to know this.
-            this.Processor.GenerateTelemetryEvents = false;
-
-            // TODO: Create guid or use same as winget?
-            this.Processor.ActivityIdentifier = Guid.NewGuid();
-
+            this.Processor.GenerateTelemetryEvents = canUseTelemetry;
             this.diagnosticCommand = diagnosticCommand;
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
@@ -1,0 +1,97 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSConfigurationProcessor.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    using System;
+    using System.Management.Automation;
+    using Microsoft.Management.Configuration;
+    using Microsoft.PowerShell.Commands;
+    using Microsoft.WinGet.Configuration.Engine.Commands;
+
+    /// <summary>
+    /// Creates configuration processor and set up diagnostic logging.
+    /// If this object is the input of another cmdlet and the cmdlet is not a
+    /// long running task (aka not Continue-*) for now the caller is responsible
+    /// of updating the AsyncCommand of this object.
+    /// In the future we can implement a singleton that handles all the signaling
+    /// for main thread actions.
+    /// </summary>
+    public class PSConfigurationProcessor
+    {
+        private static readonly object CmdletLock = new ();
+
+        private AsyncCommand diagnosticCommand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSConfigurationProcessor"/> class.
+        /// </summary>
+        /// <param name="factory">Factory.</param>
+        /// <param name="diagnosticCommand">AsyncCommand to use for diagnostics.</param>
+        internal PSConfigurationProcessor(IConfigurationSetProcessorFactory factory, AsyncCommand diagnosticCommand)
+        {
+            this.Processor = new ConfigurationProcessor(factory);
+            this.Processor.MinimumLevel = DiagnosticLevel.Verbose;
+            this.Processor.Caller = "Microsoft.WinGet.Configuration";
+            this.Processor.Diagnostics += (sender, args) => this.LogConfigurationDiagnostics(args);
+
+            // TODO: see if there's a PowerShell thing to know this.
+            this.Processor.GenerateTelemetryEvents = false;
+
+            // TODO: Create guid or use same as winget?
+            this.Processor.ActivityIdentifier = Guid.NewGuid();
+
+            this.diagnosticCommand = diagnosticCommand;
+        }
+
+        /// <summary>
+        /// Gets the ConfigurationProcessor.
+        /// </summary>
+        internal ConfigurationProcessor Processor { get; private set; }
+
+        /// <summary>
+        /// Updates the cmdlet that is used for diagnostics.
+        /// </summary>
+        /// <param name="newDiagnosticCommand">New diagnostic command.</param>
+        internal void UpdateDiagnosticCmdlet(AsyncCommand newDiagnosticCommand)
+        {
+            lock (CmdletLock)
+            {
+                this.diagnosticCommand = newDiagnosticCommand;
+            }
+        }
+
+        private void LogConfigurationDiagnostics(DiagnosticInformation diagnosticInformation)
+        {
+            // This is expensive.
+            lock (CmdletLock)
+            {
+                switch (diagnosticInformation.Level)
+                {
+                    // PowerShell doesn't have critical and critical isn't an error.
+                    case DiagnosticLevel.Critical:
+                    case DiagnosticLevel.Warning:
+                        this.diagnosticCommand.WriteWarning(diagnosticInformation.Message);
+                        return;
+                    case DiagnosticLevel.Error:
+                        // TODO: The error record requires a exception that can't be null, but there's no requirement
+                        // that it was thrown.
+                        this.diagnosticCommand.WriteError(new ErrorRecord(
+                            new WriteErrorException(),
+                            "ConfigurationDiagnosticError",
+                            ErrorCategory.WriteError,
+                            diagnosticInformation.Message));
+                        return;
+                    case DiagnosticLevel.Verbose:
+                    case DiagnosticLevel.Informational:
+                    default:
+                        this.diagnosticCommand.WriteDebug(diagnosticInformation.Message);
+                        return;
+                }
+            }
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
@@ -61,31 +61,38 @@ namespace Microsoft.WinGet.Configuration.Engine.PSObjects
 
         private void LogConfigurationDiagnostics(DiagnosticInformation diagnosticInformation)
         {
-            // This is expensive.
-            lock (CmdletLock)
+            try
             {
-                switch (diagnosticInformation.Level)
+                // This is expensive.
+                lock (CmdletLock)
                 {
-                    // PowerShell doesn't have critical and critical isn't an error.
-                    case DiagnosticLevel.Critical:
-                    case DiagnosticLevel.Warning:
-                        this.diagnosticCommand.WriteWarning(diagnosticInformation.Message);
-                        return;
-                    case DiagnosticLevel.Error:
-                        // TODO: The error record requires a exception that can't be null, but there's no requirement
-                        // that it was thrown.
-                        this.diagnosticCommand.WriteError(new ErrorRecord(
-                            new WriteErrorException(),
-                            "ConfigurationDiagnosticError",
-                            ErrorCategory.WriteError,
-                            diagnosticInformation.Message));
-                        return;
-                    case DiagnosticLevel.Verbose:
-                    case DiagnosticLevel.Informational:
-                    default:
-                        this.diagnosticCommand.WriteDebug(diagnosticInformation.Message);
-                        return;
+                    switch (diagnosticInformation.Level)
+                    {
+                        // PowerShell doesn't have critical and critical isn't an error.
+                        case DiagnosticLevel.Critical:
+                        case DiagnosticLevel.Warning:
+                            this.diagnosticCommand.WriteWarning(diagnosticInformation.Message);
+                            return;
+                        case DiagnosticLevel.Error:
+                            // TODO: The error record requires a exception that can't be null, but there's no requirement
+                            // that it was thrown.
+                            this.diagnosticCommand.WriteError(new ErrorRecord(
+                                new WriteErrorException(),
+                                "ConfigurationDiagnosticError",
+                                ErrorCategory.WriteError,
+                                diagnosticInformation.Message));
+                            return;
+                        case DiagnosticLevel.Verbose:
+                        case DiagnosticLevel.Informational:
+                        default:
+                            this.diagnosticCommand.WriteDebug(diagnosticInformation.Message);
+                            return;
+                    }
                 }
+            }
+            catch (Exception)
+            {
+                // Please don't throw here.
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationProcessor.cs
@@ -64,30 +64,28 @@ namespace Microsoft.WinGet.Configuration.Engine.PSObjects
             try
             {
                 // This is expensive.
-                lock (CmdletLock)
+                AsyncCommand asyncCommand = this.diagnosticCommand;
+                switch (diagnosticInformation.Level)
                 {
-                    switch (diagnosticInformation.Level)
-                    {
-                        // PowerShell doesn't have critical and critical isn't an error.
-                        case DiagnosticLevel.Critical:
-                        case DiagnosticLevel.Warning:
-                            this.diagnosticCommand.WriteWarning(diagnosticInformation.Message);
-                            return;
-                        case DiagnosticLevel.Error:
-                            // TODO: The error record requires a exception that can't be null, but there's no requirement
-                            // that it was thrown.
-                            this.diagnosticCommand.WriteError(new ErrorRecord(
-                                new WriteErrorException(),
-                                "ConfigurationDiagnosticError",
-                                ErrorCategory.WriteError,
-                                diagnosticInformation.Message));
-                            return;
-                        case DiagnosticLevel.Verbose:
-                        case DiagnosticLevel.Informational:
-                        default:
-                            this.diagnosticCommand.WriteDebug(diagnosticInformation.Message);
-                            return;
-                    }
+                    // PowerShell doesn't have critical and critical isn't an error.
+                    case DiagnosticLevel.Critical:
+                    case DiagnosticLevel.Warning:
+                        asyncCommand.WriteWarning(diagnosticInformation.Message);
+                        return;
+                    case DiagnosticLevel.Error:
+                        // TODO: The error record requires a exception that can't be null, but there's no requirement
+                        // that it was thrown.
+                        asyncCommand.WriteError(new ErrorRecord(
+                            new WriteErrorException(),
+                            "ConfigurationDiagnosticError",
+                            ErrorCategory.WriteError,
+                            diagnosticInformation.Message));
+                        return;
+                    case DiagnosticLevel.Verbose:
+                    case DiagnosticLevel.Informational:
+                    default:
+                        asyncCommand.WriteDebug(diagnosticInformation.Message);
+                        return;
                 }
             }
             catch (Exception)

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationSet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationSet.cs
@@ -20,11 +20,11 @@ namespace Microsoft.WinGet.Configuration.Engine.PSObjects
         /// <summary>
         /// Initializes a new instance of the <see cref="PSConfigurationSet"/> class.
         /// </summary>
-        /// <param name="processor">The configuration processor.</param>
+        /// <param name="psProcessor">The configuration processor wrapper.</param>
         /// <param name="set">The configuration set.</param>
-        internal PSConfigurationSet(ConfigurationProcessor processor, ConfigurationSet set)
+        internal PSConfigurationSet(PSConfigurationProcessor psProcessor, ConfigurationSet set)
         {
-            this.Processor = processor;
+            this.PsProcessor = psProcessor;
             this.Set = set;
         }
 
@@ -84,9 +84,9 @@ namespace Microsoft.WinGet.Configuration.Engine.PSObjects
         }
 
         /// <summary>
-        /// Gets the ConfigurationProcessor.
+        /// Gets the PSConfigurationProcessor.
         /// </summary>
-        internal ConfigurationProcessor Processor { get; private set; }
+        internal PSConfigurationProcessor PsProcessor { get; private set; }
 
         /// <summary>
         /// Gets the ConfigurationSet.


### PR DESCRIPTION
When a Start-* cmdlet starts its operation it won't write to any PowerShell stream because control is returned back to the user almost immediately.  This changes queue messages to be then displayed at Continue-* time. This way, we will have all the messages in the appropriate order. It applies for WriteDebug, WriteVerbose, WriteWarning, WriteError and WriteProgress. 

WriteProgress will only be called when the activity hasn't been completed. A caller must use `AsyncCommand.GetNewProgressActivityId` to generate a new activity id.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3222)