### PR TITLE
Guard WinRT InProc Window Package Manager Deployment APIs by EnableAp…

### DIFF
--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -304,6 +304,8 @@ namespace AppInstallerCLIE2ETests
             public const int CONFIG_ERROR_UNIT_IMPORT_MODULE = unchecked((int)0x8A15C108);
             public const int CONFIG_ERROR_UNIT_INVOKE_INVALID_RESULT = unchecked((int)0x8A15C109);
             public const int CONFIG_ERROR_UNIT_SETTING_CONFIG_ROOT = unchecked((int)0x8A15C110);
+
+            public const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
         }
 
 #pragma warning restore SA1310 // Field names should not contain underscore

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -128,10 +128,10 @@ namespace AppInstallerCLIE2ETests
         // Group Policy Error Message
         public const string BlockByWinGetPolicyErrorMessage = "This operation is disabled by Group Policy : Enable Windows Package Manager";
 
-    /// <summary>
-    /// Error codes.
-    /// </summary>
-    public class ErrorCode
+        /// <summary>
+        /// Error codes.
+        /// </summary>
+        public class ErrorCode
         {
             public const int S_OK = 0;
             public const int S_FALSE = 1;

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -125,10 +125,13 @@ namespace AppInstallerCLIE2ETests
         public const string SimpleTestModuleName = "xE2ETestResource";
         public const string LocalModuleDescriptor = "[Local]";
 
-        /// <summary>
-        /// Error codes.
-        /// </summary>
-        public class ErrorCode
+        // Group Policy Error Message
+        public const string BlockByWinGetPolicyErrorMessage = "This operation is disabled by Group Policy : Enable Windows Package Manager";
+
+    /// <summary>
+    /// Error codes.
+    /// </summary>
+    public class ErrorCode
         {
             public const int S_OK = 0;
             public const int S_FALSE = 1;
@@ -304,8 +307,6 @@ namespace AppInstallerCLIE2ETests
             public const int CONFIG_ERROR_UNIT_IMPORT_MODULE = unchecked((int)0x8A15C108);
             public const int CONFIG_ERROR_UNIT_INVOKE_INVALID_RESULT = unchecked((int)0x8A15C109);
             public const int CONFIG_ERROR_UNIT_SETTING_CONFIG_ROOT = unchecked((int)0x8A15C110);
-
-            public const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
         }
 
 #pragma warning restore SA1310 // Field names should not contain underscore

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -12,17 +12,17 @@ namespace AppInstallerCLIE2ETests.Interop
     using NUnit.Framework;
 
     /// <summary>
-    /// Group Policy Tests for Interops
+    /// Group Policy Tests for COM/WinRT Interop classes.
     /// </summary>
     [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.InProcess), Category = nameof(InstanceInitializersSource.InProcess))]
     [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.OutOfProcess), Category = nameof(InstanceInitializersSource.OutOfProcess))]
-    public class GroupPolicyForInterops : BaseInterop
+    public class GroupPolicyForInterop : BaseInterop
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GroupPolicyForInterops"/> class.
+        /// Initializes a new instance of the <see cref="GroupPolicyForInterop"/> class.
         /// </summary>
         /// <param name="initializer">Initializer.</param>
-        public GroupPolicyForInterops(IInstanceInitializer initializer)
+        public GroupPolicyForInterop(IInstanceInitializer initializer)
           : base(initializer)
         {
         }
@@ -46,7 +46,7 @@ namespace AppInstallerCLIE2ETests.Interop
         }
 
         /// <summary>
