### PR TITLE
Improve packaged test log collection and fix crash

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -92,6 +92,7 @@ Dbg
 debian
 deigh
 deleteifnotneeded
+DENYWR
 desktopappinstaller
 devhome
 dic
@@ -465,6 +466,7 @@ websites
 WERSJA
 wesome
 wfopen
+wfsopen
 wgetenv
 Whatif
 winapifamily

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -309,7 +309,7 @@ jobs:
     inputs:
       filePath: 'src\Microsoft.Management.Configuration.OutOfProc\Prepare-ConfigurationOOPTests.ps1'
       arguments: '-BuildOutputPath $(buildOutDir) -PackageLayoutPath $(packageLayoutDir)'
-      pwsh: true
+    condition: succeededOrFailed()
 
   - task: VSTest@2
     displayName: 'Run tests: Microsoft.Management.Configuration.UnitTests (OutOfProc)'
@@ -329,6 +329,7 @@ jobs:
     inputs:
       filePath: 'src\Microsoft.Management.Configuration.OutOfProc\Collect-ConfigurationOOPTests.ps1'
       arguments: '-TargetLocation $(artifactsDir)\ConfigOOPTestsLog'
+    condition: succeededOrFailed()
 
   - task: CopyFiles@2
     displayName: 'Copy Util to artifacts folder'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,28 +304,13 @@ jobs:
       configuration: '$(BuildConfiguration)'
     condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    displayName: 'Copy Microsoft.Management.Configuration.winmd'
-    inputs:
-      Contents: |
-          $(buildOutDir)\Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd
-      TargetFolder: '$(buildOutDir)\Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0'
-    condition: succeededOrFailed()
-      
   - task: PowerShell@2
-    displayName: 'Copy Microsoft.Management.Configuration.OutOfProc.dll as Microsoft.Management.Configuration.dll'
+    displayName: Prepare for Microsoft.Management.Configuration.UnitTests (OutOfProc)
     inputs:
-      targetType: 'inline'
-      script: Copy-Item '$(buildOutDir)\Microsoft.Management.Configuration.OutOfProc\Microsoft.Management.Configuration.OutOfProc.dll' '$(buildOutDir)\Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.dll' -Force
-    condition: succeededOrFailed()
-      
-  - task: PowerShell@2
-    displayName: 'Register the Dev package for OOP configuration tests'
-    inputs:
-      targetType: 'inline'
-      script: Add-AppxPackage -Register $(packageLayoutDir)\AppxManifest.xml
-    condition: succeededOrFailed()
-  
+      filePath: 'src\Microsoft.Management.Configuration.OutOfProc\Prepare-ConfigurationOOPTests.ps1'
+      arguments: '-BuildOutputPath $(buildOutDir) -PackageLayoutPath $(packageLayoutDir)'
+      pwsh: true
+
   - task: VSTest@2
     displayName: 'Run tests: Microsoft.Management.Configuration.UnitTests (OutOfProc)'
     inputs:
@@ -338,6 +323,12 @@ jobs:
       platform: '$(buildPlatform)'
       configuration: '$(BuildConfiguration)'
     condition: succeededOrFailed()
+
+  - task: PowerShell@2
+    displayName: Collect logs for Microsoft.Management.Configuration.UnitTests (OutOfProc)
+    inputs:
+      filePath: 'src\Microsoft.Management.Configuration.OutOfProc\Collect-ConfigurationOOPTests.ps1'
+      arguments: '-TargetLocation $(artifactsDir)\ConfigOOPTestsLog'
 
   - task: CopyFiles@2
     displayName: 'Copy Util to artifacts folder'

--- a/src/AppInstallerCLICore/COMContext.cpp
+++ b/src/AppInstallerCLICore/COMContext.cpp
@@ -82,7 +82,14 @@ namespace AppInstaller::CLI::Execution
 
         // TODO: Log to file for COM API calls only when debugging in visual studio
         Logging::FileLogger::Add(s_comLogFileNamePrefix);
-        Logging::FileLogger::BeginCleanup();
+
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (!Settings::User().Get<Settings::Setting::KeepAllLogFiles>())
+#endif
+        {
+            // Initiate the background cleanup of the log file location.
+            Logging::FileLogger::BeginCleanup();
+        }
 
         Logging::TraceLogger::Add();
 

--- a/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
+++ b/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
@@ -44,7 +44,7 @@ namespace AppInstaller::CLI::ConfigurationRemoting
         constexpr std::wstring_view s_RemoteServerFileName = L"ConfigurationRemotingServer\\ConfigurationRemotingServer.exe";
 
         // Represents a remote factory object that was created from a specific process.
