### PR TITLE
Treat warning not as error for CS8785

### DIFF
--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -16,6 +16,8 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <!-- Disable warning for CS1591 for cswinrt auto-generated files -->
     <NoWarn>1591</NoWarn>
+    <!-- Treat warning not as error for CS8785 to avoid compilation errors with SourceGenerator -->
+    <WarningsNotAsErrors>CS8785</WarningsNotAsErrors>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
   </PropertyGroup>
 

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -14,9 +14,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Workaround for MSB3271 error on processor architecture mismatch -->
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <!-- Disable warning for CS1591 for cswinrt auto-generated files -->
-    <NoWarn>1591</NoWarn>
-    <!-- Treat warning not as error for CS8785 to avoid compilation errors with SourceGenerator -->
+    <!-- Disable warning CS1591 for cswinrt auto-generated files and CS8785 for SourceGenerator compilation errors -->
+    <NoWarn>1591,8785</NoWarn>
     <WarningsNotAsErrors>CS8785</WarningsNotAsErrors>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
   </PropertyGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -16,7 +16,6 @@
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <!-- Disable warning CS1591 for cswinrt auto-generated files and CS8785 for SourceGenerator compilation errors -->
     <NoWarn>1591,8785</NoWarn>
-    <WarningsNotAsErrors>CS8785</WarningsNotAsErrors>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
   </PropertyGroup>
 


### PR DESCRIPTION
Build pipeline had a recent update that started treating CS8785 as an error instead of warning. Modified .csproj file so that the warning does not break the build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-cli/pull/3301)