-        /// Validates disabling WinGetPolicy should block COM/WinRT Objects creation (InProcess and OutofProcess).
+        /// Validates disabling WinGetPolicy should block COM/WinRT Objects creation (InProcess and OutOfProcess).
         /// </summary>
         [Test]
         public void DisableWinGetPolicy()

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------------
-// <copyright file="GroupPolicyForInterops.cs" company="Microsoft Corporation">
+// <copyright file="GroupPolicyForInterop.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------------

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -80,16 +80,27 @@ namespace AppInstallerCLIE2ETests.Interop
             }
             else
             {
-                try
-                {
-                    // Attempt to learn how it behaves on test pipeline.
-                    PackageManager packageManager = this.TestFactory.CreatePackageManager();
-                    Assert.IsNotNull(packageManager);
-                }
-                catch (Exception ex)
-                {
-                    Assert.AreEqual("Random String", ex.ToString());
-                }
+                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application specific error code returned from the
+                // DllActivationFactory implementation will not be surfaced to caller as it is instead WinRT auto generated implementation override the actual HRESULT with one of
+                // the standard HRESULT that we can expect from RoActivationInstance:
+                // https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roactivateinstance?source=recommendations  call.
+                // For more details look at WinRT.cs  BaseActivationFactory::BaseActivationFactory(string typeNamespace, string typeFullName) auto generated code implementation
+                // where there is a set preference that keeps HRESULT from RoGetActivationFactory over LoadLibrary call (used as a fallback approach load module form LoadLibrary).
+                Assert.Throws<TargetInvocationException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+
+                Assert.Throws<TargetInvocationException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
+
+                Assert.Throws<TargetInvocationException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
+
+                Assert.Throws<TargetInvocationException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
+
+                Assert.Throws<TargetInvocationException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
+
+                Assert.Throws<TargetInvocationException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
+
+                Assert.Throws<TargetInvocationException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
+
+                Assert.Throws<TargetInvocationException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
             }
         }
     }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -6,11 +6,9 @@
 
 namespace AppInstallerCLIE2ETests.Interop
 {
-    using System;
-    using System.Reflection;
-    using System.Runtime.InteropServices;
     using Microsoft.Management.Deployment;
     using Microsoft.Management.Deployment.Projection;
+    using Microsoft.WinGet.SharedLib.Exceptions;
     using NUnit.Framework;
 
     /// <summary>
@@ -55,52 +53,32 @@ namespace AppInstallerCLIE2ETests.Interop
         {
             GroupPolicyHelper.EnableWinget.Disable();
 
-            if (this.TestFactory.Context != ClsidContext.InProc)
+            GroupPolicyException groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
+            Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+
+            // PackageManagerSettings is not implemented in context OutOfProcDev
+            if (this.TestFactory.Context == ClsidContext.InProc)
             {
-                COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-                comException = Assert.Catch<COMException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
-                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-            }
-            else
-            {
-                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application specific error code returned from the
-                // DllActivationFactory implementation will not be surfaced to caller as it is instead WinRT auto generated implementation override the actual HRESULT with one of
-                // the standard HRESULT that we can expect from RoActivationInstance:
-                // https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roactivateinstance?source=recommendations  call.
-                // For more details look at WinRT.cs  BaseActivationFactory::BaseActivationFactory(string typeNamespace, string typeFullName) auto generated code implementation
-                // where there is a set preference that keeps HRESULT from RoGetActivationFactory over LoadLibrary call (used as a fallback approach load module form LoadLibrary).
-                Assert.Throws<TargetInvocationException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
-
-                Assert.Throws<TargetInvocationException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
-
-                Assert.Throws<TargetInvocationException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
-
-                Assert.Throws<TargetInvocationException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
-
-                Assert.Throws<TargetInvocationException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
-
-                Assert.Throws<TargetInvocationException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
-
-                Assert.Throws<TargetInvocationException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
-
-                Assert.Throws<TargetInvocationException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
+                groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
+                Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
             }
         }
     }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -6,6 +6,7 @@
 
 namespace AppInstallerCLIE2ETests.Interop
 {
+    using System;
     using System.Reflection;
     using System.Runtime.InteropServices;
     using Microsoft.Management.Deployment;
@@ -79,51 +80,16 @@ namespace AppInstallerCLIE2ETests.Interop
             }
             else
             {
-                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application specific error code returned from the
-                // DllActivationFactory implementation will not be surfaced to caller as is instead WinRT auto generated implementation override the actual HRESULT with one of
-                // the standard HRESULT that we can expect from RoActivationInstance:
-                // https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roactivateinstance?source=recommendations  call.
-                // For more details look at WinRT.cs  BaseActivationFactory::BaseActivationFactory(string typeNamespace, string typeFullName) auto generated code implementation
-                // where there is a set preference that keeps HRESULT from RoGetActivationFactory over LoadLibrary call (used as a fallback approach load module form LoadLibrary).
-                TargetInvocationException targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
-
-                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
-                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
-                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+                try
+                {
+                    // Attempt to learn how it behaves on test pipeline.
+                    PackageManager packageManager = this.TestFactory.CreatePackageManager();
+                    Assert.IsNotNull(packageManager);
+                }
+                catch (Exception ex)
+                {
+                    Assert.AreEqual("Random String", ex.ToString());
+                }
             }
         }
     }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -55,30 +55,38 @@ namespace AppInstallerCLIE2ETests.Interop
 
             GroupPolicyException groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
             Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
 
             // PackageManagerSettings is not implemented in context OutOfProcDev
             if (this.TestFactory.Context == ClsidContext.InProc)
             {
                 groupPolicyException = Assert.Catch<GroupPolicyException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
                 Assert.AreEqual(Constants.BlockByWinGetPolicyErrorMessage, groupPolicyException.Message);
+                Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, groupPolicyException.HResult);
             }
         }
     }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -6,6 +6,7 @@
 
 namespace AppInstallerCLIE2ETests.Interop
 {
+    using System.Reflection;
     using System.Runtime.InteropServices;
     using Microsoft.Management.Deployment;
     using Microsoft.Management.Deployment.Projection;
@@ -53,32 +54,76 @@ namespace AppInstallerCLIE2ETests.Interop
         {
             GroupPolicyHelper.EnableWinget.Disable();
 
-            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            comException = Assert.Catch<COMException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
-            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
-
-            // PackageManagerSettings is not implemented in context OutOfProcDev
-            if (this.TestFactory.Context == ClsidContext.InProc)
+            if (this.TestFactory.Context != ClsidContext.InProc)
             {
-                comException = Assert.Catch<COMException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
+                COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
                 Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+                comException = Assert.Catch<COMException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+            }
+            else
+            {
+                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application sepecific error code returned from the
+                // DllActivationFactory implementation will not be surfaced to caller as is instead WinRT auto generated implementation override the actual HRESULT with one of
+                // the standard HRESULT that we can expect from RoActivationInstance:
+                // https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roactivateinstance?source=recommendations  call.
+                // For more details look at WinRT.cs  BaseActivationFactory::BaseActivationFactory(string typeNamespace, string typeFullName) auto generated code implementation
+                // where there is a set preference that keeps HRESULT from RoGetActivationFactory over LoadLibrary call (used as a fallback approach load module form LoadLibrary).
+                TargetInvocationException targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
+
+                targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
+                Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
             }
         }
     }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterop.cs
