### PR TITLE
Rename portable file with command alias if symlinks are not supported

### DIFF
--- a/src/AppInstallerCLITests/TestHooks.h
+++ b/src/AppInstallerCLITests/TestHooks.h
@@ -28,6 +28,7 @@ namespace AppInstaller
         void TestHook_SetPathOverride(PathName target, const std::filesystem::path& path);
         void TestHook_SetPathOverride(PathName target, const PathDetails& details);
         void TestHook_ClearPathOverrides();
+        void TestHook_SetIsSymlinkCreationSupportedResult_Override(bool* status);
     }
 
     namespace Repository
@@ -85,6 +86,22 @@ namespace TestHook
         ~SetCreateSymlinkResult_Override()
         {
             AppInstaller::Filesystem::TestHook_SetCreateSymlinkResult_Override(nullptr);
+        }
+
+    private:
+        bool m_status;
+    };
+
+    struct SetIsSymlinkCreationSupportedResult_Override
+    {
+        SetIsSymlinkCreationSupportedResult_Override(bool status) : m_status(status)
+        {
+            AppInstaller::Runtime::TestHook_SetIsSymlinkCreationSupportedResult_Override(&m_status);
+        }
+
+        ~SetIsSymlinkCreationSupportedResult_Override()
+        {
+            AppInstaller::Runtime::TestHook_SetIsSymlinkCreationSupportedResult_Override(nullptr);
         }
 
     private:

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -110,6 +110,9 @@ namespace AppInstaller::Runtime
     // Determines whether developer mode is enabled.
     bool IsDevModeEnabled();
 
+    // Determines whether symlinks can be created
+    bool IsSymlinkCreationSupported();
+
     // Gets the default user agent string for the Windows Package Manager.
     Utility::LocIndString GetDefaultUserAgent();
 

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -632,6 +632,26 @@ namespace AppInstaller::Runtime
         }
     }
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    static bool* s_IsSymlinkCreationSupportedResult_TestHook_Override = nullptr;
+
+    void TestHook_SetIsSymlinkCreationSupportedResult_Override(bool* status)
+    {
+        s_IsSymlinkCreationSupportedResult_TestHook_Override = status;
+    }
+#endif
+
+    bool IsSymlinkCreationSupported()
+    {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (s_IsSymlinkCreationSupportedResult_TestHook_Override)
+        {
+            return *s_IsSymlinkCreationSupportedResult_TestHook_Override;
+        }
+#endif
+        return IsDevModeEnabled() || IsRunningAsAdmin();
+    }
+
     // Using "standard" user agent format
     // Keeping `winget-cli` for historical reasons
     Utility::LocIndString GetDefaultUserAgent()


### PR DESCRIPTION
Issue:
If creating a symlink is not supported AND the portable exe does not have the same name as the expected command alias, the portable alias will not be recognized. (example: Installing Microsoft.devTunnel without dev mode and running as non-admin)

Changes:
- Check whether symlink creation is supported at the start of registering ARP entry.
- If symlinkcreation is not supported, the target filename of the portable file entry is renamed with the expected command alias.
- Adding Install directory to Path is now its own step rather than a by product of failing to create a symlink. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3544)