### PR TITLE
Allow `--include-unknown` in list `--upgrade-available`

### DIFF
--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -411,6 +411,16 @@ namespace AppInstaller::CLI
         }
     }
 
+    void Argument::ValidateArgumentDependency(const Execution::Args& args, Execution::Args::Type type, Execution::Args::Type dependencyArgType)
+    {
+        if (args.Contains(type) && !args.Contains(dependencyArgType))
+        {
+            throw CommandException(Resource::String::DependencyArgumentMissing(
+                Utility::LocIndString{ ArgumentCommon::ForType(type).Name },
+                Utility::LocIndString{ ArgumentCommon::ForType(dependencyArgType).Name }));
+        }
+    }
+
     ArgTypeCategory Argument::GetCategoriesPresent(const Execution::Args& args)
     {
         auto argProperties = ArgumentCommon::GetFromExecArgs(args);

--- a/src/AppInstallerCLICore/Argument.h
+++ b/src/AppInstallerCLICore/Argument.h
@@ -183,6 +183,9 @@ namespace AppInstaller::CLI
         // Requires that at most one argument from the list is present.
         static void ValidateExclusiveArguments(const Execution::Args& args);
 
+        // Requires that if an argument depends on another one, it is not present without the dependency.
+        static void ValidateArgumentDependency(const Execution::Args& args, Execution::Args::Type type, Execution::Args::Type dependencyArgType);
+
         static ArgTypeCategory GetCategoriesPresent(const Execution::Args& arg);
 
         // Requires that arguments meet common requirements

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -27,6 +27,8 @@ namespace AppInstaller::CLI
             Argument::ForType(Execution::Args::Type::CustomHeader),
             Argument::ForType(Execution::Args::Type::AcceptSourceAgreements),
             Argument{ Execution::Args::Type::Upgrade, Resource::String::UpgradeArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },
+            Argument{ Execution::Args::Type::IncludeUnknown, Resource::String::IncludeUnknownInListArgumentDescription, ArgumentType::Flag },
+            Argument{ Execution::Args::Type::IncludePinned, Resource::String::IncludePinnedInListArgumentDescription, ArgumentType::Flag},
         };
     }
 
@@ -69,6 +71,12 @@ namespace AppInstaller::CLI
     Utility::LocIndView ListCommand::HelpLink() const
     {
         return "https://aka.ms/winget-command-list"_liv;
+    }
+
+    void ListCommand::ValidateArgumentsInternal(Execution::Args& execArgs) const
+    {
+        Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludeUnknown, Execution::Args::Type::Upgrade);
+        Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludePinned, Execution::Args::Type::Upgrade);
     }
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/ListCommand.h
+++ b/src/AppInstallerCLICore/Commands/ListCommand.h
@@ -20,6 +20,7 @@ namespace AppInstaller::CLI
         Utility::LocIndView HelpLink() const override;
 
     protected:
+        void ValidateArgumentsInternal(Execution::Args& execArgs) const override;
         void ExecuteInternal(Execution::Context& context) const override;
     };
 }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -143,6 +143,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesSkippedMessage);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesManagementError);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesManagementExitMessage);
