### PR TITLE
Group Policy update with granular settings to selectively allow/disallow entry points WinGet CLI, WinGet InProc COM, WinGet Out-Of-Proc

### DIFF
--- a/doc/admx/DesktopAppInstaller.admx
+++ b/doc/admx/DesktopAppInstaller.admx
@@ -146,5 +146,35 @@
         <decimal value="0" />
       </disabledValue>
     </policy>
+    <policy name="EnableWindowsPackageManager" class="Machine" displayName="$(string.EnableWindowsPackageManager)" explainText="$(string.EnableWindowsPackageManagerExplanation)" presentation="$(presentation.EnableWindowsPackageManagerExplanation)" key="Software\Policies\Microsoft\Windows\AppInstaller">
+      <parentCategory ref="AppInstaller" />
+      <supportedOn ref="windows:SUPPORTED_Windows_10_0_RS5" />
+      <elements>
+        <boolean id="EnableWinGetCLI" valueName="EnableWinGetCLI">
+          <trueValue>
+            <decimal value="1"></decimal>
+          </trueValue>
+          <falseValue>
+            <decimal value="0"></decimal>
+          </falseValue>
+        </boolean>
+        <boolean id="EnableWinGetInProcessCOM" valueName="EnableWinGetInProcessCOM">
+          <trueValue>
+            <decimal value="1"></decimal>
+          </trueValue>
+          <falseValue>
+            <decimal value="0"></decimal>
+          </falseValue>
+        </boolean>
+        <boolean id="EnableWinGetOutOfProcessCOM" valueName="EnableWinGetOutOfProcessCOM">
+          <trueValue>
+            <decimal value="1"></decimal>
+          </trueValue>
+          <falseValue>
+            <decimal value="0"></decimal>
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
   </policies>
 </policyDefinitions>

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -95,6 +95,22 @@ If you disable this policy, no additional sources can be configured for the Wind
 If you enable this setting, users will be able to install packages from websites that use this protocol.
 
 If you disable or do not configure this setting, users will not be able to install packages from websites that use this protocol.</string>
+      <string id="EnableWindowsPackageManager">Enable Windows Package Manager</string>
+      <string id="EnableWindowsPackageManagerExplanation">This policy determines the access level of apps and services to the Windows Package Manager COM APIs and WinGet CLI, which can be used to install or configure apps on your device.
+
+By disabling this policy, you prevent any app or service from using the Windows Package Manager COM APIs and WinGet CLI to install or configure apps on your device.
+
+By enabling this policy, you allow any app or service to use the Windows Package Manager COM APIs and WinGet CLI to install apps on your device. You can enable this policy to only allow specific types of calls to the Windows Package Manager, including:
+
+WinGet CLI – Enables the use of the “winget” command.
+
+WinGet InProcess COM – enables other applications and services to load and execute winget libraries (Example: MDM app installations). Supports elevated, non-elevated user-context executions, and system-context installs.
+
+WinGet OutOfProcess COM – enables other application and services to execute winget libraries remotely (Example: WinGet PowerShell cmdlets). Supports elevated and non-elevated user-context executions.
+
+By leaving this policy as not configured, you allow any app or service to use the Windows Package Manager COM APIs to install apps on your device.
+
+This policy will override the "Enable App Installer" policy.</string>
     </stringTable>
     <presentationTable>
       <presentation id="SourceAutoUpdateInterval">
@@ -105,6 +121,11 @@ If you disable or do not configure this setting, users will not be able to insta
       </presentation>
       <presentation id="AllowedSources">
         <listBox refId="AllowedSources" required="false">Allowed Sources: </listBox>
+      </presentation>
+      <presentation id="EnableWindowsPackageManagerExplanation">
+        <checkBox refId="EnableWinGetCLI" defaultChecked="true">WinGet CLI</checkBox>
+        <checkBox refId="EnableWinGetInProcessCOM" defaultChecked="true">WinGet InProcess COM</checkBox>
+        <checkBox refId="EnableWinGetOutOfProcessCOM" defaultChecked="true">WinGet OutOfProcess COM</checkBox>
       </presentation>
     </presentationTable>
   </resources>

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -104,7 +104,7 @@ By enabling this policy, you allow any app or service to use the Windows Package
 
 WinGet CLI – Enables the use of the “winget” command.
 
