### PR TITLE
Respect Group Policies for sources

### DIFF
--- a/src/AppInstallerCLITests/TestSource.cpp
+++ b/src/AppInstallerCLITests/TestSource.cpp
@@ -263,6 +263,11 @@ namespace TestCommon
         }
     }
 
+    std::string_view TestSourceFactory::TypeName() const
+    {
+        return "*TestSource"sv;
+    }
+
     std::shared_ptr<ISourceReference> TestSourceFactory::Create(const SourceDetails& details)
     {
         if (OnOpenWithCustomHeader)

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -137,6 +137,7 @@ namespace TestCommon
         TestSourceFactory(OpenFunctorWithCustomHeader open) : OnOpenWithCustomHeader(std::move(open)) {}
 
         // ISourceFactory
+        std::string_view TypeName() const override;
         std::shared_ptr<AppInstaller::Repository::ISourceReference> Create(const AppInstaller::Repository::SourceDetails& details) override;
         bool Add(AppInstaller::Repository::SourceDetails& details, AppInstaller::IProgressCallback&) override;
         bool Update(const AppInstaller::Repository::SourceDetails& details, AppInstaller::IProgressCallback&) override;

--- a/src/AppInstallerRepositoryCore/Microsoft/ConfigurableTestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/ConfigurableTestSourceFactory.cpp
@@ -111,6 +111,11 @@ namespace AppInstaller::Repository::Microsoft
         // The actual factory implementation.
         struct ConfigurableTestSourceFactoryImpl : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return ConfigurableTestSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
             {
                 return std::make_shared<ConfigurableTestSourceReference>(details);

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -115,6 +115,11 @@ namespace AppInstaller::Repository::Microsoft
         // The base class for a package that comes from a preindexed packaged source.
         struct PreIndexedFactoryBase : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return PreIndexedPackageSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
             {
                 // With more than one source implementation, we will probably need to probe first

--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
@@ -168,6 +168,11 @@ namespace AppInstaller::Repository::Microsoft
         // The factory for the predefined installed source.
         struct Factory : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return PredefinedInstalledSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
             {
                 THROW_HR_IF(E_INVALIDARG, details.Type != PredefinedInstalledSourceFactory::Type());

--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedWriteableSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedWriteableSourceFactory.cpp
@@ -20,6 +20,11 @@ namespace AppInstaller::Repository::Microsoft
         // The factory for the predefined installing source.
         struct PredefinedWriteableSourceFactoryImpl : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return PredefinedWriteableSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final;
 
             bool Add(SourceDetails&, IProgressCallback&) override final

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -80,6 +80,11 @@ namespace AppInstaller::Repository
 
         struct PackageTrackingCatalogSourceFactoryImpl : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return PackageTrackingCatalogSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
             {
                 THROW_HR_IF(E_INVALIDARG, !Utility::CaseInsensitiveEquals(details.Type, PackageTrackingCatalogSourceFactory::Type()));

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -603,6 +603,10 @@ namespace AppInstaller::Repository
 
         auto& sourceDetails = m_sourceReferences[0]->GetDetails();
 
+        // GetForType() has some special handling, like a default in case the type is empty.
+        // We get the canonical name here to make it easier to have checks for the source type.
+        sourceDetails.Type = ISourceFactory::GetForType(sourceDetails.Type)->TypeName();
+
         AICLI_LOG(Repo, Info, << "Adding source: Name[" << sourceDetails.Name << "], Type[" << sourceDetails.Type << "], Arg[" << sourceDetails.Arg << "]");
 
         // Check all sources for the given name.

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -259,6 +259,8 @@ namespace AppInstaller::Repository
 
     Source::Source(WellKnownSource source)
     {
+        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, !IsWellKnownSourceEnabled(source));
+
         SourceDetails details = GetWellKnownSourceDetailsInternal(source);
         m_sourceReferences.emplace_back(CreateSourceFromDetails(details));
     }

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -603,9 +603,12 @@ namespace AppInstaller::Repository
 
         auto& sourceDetails = m_sourceReferences[0]->GetDetails();
 
-        // GetForType() has some special handling, like a default in case the type is empty.
-        // We get the canonical name here to make it easier to have checks for the source type.
-        sourceDetails.Type = ISourceFactory::GetForType(sourceDetails.Type)->TypeName();
+        // If the source type is empty, use a default.
+        // AddSourceForDetails will also check for empty, but we need the actual type before that for validation.
+        if (sourceDetails.Type.empty())
+        {
+            sourceDetails.Type = ISourceFactory::GetForType("")->TypeName();
+        }
 
         AICLI_LOG(Repo, Info, << "Adding source: Name[" << sourceDetails.Name << "], Type[" << sourceDetails.Type << "], Arg[" << sourceDetails.Arg << "]");
 

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -85,6 +85,11 @@ namespace AppInstaller::Repository::Rest
         // The base class for data that comes from a rest based source.
         struct RestSourceFactoryImpl : public ISourceFactory
         {
+            std::string_view TypeName() const override final
+            {
+                return RestSourceFactory::Type();
+            }
+
             std::shared_ptr<ISourceReference> Create(const SourceDetails& details) override final
             {
                 THROW_HR_IF(E_INVALIDARG, !Utility::CaseInsensitiveEquals(details.Type, RestSourceFactory::Type()));

--- a/src/AppInstallerRepositoryCore/SourceFactory.h
+++ b/src/AppInstallerRepositoryCore/SourceFactory.h
@@ -14,6 +14,9 @@ namespace AppInstaller::Repository
     {
         virtual ~ISourceFactory() = default;
 
+        // Gets the name of the source type.
+        virtual std::string_view TypeName() const = 0;
+
         // Creates a source object from the given details.
         virtual std::shared_ptr<ISourceReference> Create(const SourceDetails& details) = 0;
 


### PR DESCRIPTION
* Group Policy for disabling the default sources was not respected when getting the catalogs through COM. Added missing check for GP.
* When we add a source and there is a Group Policy for allowed sources, we check the source details against the list of allowed sources. In this check we compare the types, but do a direct comparison without considering that an empty type defaults to the preindexed type. Meaning that if we had preindexed source S as allowed, we would accept `winget source add --type Microsoft.PreIndexed.Package S ...` but not `winget source add S ...`. Fixed this by resolving the source type name before getting to this point.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3367&drop=dogfoodAlpha