### PR TITLE
Enable configuration via IConfigurationStatics

### DIFF
--- a/src/AppInstallerCommonCore/MSStore.cpp
+++ b/src/AppInstallerCommonCore/MSStore.cpp
@@ -4,13 +4,11 @@
 #include <winget/MSStore.h>
 #include <winget/ManifestCommon.h>
 #include <winget/Runtime.h>
-#include <winget/SelfManagement.h>
 #include <AppInstallerFileLogger.h>
 #include <AppInstallerErrors.h>
 
 namespace AppInstaller::MSStore
 {
-    using namespace AppInstaller::SelfManagement;
     using namespace std::string_view_literals;
     using namespace winrt::Windows::Foundation;
     using namespace winrt::Windows::Foundation::Collections;

--- a/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.cpp
@@ -41,7 +41,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         return *result;
     }
 
-    Windows::Foundation::IAsyncActionWithProgress<uint32_t> ConfigurationStaticFunctions::EnableConfigurationAsync()
+    Windows::Foundation::IAsyncActionWithProgress<uint32_t> ConfigurationStaticFunctions::EnsureConfigurationAvailableAsync()
     {
         THROW_HR(E_NOTIMPL);
     }

--- a/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.cpp
@@ -40,4 +40,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         result->ConfigurationSetProcessorFactory(factory);
         return *result;
     }
+
+    Windows::Foundation::IAsyncActionWithProgress<uint32_t> ConfigurationStaticFunctions::EnableConfigurationAsync()
+    {
+        THROW_HR(E_NOTIMPL);
+    }
 }

--- a/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.h
@@ -13,6 +13,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         Configuration::ConfigurationSet CreateConfigurationSet();
         Windows::Foundation::IAsyncOperation<IConfigurationSetProcessorFactory> CreateConfigurationSetProcessorFactoryAsync(hstring const& handler);
         Configuration::ConfigurationProcessor CreateConfigurationProcessor(IConfigurationSetProcessorFactory const& factory);
+        bool IsConfigurationEnabled() { return true; }
+        Windows::Foundation::IAsyncActionWithProgress<uint32_t> EnableConfigurationAsync();
     };
 }
 namespace winrt::Microsoft::Management::Configuration::factory_implementation

--- a/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationStaticFunctions.h
@@ -13,8 +13,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         Configuration::ConfigurationSet CreateConfigurationSet();
         Windows::Foundation::IAsyncOperation<IConfigurationSetProcessorFactory> CreateConfigurationSetProcessorFactoryAsync(hstring const& handler);
         Configuration::ConfigurationProcessor CreateConfigurationProcessor(IConfigurationSetProcessorFactory const& factory);
-        bool IsConfigurationEnabled() { return true; }
-        Windows::Foundation::IAsyncActionWithProgress<uint32_t> EnableConfigurationAsync();
+        bool IsConfigurationAvailable() { return true; }
+        Windows::Foundation::IAsyncActionWithProgress<uint32_t> EnsureConfigurationAvailableAsync();
     };
 }
 namespace winrt::Microsoft::Management::Configuration::factory_implementation

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -715,6 +715,12 @@ namespace Microsoft.Management.Configuration
 
         // Creates a processor from the given factory.
         ConfigurationProcessor CreateConfigurationProcessor(IConfigurationSetProcessorFactory factory);
+
+        // Whether configuration is enabled.
+        Boolean IsConfigurationEnabled{ get; };
+
+        // Enables configuration. Requires store access.
+        Windows.Foundation.IAsyncActionWithProgress<UInt32> EnableConfigurationAsync();
     }
 
     // Top level entry point for configuration, enabling easier usage in out-of-process scenarios.

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -717,10 +717,10 @@ namespace Microsoft.Management.Configuration
         ConfigurationProcessor CreateConfigurationProcessor(IConfigurationSetProcessorFactory factory);
 
         // Whether configuration is enabled.
-        Boolean IsConfigurationEnabled{ get; };
+        Boolean IsConfigurationAvailable{ get; };
 
         // Enables configuration. Requires store access.
-        Windows.Foundation.IAsyncActionWithProgress<UInt32> EnableConfigurationAsync();
+        Windows.Foundation.IAsyncActionWithProgress<UInt32> EnsureConfigurationAvailableAsync();
     }
 
     // Top level entry point for configuration, enabling easier usage in out-of-process scenarios.

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -54,6 +54,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         }
         return catalogs.GetView();
     }