-WinGet InProcess COM – enables other applications and services to load and execute winget libraries (Example: Mobile device management (MDM) app installations). Supports elevated, non-elevated user-context executions, and system-context installs.
+WinGet InProcess COM – enables other applications and services to load and execute winget libraries (Example: Mobile device management app installations). Supports elevated, non-elevated user-context executions, and system-context installs.
 
 WinGet OutOfProcess COM – enables other application and services to execute winget libraries remotely (Example: WinGet PowerShell cmdlets). Supports elevated and non-elevated user-context executions.
 

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -104,7 +104,7 @@ By enabling this policy, you allow any app or service to use the Windows Package
 
 WinGet CLI – Enables the use of the “winget” command.
 
-WinGet InProcess COM – enables other applications and services to load and execute winget libraries (Example: MDM app installations). Supports elevated, non-elevated user-context executions, and system-context installs.
+WinGet InProcess COM – enables other applications and services to load and execute winget libraries (Example: Mobile device management (MDM) app installations). Supports elevated, non-elevated user-context executions, and system-context installs.
 
 WinGet OutOfProcess COM – enables other application and services to execute winget libraries remotely (Example: WinGet PowerShell cmdlets). Supports elevated and non-elevated user-context executions.
 

--- a/src/AppInstallerCLIE2ETests/GroupPolicy.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicy.cs
@@ -44,19 +44,19 @@ namespace AppInstallerCLIE2ETests
         {
             RunCommandResult result;
 
-            // Senario 1 : EnableWinGet = Disabled, EnableWingetPackageManagerCLI = NotConfigured
+            // Scenario 1 : EnableWinGet = Disabled, EnableWingetPackageManagerCLI = NotConfigured
             GroupPolicyHelper.EnableWinget.Disable();
             GroupPolicyHelper.EnableWingetPackageManagerCLI.SetNotConfigured();
             result = TestCommon.RunAICLICommand("search", "foo");
             Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
 
-            // Senario 2 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = Enabled
+            // Scenario 2 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = Enabled
             GroupPolicyHelper.EnableWingetPackageManagerCLI.Disable();
             GroupPolicyHelper.EnableWinget.Enable();
             result = TestCommon.RunAICLICommand("search", "foo");
             Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
 
-            // Senario 3 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = NotConfigured
+            // Scenario 3 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = NotConfigured
             GroupPolicyHelper.EnableWingetPackageManagerCLI.Disable();
             GroupPolicyHelper.EnableWinget.SetNotConfigured();
             result = TestCommon.RunAICLICommand("search", "foo");

--- a/src/AppInstallerCLIE2ETests/GroupPolicy.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicy.cs
@@ -8,6 +8,7 @@ namespace AppInstallerCLIE2ETests
 {
     using AppInstallerCLIE2ETests.Helpers;
     using NUnit.Framework;
+    using static AppInstallerCLIE2ETests.Helpers.TestCommon;
 
     /// <summary>
     /// Tests for enforcement of Group Policy.
@@ -41,9 +42,37 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void PolicyEnableWinget()
         {
+            RunCommandResult result;
+
+            // Senario 1 : EnableWinGet = Disabled, EnableWingetPackageManagerCLI = NotConfigured
             GroupPolicyHelper.EnableWinget.Disable();
-            var result = TestCommon.RunAICLICommand("search", "foo");
+            GroupPolicyHelper.EnableWingetPackageManagerCLI.SetNotConfigured();
+            result = TestCommon.RunAICLICommand("search", "foo");
             Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            // Senario 2 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = Enabled
+            GroupPolicyHelper.EnableWingetPackageManagerCLI.Disable();
+            GroupPolicyHelper.EnableWinget.Enable();
+            result = TestCommon.RunAICLICommand("search", "foo");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            // Senario 3 : EnableWingetPackageManagerCLI = Disabled, EnableWinGet = NotConfigured
+            GroupPolicyHelper.EnableWingetPackageManagerCLI.Disable();
+            GroupPolicyHelper.EnableWinget.SetNotConfigured();
+            result = TestCommon.RunAICLICommand("search", "foo");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            // Scenario 4 : EnableWingetPackageManagerCLI = Enabled , EnableWinGet = Disabled
+            GroupPolicyHelper.EnableWingetPackageManagerCLI.Enable();
+            GroupPolicyHelper.EnableWinget.Disable();
+            result = TestCommon.RunAICLICommand("search", "foo");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_NO_SOURCES_DEFINED, result.ExitCode);
+
+            // Scenario 5 : EnableWingetPackageManagerCLI = NotConfigured , EnableWinGet = NotConfigured
+            GroupPolicyHelper.EnableWingetPackageManagerCLI.SetNotConfigured();
+            GroupPolicyHelper.EnableWinget.SetNotConfigured();
+            result = TestCommon.RunAICLICommand("search", "foo");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_NO_SOURCES_DEFINED, result.ExitCode);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
@@ -79,7 +79,6 @@ namespace AppInstallerCLIE2ETests
         /// </summary>
         public static GroupPolicyHelper EnableWingetPackageManagerOutOfProcessCOM { get; private set; } = new GroupPolicyHelper("EnableWindowsPackageManager", "EnableWinGetOutOfProcessCOM");
 
-
         /// <summary>
         /// Gets the Enable settings policy.
         /// </summary>

--- a/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
@@ -283,11 +283,11 @@ namespace AppInstallerCLIE2ETests
                 // </elements>
                 if (this.ValueElement.Name == XmlNames.Boolean)
                 {
-                    int flaseValue = GetDecimalValue(this.ValueElement.Element(XmlNames.FalseValue));
+                    int falseValue = GetDecimalValue(this.ValueElement.Element(XmlNames.FalseValue));
 
                     using (RegistryKey key = this.GetKey())
                     {
-                        key.SetValue(this.ValueElement.Attribute(XmlNames.Attributes.ValueName).Value, flaseValue);
+                        key.SetValue(this.ValueElement.Attribute(XmlNames.Attributes.ValueName).Value, falseValue);
                     }
                 }
             }

