### PR TITLE
Update PSDesiredStateConfiguration module min version to 2.0.7

### DIFF
--- a/src/Microsoft.Management.Configuration.Processor/Constants/PowerShellConstants.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Constants/PowerShellConstants.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Management.Configuration.Processor.Constants
         internal static class Modules
         {
             public const string PSDesiredStateConfiguration = "PSDesiredStateConfiguration";
-            public const string PSDesiredStateConfigurationMinVersion = "2.0.6";
+            public const string PSDesiredStateConfigurationMinVersion = "2.0.7";
             public const string PowerShellGet = "PowerShellGet";
             public const string PowerShellGetMinVersion = "2.2.5";
             public const string PSDesiredStateConfigurationMaxVersion = "2.*";

--- a/src/Microsoft.Management.Configuration.Processor/DscModules/DscModuleV2.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DscModules/DscModuleV2.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.Configuration.Processor.DscModule
     using static Microsoft.Management.Configuration.Processor.Constants.PowerShellConstants;
 
     /// <summary>
-    /// PSDesiredStateConfiguration v2.0.6.
+    /// PSDesiredStateConfiguration v2.
     /// </summary>
     internal class DscModuleV2 : IDscModule
     {

--- a/src/Microsoft.Management.Configuration.UnitTests/Fixtures/UnitTestFixture.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Fixtures/UnitTestFixture.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Fixtures
         /// <summary>
         /// Creates a runspace adding the test module path.
         /// </summary>
+        /// <param name="validate">Validate runspace.</param>
         /// <returns>PowerShellRunspace.</returns>
         internal IProcessorEnvironment PrepareTestProcessorEnvironment(bool validate = false)
         {


### PR DESCRIPTION
Update to [PSDesiredStateConfiguration  2.0.7](https://www.powershellgallery.com/packages/PSDesiredStateConfiguration/2.0.7).

With this change, winget configure will download the 2.0.7 automatically.

This version contains a fix where Invoke-DSCResource failed when a class based resource is going to be invoke and it lives in a path with spaces on it. [Bug details](https://github.com/PowerShell/PSDesiredStateConfiguration/issues/73)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3251)