### PR TITLE
Fix new warning C26495 from wil header in VS 17.6

### DIFF
--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -61,7 +61,7 @@
 #include <vector>
 
 #pragma warning( push )
-#pragma warning ( disable : 6001 6285 6287 6340 6387 6388 26451 28196 )
+#pragma warning ( disable : 6001 6285 6287 6340 6387 6388 26451 26495 28196 )
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <wil/result_macros.h>

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -12,7 +12,7 @@
 #include <msi.h>
 
 #pragma warning( push )
-#pragma warning ( disable : 6001 6340 6387 6388 28196 )
+#pragma warning ( disable : 6001 6340 6387 6388 26495 28196 )
 #include <wil/filesystem.h>
 #include <wil/resource.h>
 #include <wil/result.h>

--- a/src/AppInstallerSharedLib/pch.h
+++ b/src/AppInstallerSharedLib/pch.h
@@ -41,7 +41,7 @@
 #include <vector>
 
 #pragma warning( push )
-#pragma warning ( disable : 6001 6285 6287 6340 6387 6388 28196 )
+#pragma warning ( disable : 6001 6285 6287 6340 6387 6388 26495 28196 )
 #include <wil/resource.h>
 #include <wil/result.h>
 #include <wil/result_macros.h>

--- a/src/WinGetUtil/pch.h
+++ b/src/WinGetUtil/pch.h
@@ -6,9 +6,10 @@
 #include <Windows.h>
 
 #pragma warning( push )
-#pragma warning ( disable : 6001 6340 6388 )
+#pragma warning ( disable : 6001 6340 6387 6388 26495 28196 )
 #include <wil/result.h>
 #include <wil/result_macros.h>
+#include <wil/filesystem.h>
 #pragma warning( pop )
 
 #include <algorithm>


### PR DESCRIPTION
An uninitialized variable warning from a buffer that is intentionally not initialized for performance reasons.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3266)