### PR TITLE
Add support for `--Installer-Type` argument for commands

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -140,6 +140,18 @@ The `architectures` behavior affects what architectures will be selected when in
     },
 ```
 
+### Installer Types
+
+The `installerTypes` behavior affects what installer types will be selected when installing a package. The matching parameter is `--installer-type`. Note that if multiple preferred installer types are available for installation, the order the installer types are specified will dictate which installer type is more preferred.
+
+```json
+    "installBehavior": {
+        "preferences": {
+            "installerTypes": ["msi", "msix"]
+        }
+    },
+```
+
 ### Default install root
 
 The `defaultInstallRoot` affects the install location when a package requires one. This can be overridden by the `--location` parameter. This setting is only used when a package manifest includes `InstallLocationRequired`, and the actual location is obtained by appending the package ID to the root.

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -142,7 +142,7 @@ The `architectures` behavior affects what architectures will be selected when in
 
 ### Installer Types
 
-The `installerTypes` behavior affects what installer types will be selected when installing a package. The matching parameter is `--installer-type`. Note that if multiple preferred installer types are available for installation, the order the installer types are specified will dictate which installer type is more preferred.
+The `installerTypes` behavior affects what installer types will be selected when installing a package. The matching parameter is `--installer-type`.
 
 ```json
     "installBehavior": {

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -93,6 +93,28 @@
             "minItems": 1,
             "maxItems": 4
           }
+        },
+        "installerTypes": {
+          "description": "The installerType(s) to use for a package install",
+          "type": "array",
+          "items": {
+            "uniqueItems": "true",
+            "type": "string",
+            "enum": [
+              "inno",
+              "wix",
+              "msi",
+              "nullsoft",
+              "zip",
+              "msix",
+              "exe",
+              "burn",
+              "msstore",
+              "portable"
+            ],
+            "minItems": 1,
+            "maxItems": 9
+          }
         }
       }
     },

--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -30,6 +30,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::Source),
             Argument{ Args::Type::InstallScope, Resource::String::InstallScopeDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument::ForType(Args::Type::InstallArchitecture),
+            Argument::ForType(Args::Type::InstallerType),
             Argument::ForType(Args::Type::Exact),
             Argument::ForType(Args::Type::Interactive),
             Argument::ForType(Args::Type::Silent),

--- a/src/AppInstallerCLICore/Commands/ShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.cpp
@@ -27,6 +27,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Execution::Args::Type::Exact),
             Argument{ Args::Type::InstallScope, Resource::String::InstallScopeDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument::ForType(Execution::Args::Type::InstallArchitecture),
+            Argument::ForType(Execution::Args::Type::InstallerType),
             Argument::ForType(Execution::Args::Type::Locale),
             Argument::ForType(Execution::Args::Type::ListVersions),
             Argument::ForType(Execution::Args::Type::CustomHeader),

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -57,6 +57,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::InstallLocation), // -l
             Argument{ Execution::Args::Type::InstallScope, Resource::String::InstalledScopeArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument::ForType(Args::Type::InstallArchitecture), // -a
+            Argument::ForType(Args::Type::InstallerType),
             Argument::ForType(Args::Type::Locale),
             Argument::ForType(Args::Type::HashOverride),
             Argument::ForType(Args::Type::SkipDependencies),

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -330,7 +330,7 @@ namespace AppInstaller::CLI::Workflow
                     bool isFirstInstallerTypePreferred = (preferredInstallerType == firstBaseInstallerType) || (preferredInstallerType == firstEffectiveInstallerType);
                     bool isSecondInstallerTypePreferred = (preferredInstallerType == secondBaseInstallerType) || (preferredInstallerType == secondEffectiveInstallerType);
 
-                    if (isFirstInstallerTypePreferred || isSecondInstallerTypePreferred)
+                    if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)
                     {
                         return isFirstInstallerTypePreferred;
                     }

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -332,7 +332,7 @@ namespace AppInstaller::CLI::Workflow
 
                     if (isFirstInstallerTypePreferred && isSecondInstallerTypePreferred)
                     {
-                        break;
+                        return false;
                     }
 
                     if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -284,9 +284,9 @@ namespace AppInstaller::CLI::Workflow
 
             std::string ExplainInapplicable(const Manifest::ManifestInstaller& installer) override
             {
-                std::string result = "InstallerType does not match required type: ";
+                std::string result = "InstallerType [";
                 result += InstallerTypeToString(installer.EffectiveInstallerType());
-                result += "Required InstallerTypes: ";
+                result += "] does not match required InstallerTypes: ";
                 result += m_requirementAsString;
                 return result;
             }
