### PR TITLE
Attempt to prevent crash in `TelemetryTraceLogger::InitializeInternal()`

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -111,6 +111,7 @@ namespace AppInstaller::Logging
 
     void TelemetryTraceLogger::Initialize()
     {
+        std::lock_guard<std::mutex> lockInitialization{ *m_initializationLock };
         if (!m_isInitialized)
         {
             InitializeInternal(Settings::User());
@@ -119,6 +120,7 @@ namespace AppInstaller::Logging
 
     bool TelemetryTraceLogger::TryInitialize()
     {
+        std::lock_guard<std::mutex> lockInitialization{ *m_initializationLock };
         if (!m_isInitialized)
         {
             auto userSettings = Settings::TryGetUser();

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -823,7 +823,7 @@ namespace AppInstaller::Logging
     std::wstring TelemetryTraceLogger::AnonymizeString(std::wstring_view input) const noexcept try
     {
         // GetPathTo() may need to read the settings, so this function should only be called after settings are initialized.
-        // To ensure that, this function is only called when emiting an event, and we disable the telemetry until settings are ready.
+        // To ensure that, this function is only called when emitting an event, and we disable the telemetry until settings are ready.
         static const std::wstring s_UserProfile = Runtime::GetPathTo(Runtime::PathName::UserProfile).wstring();
 
         return Utility::ReplaceWhileCopying(input, s_UserProfile, s_UserProfileReplacement);

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -31,6 +31,7 @@ namespace AppInstaller::Logging
         static const uint32_t s_RootExecutionId = 0;
         static std::atomic_uint32_t s_subExecutionId{ s_RootExecutionId };
 
+        // Data that is needed by AnonymizeString
         constexpr std::wstring_view s_UserProfileReplacement = L"%USERPROFILE%"sv;
 
         // TODO: Temporary code to keep existing telemetry behavior
@@ -111,7 +112,6 @@ namespace AppInstaller::Logging
 
     void TelemetryTraceLogger::Initialize()
     {
-        std::lock_guard<std::mutex> lockInitialization{ *m_initializationLock };
         if (!m_isInitialized)
         {
             InitializeInternal(Settings::User());
@@ -120,9 +120,10 @@ namespace AppInstaller::Logging
 
     bool TelemetryTraceLogger::TryInitialize()
     {
-        std::lock_guard<std::mutex> lockInitialization{ *m_initializationLock };
         if (!m_isInitialized)
         {
+            // Only initialize if we already have the user settings, so that we can respect the telemetry setting.
+            // We may not yet have the user settings if we are trying to report an error while reading them.
             auto userSettings = Settings::TryGetUser();
             if (userSettings)
             {
@@ -811,7 +812,6 @@ namespace AppInstaller::Logging
     void TelemetryTraceLogger::InitializeInternal(const AppInstaller::Settings::UserSettings& userSettings)
     {
         m_isSettingEnabled = !userSettings.Get<Settings::Setting::TelemetryDisable>();
-        m_userProfile = Runtime::GetPathTo(Runtime::PathName::UserProfile).wstring();
         m_isInitialized = true;
     }
 
@@ -822,7 +822,11 @@ namespace AppInstaller::Logging
 
     std::wstring TelemetryTraceLogger::AnonymizeString(std::wstring_view input) const noexcept try
     {
-        return Utility::ReplaceWhileCopying(input, m_userProfile, s_UserProfileReplacement);
+        // GetPathTo() may need to read the settings, so this function should only be called after settings are initialized.
+        // To ensure that, this function is only called when emiting an event, and we disable the telemetry until settings are ready.
+        static const std::wstring s_UserProfile = Runtime::GetPathTo(Runtime::PathName::UserProfile).wstring();
+
+        return Utility::ReplaceWhileCopying(input, s_UserProfile, s_UserProfileReplacement);
     }
     catch (...) { return std::wstring{ input }; }
 
@@ -845,6 +849,9 @@ namespace AppInstaller::Logging
         }
         else
         {
+            // For the global telemetry object, we may not have yet read the settings file.
+            // In that case, we will not be able to initialize it, so we need to try it
+            // each time we get the object.
             static TelemetryTraceLogger processGlobalTelemetry(/* useSummary */ false);
             processGlobalTelemetry.TryInitialize();
             return processGlobalTelemetry;

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -154,6 +154,10 @@ namespace AppInstaller::Logging
         void Initialize();
 
         // Try to capture if UserSettings is enabled and set user profile path, returns whether the action is successfully completed.
+        // There is a possible circular dependency with the user settings. When initializing the telemetry, we need to read the settings
+        // to make sure it's not disabled, but a failure when reading the settings would trigger a telemetry event. We work around that
+        // by avoiding initialization (and thus disabling telemetry) until we have successfully read the settings. Subsequent calls to
+        // TryInitialize() would finish the initialization.
         bool TryInitialize();
 
         // Store the passed in name of the Caller for COM calls
@@ -255,6 +259,7 @@ namespace AppInstaller::Logging
     protected:
         bool IsTelemetryEnabled() const noexcept;
 
+        // Initializes flags that determine whether telemetry is enabled.
         void InitializeInternal(const AppInstaller::Settings::UserSettings& userSettings);
 
         // Used to anonymize a string to the best of our ability.
@@ -262,10 +267,17 @@ namespace AppInstaller::Logging
         std::wstring AnonymizeString(const wchar_t* input) const noexcept;
         std::wstring AnonymizeString(std::wstring_view input) const noexcept;
 
-        bool m_isSettingEnabled = true;
+        // Flags used to determine whether to send telemetry. All of them are set during initialization and
+        // are CopyConstructibleAtomic to minimize the impact of multiple simultaneous initialization attempts.
+        // m_isSettingEnabled starts as false so we can don't send telemetry until we have read the
+        // settings and confirmed that it is enabled.
+        CopyConstructibleAtomic<bool> m_isSettingEnabled{ false };
+
+        // We may decide to disable telemetry at runtime, for example, for command line completion.
         CopyConstructibleAtomic<bool> m_isRuntimeEnabled{ true };
+
+        // We wait for initialization of the other flags before sending any events.
         CopyConstructibleAtomic<bool> m_isInitialized{ false };
-        std::unique_ptr<std::mutex> m_initializationLock = std::make_unique<std::mutex>();
 
         CopyConstructibleAtomic<uint32_t> m_executionStage{ 0 };
 
@@ -273,9 +285,6 @@ namespace AppInstaller::Logging
         GUID m_parentActivityId = GUID_NULL;
         std::wstring m_telemetryCorrelationJsonW = L"{}";
         std::string m_caller;
-
-        // Data that is needed by AnonymizeString
-        std::wstring m_userProfile;
 
         bool m_useSummary = true;
         mutable TelemetrySummary m_summary;

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -265,6 +265,7 @@ namespace AppInstaller::Logging
         bool m_isSettingEnabled = true;
         CopyConstructibleAtomic<bool> m_isRuntimeEnabled{ true };
         CopyConstructibleAtomic<bool> m_isInitialized{ false };
+        std::unique_ptr<std::mutex> m_initializationLock = std::make_unique<std::mutex>();
 
         CopyConstructibleAtomic<uint32_t> m_executionStage{ 0 };
 


### PR DESCRIPTION
We have been getting reports of heap corruption crashes on `AppInstaller::Logging::TelemetryTraceLogger::InitializeInternal` in calls to the COM API, with a recent spike in number of hits.
This is probably due to trying to initialize the trace logger from two places at the same time ~~, so I'm adding synchronization there.~~
I was unable to get a repro to confirm this was the issue and test that the change fixed it, so it may not actually do anything. See https://task.ms/38253096
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3527)

Edit: Changed per @johnmcpms suggestion.
* Made `m_isSettingEnabled` a `CopyConstructibleAtomic<bool>`
* Changed `m_isSettingEnabled` default value to `false`, so that we only set it to `true` after successfully readin the settings
* Moved `m_userProfile` to be a static in `AnonymizeString()`. This function is only called when emitting an event, and that happens only if we finished the initialization, which ensures that the use of the settings when getting the user profile path is safe.