### PR TITLE
Add argument for ignoring warnings

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -355,6 +355,7 @@ normalizedpackagenameandpublisher
 NOTHROW
 NOTIMPL
 NOTNULL
+nowarn
 npos
 NTFS
 NTSTATUS

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -119,6 +119,8 @@ namespace AppInstaller::CLI
         //Validate Command
         case Execution::Args::Type::ValidateManifest:
             return { type, "manifest"_liv };
+        case Execution::Args::Type::IgnoreWarnings:
+            return { type, "ignore-warnings"_liv, "nowarn"_liv};
 
         // Complete Command
         case Execution::Args::Type::Word:
@@ -313,6 +315,8 @@ namespace AppInstaller::CLI
             return Argument{ type, Resource::String::SourceTypeArgumentDescription, ArgumentType::Positional };
         case Args::Type::ValidateManifest:
             return Argument{ type, Resource::String::ValidateManifestArgumentDescription, ArgumentType::Positional, true };
+        case Args::Type::IgnoreWarnings:
+            return Argument{ type, Resource::String::IgnoreWarningsArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
         case Args::Type::NoVT:
             return Argument{ type, Resource::String::NoVTArgumentDescription, ArgumentType::Flag, Argument::Visibility::Hidden };
         case Args::Type::RainbowStyle:

--- a/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ValidateCommand.cpp
@@ -16,6 +16,7 @@ namespace AppInstaller::CLI
     {
         return {
             Argument::ForType(Execution::Args::Type::ValidateManifest),
+            Argument::ForType(Execution::Args::Type::IgnoreWarnings),
         };
     }
 
@@ -46,7 +47,7 @@ namespace AppInstaller::CLI
             {
                 ManifestValidateOption validateOption;
                 validateOption.FullValidation = true;
-                validateOption.ThrowOnWarning = true;
+                validateOption.ThrowOnWarning = !(context.Args.Contains(Execution::Args::Type::IgnoreWarnings));
                 auto manifest = YamlParser::CreateFromPath(inputFile, validateOption);
 
                 context.Add<Execution::Data::Manifest>(manifest);

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -66,6 +66,7 @@ namespace AppInstaller::CLI::Execution
 
             //Validate Command
             ValidateManifest,
+            IgnoreWarnings,
 
             // Complete Command
             Word,

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -207,6 +207,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(HelpLinkPreamble);
         WINGET_DEFINE_RESOURCE_STRINGID(IdArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(IgnoreLocalArchiveMalwareScanArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(IgnoreWarningsArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ImportCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ImportCommandReportDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(ImportCommandShortDescription);

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestWarningManifest.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestWarningManifest.yaml
@@ -1,12 +1,14 @@
-Id: TestWarning.Manifest
-Name: TestWarningManifest
-Version: 1.0.0.0
+PackageIdentifier: TestWarning.Manifest
+PackageName: TestWarningManifest
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
 Publisher: AppInstallerTest
 License: Test
 Installers:
-  - Arch: x86
-    Url: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
-    Sha256: <EXEHASH>
+  - Architecture: x86
+    InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+    InstallerSha256: <EXEHASH>
     InstallerType: exe
-    Switches:
-ManifestVersion: 0.1.0
+ShortDescription: This manifest should have only warnings, no errors
+ManifestType: singleton
+ManifestVersion: 1.6.0

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestWarningManifest.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestWarningManifest.yaml
@@ -7,7 +7,7 @@ License: Test
 Installers:
   - Architecture: x86
     InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
-    InstallerSha256: <EXEHASH>
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     InstallerType: exe
 ShortDescription: This manifest should have only warnings, no errors
 ManifestType: singleton

--- a/src/AppInstallerCLIE2ETests/ValidateCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ValidateCommand.cs
@@ -48,6 +48,29 @@ namespace AppInstallerCLIE2ETests
         }
 
         /// <summary>
+        /// Test validate manifest with warnings.
+        /// </summary>
+        [Test]
+        public void ValidateManifestWithWarnings()
+        {
+            var result = TestCommon.RunAICLICommand("validate", TestCommon.GetTestDataFile("Manifests\\TestWarningManifest.yaml"));
+            Assert.AreEqual(Constants.ErrorCode.ERROR_MANIFEST_VALIDATION_WARNING, result.ExitCode);
+            Assert.True(result.StdOut.Contains("Manifest validation succeeded with warnings."));
+        }
+
+        /// <summary>
+        /// Test validate manifest with warnings suppressed.
+        /// </summary>
+        [Test]
+        public void ValidateManifestSuppressWarnings()
+        {
+            var result = TestCommon.RunAICLICommand("validate", TestCommon.GetTestDataFile("Manifests\\TestWarningManifest.yaml") + " --ignore-warnings");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+            Assert.False(result.StdOut.Contains("Manifest validation succeeded with warnings."));
+            Assert.True(result.StdOut.Contains("Manifest validation succeeded."));
+        }
+
+        /// <summary>
         /// Test validate manifest that doesn't exist.
         /// </summary>
         [Test]

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -261,6 +261,9 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="IdArgumentDescription" xml:space="preserve">
     <value>Filter results by id</value>
   </data>
+  <data name="IgnoreWarningsArgumentDescription" xml:space="preserve">
+    <value>Suppresses warning outputs.</value>
+  </data>
   <data name="InstallationDisclaimer1" xml:space="preserve">
     <value>This application is licensed to you by its owner.</value>
   </data>


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - Resolves #3405

I wasn't sure whether or not to go with a new exit code, or keep it as a 0 exit code as mentioned in the linked issue. I ended up deciding to go with what was written in the issue as it seemed like a very specific use case. If a non-zero exit code would be a better option, I was thinking that `--suppress-warnings` could be separated from `--ignore-warnings` where ignoring completely ignores them and suppressing will hide the output but return a new exit code if there were warnings that were suppressed.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3572)