@@ -330,17 +330,14 @@ namespace AppInstaller::CLI::Workflow
                     ContainsInstallerType(m_preference, second.EffectiveInstallerType()) ||
                     ContainsInstallerType(m_preference, second.BaseInstallerType);
 
-                if (isFirstInstallerTypePreferred && isSecondInstallerTypePreferred)
+                if (isFirstInstallerTypePreferred == isSecondInstallerTypePreferred)
                 {
                     return false;
                 }
-
-                if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)
+                else
                 {
                     return isFirstInstallerTypePreferred;
                 }
-
-                return false;
             }
 
         private:

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -330,6 +330,11 @@ namespace AppInstaller::CLI::Workflow
                     bool isFirstInstallerTypePreferred = (preferredInstallerType == firstBaseInstallerType) || (preferredInstallerType == firstEffectiveInstallerType);
                     bool isSecondInstallerTypePreferred = (preferredInstallerType == secondBaseInstallerType) || (preferredInstallerType == secondEffectiveInstallerType);
 
+                    if (isFirstInstallerTypePreferred && isSecondInstallerTypePreferred)
+                    {
+                        break;
+                    }
+
                     if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)
                     {
                         return isFirstInstallerTypePreferred;

--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -331,10 +331,9 @@ namespace AppInstaller::CLI::Workflow
                     {
                         return false;
                     }
-
-                    if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)
+                    else if (isFirstInstallerTypePreferred != isSecondInstallerTypePreferred)
                     {
-                        return isFirstInstallerTypePreferred > isSecondInstallerTypePreferred;
+                        return isFirstInstallerTypePreferred;
                     }
                 }
 

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -117,6 +117,7 @@ namespace AppInstallerCLIE2ETests
         public const string PortablePackageUserRoot = "portablePackageUserRoot";
         public const string PortablePackageMachineRoot = "portablePackageMachineRoot";
         public const string InstallBehaviorScope = "scope";
