### PR TITLE
Explicity not support cmdlets in Windows PowerShell

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -76,8 +76,16 @@
   <PropertyGroup>
     <PowerShellModuleOutputDirectory>$(BuildOutputDirectory)PowerShell\Microsoft.WinGet.Client</PowerShellModuleOutputDirectory>
     <PowerShellModuleRuntimesDir>$(PowerShellModuleOutputDirectory)\runtimes\win10-$(Platform)\lib\$(TargetFramework)</PowerShellModuleRuntimesDir>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
     <PowerShellModuleSharedDependencies>$(PowerShellModuleRuntimesDir)\SharedDependencies</PowerShellModuleSharedDependencies>
     <PowerShellModuleDirectDependencies>$(PowerShellModuleRuntimesDir)\DirectDependencies</PowerShellModuleDirectDependencies>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(DesktopFramework)'">
+    <PowerShellModuleSharedDependencies>$(PowerShellModuleRuntimesDir)</PowerShellModuleSharedDependencies>
+    <PowerShellModuleDirectDependencies>$(PowerShellModuleRuntimesDir)</PowerShellModuleDirectDependencies>
   </PropertyGroup>
 
   <!-- psm1, psd1 and ps1xml-->

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/FinderPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/FinderPackageCommand.cs
@@ -6,11 +6,13 @@
 
 namespace Microsoft.WinGet.Client.Engine.Commands
 {
+    using System;
     using System.Management.Automation;
     using Microsoft.Management.Deployment;
     using Microsoft.WinGet.Client.Engine.Commands.Common;
     using Microsoft.WinGet.Client.Engine.Extensions;
     using Microsoft.WinGet.Client.Engine.Helpers;
+    using Microsoft.WinGet.Client.Engine.Properties;
     using Microsoft.WinGet.Client.Engine.PSObjects;
 
     /// <summary>
@@ -63,6 +65,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// </summary>
         public void Find()
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             var results = this.FindPackages(CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs);
             for (var i = 0; i < results.Count; i++)
             {
@@ -75,6 +80,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// </summary>
         public void Get()
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             var results = this.FindPackages(CompositeSearchBehavior.LocalCatalogs);
             for (var i = 0; i < results.Count; i++)
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/FinderPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/FinderPackageCommand.cs
@@ -46,6 +46,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             uint count)
             : base(psCmdlet)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#else
             // FinderCommand
             this.Id = id;
             this.Name = name;
@@ -58,6 +61,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             this.Tag = tag;
             this.Command = command;
             this.Count = count;
+#endif
         }
 
         /// <summary>