@@ -79,7 +79,7 @@ namespace AppInstallerCLIE2ETests.Interop
             }
             else
             {
-                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application sepecific error code returned from the
+                // [NOTE:] Currently there is a design limitation in CS WinRT/C++ WinRT that the application specific error code returned from the
                 // DllActivationFactory implementation will not be surfaced to caller as is instead WinRT auto generated implementation override the actual HRESULT with one of
                 // the standard HRESULT that we can expect from RoActivationInstance:
                 // https://learn.microsoft.com/en-us/windows/win32/api/roapi/nf-roapi-roactivateinstance?source=recommendations  call.
@@ -87,42 +87,42 @@ namespace AppInstallerCLIE2ETests.Interop
                 // where there is a set preference that keeps HRESULT from RoGetActivationFactory over LoadLibrary call (used as a fallback approach load module form LoadLibrary).
                 TargetInvocationException targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
 
                 targetInvocationException = Assert.Catch<TargetInvocationException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
                 Assert.IsNotNull(targetInvocationException.InnerException); // 0x80131534 Exception was thrown by Type's initializer
-                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Actionvation Factory
+                Assert.IsNotNull(targetInvocationException.InnerException.InnerException); // 0x80040154 Exception was thrown by WinRT Activation Factory
                 Assert.AreEqual(targetInvocationException.InnerException.InnerException.HResult, Constants.ErrorCode.REGDB_E_CLASSNOTREG);
             }
         }