+
     winrt::Microsoft::Management::Deployment::PackageCatalogReference PackageManager::GetPredefinedPackageCatalog(winrt::Microsoft::Management::Deployment::PredefinedPackageCatalog const& predefinedPackageCatalog)
     {
         ::AppInstaller::Repository::Source source;
@@ -77,6 +78,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         packageCatalogRef->Initialize(*packageCatalogInfo, source);
         return *packageCatalogRef;
     }
+
     winrt::Microsoft::Management::Deployment::PackageCatalogReference PackageManager::GetLocalPackageCatalog(winrt::Microsoft::Management::Deployment::LocalPackageCatalog const& localPackageCatalog)
     {
         ::AppInstaller::Repository::Source source;
@@ -97,6 +99,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         packageCatalogRef->Initialize(*packageCatalogInfo, source);
         return *packageCatalogRef;
     }
+
     winrt::Microsoft::Management::Deployment::PackageCatalogReference PackageManager::GetPackageCatalogByName(hstring const& catalogName)
     {
         std::string name = winrt::to_string(catalogName);
@@ -120,6 +123,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             return nullptr;
         }
     }
+
     void AddPackageManifestToContext(winrt::Microsoft::Management::Deployment::PackageVersionInfo packageVersionInfo, ::AppInstaller::CLI::Execution::Context* context)
     {
         winrt::Microsoft::Management::Deployment::implementation::PackageVersionInfo* packageVersionInfoImpl = get_self<winrt::Microsoft::Management::Deployment::implementation::PackageVersionInfo>(packageVersionInfo);
@@ -138,12 +142,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         context->Add<::AppInstaller::CLI::Execution::Data::Manifest>(std::move(manifest));
         context->Add<::AppInstaller::CLI::Execution::Data::PackageVersion>(std::move(internalPackageVersion));
     }
+
     void AddInstalledVersionToContext(winrt::Microsoft::Management::Deployment::PackageVersionInfo installedVersionInfo, ::AppInstaller::CLI::Execution::Context* context)
     {
         winrt::Microsoft::Management::Deployment::implementation::PackageVersionInfo* installedVersionInfoImpl = get_self<winrt::Microsoft::Management::Deployment::implementation::PackageVersionInfo>(installedVersionInfo);
         std::shared_ptr<::AppInstaller::Repository::IPackageVersion> internalInstalledVersion = installedVersionInfoImpl->GetRepositoryPackageVersion();
         context->Add<AppInstaller::CLI::Execution::Data::InstalledPackageVersion>(internalInstalledVersion);
     }
