### PR TITLE
Fix packages with dependencies being installed via COM

### DIFF
--- a/src/AppInstallerCLICore/ContextOrchestrator.cpp
+++ b/src/AppInstallerCLICore/ContextOrchestrator.cpp
@@ -174,7 +174,20 @@ namespace AppInstaller::CLI::Execution
         // Only do this the first time the item is queued.
         if (item->IsOnFirstCommand())
         {
-            ContextOrchestrator::Instance().AddItemManifestToInstallingSource(*item);
+            try
+            {
+                ContextOrchestrator::Instance().AddItemManifestToInstallingSource(*item);
+            }
+            catch (...)
+            {
+                std::lock_guard<std::mutex> lockQueue{ m_queueLock };
+                auto itr = FindIteratorById(item->GetId());
+                if (itr != m_queueItems.end())
+                {
+                    m_queueItems.erase(itr);
+                }
+                throw;
+            }
         }
 
         {

--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedWriteableSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedWriteableSourceFactory.cpp
@@ -60,8 +60,8 @@ namespace AppInstaller::Repository::Microsoft
                 std::call_once(g_InstallingSourceOnceFlag,
                     [&]()
                     {
-                        // Create an in memory index
-                        SQLiteIndex index = SQLiteIndex::CreateNew(SQLITE_MEMORY_DB_CONNECTION_TARGET, Schema::Version::Latest());
+                        // Create an in memory index without paths or dependencies
+                        SQLiteIndex index = SQLiteIndex::CreateNew(SQLITE_MEMORY_DB_CONNECTION_TARGET, Schema::Version::Latest(), SQLiteIndex::CreateOptions::SupportPathless | SQLiteIndex::CreateOptions::DisableDependenciesSupport);
 
                         g_sharedSource = std::make_shared<SQLiteIndexWriteableSource>(m_details, std::move(index), Synchronization::CrossProcessReaderWriteLock{}, true);
                     });


### PR DESCRIPTION
## Problem
Packages with dependencies were not being indexed into the database (unless one also happened to install the dependency tree ahead of them).  This was causing both an error to install and future installation attempts to fail.

## Change
Disable dependency indexing for the installing database, and on a failure to index the manifest, remove the item from the queue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3254)