### PR TITLE
Explicitly close file stream on FileLogger destruction

### DIFF
--- a/src/AppInstallerCommonCore/FileLogger.cpp
+++ b/src/AppInstallerCommonCore/FileLogger.cpp
@@ -37,6 +37,9 @@ namespace AppInstaller::Logging
     FileLogger::~FileLogger()
     {
         m_stream.flush();
+        // When std::ofstream is constructed from an existing File handle, it does not call fclose on destruction
+        // Only calling close() explicitly will close the file handle.
+        m_stream.close();
     }
 
     std::string FileLogger::GetNameForPath(const std::filesystem::path& filePath)


### PR DESCRIPTION
The issue was found during the work to pull latest wingetutil to winget service. Winget service has unit tests that reuse a same log file. After the fix, winget service unit tests passed.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3424&drop=dogfoodAlpha