@@ -65,9 +69,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// </summary>
         public void Find()
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             var results = this.FindPackages(CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs);
             for (var i = 0; i < results.Count; i++)
             {
@@ -80,9 +81,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// </summary>
         public void Get()
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             var results = this.FindPackages(CompositeSearchBehavior.LocalCatalogs);
             for (var i = 0; i < results.Count; i++)
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -96,6 +96,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageInstallScope,
             string psProcessorArchitecture)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs, (package, version) =>
             {
                 InstallOptions options = this.GetInstallOptions(version);
@@ -118,6 +121,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="includeUnknown">If updating to an unknown version is allowed.</param>
         public void Update(bool includeUnknown)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.LocalCatalogs, (package, version) =>
             {
                 InstallOptions options = this.GetInstallOptions(version);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.WinGet.Client.Engine.Commands
 {
+    using System;
     using System.Management.Automation;
     using Microsoft.Management.Deployment;
     using Microsoft.WinGet.Client.Engine.Commands.Common;
@@ -13,7 +14,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
     using Microsoft.WinGet.Client.Engine.Helpers;
     using Microsoft.WinGet.Client.Engine.Properties;
     using Microsoft.WinGet.Client.Engine.PSObjects;
-    using Windows.System;
 
     /// <summary>
     /// Installs or updates a package from the pipeline or from a configured source.
@@ -60,6 +60,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string matchOption)
             : base(psCmdlet)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#else
             // InstallCommand.
             this.Mode = PSEnumHelpers.ToPackageInstallMode(psInstallMode);
             this.Override = @override;
@@ -85,6 +88,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             this.Source = source;
             this.Query = query;
             this.MatchOption = PSEnumHelpers.ToPackageFieldMatchOption(matchOption);
+#endif
         }
 
         /// <summary>
@@ -96,9 +100,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageInstallScope,
             string psProcessorArchitecture)
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs, (package, version) =>
             {
                 InstallOptions options = this.GetInstallOptions(version);
@@ -121,9 +122,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="includeUnknown">If updating to an unknown version is allowed.</param>
         public void Update(bool includeUnknown)
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.LocalCatalogs, (package, version) =>
             {
                 InstallOptions options = this.GetInstallOptions(version);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/SourceCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/SourceCommand.cs
@@ -6,8 +6,10 @@
 
 namespace Microsoft.WinGet.Client.Engine.Commands
 {
+    using System;
     using System.Management.Automation;
     using Microsoft.WinGet.Client.Engine.Commands.Common;
+    using Microsoft.WinGet.Client.Engine.Properties;
     using Microsoft.WinGet.Client.Engine.PSObjects;
 
     /// <summary>
@@ -23,6 +25,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public SourceCommand(PSCmdlet psCmdlet)
             : base(psCmdlet)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
         }
 
         /// <summary>
@@ -31,9 +36,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="name">Optional name.</param>
         public void Get(string name)
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             var results = GetPackageCatalogReferences(name);
             for (var i = 0; i < results.Count; i++)
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/SourceCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/SourceCommand.cs
@@ -31,6 +31,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="name">Optional name.</param>
         public void Get(string name)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             var results = GetPackageCatalogReferences(name);
             for (var i = 0; i < results.Count; i++)
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
@@ -72,6 +72,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageUninstallMode,
             bool force)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.LocalCatalogs, (package, version) =>
             {
                 UninstallOptions options = this.GetUninstallOptions(version, PSEnumHelpers.ToPackageUninstallMode(psPackageUninstallMode), force);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
@@ -45,6 +45,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string matchOption)
             : base(psCmdlet)
         {
+#if POWERSHELL_WINDOWS
+            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
+#else
             // PackageCommand.
             if (psCatalogPackage != null)
             {
@@ -61,6 +64,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             this.Source = source;
             this.Query = query;
             this.MatchOption = PSEnumHelpers.ToPackageFieldMatchOption(matchOption);
+#endif
         }
 
         /// <summary>
@@ -72,9 +76,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageUninstallMode,
             bool force)
         {
-#if POWERSHELL_WINDOWS
-            throw new NotSupportedException(Resources.WindowsPowerShellNotSupported);
-#endif
             this.GetPackageAndExecute(CompositeSearchBehavior.LocalCatalogs, (package, version) =>
             {
                 UninstallOptions options = this.GetUninstallOptions(version, PSEnumHelpers.ToPackageUninstallMode(psPackageUninstallMode), force);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
@@ -259,6 +259,15 @@ namespace Microsoft.WinGet.Client.Engine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This cmdlet is no supported in Windows PowerShell.
+        /// </summary>
+        internal static string WindowsPowerShellNotSupported {
+            get {
+                return ResourceManager.GetString("WindowsPowerShellNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Command {0} failed with exit code {1}.
         /// </summary>
         internal static string WinGetCLIExceptionMessage {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
@@ -205,6 +205,6 @@
     <comment>{Locked="STA","MTA"}</comment>
   </data>
   <data name="WindowsPowerShellNotSupported" xml:space="preserve">
-    <value>This cmdlet is no supported in Windows PowerShell</value>
+    <value>This cmdlet is not supported in Windows PowerShell.</value>
   </data>
 </root>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
@@ -204,4 +204,7 @@
     <value>Single threaded apartment (STA) is not currently supported in this context; run PowerShell in Multi-threaded apartment mode (MTA).</value>
     <comment>{Locked="STA","MTA"}</comment>
   </data>
+  <data name="WindowsPowerShellNotSupported" xml:space="preserve">
+    <value>This cmdlet is no supported in Windows PowerShell</value>
+  </data>
 </root>


### PR DESCRIPTION
These cmdlets are not suported on Windows PowerShell

- Find-WinGetPackage
- Get-WinGetPackage
- Get-WinGetSource
- Install-WinGetPackage
- Uninstall-WinGetPackage
- Update-WinGetPackage

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3238)