### PR TITLE
Rename file in single portable installs

### DIFF
--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -196,7 +196,7 @@ namespace AppInstaller::CLI::Workflow
             for (const auto& nestedInstallerFile : nestedInstallerFiles)
             {
                 const std::filesystem::path& targetPath = targetInstallDirectory / ConvertToUTF16(nestedInstallerFile.RelativeFilePath);
-                
+
                 std::filesystem::path commandAlias;
                 if (nestedInstallerFile.PortableCommandAlias.empty())
                 {
@@ -215,31 +215,20 @@ namespace AppInstaller::CLI::Workflow
         {
             std::string_view renameArg = context.Args.GetArg(Execution::Args::Type::Rename);
             const std::vector<string_t>& commands = context.Get<Execution::Data::Installer>()->Commands;
-            std::filesystem::path fileName;
-            std::filesystem::path commandAlias;
-            
+            std::filesystem::path commandAlias = installerPath.filename();
+
+            if (!commands.empty())
+            {
+                commandAlias = ConvertToUTF16(commands[0]);
+            }
+
             if (!renameArg.empty())
             {
-                fileName = commandAlias = ConvertToUTF16(renameArg);
+                commandAlias = ConvertToUTF16(renameArg);
             }
-            else
-            {
-                if (!commands.empty())
-                {
-                    commandAlias = ConvertToUTF16(commands[0]);
-                }
-                else
-                {
-                    commandAlias = installerPath.filename();
-                }
-
-                fileName = installerPath.filename();
-            }
-
-            AppInstaller::Filesystem::AppendExtension(fileName, ".exe");
             AppInstaller::Filesystem::AppendExtension(commandAlias, ".exe");
 
-            const std::filesystem::path& targetFullPath = targetInstallDirectory / fileName;
+            const std::filesystem::path& targetFullPath = targetInstallDirectory / commandAlias;
             entries.emplace_back(std::move(PortableFileEntry::CreateFileEntry(installerPath, targetFullPath, {})));
             entries.emplace_back(std::move(PortableFileEntry::CreateSymlinkEntry(symlinkDirectory / commandAlias, targetFullPath)));
         }

--- a/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
@@ -445,8 +445,11 @@ namespace AppInstallerCLIE2ETests.Helpers
             bool shouldExist,
             Scope scope = Scope.User)
         {
+            // When portables are installed, if the exe path is inside a directory it will not be aliased
+            // if the exe path is at the root level, it will be aliased. Therefore, if either exist, the exe exists
             string exePath = Path.Combine(installDir, filename);
-            bool exeExists = File.Exists(exePath);
+            string exeAliasedPath = Path.Combine(installDir, commandAlias);
+            bool exeExists = File.Exists(exePath) || File.Exists(exeAliasedPath);
 
             string symlinkDirectory = GetPortableSymlinkDirectory(scope);
             string symlinkPath = Path.Combine(symlinkDirectory, commandAlias);


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
    * Partially #3437

This should work for renaming whenever the portable is a loose binary, or when it is not inside of a directory in a zip file. With the way directory extraction works with Zip files, I wasn't able to add just a file entry to move the file since the Desired State entries are not guaranteed to process in order. I'd like some guidance on how that should be handled, perhaps that should be a separate PR?
    
-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3439&drop=dogfoodAlpha