### PR TITLE
Fix missing space in help usage localization

### DIFF
--- a/Localization/Resources/de-DE/winget.resw
+++ b/Localization/Resources/de-DE/winget.resw
@@ -706,7 +706,7 @@ Sie können über die Einstellungsdatei „winget settings“ konfiguriert werde
     <value>Zeigt verfügbare Upgrades an und führt sie aus.</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>Verwendung: {0}{1}</value>
+    <value>Verwendung: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/es-ES/winget.resw
+++ b/Localization/Resources/es-ES/winget.resw
@@ -706,7 +706,7 @@ Se pueden configurar mediante el archivo de configuración "winget settings".</v
     <value>Muestra y realiza actualizaciones disponibles</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>uso: {0}{1}</value>
+    <value>uso: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/fr-FR/winget.resw
+++ b/Localization/Resources/fr-FR/winget.resw
@@ -706,7 +706,7 @@ Elles peuvent être configurées par le biais du fichier de paramètres « wing
     <value>Affiche et effectue les mises à niveau disponibles.</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>Utilisation : {0}{1}</value>
+    <value>Utilisation: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/it-IT/winget.resw
+++ b/Localization/Resources/it-IT/winget.resw
@@ -706,7 +706,7 @@ Possono essere configurati tramite il file di impostazioni ' winget settings '.<
     <value>Mostra ed esegue gli aggiornamenti disponibili</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>utilizzo: {0}{1}</value>
+    <value>utilizzo: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/ja-JP/winget.resw
+++ b/Localization/Resources/ja-JP/winget.resw
@@ -706,7 +706,7 @@
     <value>利用可能なアップグレードの表示と実行</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>使用法: {0}{1}</value>
+    <value>使用法: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/ko-KR/winget.resw
+++ b/Localization/Resources/ko-KR/winget.resw
@@ -706,7 +706,7 @@
     <value>사용 가능한 업그레이드를 표시하고 수행합니다.</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>사용 현황: {0}{1}</value>
+    <value>사용 현황: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/pt-BR/winget.resw
+++ b/Localization/Resources/pt-BR/winget.resw
@@ -706,7 +706,7 @@ Eles podem ser configurados por meio do arquivo de configurações ' winget sett
     <value>Mostra e executa atualizações disponíveis</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>uso: {0}{1}</value>
+    <value>uso: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/ru-RU/winget.resw
+++ b/Localization/Resources/ru-RU/winget.resw
@@ -706,7 +706,7 @@
     <value>Отображает и выполняет доступные обновления</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>использование: {0}{1}</value>
+    <value>использование: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -706,7 +706,7 @@
     <value>显示并执行可用升级</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>使用情况: {0}{1}</value>
+    <value>使用情况: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -706,7 +706,7 @@
     <value>顯示並執行可用的升級</value>
   </data>
   <data name="Usage" xml:space="preserve">
-    <value>使用狀況: {0}{1}</value>
+    <value>使用狀況: {0} {1}</value>
     <comment>{Locked="{0} {1}"} Message displayed to provide the user with instructions on how to use a command. {0} is a placeholder replaced by the program name (e.g. 'winget'). {1} is a placeholder replaced by the pattern for using the selected command.</comment>
   </data>
   <data name="ValidateCommandLongDescription" xml:space="preserve">


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [X] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [X] This pull request is related to an issue.
-----
Adds missing space in localized help usage resources
resolves #3412 

Issue:
![grafik](https://github.com/microsoft/winget-cli/assets/56564725/a04ddabd-af47-47a6-a52e-38434e05fb1f)

Fixed:  
![grafik](https://github.com/microsoft/winget-cli/assets/56564725/6aa1a2a9-da59-44f7-9179-4cb72b27ae86)


 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3490&drop=dogfoodAlpha