+        WINGET_DEFINE_RESOURCE_STRINGID(DependencyArgumentMissing);
         WINGET_DEFINE_RESOURCE_STRINGID(DisabledByGroupPolicy);
         WINGET_DEFINE_RESOURCE_STRINGID(DisableAdminSettingFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(DisableInteractivityArgumentDescription);
@@ -212,7 +213,9 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ImportInstallFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(ImportSourceNotInstalled);
         WINGET_DEFINE_RESOURCE_STRINGID(IncludePinnedArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(IncludePinnedInListArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(IncludeUnknownArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(IncludeUnknownInListArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(IncompatibleArgumentsProvided);
         WINGET_DEFINE_RESOURCE_STRINGID(InstallationAbandoned);
         WINGET_DEFINE_RESOURCE_STRINGID(InstallationDisclaimer1);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1328,6 +1328,10 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
     <value>Upgrade packages even if their current version cannot be determined</value>
   </data>
+  <data name="IncludeUnknownArgumentInListDescription" xml:space="preserve">
+    <value>List packages even if their current version cannot be determined. Can only be used with the --upgrade argument</value>
+    <comment>{Locked="--upgrade"}</comment>
+  </data>
   <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
     <value>This package's version number cannot be determined. To upgrade it anyway, add the argument --include-unknown to your previous command.</value>
     <comment>{Locked="--include-unknown"}</comment>
@@ -1655,6 +1659,10 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Multiple mutually exclusive arguments provided: {0}</value>
     <comment>{Locked="{0}"} Error message shown when mutually incompatible command line arguments are used. {0} is a placeholder replaced by the arguments that cannot be specified together</comment>
   </data>
+  <data name="DependencyArgumentMissing" xml:space="preserve">
+    <value>Argument {0} can only be used with {1}</value>
+    <comment>{Locked="{0}","{1}"} Error message shown when having an argument needs another to be present, but that is missing. {0} and {1} are replaced by the arguments. For example "Argument --include-unknown can only be used with --upgrade"</comment>
+  </data>
   <data name="StateDisabled" xml:space="preserve">
     <value>Disabled</value>
     <comment>As in enabled/disabled</comment>
@@ -1688,6 +1696,10 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="IncludePinnedArgumentDescription" xml:space="preserve">
     <value>Upgrade packages even if they have a non-blocking pin</value>
+  </data>
+  <data name="IncludePinnedArgumentInListDescription" xml:space="preserve">
+    <value>List packages even if they have a pin that prevents upgrade. Can only be used with the --upgrade argument</value>
+    <comment>{Locked="--upgrade"}</comment>
   </data>
   <data name="PinRemovedSuccessfully" xml:space="preserve">
     <value>Pin removed successfully</value>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1328,7 +1328,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="IncludeUnknownArgumentDescription" xml:space="preserve">
     <value>Upgrade packages even if their current version cannot be determined</value>
   </data>
-  <data name="IncludeUnknownArgumentInListDescription" xml:space="preserve">
+  <data name="IncludeUnknownInListArgumentDescription" xml:space="preserve">
     <value>List packages even if their current version cannot be determined. Can only be used with the --upgrade argument</value>
     <comment>{Locked="--upgrade"}</comment>
   </data>
@@ -1697,7 +1697,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="IncludePinnedArgumentDescription" xml:space="preserve">
     <value>Upgrade packages even if they have a non-blocking pin</value>
   </data>
-  <data name="IncludePinnedArgumentInListDescription" xml:space="preserve">
+  <data name="IncludePinnedInListArgumentDescription" xml:space="preserve">
     <value>List packages even if they have a pin that prevents upgrade. Can only be used with the --upgrade argument</value>
     <comment>{Locked="--upgrade"}</comment>
   </data>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1329,8 +1329,8 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Upgrade packages even if their current version cannot be determined</value>
   </data>
   <data name="IncludeUnknownInListArgumentDescription" xml:space="preserve">
-    <value>List packages even if their current version cannot be determined. Can only be used with the --upgrade argument</value>
-    <comment>{Locked="--upgrade"}</comment>
+    <value>List packages even if their current version cannot be determined. Can only be used with the --upgrade-available argument</value>
+    <comment>{Locked="--upgrade-available"}</comment>
   </data>
   <data name="UpgradeUnknownVersionExplanation" xml:space="preserve">
     <value>This package's version number cannot be determined. To upgrade it anyway, add the argument --include-unknown to your previous command.</value>
@@ -1698,8 +1698,8 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Upgrade packages even if they have a non-blocking pin</value>
   </data>
   <data name="IncludePinnedInListArgumentDescription" xml:space="preserve">
-    <value>List packages even if they have a pin that prevents upgrade. Can only be used with the --upgrade argument</value>
-    <comment>{Locked="--upgrade"}</comment>
+    <value>List packages even if they have a pin that prevents upgrade. Can only be used with the --upgrade-available argument</value>
+    <comment>{Locked="--upgrade-available"}</comment>
   </data>
   <data name="PinRemovedSuccessfully" xml:space="preserve">
     <value>Pin removed successfully</value>


### PR DESCRIPTION
Allow using `--include-unknown` and `--include-pinned` when using `winget list --upgrade-available`. Also block those args from being used without `--upgrade-available`

Solves #3456
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3473&drop=dogfoodAlpha