+        public const string InstallerTypes = "installerTypes";
 
         // Configuration
         public const string PSGalleryName = "PSGallery";

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -94,13 +94,7 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="status">Status.</param>
         public static void ConfigureFeature(string featureName, bool status)
         {
-            JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
-
-            if (!settingsJson.ContainsKey("experimentalFeatures"))
-            {
-                settingsJson["experimentalFeatures"] = new JObject();
-            }
-
+            JObject settingsJson = GetJsonSettingsObject("experimentalFeatures");
             var experimentalFeatures = settingsJson["experimentalFeatures"];
             experimentalFeatures[featureName] = status;
 
@@ -114,13 +108,7 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value.</param>
         public static void ConfigureInstallBehavior(string settingName, string value)
         {
-            JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
-
-            if (!settingsJson.ContainsKey("installBehavior"))
-            {
-                settingsJson["installBehavior"] = new JObject();
-            }
-
+            JObject settingsJson = GetJsonSettingsObject("installBehavior");
             var installBehavior = settingsJson["installBehavior"];
             installBehavior[settingName] = value;
 
@@ -134,8 +122,14 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value.</param>
         public static void ConfigureInstallBehaviorPreferences(string settingName, string value)
         {
-            JObject settingsJson = GetJsonSettingsObject("installBehavior", "preferences");
+            JObject settingsJson = GetJsonSettingsObject("installBehavior");
             var installBehavior = settingsJson["installBehavior"];
+
+            if (installBehavior["preferences"] == null)
+            {
+                installBehavior["preferences"] = new JObject();
+            }
+
             var preferences = installBehavior["preferences"];
             preferences[settingName] = value;
 
@@ -149,8 +143,14 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value array.</param>
         public static void ConfigureInstallBehaviorPreferences(string settingName, string[] value)
         {
-            JObject settingsJson = GetJsonSettingsObject("installBehavior", "preferences");
+            JObject settingsJson = GetJsonSettingsObject("installBehavior");
             var installBehavior = settingsJson["installBehavior"];
+
+            if (installBehavior["preferences"] == null)
+            {
+                installBehavior["preferences"] = new JObject();
+            }
+
             var preferences = installBehavior["preferences"];
             preferences[settingName] = new JArray(value);
 
@@ -164,8 +164,14 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value.</param>
         public static void ConfigureInstallBehaviorRequirements(string settingName, string value)
         {
-            JObject settingsJson = GetJsonSettingsObject("installBehavior", "requirements");
+            JObject settingsJson = GetJsonSettingsObject("installBehavior");
             var installBehavior = settingsJson["installBehavior"];
+
+            if (installBehavior["requirements"] == null)
+            {
+                installBehavior["requirements"] = new JObject();
+            }
+
             var requirements = installBehavior["requirements"];
             requirements[settingName] = value;
 
@@ -179,8 +185,14 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value array.</param>
         public static void ConfigureInstallBehaviorRequirements(string settingName, string[] value)
         {
-            JObject settingsJson = GetJsonSettingsObject("installBehavior", "requirements");
+            JObject settingsJson = GetJsonSettingsObject("installBehavior");
             var installBehavior = settingsJson["installBehavior"];
+
+            if (installBehavior["requirements"] == null)
+            {
+                installBehavior["requirements"] = new JObject();
+            }
+
             var requirements = installBehavior["requirements"];
             requirements[settingName] = new JArray(value);
 
@@ -203,20 +215,13 @@ namespace AppInstallerCLIE2ETests.Helpers
             ConfigureFeature("download", status);
         }
 
-        private static JObject GetJsonSettingsObject(string objectName, string propertyName)
+        private static JObject GetJsonSettingsObject(string objectName)
         {
             JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
 
             if (!settingsJson.ContainsKey(objectName))
             {
                 settingsJson[objectName] = new JObject();
-            }
-
-            var installBehavior = settingsJson[objectName];
-
-            if (installBehavior[propertyName] == null)
-            {
-                installBehavior[propertyName] = new JObject();
             }
 
             return settingsJson;

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -134,22 +134,25 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value.</param>
         public static void ConfigureInstallBehaviorPreferences(string settingName, string value)
         {
-            JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
-
-            if (!settingsJson.ContainsKey("installBehavior"))
-            {
-                settingsJson["installBehavior"] = new JObject();
-            }
-
+            JObject settingsJson = GetJsonSettingsObject("installBehavior", "preferences");
             var installBehavior = settingsJson["installBehavior"];
-
-            if (installBehavior["preferences"] == null)
-            {
-                installBehavior["preferences"] = new JObject();
-            }
-
             var preferences = installBehavior["preferences"];
             preferences[settingName] = value;
+
+            File.WriteAllText(TestSetup.Parameters.SettingsJsonFilePath, settingsJson.ToString());
+        }
+
+        /// <summary>
+        /// Configure the install behavior preferences.
+        /// </summary>
+        /// <param name="settingName">Setting name.</param>
+        /// <param name="value">Setting value array.</param>
+        public static void ConfigureInstallBehaviorPreferences(string settingName, string[] value)
+        {
+            JObject settingsJson = GetJsonSettingsObject("installBehavior", "preferences");
+            var installBehavior = settingsJson["installBehavior"];
+            var preferences = installBehavior["preferences"];
+            preferences[settingName] = new JArray(value);
 
             File.WriteAllText(TestSetup.Parameters.SettingsJsonFilePath, settingsJson.ToString());
         }
@@ -161,22 +164,25 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="value">Setting value.</param>
         public static void ConfigureInstallBehaviorRequirements(string settingName, string value)
         {
-            JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
-
-            if (!settingsJson.ContainsKey("installBehavior"))
-            {
-                settingsJson["installBehavior"] = new JObject();
-            }
-
+            JObject settingsJson = GetJsonSettingsObject("installBehavior", "requirements");
             var installBehavior = settingsJson["installBehavior"];
-
-            if (installBehavior["requirements"] == null)
-            {
-                installBehavior["requirements"] = new JObject();
-            }
-
             var requirements = installBehavior["requirements"];
             requirements[settingName] = value;
+
+            File.WriteAllText(TestSetup.Parameters.SettingsJsonFilePath, settingsJson.ToString());
+        }
+
+        /// <summary>
+        /// Configure the install behavior requirements.
+        /// </summary>
+        /// <param name="settingName">Setting name.</param>
+        /// <param name="value">Setting value array.</param>
+        public static void ConfigureInstallBehaviorRequirements(string settingName, string[] value)
+        {
+            JObject settingsJson = GetJsonSettingsObject("installBehavior", "requirements");
+            var installBehavior = settingsJson["installBehavior"];
+            var requirements = installBehavior["requirements"];
+            requirements[settingName] = new JArray(value);
 
             File.WriteAllText(TestSetup.Parameters.SettingsJsonFilePath, settingsJson.ToString());
         }
@@ -195,6 +201,25 @@ namespace AppInstallerCLIE2ETests.Helpers
             ConfigureFeature("configuration", status);
             ConfigureFeature("windowsFeature", status);
             ConfigureFeature("download", status);
+        }
+
+        private static JObject GetJsonSettingsObject(string objectName, string propertyName)
+        {
+            JObject settingsJson = JObject.Parse(File.ReadAllText(TestSetup.Parameters.SettingsJsonFilePath));
+
+            if (!settingsJson.ContainsKey(objectName))
+            {
+                settingsJson[objectName] = new JObject();
+            }
+
+            var installBehavior = settingsJson[objectName];
+
+            if (installBehavior[propertyName] == null)
+            {
+                installBehavior[propertyName] = new JObject();
+            }
+
+            return settingsJson;
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -693,7 +693,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void InstallWithInstallerTypePreference()
         {
-            string[] installerTypePreference = { "exe" };
+            string[] installerTypePreference = { "nullsoft" };
             WinGetSettingsHelper.ConfigureInstallBehaviorPreferences(Constants.InstallerTypes, installerTypePreference);
 
             string installDir = TestCommon.GetRandomTestDir();
@@ -704,7 +704,7 @@ namespace AppInstallerCLIE2ETests
 
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully installed"));
-            Assert.True(TestCommon.VerifyTestExeInstalledAndCleanup(installDir, "/execustom"));
+            Assert.True(TestCommon.VerifyTestExeInstalledAndCleanup(installDir));
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -6,6 +6,7 @@
 
 namespace AppInstallerCLIE2ETests
 {
+    using System;
     using System.IO;
     using AppInstallerCLIE2ETests.Helpers;
     using NUnit.Framework;
@@ -698,8 +699,8 @@ namespace AppInstallerCLIE2ETests
             string installDir = TestCommon.GetRandomTestDir();
             var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestMultipleInstallers --silent -l {installDir}");
 
-            // Reinitialize settings file to reset preferences.
-            WinGetSettingsHelper.InitializeWingetSettings();
+            // Reset installer type preferences.
+            WinGetSettingsHelper.ConfigureInstallBehaviorPreferences(Constants.InstallerTypes, Array.Empty<string>());
 
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully installed"));
@@ -718,8 +719,8 @@ namespace AppInstallerCLIE2ETests
             string installDir = TestCommon.GetRandomTestDir();
             var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestMultipleInstallers --silent -l {installDir}");
 
-            // Reinitialize settings file to reset requirements.
-            WinGetSettingsHelper.InitializeWingetSettings();
+            // Reset installer type requirements.
+            WinGetSettingsHelper.ConfigureInstallBehaviorRequirements(Constants.InstallerTypes, Array.Empty<string>());
 
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICABLE_INSTALLER, result.ExitCode);
             Assert.True(result.StdOut.Contains("No applicable installer found; see logs for more details."));

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -704,7 +704,7 @@ namespace AppInstallerCLIE2ETests
 
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully installed"));
-            Assert.True(TestCommon.VerifyTestExeInstalledAndCleanup(installDir));
+            Assert.True(TestCommon.VerifyTestExeInstalledAndCleanup(installDir), "/S");
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -693,7 +693,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void InstallWithInstallerTypePreference()
         {
-            string[] installerTypePreference = { "msi" };
+            string[] installerTypePreference = { "exe" };
             WinGetSettingsHelper.ConfigureInstallBehaviorPreferences(Constants.InstallerTypes, installerTypePreference);
 
             string installDir = TestCommon.GetRandomTestDir();
@@ -704,7 +704,7 @@ namespace AppInstallerCLIE2ETests
 
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Successfully installed"));
-            Assert.True(TestCommon.VerifyTestMsiInstalledAndCleanup(installDir));
+            Assert.True(TestCommon.VerifyTestExeInstalledAndCleanup(installDir, "/execustom"));
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/Interop/InstallInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/InstallInterop.cs
@@ -598,6 +598,31 @@ namespace AppInstallerCLIE2ETests.Interop
         }
 
         /// <summary>
+        /// Test installing a package with a specific installer type install option.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task InstallWithInstallerType()
+        {
+            // Find package
+            var searchResult = this.FindOnePackage(this.testSource, PackageMatchField.Id, PackageFieldMatchOption.Equals, "AppInstallerTest.TestMultipleInstallers");
+
+            // Configure installation
+            var installOptions = this.TestFactory.CreateInstallOptions();
+            installOptions.PackageInstallMode = PackageInstallMode.Silent;
+            installOptions.PreferredInstallLocation = this.installDir;
+            installOptions.InstallerType = PackageInstallerType.Msi;
+            installOptions.AcceptPackageAgreements = true;
+
+            // Install
+            var installResult = await this.packageManager.InstallPackageAsync(searchResult.CatalogPackage, installOptions);
+
+            // Assert
+            Assert.AreEqual(InstallResultStatus.Ok, installResult.Status);
+            Assert.True(TestCommon.VerifyTestMsiInstalledAndCleanup(this.installDir));
+        }
+
+        /// <summary>
         /// Test to verify the GetApplicableInstaller() COM call returns the correct manifest installer metadata.
         /// </summary>
         [Test]

--- a/src/AppInstallerCLIE2ETests/ShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ShowCommand.cs
@@ -124,5 +124,29 @@ namespace AppInstallerCLIE2ETests
             Assert.AreEqual(Constants.ErrorCode.ERROR_NO_APPLICATIONS_FOUND, result.ExitCode);
             Assert.True(result.StdOut.Contains("No package found matching input criteria."));
         }
+
+        /// <summary>
+        /// Test show with installer type.
+        /// </summary>
+        [Test]
+        public void ShowWithInstallerTypeArg()
+        {
+            var result = TestCommon.RunAICLICommand("show", $"--id AppInstallerTest.TestMultipleInstallers --installer-type msi");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+            Assert.True(result.StdOut.Contains("Found TestMultipleInstallers [AppInstallerTest.TestMultipleInstallers]"));
+            Assert.True(result.StdOut.Contains("Installer Type: msi"));
+        }
+
+        /// <summary>
+        /// Test show with an archive installer type.
+        /// </summary>
+        [Test]
+        public void ShowWithZipInstallerTypeArg()
+        {
+            var result = TestCommon.RunAICLICommand("show", $"--id AppInstallerTest.TestMultipleInstallers --installer-type zip");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+            Assert.True(result.StdOut.Contains("Found TestMultipleInstallers [AppInstallerTest.TestMultipleInstallers]"));
+            Assert.True(result.StdOut.Contains("Installer Type: exe (zip)"));
+        }
     }
 }

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestMultipleInstallers.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestMultipleInstallers.yaml
@@ -11,6 +11,8 @@ Installers:
     InstallerType: nullsoft
     InstallerSha256: <EXEHASH>
     Scope: user
+    InstallerSwitches:
+        InstallLocation: /InstallDir <INSTALLPATH>
   - Architecture: x86
     InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestMsiInstaller/AppInstallerTestMsiInstaller.msi
     InstallerSha256: <MSIHASH>

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -812,6 +812,17 @@ TEST_CASE("ManifestComparator_InstallerType", "[manifest_comparator]")
         RequireInstaller(result, exe);
         REQUIRE(inapplicabilities.size() == 0);
     }
+    SECTION("Multiple preferences alternate order")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Msix, InstallerTypeEnum::Exe });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, msix);
+        REQUIRE(inapplicabilities.size() == 0);
+    }
     SECTION("Exe requirement")
     {
         TestUserSettings settings;

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -804,17 +804,6 @@ TEST_CASE("ManifestComparator_InstallerType", "[manifest_comparator]")
     SECTION("Multiple preferences")
     {
         TestUserSettings settings;
-        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Msix, InstallerTypeEnum::Exe });
-
-        ManifestComparator mc(ManifestComparatorTestContext{}, {});
-        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
-
-        RequireInstaller(result, msix);
-        REQUIRE(inapplicabilities.size() == 0);
-    }
-    SECTION("Multiple preferences with different order")
-    {
-        TestUserSettings settings;
         settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Exe, InstallerTypeEnum::Msix });
 
         ManifestComparator mc(ManifestComparatorTestContext{}, {});

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -738,3 +738,111 @@ TEST_CASE("ManifestComparator_Scope_AllowUnknown", "[manifest_comparator]")
         REQUIRE(inapplicabilities.size() == 0);
     }
 }
