### PR TITLE
Make all portable installs write metadata to index

### DIFF
--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -140,6 +140,7 @@ namespace AppInstaller::CLI::Portable
             }
             else
             {
+                // This scenario should not occur since symlink entries should only exist if they are supported.
                 AICLI_LOG(Core, Info, << "Failed to create symlink at: " << filePath);
                 THROW_HR(HRESULT_FROM_WIN32(ERROR_SYMLINK_NOT_SUPPORTED));
             }

--- a/src/AppInstallerCLICore/PortableInstaller.h
+++ b/src/AppInstallerCLICore/PortableInstaller.h
@@ -37,7 +37,6 @@ namespace AppInstaller::CLI::Portable
 
         bool IsUpdate = false;
         bool Purge = false;
-        bool RecordToIndex = false;
 
         // This is the incoming target install location determined from the context args.
         std::filesystem::path TargetInstallLocation;

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -165,12 +165,10 @@ namespace AppInstaller::CLI::Workflow
     {
         std::filesystem::path& installerPath = context.Get<Execution::Data::InstallerPath>();
         PortableInstaller& portableInstaller = context.Get<Execution::Data::PortableInstaller>();
-        std::vector<PortableFileEntry> entries;
 
+        std::vector<PortableFileEntry> entries;
         const std::filesystem::path& targetInstallDirectory = portableInstaller.TargetInstallLocation;
         const std::filesystem::path& symlinkDirectory = GetPortableLinksLocation(portableInstaller.GetScope());
-
-        bool isSymlinkCreationSupported = AppInstaller::Runtime::IsSymlinkCreationSupported();
 
         // InstallerPath will point to a directory if it is extracted from an archive.
         if (std::filesystem::is_directory(installerPath))
@@ -210,7 +208,7 @@ namespace AppInstaller::CLI::Workflow
 
                 Filesystem::AppendExtension(commandAlias, ".exe");
 
-                if (isSymlinkCreationSupported)
+                if (AppInstaller::Runtime::IsSymlinkCreationSupported())
                 {
                     entries.emplace_back(std::move(PortableFileEntry::CreateSymlinkEntry(symlinkDirectory / commandAlias, targetPath)));
                 }

--- a/src/AppInstallerCLITests/PortableInstaller.cpp
+++ b/src/AppInstallerCLITests/PortableInstaller.cpp
@@ -23,7 +23,7 @@ using namespace AppInstaller::Repository::Microsoft::Schema;
 using namespace AppInstaller::Utility;
 using namespace TestCommon;
 
-TEST_CASE("PortableInstaller_InstallToRegistry", "[PortableInstaller]")
+TEST_CASE("PortableInstaller_SingleInstall", "[PortableInstaller]")
 {
     TempDirectory tempDirectory = TestCommon::TempDirectory("TempDirectory", false);
 
@@ -48,16 +48,14 @@ TEST_CASE("PortableInstaller_InstallToRegistry", "[PortableInstaller]")
 
     PortableInstaller portableInstaller2 = PortableInstaller(ScopeEnum::User, Architecture::X64, "testProductCode");
     REQUIRE(portableInstaller2.ARPEntryExists());
-    REQUIRE(std::filesystem::exists(portableInstaller2.PortableTargetFullPath));
-    REQUIRE(AppInstaller::Filesystem::SymlinkExists(portableInstaller2.PortableSymlinkFullPath));
+    REQUIRE(AppInstaller::Filesystem::SymlinkExists(symlinkPath));
 
     portableInstaller2.Uninstall();
-    REQUIRE_FALSE(std::filesystem::exists(portableInstaller2.PortableTargetFullPath));
-    REQUIRE_FALSE(AppInstaller::Filesystem::SymlinkExists(portableInstaller2.PortableSymlinkFullPath));
+    REQUIRE_FALSE(AppInstaller::Filesystem::SymlinkExists(symlinkPath));
     REQUIRE_FALSE(std::filesystem::exists(portableInstaller2.InstallLocation));
 }
 
-TEST_CASE("PortableInstaller_InstallToIndex_CreateInstallRoot", "[PortableInstaller]")
+TEST_CASE("PortableInstaller_CreateInstallRoot", "[PortableInstaller]")
 {
     TempDirectory installRootDirectory = TestCommon::TempDirectory("PortableInstallRoot", false);
 
@@ -88,7 +86,6 @@ TEST_CASE("PortableInstaller_InstallToIndex_CreateInstallRoot", "[PortableInstal
 
     PortableInstaller portableInstaller = PortableInstaller(ScopeEnum::User, Architecture::X64, "testProductCode");
     portableInstaller.TargetInstallLocation = installRootDirectory.GetPath();
-    portableInstaller.RecordToIndex = true;
     portableInstaller.SetDesiredState(desiredTestState);
     REQUIRE(portableInstaller.VerifyExpectedState());
 
@@ -115,7 +112,7 @@ TEST_CASE("PortableInstaller_InstallToIndex_CreateInstallRoot", "[PortableInstal
     REQUIRE_FALSE(std::filesystem::exists(directoryPath));
 }
 
-TEST_CASE("PortableInstaller_InstallToIndex_ExistingInstallRoot", "[PortableInstaller]")
+TEST_CASE("PortableInstaller_InstallToExistingRoot", "[PortableInstaller]")
 {
     TempDirectory installRootDirectory = TestCommon::TempDirectory("PortableInstallRoot", true);
 
@@ -146,7 +143,6 @@ TEST_CASE("PortableInstaller_InstallToIndex_ExistingInstallRoot", "[PortableInst
 
     PortableInstaller portableInstaller = PortableInstaller(ScopeEnum::User, Architecture::X64, "testProductCode");
     portableInstaller.TargetInstallLocation = installRootDirectory.GetPath();
-    portableInstaller.RecordToIndex = true;
     portableInstaller.SetDesiredState(desiredTestState);
     REQUIRE(portableInstaller.VerifyExpectedState());
 

--- a/src/AppInstallerCLITests/TestHooks.h
+++ b/src/AppInstallerCLITests/TestHooks.h
@@ -28,6 +28,7 @@ namespace AppInstaller
         void TestHook_SetPathOverride(PathName target, const std::filesystem::path& path);
         void TestHook_SetPathOverride(PathName target, const PathDetails& details);
         void TestHook_ClearPathOverrides();
+        void TestHook_SetIsSymlinkCreationSupportedResult_Override(bool* status);
     }
 
     namespace Repository
@@ -85,6 +86,22 @@ namespace TestHook
         ~SetCreateSymlinkResult_Override()
         {
             AppInstaller::Filesystem::TestHook_SetCreateSymlinkResult_Override(nullptr);
+        }
+
+    private:
+        bool m_status;
+    };
+
+    struct SetIsSymlinkCreationSupportedResult_Override
+    {
+        SetIsSymlinkCreationSupportedResult_Override(bool status) : m_status(status)
+        {
+            AppInstaller::Runtime::TestHook_SetIsSymlinkCreationSupportedResult_Override(&m_status);
+        }
+
+        ~SetIsSymlinkCreationSupportedResult_Override()
+        {
+            AppInstaller::Runtime::TestHook_SetIsSymlinkCreationSupportedResult_Override(nullptr);
         }
 
     private:

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -177,15 +177,14 @@ TEST_CASE("UpdateFlow_UpdatePortable", "[UpdateFlow][workflow]")
     REQUIRE(std::filesystem::exists(updateResultPath.GetPath()));
 }
 
-TEST_CASE("UpdateFlow_Portable_SymlinkCreationFail", "[UpdateFlow][workflow]")
+TEST_CASE("UpdateFlow_Portable_SymlinkNotSupported", "[UpdateFlow][workflow]")
 {
-    // Update portable with symlink creation failure verify that it succeeds.
     TestCommon::TempDirectory tempDirectory("TestPortableInstallRoot", false);
     std::ostringstream updateOutput;
     TestContext context{ updateOutput, std::cin };
     auto PreviousThreadGlobals = context.SetForCurrentThread();
-    bool overrideCreateSymlinkStatus = false;
-    AppInstaller::Filesystem::TestHook_SetCreateSymlinkResult_Override(&overrideCreateSymlinkStatus);
+    TestHook::SetIsSymlinkCreationSupportedResult_Override isSymlinkCreationSupportedResultOverride(false);
+
     OverridePortableInstaller(context);
     OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
     const auto& targetDirectory = tempDirectory.GetPath();
@@ -212,6 +211,35 @@ TEST_CASE("UpdateFlow_Portable_SymlinkCreationFail", "[UpdateFlow][workflow]")
     INFO(uninstallOutput.str());
 
     REQUIRE_FALSE(std::filesystem::exists(portableTargetPath));
+}
+
+TEST_CASE("UpdateFlow_Portable_SymlinkCreationFail", "[UpdateFlow][workflow]")
+{
+    // Update portable with symlink creation failure verify that it succeeds.
+    TestCommon::TempDirectory tempDirectory("TestPortableInstallRoot", false);
+    std::ostringstream updateOutput;
+    TestContext context{ updateOutput, std::cin };
+    auto PreviousThreadGlobals = context.SetForCurrentThread();
+    bool overrideCreateSymlinkStatus = false;
+    AppInstaller::Filesystem::TestHook_SetCreateSymlinkResult_Override(&overrideCreateSymlinkStatus);
+
+    OverridePortableInstaller(context);
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Portable }));
+    const auto& targetDirectory = tempDirectory.GetPath();
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Portable.Query);
+    context.Args.AddArg(Execution::Args::Type::InstallLocation, targetDirectory.u8string());
+    context.Args.AddArg(Execution::Args::Type::InstallScope, "user"sv);
+
+    UpgradeCommand update({});
+    update.Execute(context);
+    INFO(updateOutput.str());
+
+    REQUIRE_TERMINATED_WITH(context, APPINSTALLER_CLI_ERROR_PORTABLE_INSTALL_FAILED);
+
+    // Update should not remove existing portable.
+    const auto& portableTargetPath = targetDirectory / "AppInstallerTestExeInstaller.exe";
+    REQUIRE(std::filesystem::exists(portableTargetPath));
+    REQUIRE(context.Get<Execution::Data::PortableInstaller>().ARPEntryExists());
 }
 
 TEST_CASE("UpdateFlow_UpdateExeWithUnsupportedArgs", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -110,6 +110,9 @@ namespace AppInstaller::Runtime
     // Determines whether developer mode is enabled.
     bool IsDevModeEnabled();
 
+    // Determines whether symlinks can be created.
+    bool IsSymlinkCreationSupported();
+
     // Gets the default user agent string for the Windows Package Manager.
     Utility::LocIndString GetDefaultUserAgent();
 

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -632,6 +632,27 @@ namespace AppInstaller::Runtime
         }
     }
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    static bool* s_IsSymlinkCreationSupportedResult_TestHook_Override = nullptr;
+
+    void TestHook_SetIsSymlinkCreationSupportedResult_Override(bool* status)
+    {
+        s_IsSymlinkCreationSupportedResult_TestHook_Override = status;
+    }
+#endif
+
+    bool IsSymlinkCreationSupported()
+    {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (s_IsSymlinkCreationSupportedResult_TestHook_Override)
+        {
+            return *s_IsSymlinkCreationSupportedResult_TestHook_Override;
+        }
+#endif
+
+        return IsDevModeEnabled() || IsRunningAsAdmin();
+    }
+
     // Using "standard" user agent format
     // Keeping `winget-cli` for historical reasons
     Utility::LocIndString GetDefaultUserAgent()


### PR DESCRIPTION
Issue:
1. Currently, installing a single portable writes to the ARP registry, while installing portable(s) from an archive, writes to an index. The installation process should be the same since they are the same installer type.
2. If creating a symlink is not supported AND the portable exe does not have the same name as the expected command alias, the portable alias will not be recognized. (example: Installing Microsoft.devTunnel without dev mode and running as non-admin)

Changes:
1. I have removed the separation of the flows and write all of the required portable metadata to the portable's index. I have left behind the logic for uninstalling a portable that reads from the ARP registry. This is to ensure that older portables can still be uninstalled successfully. 
2. Since we determine our expected entries prior to creating a symlink, I believe it is better to first check whether creating a symlink is supported, so we can determine whether the portable file entry we add needs to be renamed to match the expected command alias. Checking whether a symlink can be created also determines whether we add the install directory directly to PATH.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3533)