-        struct RemoteFactory : winrt::implements<RemoteFactory, IConfigurationSetProcessorFactory, SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties, WinRT::ILifetimeWatcher>, WinRT::LifetimeWatcherBase
+        struct RemoteFactory : winrt::implements<RemoteFactory, IConfigurationSetProcessorFactory, SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties, winrt::cloaked<WinRT::ILifetimeWatcher>>, WinRT::LifetimeWatcherBase
         {
             RemoteFactory()
             {

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -77,8 +77,13 @@ namespace AppInstaller::CLI
         Logging::Telemetry().SetCaller("winget-cli");
         Logging::Telemetry().LogStartup();
 
-        // Initiate the background cleanup of the log file location.
-        Logging::FileLogger::BeginCleanup();
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (!Settings::User().Get<Settings::Setting::KeepAllLogFiles>())
+#endif
+        {
+            // Initiate the background cleanup of the log file location.
+            Logging::FileLogger::BeginCleanup();
+        }
 
         context << Workflow::ReportExecutionStage(Workflow::ExecutionStage::ParseArgs);
 
@@ -152,6 +157,13 @@ namespace AppInstaller::CLI
 
     void ServerInitialize()
     {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (Settings::User().Get<Settings::Setting::EnableSelfInitiatedMinidump>())
+        {
+            Debugging::EnableSelfInitiatedMinidump();
+        }
+#endif
+
         AppInstaller::CLI::Execution::COMContext::SetLoggers();
     }
 }

--- a/src/AppInstallerCLIE2ETests/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/TestCommon.cs
@@ -538,12 +538,6 @@ namespace AppInstallerCLIE2ETests
             string testLogsPackagedDestPath = Path.Combine(testLogsDestPath, "Packaged");
             string testLogsUnpackagedDestPath = Path.Combine(testLogsDestPath, "Unpackaged");
 
-            if (Directory.Exists(testLogsDestPath))
-            {
-                TestIndexSetup.DeleteDirectoryContents(new DirectoryInfo(testLogsDestPath));
-                Directory.Delete(testLogsDestPath);
-            }
-
             if (Directory.Exists(testLogsPackagedSourcePath))
             {
                 TestIndexSetup.CopyDirectory(testLogsPackagedSourcePath, testLogsPackagedDestPath);

--- a/src/AppInstallerCLIE2ETests/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/WinGetSettingsHelper.cs
@@ -49,7 +49,8 @@ namespace AppInstallerCLIE2ETests
                     "debugging",
                     new Hashtable()
                     {
-                        { "enableSelfInitiatedMinidump", false },
+                        { "enableSelfInitiatedMinidump", true },
+                        { "keepAllLogFiles", true },
                     }
                 },
                 {

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -99,6 +99,7 @@ namespace AppInstaller::Settings
         InteractivityDisable,
         // Debug
         EnableSelfInitiatedMinidump,
+        KeepAllLogFiles,
         Max
     };
 
@@ -164,8 +165,11 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDownloader, std::string, InstallerDownloader, InstallerDownloader::Default, ".network.downloader"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDOProgressTimeoutInSeconds, uint32_t, std::chrono::seconds, 60s, ".network.doProgressTimeoutInSeconds"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkWingetAlternateSourceURL, bool, bool, true, ".network.enableWingetAlternateSourceURL"sv);
+#ifndef AICLI_DISABLE_TEST_HOOKS
         // Debug
         SETTINGMAPPING_SPECIALIZATION(Setting::EnableSelfInitiatedMinidump, bool, bool, false, ".debugging.enableSelfInitiatedMinidump"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::KeepAllLogFiles, bool, bool, false, ".debugging.keepAllLogFiles"sv);
+#endif
         // Logging
         SETTINGMAPPING_SPECIALIZATION(Setting::LoggingLevelPreference, std::string, Logging::Level, Logging::Level::Info, ".logging.level"sv);
         // Interactivity

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -265,11 +265,15 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(AnonymizePathForDisplay)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(InteractivityDisable)
-        WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
         WINGET_VALIDATE_PASS_THROUGH(InstallSkipDependencies)
         WINGET_VALIDATE_PASS_THROUGH(DisableInstallNotes)
         WINGET_VALIDATE_PASS_THROUGH(UninstallPurgePortablePackage)
         WINGET_VALIDATE_PASS_THROUGH(NetworkWingetAlternateSourceURL)