+
+TEST_CASE("ManifestComparator_InstallerType", "[manifest_comparator]")
+{
+    Manifest manifest;
+    ManifestInstaller msi = AddInstaller(manifest, Architecture::Neutral, InstallerTypeEnum::Msi, ScopeEnum::User);
+    ManifestInstaller exe = AddInstaller(manifest, Architecture::Neutral, InstallerTypeEnum::Exe, ScopeEnum::User);
+    ManifestInstaller msix = AddInstaller(manifest, Architecture::Neutral, InstallerTypeEnum::Msix, ScopeEnum::User);
+
+    SECTION("Msi arg requirement")
+    {
+        ManifestComparatorTestContext context;
+        context.Args.AddArg(Args::Type::InstallerType, "msi"s);
+
+        ManifestComparator mc(context, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, msi);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
+    }
+    SECTION("Msix arg requirement")
+    {
+        ManifestComparatorTestContext context;
+        context.Args.AddArg(Args::Type::InstallerType, "msix"s);
+
+        ManifestComparator mc(context, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, msix);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
+    }
+    SECTION("Portable arg requirement")
+    {
+        ManifestComparatorTestContext context;
+        context.Args.AddArg(Args::Type::InstallerType, "portable"s);
+
+        ManifestComparator mc(context, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        REQUIRE(!result);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
+    }
+    SECTION("Exe preference")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Exe });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, exe);
+        REQUIRE(inapplicabilities.size() == 0);
+    }
+    SECTION("Preference does not exist")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Portable });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, msi);
+        REQUIRE(inapplicabilities.size() == 0);
+    }
+    SECTION("Multiple preferences")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Msix, InstallerTypeEnum::Exe });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, msix);
+        REQUIRE(inapplicabilities.size() == 0);
+    }
+    SECTION("Multiple preferences with different order")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypePreference>({ InstallerTypeEnum::Exe, InstallerTypeEnum::Msix });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, exe);
+        REQUIRE(inapplicabilities.size() == 0);
+    }
+    SECTION("Exe requirement")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypeRequirement>({ InstallerTypeEnum::Exe });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        RequireInstaller(result, exe);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
+    }
+    SECTION("Inno requirement")
+    {
+        TestUserSettings settings;
+        settings.Set<Setting::InstallerTypeRequirement>({ InstallerTypeEnum::Inno });
+
+        ManifestComparator mc(ManifestComparatorTestContext{}, {});
+        auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+        REQUIRE(!result);
+        RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
+    }
+}

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -83,6 +83,8 @@ namespace AppInstaller::Settings
         InstallArchitectureRequirement,
         InstallLocalePreference,
         InstallLocaleRequirement,