--- a/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------------
-// <copyright file="CheckInstalledStatusInterop.cs" company="Microsoft Corporation">
+// <copyright file="PackageManagerInterop.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------------

--- a/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
@@ -112,7 +112,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
         /// </summary>
         [Test]
-        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetEnabled()
+        public void PolicyWinGetPackageManagerNotConfiguredAndPolicyEnableWinGetEnabled()
         {
             // Scenario:
             // EnableWinGetOutOfProcessCOM = NotConfigured
@@ -126,7 +126,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
         /// </summary>
         [Test]
-        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetDisabled()
+        public void PolicyWinGetPackageManagerNotConfiguredAndPolicyEnableWinGetDisabled()
         {
             // Scenario :
             // EnableWinGetOutOfProcessCOM = NotConfigured

--- a/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
@@ -95,10 +95,10 @@ namespace AppInstallerCLIE2ETests.Interop
         }
 
         /// <summary>
-        /// Create PackageManager Instance when WinGetPackageManager policy is NotConfigure and EnabledAppInstaller Policy Disabled.
+        /// Create PackageManager Instance when WinGetPackageManager policy is NotConfigured and EnabledAppInstaller Policy Disabled.
         /// </summary>
         [Test]
-        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetNotConfigured()
+        public void PolicyWinGetPackageManagerNotConfiguredAndPolicyEnableWinGetNotConfigured()
         {
             // Scenario :
             // EnableWinGetOutOfProcessCOM = NotConfigured
@@ -126,7 +126,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
         /// </summary>
         [Test]
-        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetDiabled()
+        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetDisabled()
         {
             // Scenario :
             // EnableWinGetOutOfProcessCOM = NotConfigured
@@ -142,7 +142,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// Create PackageManager Instance when WinGetPackageManager policy is disabled.
         /// </summary>
         [Test]
-        public void PolicyWinGetPackageManagerDisabledAndPolicyEnableWinGetNotCofigured()
+        public void PolicyWinGetPackageManagerDisabledAndPolicyEnableWinGetNotConfigured()
         {
             // Scenario :
             // EnableWinGetOutOfProcessCOM = Disabled

--- a/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/PackageManagerInterop.cs
@@ -1,0 +1,214 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="CheckInstalledStatusInterop.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace AppInstallerCLIE2ETests.Interop
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.InteropServices;
+    using System.Security.Permissions;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.Management.Deployment;
+    using Microsoft.Management.Deployment.Projection;
+    using Microsoft.Management.Infrastructure;
+    using NUnit.Framework;
+    using WinRT;
+
+    /// <summary>
+    /// Tests check installed status.
+    /// </summary>
+    [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.OutOfProcess), Category = nameof(InstanceInitializersSource.OutOfProcess))]
+    public class PackageManagerInterop : BaseInterop
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageManagerInterop"/> class.
+        /// </summary>
+        /// <param name="initializer">Initializer.</param>
+        public PackageManagerInterop(IInstanceInitializer initializer)
+            : base(initializer)
+        {
+        }
+
+        /// <summary>
+        /// Set up.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            InitEnvironment(this.TestFactory.Context);
+        }
+
+        /// <summary>
+        /// Tear down.
+        /// </summary>
+        [TearDown]
+        public void Teardown()
+        {
+            InitEnvironment(this.TestFactory.Context);
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is enabled when EnabledAppInstaller Policy NotConfigured.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerEnabledAndPolicyEnableWinGetNotConfigured()
+        {
+            // Scenario:
+            // EnableWinGetOutOfProcessCOM = Enabled
+            // EnabledAppInstaller Policy = NotConfigured.
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Enable();
+            GroupPolicyHelper.EnableWinget.SetNotConfigured();
+            Assert.DoesNotThrow(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Enabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerEnabledAndPolicyEnableWinGetEnabled()
+        {
+            // Scenario:
+            // EnableWinGetOutOfProcessCOM = Enabled
+            // EnabledAppInstaller Policy = Enabled.
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Enable();
+            GroupPolicyHelper.EnableWinget.Enable();
+            Assert.DoesNotThrow(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerEnabledAndPolicyEnableWinGetDisabled()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = Enabled
+            // EnabledAppInstaller Policy = Disabled.
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Enable();
+            GroupPolicyHelper.EnableWinget.Disable();
+            Assert.DoesNotThrow(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is NotConfigure and EnabledAppInstaller Policy Disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetNotConfigured()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = NotConfigured
+            // EnabledAppInstaller Policy = NotConfigured.
+            GroupPolicyHelper.EnableWinget.SetNotConfigured();
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.SetNotConfigured();
+            Assert.DoesNotThrow(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetEnabled()
+        {
+            // Scenario:
+            // EnableWinGetOutOfProcessCOM = NotConfigured
+            // EnabledAppInstaller Policy = Enabled.
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.SetNotConfigured();
+            GroupPolicyHelper.EnableWinget.Enable();
+            Assert.DoesNotThrow(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is enabled and EnabledAppInstaller Policy Disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagertNotConfiguredAndPolicyEnableWinGetDiabled()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = NotConfigured
+            // EnabledAppInstaller Policy = Disabled.
+            // Expect COMException: APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY - 0x8A15003A
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.SetNotConfigured();
+            GroupPolicyHelper.EnableWinget.Disable();
+            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerDisabledAndPolicyEnableWinGetNotCofigured()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = Disabled
+            // EnabledAppInstaller Policy = NotConfigured
+            // Expect COMException: APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY - 0x8A15003A
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Disable();
+            GroupPolicyHelper.EnableWinget.SetNotConfigured();
+            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerDisabledAndPolicyEnableWinGetEnabled()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = Disabled
+            // EnabledAppInstaller Policy = Enabled.
+            // Expect COMException: APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY - 0x8A15003A
+            GroupPolicyHelper.EnableWinget.Enable();
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Disable();
+            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+        }
+
+        /// <summary>
+        /// Create PackageManager Instance when WinGetPackageManager policy is disabled.
+        /// </summary>
+        [Test]
+        public void PolicyWinGetPackageManagerDisabledAndPolicyEnableWinGetDisabled()
+        {
+            // Scenario :
+            // EnableWinGetOutOfProcessCOM = Disabled
+            // EnabledAppInstaller Policy = Disabled.
+            // Expect COMException: APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY - 0x8A15003A
+            GroupPolicyHelper.EnableWinget.Disable();
+            GroupPolicyHelper.EnableWingetPackageManagerOutOfProcessCOM.Disable();
+            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+        }
+
+        private static void InitEnvironment(ClsidContext clsidContext)
+        {
+            GroupPolicyHelper.DeleteExistingPolicies();
+
+            // To ensure Group Policy setting that tests apply correctly to WindowsPackageManagerServer (COM Server)
+            // we need to be running a fresh instance of COM Server after applying Group Policy this is due to the
+            // fact that the COM Server will only read Group Policy setting at the start of the process and it caches
+            // it until Server Process terminates.
+            if (clsidContext != ClsidContext.InProc)
+            {
+                try
+                {
+                    foreach (var process in Process.GetProcessesByName(Constants.WindowsPackageManagerServer))
+                    {
+                        process.Kill();
+                        process.WaitForExit(30 * 1000);
+                    }
+                }
+                catch (Exception)
+                {
+                    // Do nothing.
+                }
+            }
+        }
+    }
+}

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -903,6 +903,15 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="PolicyEnableWinGet" xml:space="preserve">
     <value>Enable Windows Package Manager</value>
   </data>
+    <data name="PolicyWinGetCLI" xml:space="preserve">
+    <value>Enable Windows Package Manager CLI</value>
+  </data>
+  <data name="PolicyWinGetInProcess" xml:space="preserve">
+    <value>Enable Windows Package Manager In Process</value>
+  </data>
+  <data name="PolicyWinGetOutOfProcess" xml:space="preserve">
+    <value>Enable Windows Package Manager Out Of Process</value>
+  </data>
   <data name="PolicySourceAutoUpdateInterval" xml:space="preserve">
     <value>Set Windows Package Manager Source Auto Update Interval In Minutes</value>
   </data>

--- a/src/AppInstallerCommonCore/GroupPolicy.cpp
+++ b/src/AppInstallerCommonCore/GroupPolicy.cpp
@@ -285,6 +285,12 @@ namespace AppInstaller::Settings
             return TogglePolicy(policy, "EnableAllowedSources"sv, String::PolicyAllowedSources);
         case TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore:
             return TogglePolicy(policy, "EnableBypassCertificatePinningForMicrosoftStore"sv, String::PolicyEnableBypassCertificatePinningForMicrosoftStore);
+        case TogglePolicy::Policy::WinGetCLI:
+            return TogglePolicy(policy, "EnableWinGetCLI"sv, String::PolicyEnableWinGetPackageManagerCLI);
+        case TogglePolicy::Policy::WinGetInProcessCOM:
+            return TogglePolicy(policy, "EnableWinGetInProcessCOM"sv, String::PolicyEnableWinGetPackageManagerInProcess);
+        case TogglePolicy::Policy::WinGetOutOfProcessCOM:
+            return TogglePolicy(policy, "EnableWinGetOutOfProcessCOM"sv, String::PolicyEnableWinGetPackageManagerOutOfProcess);
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCommonCore/Public/winget/GroupPolicy.h
+++ b/src/AppInstallerCommonCore/Public/winget/GroupPolicy.h
@@ -43,6 +43,9 @@ namespace AppInstaller::Settings
             AdditionalSources,
             AllowedSources,
             BypassCertificatePinningForMicrosoftStore,
+            WinGetCLI,
+            WinGetInProcessCOM,
+            WinGetOutOfProcessCOM,
             Max,
         };
 

--- a/src/AppInstallerSharedLib/Public/winget/Resources.h
+++ b/src/AppInstallerSharedLib/Public/winget/Resources.h
@@ -45,6 +45,9 @@ namespace AppInstaller
         struct String
         {
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWinGet);
+            WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWinGetPackageManagerCLI);
+            WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWinGetPackageManagerInProcess);
+            WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWinGetPackageManagerOutOfProcess);
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWingetSettings);
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableExperimentalFeatures);
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableLocalManifests);