+
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        WINGET_VALIDATE_PASS_THROUGH(EnableSelfInitiatedMinidump)
+        WINGET_VALIDATE_PASS_THROUGH(KeepAllLogFiles)
+#endif
 
         WINGET_VALIDATE_SIGNATURE(PortablePackageUserRoot)
         {

--- a/src/AppInstallerSharedLib/Public/winget/SharedThreadGlobals.h
+++ b/src/AppInstallerSharedLib/Public/winget/SharedThreadGlobals.h
@@ -30,9 +30,10 @@ namespace AppInstaller::ThreadLocalStorage
     {
         ~PreviousThreadGlobals();
 
-        PreviousThreadGlobals(ThreadGlobals* previous) : m_previous(previous) {};
+        PreviousThreadGlobals(ThreadGlobals* previous);
 
     private:
         ThreadGlobals* m_previous;
+        DWORD m_threadId;
     };
 }

--- a/src/AppInstallerSharedLib/SharedThreadGlobals.cpp
+++ b/src/AppInstallerSharedLib/SharedThreadGlobals.cpp
@@ -31,8 +31,15 @@ namespace AppInstaller::ThreadLocalStorage
         return SetOrGetThreadGlobals(false);
     }
 
+    PreviousThreadGlobals::PreviousThreadGlobals(ThreadGlobals* previous) : m_previous(previous)
+    {
+        m_threadId = GetCurrentThreadId();
+    }
+
     PreviousThreadGlobals::~PreviousThreadGlobals()
     {
+        // Not remaining on the same thread is a serious issue that must be resolved
+        FAIL_FAST_IF(GetCurrentThreadId() != m_threadId);
         std::ignore = SetOrGetThreadGlobals(true, m_previous);
     }
 }

--- a/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
@@ -1,0 +1,1 @@
+Copy log directory to a new artifacts directory

--- a/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
@@ -8,4 +8,6 @@ param(
 $Local:settingsExport = ConvertFrom-Json (wingetdev.exe settings export)
 $Local:logsFilePath = Join-Path (Split-Path $Local:settingsExport.userSettingsFile -Parent) "DiagOutputDir"
 
-Copy-Item $Local:logsFilePath $TargetLocation -Recurse -Force
+Get-AppxPackage WinGetDevCLI | Remove-AppxPackage
+
+Copy-Item $Local:logsFilePath $TargetLocation -Recurse -Force -ErrorAction Ignore

--- a/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Collect-ConfigurationOOPTests.ps1
@@ -1,1 +1,11 @@
-Copy log directory to a new artifacts directory
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+[CmdletBinding()]
+param(
+    [string]$TargetLocation
+)
+
+$Local:settingsExport = ConvertFrom-Json (wingetdev.exe settings export)
+$Local:logsFilePath = Join-Path (Split-Path $Local:settingsExport.userSettingsFile -Parent) "DiagOutputDir"
+
+Copy-Item $Local:logsFilePath $TargetLocation -Recurse -Force

--- a/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj
@@ -471,7 +471,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Collect-ConfigurationOOPTests.ps1" />
     <None Include="packages.config" />
+    <None Include="Prepare-ConfigurationOOPTests.ps1" />
     <None Include="PropertySheet.props" />
     <None Include="Source.def" />
   </ItemGroup>

--- a/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj.filters
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj.filters
@@ -51,5 +51,7 @@
     <None Include="Source.def">
       <Filter>Source Files</Filter>
     </None>
+    <None Include="Collect-ConfigurationOOPTests.ps1" />
+    <None Include="Prepare-ConfigurationOOPTests.ps1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
@@ -1,2 +1,32 @@
-Move the 3 current setup tasks for config OOP here
-Configure the settings to enable crash dumps and keeping log files
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+[CmdletBinding()]
+param(
+    [string]$BuildOutputPath,
+
+    [string]$PackageLayoutPath
+)
+
+# Copy the winmd into the unit test directory since it will be needed for marshalling
+$Local:winmdSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd"
+$Local:winmdTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.winmd"
+
+Copy-Item $Local:winmdSourcePath $Local:winmdTargetPath -Force
+
+# Copy the OOP helper dll into the unit test directory to make activation look the same as in-proc
+$Local:dllSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.OutOfProc\Microsoft.Management.Configuration.OutOfProc.dll"
+$Local:dllTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.dll"
+
+Copy-Item $Local:dllSourcePath $Local:dllTargetPath -Force
+
+# Register the package
+$Local:packageManifestPath = Join-Path $PackageLayoutPath "AppxManifest.xml"
+
+Add-AppxPackage -Register $Local:packageManifestPath
+
+# Configure crash dump and log file settings
+$Local:settingsExport = ConvertFrom-Json (wingetdev.exe settings export)
+$Local:settingsFilePath = $Local:settingsExport.userSettingsFile
+$Local:settingsFileContent = ConvertTo-Json @{ debugging= @{ enableSelfInitiatedMinidump=$true ; keepAllLogFiles=$true } }
+
+Set-Content -Path $Local:settingsFilePath -Value $Local:settingsFileContent

--- a/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
@@ -1,0 +1,2 @@
+Move the 3 current setup tasks for config OOP here
+Configure the settings to enable crash dumps and keeping log files

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
@@ -99,6 +99,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                     return AppInstaller::Utility::ConvertToUTF8(message);
                     }());
             }
