### PR TITLE
Add configuration alias

### DIFF
--- a/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
@@ -12,7 +12,7 @@ using namespace AppInstaller::CLI::Workflow;
 namespace AppInstaller::CLI
 {
     ConfigureCommand::ConfigureCommand(std::string_view parent) :
-        Command("configure", {}, parent, Settings::ExperimentalFeature::Feature::Configuration)
+        Command("configure", { "configuration" }, parent, Settings::ExperimentalFeature::Feature::Configuration)
     {
         SelectCurrentCommandIfUnrecognizedSubcommandFound(true);
     }


### PR DESCRIPTION
## Change
Adds `configuration` as an alias for the `configure` command.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3225)