+        InstallerTypePreference,
+        InstallerTypeRequirement,
         InstallDefaultRoot,
         InstallSkipDependencies,
         DisableInstallNotes,
@@ -160,6 +162,8 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallScopeRequirement, std::string, Manifest::ScopeEnum, Manifest::ScopeEnum::Unknown, ".installBehavior.requirements.scope"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocalePreference, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.preferences.locale"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallLocaleRequirement, std::vector<std::string>, std::vector<std::string>, {}, ".installBehavior.requirements.locale"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallerTypePreference, std::vector<std::string>, std::vector<Manifest::InstallerTypeEnum>, {}, ".installBehavior.preferences.installerTypes"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::InstallerTypeRequirement, std::vector<std::string>, std::vector<Manifest::InstallerTypeEnum>, {}, ".installBehavior.requirements.installerTypes"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::InstallSkipDependencies, bool, bool, false, ".installBehavior.skipDependencies"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::DisableInstallNotes, bool, bool, false, ".installBehavior.disableInstallNotes"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::PortablePackageUserRoot, std::string, std::filesystem::path, {}, ".installBehavior.portablePackageUserRoot"sv);

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -289,7 +289,8 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_SIGNATURE(InstallArchitecturePreference)
         {
             std::vector<Utility::Architecture> archs;
-            for (auto const& i : value) {
+            for (auto const& i : value)
+            {
                 Utility::Architecture arch = Utility::ConvertToArchitectureEnum(i);
                 if (Utility::IsApplicableArchitecture(arch) == Utility::InapplicableArchitecture)
                 {
@@ -343,6 +344,26 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_SIGNATURE(InstallLocaleRequirement)
         {
             return SettingMapping<Setting::InstallLocalePreference>::Validate(value);
+        }
+
+        WINGET_VALIDATE_SIGNATURE(InstallerTypePreference)
+        {
+            std::vector<Manifest::InstallerTypeEnum> installerTypes;
+            for (auto const& i : value)
+            {
+                Manifest::InstallerTypeEnum installerType = Manifest::ConvertToInstallerTypeEnum(i);
+                if (installerType == Manifest::InstallerTypeEnum::Unknown)
+                {
+                    return {};
+                }
+                installerTypes.emplace_back(installerType);
+            }
+            return installerTypes;
+        }
+
+        WINGET_VALIDATE_SIGNATURE(InstallerTypeRequirement)
+        {
+            return SettingMapping<Setting::InstallerTypePreference>::Validate(value);
         }
 
         WINGET_VALIDATE_SIGNATURE(InstallDefaultRoot)

--- a/src/Microsoft.Management.Deployment/InstallOptions.cpp
+++ b/src/Microsoft.Management.Deployment/InstallOptions.cpp
@@ -60,6 +60,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         m_packageInstallMode = value;
     }
+    winrt::Microsoft::Management::Deployment::PackageInstallerType InstallOptions::InstallerType()
+    {
+        return m_installerType;
+    }
+    void InstallOptions::InstallerType(winrt::Microsoft::Management::Deployment::PackageInstallerType const& value)
+    {
+        m_installerType = value;
+    }
     hstring InstallOptions::LogOutputPath()
     {
         return hstring(m_logOutputPath);

--- a/src/Microsoft.Management.Deployment/InstallOptions.h
+++ b/src/Microsoft.Management.Deployment/InstallOptions.h
@@ -45,7 +45,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         bool SkipDependencies();
         void SkipDependencies(bool value);
 
-
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         winrt::Microsoft::Management::Deployment::PackageVersionId m_packageVersionId{ nullptr };

--- a/src/Microsoft.Management.Deployment/InstallOptions.h
+++ b/src/Microsoft.Management.Deployment/InstallOptions.h
@@ -19,6 +19,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         void PackageInstallScope(winrt::Microsoft::Management::Deployment::PackageInstallScope const& value);
         winrt::Microsoft::Management::Deployment::PackageInstallMode PackageInstallMode();
         void PackageInstallMode(winrt::Microsoft::Management::Deployment::PackageInstallMode const& value);
+        winrt::Microsoft::Management::Deployment::PackageInstallerType InstallerType();
+        void InstallerType(winrt::Microsoft::Management::Deployment::PackageInstallerType const& value);
         hstring LogOutputPath();
         void LogOutputPath(hstring const& value);
         bool AllowHashMismatch();
@@ -43,12 +45,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         bool SkipDependencies();
         void SkipDependencies(bool value);
 
+
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         winrt::Microsoft::Management::Deployment::PackageVersionId m_packageVersionId{ nullptr };
         std::wstring m_preferredInstallLocation = L"";
         winrt::Microsoft::Management::Deployment::PackageInstallScope m_packageInstallScope = winrt::Microsoft::Management::Deployment::PackageInstallScope::Any;
         winrt::Microsoft::Management::Deployment::PackageInstallMode m_packageInstallMode = winrt::Microsoft::Management::Deployment::PackageInstallMode::Default;
+        winrt::Microsoft::Management::Deployment::PackageInstallerType m_installerType = winrt::Microsoft::Management::Deployment::PackageInstallerType::Unknown;
         std::wstring m_logOutputPath = L"";
         bool m_allowHashMismatch = false;
         bool m_bypassIsStoreClientBlockedPolicyCheck = false;

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -386,6 +386,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 context->Args.AddArg(Execution::Args::Type::Silent);
             }
 
+            auto installerType = GetManifestInstallerType(options.InstallerType());
+            if (installerType != AppInstaller::Manifest::InstallerTypeEnum::Unknown)
+            {
+                context->Args.AddArg(Execution::Args::Type::InstallerType, AppInstaller::Manifest::InstallerTypeToString(installerType));
+            }
+
             if (!options.PreferredInstallLocation().empty())
             {
                 context->Args.AddArg(Execution::Args::Type::InstallLocation, ::AppInstaller::Utility::ConvertToUTF8(options.PreferredInstallLocation()));

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -889,6 +889,9 @@ namespace Microsoft.Management.Deployment
         {
             // Skip installing the dependencies for the package.
             Boolean SkipDependencies;
+
+            /// The package installer type.
+            PackageInstallerType InstallerType;
         }
     }
 


### PR DESCRIPTION
Resolves #1166 

Changes:
- Adds the `--installer-type` argument to the Install, Upgrade, and Show command.
- Modifies settings schema to allow for installer type preferences and requirements.
- Added the corresponding argument to the COM InstallOptions.
- Updated the manifest installer comparator to handle both installer type preferences and requirements.

Tests:
- Unit tests to verify the manifest comparator when providing the installerType arg, preference, and requirements.
- E2E tests to verify the behavior for COM install, Install, and Show.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-cli/pull/3516&drop=dogfoodAlpha