+
+            static void Ensure()
+            {
+                static AttachWilFailureCallback s_callbackAttach;
+            }
         };
 
         // Specifies the set of intents that should execute during a Test request
@@ -123,7 +128,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
     event_token ConfigurationProcessor::Diagnostics(const Windows::Foundation::EventHandler<IDiagnosticInformation>& handler)
     {
-        static AttachWilFailureCallback s_callbackAttach;
+        AttachWilFailureCallback::Ensure();
         return m_diagnostics.add(handler);
     }
 

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -15,7 +15,7 @@
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
-    struct ConfigurationProcessor : ConfigurationProcessorT<ConfigurationProcessor, AppInstaller::WinRT::ILifetimeWatcher>, AppInstaller::WinRT::LifetimeWatcherBase
+    struct ConfigurationProcessor : ConfigurationProcessorT<ConfigurationProcessor, winrt::cloaked<AppInstaller::WinRT::ILifetimeWatcher>>, AppInstaller::WinRT::LifetimeWatcherBase
     {
         using ConfigurationSet = Configuration::ConfigurationSet;
         using ConfigurationSetChangeData = Configuration::ConfigurationSetChangeData;

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.h
@@ -10,7 +10,7 @@
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
-    struct ConfigurationSet : ConfigurationSetT<ConfigurationSet, AppInstaller::WinRT::ILifetimeWatcher>, AppInstaller::WinRT::LifetimeWatcherBase
+    struct ConfigurationSet : ConfigurationSetT<ConfigurationSet, winrt::cloaked<AppInstaller::WinRT::ILifetimeWatcher>>, AppInstaller::WinRT::LifetimeWatcherBase
     {
         using WinRT_Self = ::winrt::Microsoft::Management::Configuration::ConfigurationSet;
         using ConfigurationUnit = ::winrt::Microsoft::Management::Configuration::ConfigurationUnit;

--- a/src/Microsoft.Management.Configuration/ConfigurationUnit.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationUnit.h
@@ -9,7 +9,7 @@
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
-    struct ConfigurationUnit : ConfigurationUnitT<ConfigurationUnit, AppInstaller::WinRT::ILifetimeWatcher>, AppInstaller::WinRT::LifetimeWatcherBase
+    struct ConfigurationUnit : ConfigurationUnitT<ConfigurationUnit, winrt::cloaked<AppInstaller::WinRT::ILifetimeWatcher>>, AppInstaller::WinRT::LifetimeWatcherBase
     {
         ConfigurationUnit();
 

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -44,6 +44,7 @@ namespace ConfigurationShim
 
         winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Management::Configuration::IConfigurationSetProcessorFactory> CreateConfigurationSetProcessorFactoryAsync(winrt::hstring const& handler)
         {
+            auto strong_this{ get_strong() };
             std::wstring lowerHandler = AppInstaller::Utility::ToLower(handler);
 
             co_await winrt::resume_background();


### PR DESCRIPTION
## Change
Collect all of the logs from the E2E test runs, rather than just the logs from the last one of them run.
Re-enable crash dumps on E2E tests runs.
Collect logs and crash dumps from OOP configuration tests as well.

Fixes for the following issues:
1. Asynchronous functions in OOP configuration need to keep a reference to the object
  a. Done using `get_strong` at the top of each async function
2. Thread globals being set and then switching threads in `OpenConfigurationSetAsync` (via `co_await`)
  a. Done by not using `co_await` and instead polling the operation and cancelling it if we are cancelled
3. `Diagnostics` delegates need to keep a reference to the processor
  a. Done by capturing `get_weak` into the lambda that we pass along to the factory
4. Diagnostics failures can lead to a recursion and stack exhaustion
  a. Done by putting a recursive mutex around the diagnostics call and writing the error that must have occurred sending the diagnostic message to the debugger

Also makes the file logger files share read so that they can be opened while the server is still running.

## Validation
Upon attempting to repro locally, only Release builds would hit anything.  After these fixes, I ran the OOP configuration tests in a loop ~50 times without issue.
###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3395&drop=dogfoodAlpha