--- a/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterops.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/GroupPolicyForInterops.cs
@@ -1,0 +1,85 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="GroupPolicyForInterops.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace AppInstallerCLIE2ETests.Interop
+{
+    using System.Runtime.InteropServices;
+    using Microsoft.Management.Deployment;
+    using Microsoft.Management.Deployment.Projection;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Group Policy Tests for Interops
+    /// </summary>
+    [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.InProcess), Category = nameof(InstanceInitializersSource.InProcess))]
+    [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.OutOfProcess), Category = nameof(InstanceInitializersSource.OutOfProcess))]
+    public class GroupPolicyForInterops : BaseInterop
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroupPolicyForInterops"/> class.
+        /// </summary>
+        /// <param name="initializer">Initializer.</param>
+        public GroupPolicyForInterops(IInstanceInitializer initializer)
+          : base(initializer)
+        {
+        }
+
+        /// <summary>
+        /// Test setup.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            GroupPolicyHelper.DeleteExistingPolicies();
+        }
+
+        /// <summary>
+        /// Clean up.
+        /// </summary>
+        [TearDown]
+        public void CleanUp()
+        {
+            GroupPolicyHelper.DeleteExistingPolicies();
+        }
+
+        /// <summary>
+        /// Validates disabling WinGetPolicy should block COM/WinRT Objects creation (InProcess and OutofProcess).
+        /// </summary>
+        [Test]
+        public void DisableWinGetPolicy()
+        {
+            GroupPolicyHelper.EnableWinget.Disable();
+
+            COMException comException = Assert.Catch<COMException>(() => { PackageManager packageManager = this.TestFactory.CreatePackageManager(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { FindPackagesOptions findPackagesOptions = this.TestFactory.CreateFindPackagesOptions(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { CreateCompositePackageCatalogOptions createCompositePackageCatalogOptions = this.TestFactory.CreateCreateCompositePackageCatalogOptions(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { InstallOptions installOptions = this.TestFactory.CreateInstallOptions(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { UninstallOptions uninstallOptions = this.TestFactory.CreateUninstallOptions(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { DownloadOptions downloadOptions = this.TestFactory.CreateDownloadOptions(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            comException = Assert.Catch<COMException>(() => { PackageMatchFilter packageMatchFilter = this.TestFactory.CreatePackageMatchFilter(); });
+            Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+
+            // PackageManagerSettings is not implemented in context OutOfProcDev
+            if (this.TestFactory.Context == ClsidContext.InProc)
+            {
+                comException = Assert.Catch<COMException>(() => { PackageManagerSettings packageManagerSettings = this.TestFactory.CreatePackageManagerSettings(); });
+                Assert.AreEqual(comException.HResult, Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Management.Deployment.Projection/Initializers/ActivationFactoryInstanceInitializer.cs
+++ b/src/Microsoft.Management.Deployment.Projection/Initializers/ActivationFactoryInstanceInitializer.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Management.Deployment.Projection
 {
+    using Microsoft.Management.Deployment.Projection.Initializers;
+
     /// <summary>
     /// Activation factory instance initializer requires that:
     /// - DllGetActivationFactory is exported
@@ -11,12 +13,12 @@ namespace Microsoft.Management.Deployment.Projection
     ///   to match the projected classes (e.g. PackageManager) namespace
     ///   More details: https://docs.microsoft.com/en-us/windows/apps/develop/platform/csharp-winrt/#winrt-type-activation
     /// </summary>
-    public class ActivationFactoryInstanceInitializer : IInstanceInitializer
+    public class ActivationFactoryInstanceInitializer : PolicyEnforcedInstanceInitializer
     {
         /// <summary>
         /// In-process context
         /// </summary>
-        public ClsidContext Context => ClsidContext.InProc;
+        public override ClsidContext Context => ClsidContext.InProc;
 
         /// <summary>
         /// Calls default projected class constructor implemented by CsWinRT.
@@ -25,6 +27,6 @@ namespace Microsoft.Management.Deployment.Projection
         /// </summary>
         /// <typeparam name="T">Projected class type</typeparam>
         /// <returns>Instance of the provided type.</returns>
-        public T CreateInstance<T>() where T : new() => new();
+        protected override T CreateInstanceInternal<T>() => new();
     }
 }

--- a/src/Microsoft.Management.Deployment.Projection/Initializers/LocalServerInstanceInitializer.cs
+++ b/src/Microsoft.Management.Deployment.Projection/Initializers/LocalServerInstanceInitializer.cs
@@ -3,15 +3,16 @@
 
 namespace Microsoft.Management.Deployment.Projection
 {
+    using Microsoft.Management.Deployment.Projection.Initializers;
     using WinRT;
 
     // Out-of-process COM instance initializer.
-    public class LocalServerInstanceInitializer : IInstanceInitializer
+    public class LocalServerInstanceInitializer : PolicyEnforcedInstanceInitializer
     {
         /// <summary>
         /// Out-of-process context.
         /// </summary>
-        public ClsidContext Context => UseDevClsids ? ClsidContext.OutOfProcDev : ClsidContext.OutOfProc;
+        public override ClsidContext Context => UseDevClsids ? ClsidContext.OutOfProcDev : ClsidContext.OutOfProc;
 
         /// <summary>
         /// Allow lower trust registration.
@@ -29,8 +30,7 @@ namespace Microsoft.Management.Deployment.Projection
         /// </summary>
         /// <typeparam name="T">Projected class type.</typeparam>
         /// <returns>Instance of the provided type.</returns>
-        public T CreateInstance<T>()
-            where T : new()
+        protected override T CreateInstanceInternal<T>()
         {
             var clsid = ClassesDefinition.GetClsid<T>(Context);
             var iid = ClassesDefinition.GetIid<T>();

--- a/src/Microsoft.Management.Deployment.Projection/Initializers/PolicyEnforcedInstanceInitializer.cs
+++ b/src/Microsoft.Management.Deployment.Projection/Initializers/PolicyEnforcedInstanceInitializer.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Management.Deployment.Projection.Initializers
     using Microsoft.WinGet.SharedLib.PolicySettings;
 
     /// <summary>
-    /// An abstract base that enforces group policy before creating drived class instance.
+    /// An abstract base that enforces group policy before creating derived class instance.
     /// </summary>
     public abstract class PolicyEnforcedInstanceInitializer : IInstanceInitializer
     {

--- a/src/Microsoft.Management.Deployment.Projection/Initializers/PolicyEnforcedInstanceInitializer.cs
+++ b/src/Microsoft.Management.Deployment.Projection/Initializers/PolicyEnforcedInstanceInitializer.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Management.Deployment.Projection.Initializers
+{
+    using Microsoft.WinGet.SharedLib.Exceptions;
+    using Microsoft.WinGet.SharedLib.PolicySettings;
+
+    /// <summary>
+    /// An abstract base that enforces group policy before creating drived class instance.
+    /// </summary>
+    public abstract class PolicyEnforcedInstanceInitializer : IInstanceInitializer
+    {
+        /// <summary>
+        /// CLSID context.
+        /// </summary>
+        public abstract ClsidContext Context { get; }
+
+        /// <summary>
+        /// Create instance of the provided type.
+        /// </summary>
+        /// <typeparam name="T">Projected class type.</typeparam>
+        /// <returns>Instance of the provided type.</returns>
+        public T CreateInstance<T>() where T : new()
+        {
+            GroupPolicy groupPolicy = GroupPolicy.GetInstance();
+
+            if (!groupPolicy.IsEnabled(Policy.WinGet))
+            {
+                throw new GroupPolicyException(Policy.WinGet, GroupPolicyFailureType.BlockedByPolicy);
+            }
+
+            return this.CreateInstanceInternal<T>();
+        }
+
+        protected abstract T CreateInstanceInternal<T>() where T : new();
+    }
+}

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -26,5 +26,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ReferenceOutputAssembly>True</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\PowerShell\Microsoft.WinGet.SharedLib\Microsoft.WinGet.SharedLib.csproj" />
   </ItemGroup>
 </Project>

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/Exceptions/ErrorCodes.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/Exceptions/ErrorCodes.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="ErrorCodes.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.SharedLib.Exceptions
+{
+    /// <summary>
+    /// This should match the ones in AppInstallerErrors.h.
+    /// </summary>
+    internal static class ErrorCodes
+    {
+#pragma warning disable SA1600 // ElementsMustBeDocumented
+        internal const int AppInstallerCLIErrorInternalError = unchecked((int)0x8A150001);
+        internal const int AppInstallerCLIErrorBlockedByPolicy = unchecked((int)0x8A15003A);
+#pragma warning restore SA1600 // ElementsMustBeDocumented
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/Exceptions/GroupPolicyException.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/Exceptions/GroupPolicyException.cs
@@ -24,6 +24,7 @@ namespace Microsoft.WinGet.SharedLib.Exceptions
         public GroupPolicyException(Policy policy, GroupPolicyFailureType policyFailureType)
             : base(string.Format(policyFailureType.GetFailureString(), policy.GetResourceString()))
         {
+            this.HResult = policyFailureType.GetErrorCode();
         }
 
         /// <summary>
@@ -34,6 +35,7 @@ namespace Microsoft.WinGet.SharedLib.Exceptions
         public GroupPolicyException(GroupPolicyFailureType policyFailureType, Exception innerException)
             : base(policyFailureType.GetFailureString(), innerException)
         {
+            this.HResult = policyFailureType.GetErrorCode();
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/Extensions/EnumPolicyExtension.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/Extensions/EnumPolicyExtension.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.WinGet.SharedLib.Extensions
 {
+    using Microsoft.WinGet.SharedLib.Exceptions;
     using Microsoft.WinGet.SharedLib.PolicySettings;
     using Microsoft.WinGet.SharedLib.Resources;
 
@@ -68,6 +69,24 @@ namespace Microsoft.WinGet.SharedLib.Extensions
                 case GroupPolicyFailureType.LoadError:
                     return GroupPolicyResource.PolicyLoadError;
                 default: return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets ErrorCode mapped to GroupPolicyFailureType.
+        /// </summary>
+        /// <param name="policyFailure">GroupPolicyFailureType.</param>
+        /// <returns>ErrorCode.</returns>
+        public static int GetErrorCode(this GroupPolicyFailureType policyFailure)
+        {
+            switch (policyFailure)
+            {
+                case GroupPolicyFailureType.BlockedByPolicy:
+                    return ErrorCodes.AppInstallerCLIErrorBlockedByPolicy;
+                case GroupPolicyFailureType.NotFound:
+                case GroupPolicyFailureType.LoadError:
+                default:
+                    return ErrorCodes.AppInstallerCLIErrorInternalError;
             }
         }
     }

--- a/src/WindowsPackageManager/main.cpp
+++ b/src/WindowsPackageManager/main.cpp
@@ -13,6 +13,8 @@
 #include <AppInstallerFileLogger.h>
 #include <AppInstallerStrings.h>
 #include <AppInstallerTelemetry.h>
+#include <AppInstallerErrors.h>
+#include <winget/GroupPolicy.h>
 #include <ComClsids.h>
 
 using namespace winrt::Microsoft::Management::Deployment;
@@ -112,6 +114,8 @@ extern "C"
 
     WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerInProcModuleGetActivationFactory(HSTRING classId, void** factory) try
     {
+        RETURN_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, !::AppInstaller::Settings::GroupPolicies().IsEnabled(::AppInstaller::Settings::TogglePolicy::Policy::WinGet));
+
         return WINRT_GetActivationFactory(classId, factory);
     }
     CATCH_RETURN();


### PR DESCRIPTION
…pInstaller GroupPolicy

**[WHY:]**
WINRT InProcess Deployment APIs are current not guarded by EnableAppInstaller GroupPolicy. where as COM InProcess/OutProcess API are guarded by group policy.

**[WHAT:]**
- This fix is introducing the Group Policy check for WinRT InProcess deployment APIs to block them if EnableAppInstaller is disabled.
   -  Added a group policy check in DllGetActivationFactory but this is to prevent external code calling into WinRT In Proc API goes through group policy check.
 - Added Group Policy check in our Projection layer
   - ActivationFactoryInstanceInitializer  : WinRT InProc object initializer
   - LocalServerInstanceInitializer : COM out of proc object initalizer
   This way consumer of this code doesn't have to rely too much on error message that bubbles from WinRT DllGetActionvationFactory implementation, and it also doesn't surface actual group policy error when there is a failure for consistent client experience.
- Update GroupPolicy Exception code to map appropriate error code based on the type of failure triggered the exception.
   
- Added some group policy tests for the InProcess/ OutOfProcess Interops to validate group policy indeed blocks the Object creation when policy is disabled.

**[How Tested:]**
- Copied the fix and applied wingetdev package
- GroupPolicyForInterops test run to ensure they all behave as expected.

Related to : https://microsoft.visualstudio.com/OS/_workitems/edit/45796608/

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3537)