### PR TITLE
Don't read past the end of the HTTP stream

### DIFF
--- a/src/AppInstallerCommonCore/HttpStream/HttpClientWrapper.h
+++ b/src/AppInstallerCommonCore/HttpStream/HttpClientWrapper.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #pragma once
-
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Web.Http.h>
 
 namespace AppInstaller::Utility::HttpStream
 {

--- a/src/AppInstallerCommonCore/HttpStream/HttpLocalCache.cpp
+++ b/src/AppInstallerCommonCore/HttpStream/HttpLocalCache.cpp
@@ -217,6 +217,9 @@ namespace AppInstaller::Utility::HttpStream
         UINT32 trimStartIndex,
         UINT32 size)
     {
+        uint32_t bufferLength = originalBuffer.Length();
+        THROW_HR_IF(E_INVALIDARG, trimStartIndex > bufferLength);
+
         originalBuffer.as<::IInspectable>();
 
         // Get the byte array from the IBuffer object
@@ -228,7 +231,7 @@ namespace AppInstaller::Utility::HttpStream
 
         // Create the array of bytes holding the trimmed bytes
         IBuffer trimmedBuffer = CryptographicBuffer::CreateFromByteArray(
-            { byteBuffer + trimStartIndex, byteBuffer + trimStartIndex + size });
+            { byteBuffer + trimStartIndex, std::min(size, bufferLength - trimStartIndex) });
 
         return trimmedBuffer;
     }

--- a/src/AppInstallerCommonCore/HttpStream/HttpLocalCache.h
+++ b/src/AppInstallerCommonCore/HttpStream/HttpLocalCache.h
@@ -18,8 +18,8 @@ namespace AppInstaller::Utility::HttpStream
     class HttpLocalCache
     {
     public:
-        const UINT32 PAGE_SIZE = 2 << 16;   // each entry in the cache is 64 KB
-        const UINT32 MAX_PAGES = 200;       // cache size capped at 12.5 MB (200 * 64KB)
+        static constexpr UINT32 PAGE_SIZE = 2 << 16;   // each entry in the cache is 64 KB
+        static constexpr UINT32 MAX_PAGES = 200;       // cache size capped at 12.5 MB (200 * 64KB)
 
         // Returns a buffer matching the requested range by reading the parts of the range that are cached
         // and downloading the rest using the provided httpClientWrapper object

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -4,6 +4,7 @@
 #include <AppInstallerProgress.h>
 
 #include <urlmon.h>
+#include <wrl/client.h>
 
 #include <filesystem>
 #include <optional>


### PR DESCRIPTION
Fixes #3297 (based on crash reports + code review + issue report alignment)

There is a bug in this stream implementation that allows it to attempt to read past the end of the stream if requested.  That aligns with the issue reports, which appear to be crashes in the attempt to update the source information, which uses this code.  It also aligns with the crash reports, which show an access violation on a page boundary when reading from the stream.

## Change
Ensures that the trim start location is at least not past the end of the given buffer.  Ensures that the `array_view` will not reference bytes past the end of the given buffer.

## Validation
Added a new test to ensure that we get the number of bytes expected based on the stream size (the 0 byte file issue persists, so I put a retry loop on the test).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3300)