### PR TITLE
Fix wingetutil nuget publish pipeline

### DIFF
--- a/WinGetUtil.nuspec
+++ b/WinGetUtil.nuspec
@@ -19,13 +19,13 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="src\x64\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x64\native\WinGetUtil.dll"/>
-    <file src="src\x64\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x64\native\WinGetUtil.pdb"/>
-    <file src="src\x86\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x86\native\WinGetUtil.dll"/>
-    <file src="src\x86\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x86\native\WinGetUtil.pdb"/>
-    <file src="schemas\JSON\manifests\**" target="content\schemas\JSON\manifests" />
-    <file src="src\WinGetUtilInterop\bin\Release\netstandard2.0\WinGetUtilInterop.dll" target="lib/netstandard2.0/WinGetUtilInterop.dll" />
-    <file src="src\WinGetUtilInterop\bin\Release\netstandard2.0\WinGetUtilInterop.pdb" target="lib/netstandard2.0/WinGetUtilInterop.pdb" />
-    <file src="src\WinGetUtilInterop\build\Microsoft.WindowsPackageManager.Utils.targets" target="build/Microsoft.WindowsPackageManager.Utils.targets" />
+    <file src="Build.x64release\src\x64\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x64\native\WinGetUtil.dll"/>
+    <file src="Build.x64release\src\x64\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x64\native\WinGetUtil.pdb"/>
+    <file src="Build.x86release\src\x86\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x86\native\WinGetUtil.dll"/>
+    <file src="Build.x86release\src\x86\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x86\native\WinGetUtil.pdb"/>
+    <file src="Build.x64release\schemas\JSON\manifests\**" target="content\schemas\JSON\manifests" />
+    <file src="Build.x64release\src\WinGetUtilInterop\bin\Release\netstandard2.0\WinGetUtilInterop.dll" target="lib/netstandard2.0/WinGetUtilInterop.dll" />
+    <file src="Build.x64release\src\WinGetUtilInterop\bin\Release\netstandard2.0\WinGetUtilInterop.pdb" target="lib/netstandard2.0/WinGetUtilInterop.pdb" />
+    <file src="Build.x64release\src\WinGetUtilInterop\build\Microsoft.WindowsPackageManager.Utils.targets" target="build/Microsoft.WindowsPackageManager.Utils.targets" />
   </files>
 </package>

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -18,13 +18,13 @@ jobs:
   - job: "Build"
     timeoutInMinutes: 120
     strategy:
-    matrix:
-      x86_release:
-        buildConfiguration: 'Release'
-        buildPlatform: 'x86'
-      x64_release:
-        buildConfiguration: 'Release'
-        buildPlatform: 'x64'
+      matrix:
+        x86_release:
+          buildConfiguration: 'Release'
+          buildPlatform: 'x86'
+        x64_release:
+          buildConfiguration: 'Release'
+          buildPlatform: 'x64'
     variables:
       artifactsDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)
     steps:

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -10,15 +10,23 @@ pool:
 
 variables:
   solution: "src/AppInstallerCLI.sln"
-  buildConfiguration: "Release"
   packageName: Microsoft.WindowsPackageManager.Utils
+  buildVer: $[counter(${{ parameters.version }}, 1)]
+  version: ${{ parameters.version }}.$(buildVer)
 
 jobs:
   - job: "Build"
     timeoutInMinutes: 120
+    strategy:
+    matrix:
+      x86_release:
+        buildConfiguration: 'Release'
+        buildPlatform: 'x86'
+      x64_release:
+        buildConfiguration: 'Release'
+        buildPlatform: 'x64'
     variables:
-      BuildVer: $[counter(${{ parameters.version }}, 1)]
-      version: ${{ parameters.version }}.$(BuildVer)
+      artifactsDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)
     steps:
       - script: echo $(version)
 
@@ -55,20 +63,13 @@ jobs:
         condition: not(eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           filePath: 'src\binver\Update-BinVer.ps1'
-          arguments: '-TargetFile binver\binver\version.h -BuildVersion $(BuildVer) -MajorMinorOverride ${{ parameters.version }}'
+          arguments: '-TargetFile binver\binver\version.h -BuildVersion $(buildVer) -MajorMinorOverride ${{ parameters.version }}'
           workingDirectory: "src"
 
       - task: VSBuild@1
-        displayName: Build Solution x86
+        displayName: Build Solution
         inputs:
-          platform: "x86"
-          solution: "$(solution)"
-          configuration: "$(buildConfiguration)"
-
-      - task: VSBuild@1
-        displayName: Build Solution x64
-        inputs:
-          platform: "x64"
+          platform: "$(buildPlatform)"
           solution: "$(solution)"
           configuration: "$(buildConfiguration)"
 
@@ -105,6 +106,27 @@ jobs:
                   "ToolVersion" : "1.0"
               }
             ]
+      - task: CopyFiles@2
+        displayName: 'Copy Util to artifacts folder'
+        inputs:
+          Contents: |
+              src\$(buildPlatform)\$(buildConfiguration)\WinGetUtil\WinGetUtil.dll
+              src\$(buildPlatform)\$(buildConfiguration)\WinGetUtil\WinGetUtil.pdb
+              src\WinGetUtilInterop\bin\$(buildConfiguration)\netstandard2.0\WinGetUtilInterop.dll
+              src\WinGetUtilInterop\bin\$(buildConfiguration)\netstandard2.0\WinGetUtilInterop.pdb
+              src\WinGetUtilInterop\build\Microsoft.WindowsPackageManager.Utils.targets
+              schemas\JSON\manifests\**
+          TargetFolder: '$(artifactsDir)'
+
+      - task: PublishPipelineArtifact@1
+        displayName: Publish Pipeline Artifacts
+        inputs:
+          targetPath: '$(artifactsDir)'
+
+  - job: "Nuget"
+    steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download Build Artifacts'
 
       - task: NuGetCommand@2
         displayName: Pack WingetUtil nuget package