+
     winrt::Microsoft::Management::Deployment::PackageCatalogReference PackageManager::CreateCompositePackageCatalog(winrt::Microsoft::Management::Deployment::CreateCompositePackageCatalogOptions const& options)
     {
         if (!options)

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -174,7 +174,8 @@ namespace ConfigurationShim
 
             auto progress = co_await winrt::get_progress_token();
 
-            // Don't use UpgradePackageAsync
+            // Don't use UpgradePackageAsync, we don't support upgrade for packages from the msstore
+            // it has to be install and internally we know is an update.
             auto installTask = packageManager.InstallPackageAsync(catalogPackage, installOptions);
             installTask.Progress([progress](auto const&, InstallProgress installProgress)
             {

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -181,11 +181,11 @@ namespace ConfigurationShim
             {
                 if (installProgress.State == PackageInstallProgressState::Downloading && installProgress.BytesRequired != 0)
                 {
-                    progress((uint32_t)(installProgress.DownloadProgress * 50));
+                    progress((uint32_t)(installProgress.DownloadProgress * 80));
                 }
                 else if (installProgress.State == PackageInstallProgressState::Installing)
                 {
-                    progress(((uint32_t)installProgress.InstallationProgress * 50) + 50);
+                    progress(((uint32_t)installProgress.InstallationProgress * 20) + 80);
                 }
             });
 

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -140,6 +140,7 @@ namespace ConfigurationShim
                 return;
             }
 
+            auto strong_this{ get_strong() };
             co_await winrt::resume_background();
 
             SetStubPreferred(false);

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -48,7 +48,7 @@ namespace ConfigurationShim
             diagnosticsLogger.SetLevel(AppInstaller::Logging::Level::Verbose);
             diagnosticsLogger.AddLogger(std::make_unique<AppInstaller::Logging::FileLogger>("ConfigStatics"sv));
 
-            if (IsConfigurationEnabled())
+            if (IsConfigurationAvailable())
             {
                 m_statics = winrt::Microsoft::Management::Configuration::ConfigurationStaticFunctions();
             }
@@ -56,7 +56,7 @@ namespace ConfigurationShim
 
         winrt::Microsoft::Management::Configuration::ConfigurationUnit CreateConfigurationUnit()
         {
-            RETURN_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
+            THROW_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
 
             if (!m_statics)
             {
@@ -70,7 +70,7 @@ namespace ConfigurationShim
 
         winrt::Microsoft::Management::Configuration::ConfigurationSet CreateConfigurationSet()
         {
-            RETURN_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
+            THROW_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
 
             if (!m_statics)
             {
@@ -84,7 +84,7 @@ namespace ConfigurationShim
 
         winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Management::Configuration::IConfigurationSetProcessorFactory> CreateConfigurationSetProcessorFactoryAsync(winrt::hstring const& handler)
         {
-            RETURN_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
+            THROW_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
 
             auto strong_this{ get_strong() };
             std::wstring lowerHandler = AppInstaller::Utility::ToLower(handler);
@@ -114,7 +114,7 @@ namespace ConfigurationShim
 
         winrt::Microsoft::Management::Configuration::ConfigurationProcessor CreateConfigurationProcessor(winrt::Microsoft::Management::Configuration::IConfigurationSetProcessorFactory const& factory)
         {
-            RETURN_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
+            THROW_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
 
             if (!m_statics)
             {
@@ -126,16 +126,16 @@ namespace ConfigurationShim
             return result;
         }
 
-        bool IsConfigurationEnabled()
+        bool IsConfigurationAvailable()
         {
             return !IsStubPackage();
         }
 
-        winrt::Windows::Foundation::IAsyncActionWithProgress<uint32_t> EnableConfigurationAsync()
+        winrt::Windows::Foundation::IAsyncActionWithProgress<uint32_t> EnsureConfigurationAvailableAsync()
         {
-            RETURN_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
+            THROW_HR_IF(CO_E_CLASS_DISABLED, !s_canBeCreated);
 
-            if (IsConfigurationEnabled())
+            if (IsConfigurationAvailable())
             {
                 return;
             }

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -158,8 +158,8 @@ namespace ConfigurationShim
 
             auto progress = co_await winrt::get_progress_token();
 
+            // Don't use UpgradePackageAsync
             auto installTask = packageManager.InstallPackageAsync(catalogPackage, installOptions);
-
             installTask.Progress([progress](auto const&, InstallProgress installProgress)
             {
                 if (installProgress.State == PackageInstallProgressState::Downloading && installProgress.BytesRequired != 0)


### PR DESCRIPTION
Winget configuration is not going to be enabled by default. The user needs to opt-in by calling `winget configuration --enable`.  Callers that are interested in using the OOP Microsoft.Management.Configuration APIs need a way to ensure configuration is enabled and enable it if not. This PR address that.

### New IConfigurationStatics methods
- `IsConfigurationEnabled` - Checks if the configuration is enabled by checking if the current AppInstaller package is the stub or full package.  Inproc implementation always returns true.
- `EnableConfigurationAsync` - Asynchronously enables configuration. This changes the stub preference to full package and calls our own APIs to install AppIntaller. By design, this also updates AppInstaller to the newest version.

### Caveats
Callers need to understand that this is effectively saying "winget please update yourself". Which means that once `EnableConfigurationAsync` is done, configuration isn't ready yet. At this point, deployment scheduled AppInstaller for an update. The server process that owns the configuration statics object is already gone (or is about to) and a new instance of ConfigurationStaticFunctions needs to be created in order validate configuration is enabled. It is possible that creating that object fails with an error that the upgrade is in progress. Yes, this is awkward.

### Testing
It is complicated to write automated tests for this without faking most of the stack. I manually created an AppInstaller package with an older version to what we internally have to do these tests. Then I used the current OOP configuration tests to update it.

This is how I programmatically verified it
```
            {
                var statics1 = new ConfigurationStaticFunctions();

                Assert.False(statics1.IsConfigurationEnabled);

                var task = statics1.EnableConfigurationAsync();
                task.Progress = (asyncInfo, progress) =>
                {
                    // show progress
                };

                await task;
            }

            await System.Threading.Tasks.Task.Delay(120000);

            {
                var statics2 = new ConfigurationStaticFunctions(); // This failed with E_NOINTERFACE because the "newer" package in the store doesn't have my changes
                Assert.True(statics2.IsConfigurationEnabled);
            }
```


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3576)