--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -7,6 +7,7 @@
 #include <winrt/Windows.Security.Authorization.AppCapabilityAccess.h>
 #include <appmodel.h>
 #include <Helpers.h>
+#include <winget/Runtime.h>
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -117,5 +118,26 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         }
 
         return {};
+    }
+
+    bool IsCOMServerRunningInPackagedContext()
+    {
+        std::wstring packageFamilyName = AppInstaller::Runtime::GetPackageFamilyName();
+
+#if USE_PROD_CLSIDS 
+        if (_wcsicmp(packageFamilyName.c_str(), L"Microsoft.DesktopAppInstaller_8wekyb3d8bbwe") == 0)
+#else 
+        if (_wcsicmp(packageFamilyName.c_str(), L"WinGetDevCLI_8wekyb3d8bbwe") == 0)
+#endif
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool IsOutOfProcCOMInvocation()
+    {
+        return IsCOMServerRunningInPackagedContext();
     }
 }

--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -136,7 +136,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         return false;
     }
 
-    bool IsOutOfProcCOMInvocation()
+    bool IsOutOfProcCOMCall()
     {
         return IsCOMServerRunningInPackagedContext();
     }

--- a/src/Microsoft.Management.Deployment/Helpers.h
+++ b/src/Microsoft.Management.Deployment/Helpers.h
@@ -19,5 +19,5 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     std::pair<HRESULT, DWORD> GetCallerProcessId();
     std::wstring TryGetCallerProcessInfo(DWORD callerProcessId);
     bool IsCOMServerRunningInPackagedContext();
