### PR TITLE
Fix using expired cert in tests

### DIFF
--- a/src/AppInstallerCLITests/Certificates.cpp
+++ b/src/AppInstallerCLITests/Certificates.cpp
@@ -13,10 +13,10 @@ using namespace AppInstaller::Certificates;
 TEST_CASE("Certificates_NoPinningSucceeds", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::None);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::None);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(expected.Validate(actual.GetCertificate()));
 }
@@ -24,10 +24,10 @@ TEST_CASE("Certificates_NoPinningSucceeds", "[certificates]")
 TEST_CASE("Certificates_PublicKeyMismatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(!expected.Validate(actual.GetCertificate()));
 }
@@ -35,10 +35,10 @@ TEST_CASE("Certificates_PublicKeyMismatch", "[certificates]")
 TEST_CASE("Certificates_PublicKeyMatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2);
 
     REQUIRE(expected.Validate(actual.GetCertificate()));
 }
@@ -46,10 +46,10 @@ TEST_CASE("Certificates_PublicKeyMatch", "[certificates]")
 TEST_CASE("Certificates_SubjectMismatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::Subject);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::Subject);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2);
 
     REQUIRE(!expected.Validate(actual.GetCertificate()));
 }
@@ -57,10 +57,10 @@ TEST_CASE("Certificates_SubjectMismatch", "[certificates]")
 TEST_CASE("Certificates_SubjectMatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2);
 
     REQUIRE(expected.Validate(actual.GetCertificate()));
 }
@@ -68,10 +68,10 @@ TEST_CASE("Certificates_SubjectMatch", "[certificates]")
 TEST_CASE("Certificates_IssuerMismatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Issuer);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Issuer);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(!expected.Validate(actual.GetCertificate()));
 }
@@ -79,10 +79,10 @@ TEST_CASE("Certificates_IssuerMismatch", "[certificates]")
 TEST_CASE("Certificates_IssuerMatch", "[certificates]")
 {
     PinningDetails expected;
-    expected.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Issuer);
+    expected.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Issuer);
 
     PinningDetails actual;
-    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    actual.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(expected.Validate(actual.GetCertificate()));
 }
@@ -91,15 +91,15 @@ TEST_CASE("Certificates_ChainLengthDiffers", "[certificates]")
 {
     PinningChain chain;
     auto chainElement = chain.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     PinningConfiguration config;
     config.AddChain(chain);
 
     PinningDetails details;
-    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(!config.Validate(details.GetCertificate()));
 }
@@ -112,7 +112,7 @@ TEST_CASE("Certificates_EmptyChainRejects", "[certificates]")
     config.AddChain(chain);
 
     PinningDetails details;
-    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(!config.Validate(details.GetCertificate()));
 }
@@ -121,17 +121,17 @@ TEST_CASE("Certificates_ChainOrderDiffers", "[certificates]")
 {
     PinningChain chain;
     auto chainElement = chain.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     PinningConfiguration config;
     config.AddChain(chain);
 
     PinningDetails details;
-    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(!config.Validate(details.GetCertificate()));
 }
@@ -140,17 +140,17 @@ TEST_CASE("Certificates_StoreChain_BuiltInTest", "[certificates]")
 {
     PinningChain chain;
     auto chainElement = chain.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     PinningConfiguration config;
     config.AddChain(chain);
 
     PinningDetails details;
-    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(config.Validate(details.GetCertificate()));
 }
@@ -159,27 +159,27 @@ TEST_CASE("Certificates_MultipleChains_Success", "[certificates]")
 {
     PinningChain chainOutOfOrder;
     auto chainElement = chainOutOfOrder.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     PinningConfiguration config;
     config.AddChain(chainOutOfOrder);
 
     PinningChain chain;
     chainElement = chain.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     config.AddChain(chain);
 
     PinningDetails details;
-    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+    details.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
     REQUIRE(config.Validate(details.GetCertificate()));
 }

--- a/src/AppInstallerCLITests/GroupPolicy.cpp
+++ b/src/AppInstallerCLITests/GroupPolicy.cpp
@@ -280,11 +280,11 @@ TEST_CASE("GroupPolicy_Sources", "[groupPolicy]")
         auto additionalSourcesKey = RegCreateVolatileSubKey(policiesKey.get(), AdditionalSourcesPolicyKeyName);
 
         PinningDetails rootCert;
-        rootCert.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1);
+        rootCert.LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2);
         PinningDetails intermediateCert;
-        intermediateCert.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1);
+        intermediateCert.LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2);
         PinningDetails leafCert;
-        leafCert.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1);
+        leafCert.LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2);
 
         auto getBytesString = [](const PinningDetails& details)
         {

--- a/src/AppInstallerCLITests/HttpClientHelper.cpp
+++ b/src/AppInstallerCLITests/HttpClientHelper.cpp
@@ -65,11 +65,11 @@ TEST_CASE("HttpClientHelper_PinningConfiguration", "[RestSource]")
     // Create the Store chain config
     PinningChain chain;
     auto chainElement = chain.Root();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_1).SetPinning(PinningVerificationType::PublicKey);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_ROOT_2).SetPinning(PinningVerificationType::PublicKey);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_INTERMEDIATE_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
     chainElement = chainElement.Next();
-    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_1).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
+    chainElement->LoadCertificate(IDX_CERTIFICATE_STORE_LEAF_2).SetPinning(PinningVerificationType::Subject | PinningVerificationType::Issuer);
 
     PinningConfiguration config;
     config.AddChain(chain);


### PR DESCRIPTION
StoreLeaf1.cer expired today. This is a band-aid until 3/22/24.

Real fix should be using certs that expire in a long long time, but I don't want to keep PRs broken.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3435&drop=dogfoodAlpha