@@ -114,6 +136,7 @@ jobs:
           versioningScheme: byEnvVar
           versionEnvVar: version
           packDestination: "$(Build.ArtifactStagingDirectory)"
+          basePath: $(Pipeline.Workspace)
 
       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
         displayName: "ESRP CodeSigning - NuGet package"
@@ -149,6 +172,7 @@ jobs:
 
       - task: NuGetCommand@2
         displayName: Push WingetUtil nuget package to nuget.org
+        condition: eq(1,2)
         inputs:
           command: push
           nuGetFeedType: external

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -73,7 +73,7 @@ jobs:
           solution: "$(solution)"
           configuration: "$(buildConfiguration)"
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
         displayName: "ESRP CodeSigning - Package contents"
         inputs:
           ConnectedServiceName: "WindowsPackageManager ESRP CodeSigning"
@@ -138,7 +138,7 @@ jobs:
           packDestination: "$(Build.ArtifactStagingDirectory)"
           basePath: $(Pipeline.Workspace)
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
         displayName: "ESRP CodeSigning - NuGet package"
         inputs:
           ConnectedServiceName: "WindowsPackageManager ESRP CodeSigning"

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -181,7 +181,7 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: Publish nuget package to artifacts
         inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(packageName).$(version).nupkg'
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
           ArtifactName: $(packageName)
           publishLocation: Container
 

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -135,22 +135,22 @@ jobs:
         displayName: 'Download Build.x64release artifacts'
         inputs:
           artifactName: Build.x64release
-          targetPath: '$(Pipeline.Workspace)/Build.x64release'
+          targetPath: '$(Pipeline.Workspace)\Build.x64release'
 
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Build.x86release artifacts'
         inputs:
           artifactName: Build.x86release
-          targetPath: '$(Pipeline.Workspace)/Build.x86release'
+          targetPath: '$(Pipeline.Workspace)\Build.x86release'
 
       - task: NuGetCommand@2
         displayName: Pack WingetUtil nuget package
         inputs:
           command: pack
-          packagesToPack: 'Build.x64release\WinGetUtil.nuspec'
+          packagesToPack: '$(Pipeline.Workspace)\Build.x64release\WinGetUtil.nuspec'
           versioningScheme: byEnvVar
           versionEnvVar: version
-          packDestination: "$(Build.ArtifactStagingDirectory)"
+          packDestination: '$(Build.ArtifactStagingDirectory)'
           basePath: $(Pipeline.Workspace)
 
       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -126,6 +126,8 @@ jobs:
           targetPath: '$(artifactsDir)'
 
   - job: "Nuget"
+    timeoutInMinutes: 60
+    dependsOn: 'Build'
     steps:
       - checkout: none
 

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -181,13 +181,12 @@ jobs:
       - task: PublishBuildArtifacts@1
         displayName: Publish nuget package to artifacts
         inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(packageName).$(version).nupkg'
           ArtifactName: $(packageName)
           publishLocation: Container
 
       - task: NuGetCommand@2
         displayName: Push WingetUtil nuget package to nuget.org
-        condition: eq(1,2)
         inputs:
           command: push
           nuGetFeedType: external

--- a/azure-pipelines.nuget.yml
+++ b/azure-pipelines.nuget.yml
@@ -106,10 +106,12 @@ jobs:
                   "ToolVersion" : "1.0"
               }
             ]
+
       - task: CopyFiles@2
-        displayName: 'Copy Util to artifacts folder'
+        displayName: 'Copy nuget pack files to artifacts folder'
         inputs:
           Contents: |
+              WinGetUtil.nuspec
               src\$(buildPlatform)\$(buildConfiguration)\WinGetUtil\WinGetUtil.dll
               src\$(buildPlatform)\$(buildConfiguration)\WinGetUtil\WinGetUtil.pdb
               src\WinGetUtilInterop\bin\$(buildConfiguration)\netstandard2.0\WinGetUtilInterop.dll
@@ -125,14 +127,25 @@ jobs:
 
   - job: "Nuget"
     steps:
+      - checkout: none
+
       - task: DownloadPipelineArtifact@2
-        displayName: 'Download Build Artifacts'
+        displayName: 'Download Build.x64release artifacts'
+        inputs:
+          artifactName: Build.x64release
+          targetPath: '$(Pipeline.Workspace)/Build.x64release'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download Build.x86release artifacts'
+        inputs:
+          artifactName: Build.x86release
+          targetPath: '$(Pipeline.Workspace)/Build.x86release'
 
       - task: NuGetCommand@2
         displayName: Pack WingetUtil nuget package
         inputs:
           command: pack
-          packagesToPack: WinGetUtil.nuspec
+          packagesToPack: 'Build.x64release\WinGetUtil.nuspec'
           versioningScheme: byEnvVar
           versionEnvVar: version
           packDestination: "$(Build.ArtifactStagingDirectory)"


### PR DESCRIPTION
Nuget publish pipeline failed with out of disk space. Modified to use the same strategy as the build pipeline (build each arch separately).

Sample run without actual publishing is at https://dev.azure.com/ms/winget-cli/_build/results?buildId=471734&view=results
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3396&drop=dogfoodAlpha