-    bool IsOutOfProcCOMInvocation();
+    bool IsOutOfProcCOMCall();
 }

--- a/src/Microsoft.Management.Deployment/Helpers.h
+++ b/src/Microsoft.Management.Deployment/Helpers.h
@@ -18,4 +18,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     HRESULT EnsureComCallerHasCapability(Capability requiredCapability);
     std::pair<HRESULT, DWORD> GetCallerProcessId();
     std::wstring TryGetCallerProcessInfo(DWORD callerProcessId);
+    bool IsCOMServerRunningInPackagedContext();
+    bool IsOutOfProcCOMInvocation();
 }

--- a/src/Microsoft.Management.Deployment/Public/CoCreatableMicrosoftManagementDeploymentClass.h
+++ b/src/Microsoft.Management.Deployment/Public/CoCreatableMicrosoftManagementDeploymentClass.h
@@ -18,20 +18,20 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         {
             *object = nullptr;
 
-            AppInstaller::Settings::PolicyState wingetCOMInProcOrOutOfProcPolicyState = AppInstaller::Settings::PolicyState::NotConfigured;
+            AppInstaller::Settings::PolicyState wingetCOMPolicyState = AppInstaller::Settings::PolicyState::NotConfigured;
 
             if (IsOutOfProcCOMCall())
             {
-                wingetCOMInProcOrOutOfProcPolicyState =  AppInstaller::Settings::GroupPolicies().GetState(::AppInstaller::Settings::TogglePolicy::Policy::WinGetOutOfProcessCOM);
+                wingetCOMPolicyState =  AppInstaller::Settings::GroupPolicies().GetState(::AppInstaller::Settings::TogglePolicy::Policy::WinGetOutOfProcessCOM);
             }
             else
             {
-                wingetCOMInProcOrOutOfProcPolicyState = AppInstaller::Settings::GroupPolicies().GetState(::AppInstaller::Settings::TogglePolicy::Policy::WinGetInProcessCOM);
+                wingetCOMPolicyState = AppInstaller::Settings::GroupPolicies().GetState(::AppInstaller::Settings::TogglePolicy::Policy::WinGetInProcessCOM);
             }
 
-            RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, wingetCOMInProcOrOutOfProcPolicyState == AppInstaller::Settings::PolicyState::Disabled);
+            RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, wingetCOMPolicyState == AppInstaller::Settings::PolicyState::Disabled);
 
-            RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, wingetCOMInProcOrOutOfProcPolicyState == AppInstaller::Settings::PolicyState::NotConfigured && !::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet));
+            RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, wingetCOMPolicyState == AppInstaller::Settings::PolicyState::NotConfigured && !::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet));
 
             return ::wil::wrl_factory_for_winrt_com_class<TCppWinRTClass>::CreateInstance(unknownOuter, riid, object);
         }

--- a/src/Microsoft.Management.Deployment/Public/CoCreatableMicrosoftManagementDeploymentClass.h
+++ b/src/Microsoft.Management.Deployment/Public/CoCreatableMicrosoftManagementDeploymentClass.h
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
             AppInstaller::Settings::PolicyState wingetCOMInProcOrOutOfProcPolicyState = AppInstaller::Settings::PolicyState::NotConfigured;
 
-            if (IsOutOfProcCOMInvocation())
+            if (IsOutOfProcCOMCall())
             {
                 wingetCOMInProcOrOutOfProcPolicyState =  AppInstaller::Settings::GroupPolicies().GetState(::AppInstaller::Settings::TogglePolicy::Policy::WinGetOutOfProcessCOM);
             }


### PR DESCRIPTION
Group Policy update with granular settings to selectively allow/disallow entry points WinGet CLI, WinGet InProc COM, WinGet Out-Of-Proc

Changes included :
- New Group Policy called "Enable Windows Package Manager" exposes sub settings
  - WinGet CLI
  - WinGet InProcess COM
  - WinGet OutOfProcess COM to control different WinGet endpoints specified which works in combination with V1 "EnableAppInstaller" Policy. i.e when  "Enable Windows Package Manager" Policy is set it has precedence over "EnableAppInstaller" Policy & when NotConfigured the default behavior for "EnableAppInstaller" Policy gets applied.
 - E2E Tests for CLI scenarios
 - E2E Tests for OutOfProc call scenario

 [How Tested:]
 - Applied new group policy adml/admx template onto test machine
 - Built & Deployed WinGetDev test package executed all the applicable scenarios to be gated by the policy
 - InProc COM - Used sample C# dotnet framework project that attempts to create InProc COM object using CLSIDs with different InProc COM Policy combination and ensured they are now gated by new policy in combination with EnableAppInstaller
 - Executed Out-Of-Proc tests part of this change and ensured they all behave as expected.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3491&drop=dogfoodAlpha