### PR TITLE
Add new cmdlets and cancellation support for Microsoft.WinGet.Configuration

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/CompleteWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/CompleteWinGetConfigurationCmdlet.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.WinGet.Configuration.Cmdlets
 {
     using System.Management.Automation;
-    using System.Threading;
     using Microsoft.WinGet.Configuration.Engine.Commands;
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
@@ -19,6 +18,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     [Cmdlet(VerbsLifecycle.Complete, "WinGetConfiguration")]
     public sealed class CompleteWinGetConfigurationCmdlet : PSCmdlet
     {
+        private ConfigurationCommand runningCommand = null;
+
         /// <summary>
         /// Gets or sets the configuration task.
         /// </summary>
@@ -34,8 +35,20 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            var configCommand = new ConfigurationCommand(this);
-            configCommand.Continue(this.ConfigurationJob);
+            this.runningCommand = new ConfigurationCommand(this);
+            this.runningCommand.Continue(this.ConfigurationJob);
+        }
+
+        /// <summary>
+        /// Interrupts currently running code within the command.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            if (this.runningCommand != null)
+            {
+                this.runningCommand.Cancel(this.ConfigurationJob);
+                this.runningCommand.Cancel();
+            }
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/ConfirmWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/ConfirmWinGetConfigurationCmdlet.cs
@@ -1,0 +1,38 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="ConfirmWinGetConfigurationCmdlet.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Cmdlets
+{
+    using System.Management.Automation;
+    using Microsoft.WinGet.Configuration.Engine.Commands;
+    using Microsoft.WinGet.Configuration.Engine.PSObjects;
+
+    /// <summary>
+    /// Validates winget configuration.
+    /// </summary>
+    [Cmdlet(VerbsLifecycle.Confirm, "WinGetConfiguration")]
+    public class ConfirmWinGetConfigurationCmdlet : PSCmdlet
+    {
+        /// <summary>
+        /// Gets or sets the configuration set.
+        /// </summary>
+        [Parameter(
+            Position = 0,
+            Mandatory = true,
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        public PSConfigurationSet Set { get; set; }
+
+        /// <summary>
+        /// Validate configuration.
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+            var configCommand = new ConfigurationCommand(this);
+            configCommand.Validate(this.Set);
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/ConfirmWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/ConfirmWinGetConfigurationCmdlet.cs
@@ -34,8 +34,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            var configCommand = new ConfigurationCommand(this);
-            configCommand.Validate(this.Set);
+            this.runningCommand = new ConfigurationCommand(this);
+            this.runningCommand.Validate(this.Set);
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
@@ -18,6 +18,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     [Cmdlet(VerbsCommon.Get, "WinGetConfigurationDetails")]
     public sealed class GetWinGetConfigurationDetailsCmdlet : PSCmdlet
     {
+        private ConfigurationCommand runningCommand = null;
+
         /// <summary>
         /// Gets or sets the configuration set.
         /// </summary>
@@ -35,6 +37,17 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             var configCommand = new ConfigurationCommand(this);
             configCommand.GetDetails(this.Set);
+        }
+
+        /// <summary>
+        /// Interrupts currently running code within the command.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            if (this.runningCommand != null)
+            {
+                this.runningCommand.Cancel();
+            }
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/GetWinGetConfigurationDetailsCmdlet.cs
@@ -35,8 +35,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void ProcessRecord()
         {
-            var configCommand = new ConfigurationCommand(this);
-            configCommand.GetDetails(this.Set);
+            this.runningCommand = new ConfigurationCommand(this);
+            this.runningCommand.GetDetails(this.Set);
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void BeginProcessing()
         {
-            this.acceptedAgreements = ConfigurationCommand.ConfirmConfigurationProcessing(this, this.AcceptConfigurationAgreements.ToBool());
+            this.acceptedAgreements = ConfigurationCommand.ConfirmConfigurationProcessing(this, this.AcceptConfigurationAgreements.ToBool(), true);
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/InvokeWinGetConfigurationCmdlet.cs
@@ -6,8 +6,8 @@
 
 namespace Microsoft.WinGet.Configuration.Cmdlets
 {
+    using System;
     using System.Management.Automation;
-    using System.Threading;
     using Microsoft.WinGet.Configuration.Engine.Commands;
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
@@ -20,6 +20,7 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     public sealed class InvokeWinGetConfigurationCmdlet : PSCmdlet
     {
         private bool acceptedAgreements = false;
+        private ConfigurationCommand runningCommand = null;
 
         /// <summary>
         /// Gets or sets the configuration set.
@@ -52,8 +53,19 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             if (this.acceptedAgreements)
             {
-                var configCommand = new ConfigurationCommand(this);
-                configCommand.Apply(this.Set);
+                this.runningCommand = new ConfigurationCommand(this);
+                this.runningCommand.Apply(this.Set);
+            }
+        }
+
+        /// <summary>
+        /// Interrupts currently running code within the command.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            if (this.runningCommand != null)
+            {
+                this.runningCommand.Cancel();
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/StopWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/StopWinGetConfigurationCmdlet.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------------
-// <copyright file="ConfirmWinGetConfigurationCmdlet.cs" company="Microsoft Corporation">
+// <copyright file="StopWinGetConfigurationCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------------
@@ -11,42 +11,29 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
     /// <summary>
-    /// Confirm-WinGetConfiguration
-    /// Validates winget configuration.
+    /// Stop-WinGetConfiguration.
+    /// Cancels a configuration previously started by Start-WinGetConfiguration.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Confirm, "WinGetConfiguration")]
-    public class ConfirmWinGetConfigurationCmdlet : PSCmdlet
+    [Cmdlet(VerbsLifecycle.Stop, "WinGetConfiguration")]
+    public sealed class StopWinGetConfigurationCmdlet : PSCmdlet
     {
-        private ConfigurationCommand runningCommand = null;
-
         /// <summary>
-        /// Gets or sets the configuration set.
+        /// Gets or sets the configuration task.
         /// </summary>
         [Parameter(
             Position = 0,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
-        public PSConfigurationSet Set { get; set; }
+        public PSConfigurationJob ConfigurationJob { get; set; }
 
         /// <summary>
-        /// Validate configuration.
+        /// Starts to apply the configuration and wait for it to complete.
         /// </summary>
         protected override void ProcessRecord()
         {
             var configCommand = new ConfigurationCommand(this);
-            configCommand.Validate(this.Set);
-        }
-
-        /// <summary>
-        /// Interrupts currently running code within the command.
-        /// </summary>
-        protected override void StopProcessing()
-        {
-            if (this.runningCommand != null)
-            {
-                this.runningCommand.Cancel();
-            }
+            configCommand.Cancel(this.ConfigurationJob);
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
@@ -51,8 +51,8 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         {
             if (this.acceptedAgreements)
             {
-                var configCommand = new ConfigurationCommand(this);
-                configCommand.Test(this.Set);
+                this.runningCommand = new ConfigurationCommand(this);
+                this.runningCommand.Test(this.Set);
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
@@ -11,12 +11,14 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
     /// <summary>
-    /// Test winget configuration.
+    /// Test-WinGetConfiguration
+    /// Tests configuration.
     /// </summary>
     [Cmdlet(VerbsDiagnostic.Test, "WinGetConfiguration")]
     public class TestWinGetConfigurationCmdlet : PSCmdlet
     {
         private bool acceptedAgreements = false;
+        private ConfigurationCommand runningCommand = null;
 
         /// <summary>
         /// Gets or sets the configuration set.
@@ -51,6 +53,17 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
             {
                 var configCommand = new ConfigurationCommand(this);
                 configCommand.Test(this.Set);
+            }
+        }
+
+        /// <summary>
+        /// Interrupts currently running code within the command.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            if (this.runningCommand != null)
+            {
+                this.runningCommand.Cancel();
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Cmdlets/TestWinGetConfigurationCmdlet.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------------
-// <copyright file="StartWinGetConfigurationCmdlet.cs" company="Microsoft Corporation">
+// <copyright file="TestWinGetConfigurationCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------------
@@ -11,12 +11,10 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
 
     /// <summary>
-    /// Start-WinGetConfiguration.
-    /// Start to apply the configuration.
-    /// Does not wait for completion.
+    /// Test winget configuration.
     /// </summary>
-    [Cmdlet(VerbsLifecycle.Start, "WinGetConfiguration")]
-    public sealed class StartWinGetConfigurationCmdlet : PSCmdlet
+    [Cmdlet(VerbsDiagnostic.Test, "WinGetConfiguration")]
+    public class TestWinGetConfigurationCmdlet : PSCmdlet
     {
         private bool acceptedAgreements = false;
 
@@ -41,18 +39,18 @@ namespace Microsoft.WinGet.Configuration.Cmdlets
         /// </summary>
         protected override void BeginProcessing()
         {
-            this.acceptedAgreements = ConfigurationCommand.ConfirmConfigurationProcessing(this, this.AcceptConfigurationAgreements.ToBool(), true);
+            this.acceptedAgreements = ConfigurationCommand.ConfirmConfigurationProcessing(this, this.AcceptConfigurationAgreements.ToBool(), false);
         }
 
         /// <summary>
-        /// Starts to apply the configuration and wait for it to complete.
+        /// Test configuration.
         /// </summary>
         protected override void ProcessRecord()
         {
             if (this.acceptedAgreements)
             {
                 var configCommand = new ConfigurationCommand(this);
-                configCommand.StartApply(this.Set);
+                configCommand.Test(this.Set);
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/AsyncCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/AsyncCommand.cs
@@ -32,8 +32,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         private readonly Thread originalThread;
 
         private readonly CancellationTokenSource source = new ();
-
-        private CancellationToken cancellationToken;
         private BlockingCollection<QueuedStream> queuedStreams = new ();
 
         private int progressActivityId = 0;
@@ -73,7 +71,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
 
             this.PsCmdlet = psCmdlet;
             this.originalThread = Thread.CurrentThread;
-            this.cancellationToken = this.source.Token;
         }
 
         /// <summary>
@@ -121,6 +118,14 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// Gets the base cmdlet.
         /// </summary>
         protected PSCmdlet PsCmdlet { get; private set; }
+
+        /// <summary>
+        /// Request cancellation for this command.
+        /// </summary>
+        public void Cancel()
+        {
+            this.source.Cancel();
+        }
 
         /// <summary>
         /// Complete this operation.
@@ -376,6 +381,15 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         internal int GetNewProgressActivityId()
         {
             return Interlocked.Increment(ref this.progressActivityId);
+        }
+
+        /// <summary>
+        /// Gets the cancellation token.
+        /// </summary>
+        /// <returns>CancellationToken.</returns>
+        protected CancellationToken GetCancellationToken()
+        {
+            return this.source.Token;
         }
 
         private void CmdletWrite(StreamType streamType, object data, AsyncCommand writeCommand)

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
@@ -270,6 +270,15 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             this.Write(StreamType.Object, runningTask.Result);
         }
 
+        /// <summary>
+        /// Cancels a configuration job.
+        /// </summary>
+        /// <param name="psConfigurationJob">PSConfiguration job.</param>
+        public void Cancel(PSConfigurationJob psConfigurationJob)
+        {
+            psConfigurationJob.StartCommand.Cancel();
+        }
+
         private void ContinueHelper(PSConfigurationJob psConfigurationJob)
         {
             // Signal the command that it can write to streams and wait for task.
@@ -367,7 +376,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
 
             try
             {
-                var result = await applyTask;
+                var result = await applyTask.AsTask(this.GetCancellationToken());
                 applyProgressOutput.HandleProgress(result);
                 return result;
             }
@@ -401,7 +410,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
 
             try
             {
-                var result = await testTask;
+                var result = await testTask.AsTask(this.GetCancellationToken());
                 testProgressOutput.HandleProgress(result);
 
                 return new PSTestConfigurationSetResult(result);
@@ -439,7 +448,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
 
                 try
                 {
-                    var result = await detailsTask;
+                    var result = await detailsTask.AsTask(this.GetCancellationToken());
                     detailsProgressOutput.HandleProgress(result);
 
                     if (result.UnitResults.Where(u => u.ResultInformation.ResultCode != null).Any())

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
@@ -41,15 +41,17 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
         /// </summary>
         /// <param name="psCmdlet">PSCmdlet.</param>
         /// <param name="hasAccepted">Has already accepted.</param>
+        /// <param name="isApply">If prompt is for apply.</param>
         /// <returns>If accepted.</returns>
-        public static bool ConfirmConfigurationProcessing(PSCmdlet psCmdlet, bool hasAccepted)
+        public static bool ConfirmConfigurationProcessing(PSCmdlet psCmdlet, bool hasAccepted, bool isApply)
         {
             bool result = false;
             if (!hasAccepted)
             {
+                var prompt = isApply ? Resources.ConfigurationWarningPromptApply : Resources.ConfigurationWarningPromptTest;
                 bool yesToAll = false;
                 bool noToAll = false;
-                result = psCmdlet.ShouldContinue(Resources.ConfigurationWarningPrompt, Resources.ConfigurationWarning, true, ref yesToAll, ref noToAll);
+                result = psCmdlet.ShouldContinue(prompt, Resources.ConfigurationWarning, true, ref yesToAll, ref noToAll);
 
                 if (yesToAll)
                 {
@@ -232,6 +234,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
                     }
                 });
 
+            this.Wait(runningTask);
             this.Write(StreamType.Object, runningTask.Result);
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Exceptions/OpenConfigurationSetException.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Exceptions/OpenConfigurationSetException.cs
@@ -29,32 +29,32 @@ namespace Microsoft.WinGet.Configuration.Engine.Exceptions
         private static string GetMessage(OpenConfigurationSetResult openResult, string configurationFile)
         {
             var sb = new StringBuilder();
-            sb.AppendLine($"Failed to open configuration set at {configurationFile} with error 0x{openResult.ResultCode.HResult:X}");
+            sb.Append($"Failed to open configuration set at {configurationFile} with error 0x{openResult.ResultCode.HResult:X} ");
 
             switch (openResult.ResultCode.HResult)
             {
                 case ErrorCodes.WingetConfigErrorInvalidFieldType:
-                    sb.AppendLine(string.Format(Resources.ConfigurationFieldInvalidType, openResult.Field));
+                    sb.Append(string.Format(Resources.ConfigurationFieldInvalidType, openResult.Field));
                     break;
                 case ErrorCodes.WingetConfigErrorInvalidFieldValue:
-                    sb.AppendLine(string.Format(Resources.ConfigurationFieldInvalidValue, openResult.Field, openResult.Value));
+                    sb.Append(string.Format(Resources.ConfigurationFieldInvalidValue, openResult.Field, openResult.Value));
                     break;
                 case ErrorCodes.WingetConfigErrorMissingField:
-                    sb.AppendLine(string.Format(Resources.ConfigurationFieldMissing, openResult.Field));
+                    sb.Append(string.Format(Resources.ConfigurationFieldMissing, openResult.Field));
                     break;
                 case ErrorCodes.WingetConfigErrorUnknownConfigurationFileVersion:
-                    sb.AppendLine(string.Format(Resources.ConfigurationFileVersionUnknown, openResult.Value));
+                    sb.Append(string.Format(Resources.ConfigurationFileVersionUnknown, openResult.Value));
                     break;
                 case ErrorCodes.WingetConfigErrorInvalidConfigurationFile:
                 case ErrorCodes.WingetConfigErrorInvalidYaml:
                 default:
-                    sb.AppendLine(Resources.ConfigurationFileInvalid);
+                    sb.Append(Resources.ConfigurationFileInvalid);
                     break;
             }
 
             if (openResult.Line != 0)
             {
-                sb.AppendLine(string.Format(Resources.SeeLineAndColumn, openResult.Line, openResult.Column));
+                sb.Append($" {string.Format(Resources.SeeLineAndColumn, openResult.Line, openResult.Column)}");
             }
 
             return sb.ToString();

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Extensions/IAsyncOperationExtensions.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Extensions/IAsyncOperationExtensions.cs
@@ -1,0 +1,74 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="IAsyncOperationExtensions.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.Extensions
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Windows.Foundation;
+
+    /// <summary>
+    /// Extension methods for IAsyncOperation objects.
+    /// </summary>
+    internal static class IAsyncOperationExtensions
+    {
+        /// <summary>
+        /// Wrap IAsyncOperationWithProgress into a task with cancellation support.
+        /// </summary>
+        /// <typeparam name="TOperationResult">The result of the operation.</typeparam>
+        /// <typeparam name="TProgressData">The progress data of the operation.</typeparam>
+        /// <param name="asyncOperation">The async operation.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
+        /// <returns>A task.</returns>
+        public static Task<TOperationResult> AsTask<TOperationResult, TProgressData>(this IAsyncOperationWithProgress<TOperationResult, TProgressData> asyncOperation, CancellationToken cancellationToken = default)
+        {
+            var tcs = new TaskCompletionSource<TOperationResult>();
+            if (cancellationToken != default)
+            {
+                cancellationToken.Register(asyncOperation.Cancel);
+            }
+
+            asyncOperation.Completed = (asyncInfo, asyncStatus) =>
+            {
+                switch (asyncStatus)
+                {
+                    case AsyncStatus.Canceled:
+                        tcs.SetCanceled();
+                        break;
+                    case AsyncStatus.Completed:
+                        tcs.SetResult(asyncInfo.GetResults());
+                        break;
+                    case AsyncStatus.Error:
+                        tcs.SetException(asyncInfo.ErrorCode);
+                        break;
+                    case AsyncStatus.Started:
+                        break;
+                    default:
+                        break;
+                }
+            };
+
+            // Make sure to throw operation cancelled exception if needed.
+            return tcs.Task.ContinueWith(
+                t =>
+                {
+                    if (t.IsCanceled)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    if (!t.IsFaulted)
+                    {
+                        return t.Result;
+                    }
+
+                    // If IsFaulted is true, the task's Status is equal to Faulted,
+                    // and its Exception property will be non-null.
+                    throw t.Exception!;
+                });
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/TestConfigurationSetProgressOutput.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/TestConfigurationSetProgressOutput.cs
@@ -1,0 +1,58 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="TestConfigurationSetProgressOutput.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.Helpers
+{
+    using Microsoft.Management.Configuration;
+    using Microsoft.WinGet.Configuration.Engine.Commands;
+    using Windows.Foundation;
+
+    /// <summary>
+    /// Helper to handle progress callbacks for TestSetAsync.
+    /// </summary>
+    internal class TestConfigurationSetProgressOutput : ConfigurationSetProgressOutputBase<TestConfigurationSetResult, TestConfigurationUnitResult>
+    {
+        private bool isFirstProgress = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestConfigurationSetProgressOutput"/> class.
+        /// </summary>
+        /// <param name="cmd">Command that outputs the messages.</param>
+        /// <param name="activityId">The activity id of the progress bar.</param>
+        /// <param name="activity">The activity.</param>
+        /// <param name="inProgressMessage">The message in the progress bar.</param>
+        /// <param name="completeMessage">The activity complete message.</param>
+        /// <param name="totalUnitsExpected">Total of units expected.</param>
+        public TestConfigurationSetProgressOutput(AsyncCommand cmd, int activityId, string activity, string inProgressMessage, string completeMessage, int totalUnitsExpected)
+            : base(cmd, activityId, activity, inProgressMessage, completeMessage, totalUnitsExpected)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Progress(IAsyncOperationWithProgress<TestConfigurationSetResult, TestConfigurationUnitResult> operation, TestConfigurationUnitResult data)
+        {
+            if (this.isFirstProgress)
+            {
+                this.HandleProgress(operation.GetResults());
+            }
+
+            this.CompleteUnit(data.Unit);
+        }
+
+        /// <inheritdoc/>
+        public override void HandleProgress(TestConfigurationSetResult result)
+        {
+            if (!this.isFirstProgress)
+            {
+                this.isFirstProgress = false;
+                foreach (var unitResult in result.UnitResults)
+                {
+                    this.CompleteUnit(unitResult.Unit);
+                }
+            }
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/Utilities.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/Utilities.cs
@@ -85,6 +85,24 @@ namespace Microsoft.WinGet.Configuration.Engine.Helpers
         }
 
         /// <summary>
+        /// Converts ConfigurationTestResult string value to PSConfigurationTestResult.
+        /// </summary>
+        /// <param name="value">ConfigurationTestResult value.</param>
+        /// <returns>PSConfigurationTestResult.</returns>
+        public static PSConfigurationTestResult ToPSConfigurationTestResult(ConfigurationTestResult value)
+        {
+            return value switch
+            {
+                ConfigurationTestResult.Unknown => PSConfigurationTestResult.Unknown,
+                ConfigurationTestResult.Positive => PSConfigurationTestResult.Positive,
+                ConfigurationTestResult.Negative => PSConfigurationTestResult.Negative,
+                ConfigurationTestResult.Failed => PSConfigurationTestResult.Failed,
+                ConfigurationTestResult.NotRun => PSConfigurationTestResult.NotRun,
+                _ => throw new InvalidOperationException(),
+            };
+        }
+
+        /// <summary>
         /// Converts ConfigurationUnitState string value to PSConfigurationUnitState.
         /// </summary>
         /// <param name="value">ConfigurationUnitState value.</param>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationTestResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSConfigurationTestResult.cs
@@ -1,0 +1,39 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSConfigurationTestResult.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    /// <summary>
+    /// Must match ConfigurationTestResult.
+    /// </summary>
+    public enum PSConfigurationTestResult
+    {
+        /// <summary>
+        /// The result is unknown.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// The system is in the state described by the configuration.
+        /// </summary>
+        Positive,
+
+        /// <summary>
+        /// The system is not in the state described by the configuration.
+        /// </summary>
+        Negative,
+
+        /// <summary>
+        /// Running the test failed.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// The test was not run because it was not applicable.
+        /// </summary>
+        NotRun,
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSTestConfigurationSetResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSTestConfigurationSetResult.cs
@@ -1,0 +1,45 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSTestConfigurationSetResult.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Management.Configuration;
+    using Microsoft.WinGet.Configuration.Engine.Helpers;
+
+    /// <summary>
+    /// Wrapper for TestConfigurationSetResult.
+    /// </summary>
+    public class PSTestConfigurationSetResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSTestConfigurationSetResult"/> class.
+        /// </summary>
+        /// <param name="testSetResult">Test set result.</param>
+        internal PSTestConfigurationSetResult(TestConfigurationSetResult testSetResult)
+        {
+            this.TestResult = Utilities.ToPSConfigurationTestResult(testSetResult.TestResult);
+
+            var unitResults = new List<PSTestConfigurationUnitResult>();
+            foreach (var unitResult in testSetResult.UnitResults)
+            {
+                unitResults.Add(new PSTestConfigurationUnitResult(unitResult));
+            }
+
+            this.UnitResults = unitResults;
+        }
+
+        /// <summary>
+        /// Gets the test result.
+        /// </summary>
+        public PSConfigurationTestResult TestResult { get; private init; }
+
+        /// <summary>
+        /// Gets the results of the units.
+        /// </summary>
+        public IReadOnlyList<PSTestConfigurationUnitResult> UnitResults { get; private init; }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSTestConfigurationUnitResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSTestConfigurationUnitResult.cs
@@ -1,0 +1,32 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSTestConfigurationUnitResult.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    using Microsoft.Management.Configuration;
+    using Microsoft.WinGet.Configuration.Engine.Helpers;
+
+    /// <summary>
+    /// Wrapper for TestConfigurationUnitResult.
+    /// </summary>
+    public class PSTestConfigurationUnitResult : PSUnitResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSTestConfigurationUnitResult"/> class.
+        /// </summary>
+        /// <param name="testUnitResult">Test unit result.</param>
+        internal PSTestConfigurationUnitResult(TestConfigurationUnitResult testUnitResult)
+            : base(testUnitResult.Unit, testUnitResult.ResultInformation)
+        {
+            this.TestResult = Utilities.ToPSConfigurationTestResult(testUnitResult.TestResult);
+        }
+
+        /// <summary>
+        /// Gets the test result.
+        /// </summary>
+        public PSConfigurationTestResult TestResult { get; private init; }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSValidateConfigurationSetResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSValidateConfigurationSetResult.cs
@@ -1,0 +1,45 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSValidateConfigurationSetResult.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    using System.Collections.Generic;
+    using Microsoft.Management.Configuration;
+    using Microsoft.WinGet.Configuration.Engine.Exceptions;
+
+    /// <summary>
+    /// Wrapper for ApplyConfigurationSetResult for validate.
+    /// </summary>
+    public class PSValidateConfigurationSetResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSValidateConfigurationSetResult"/> class.
+        /// </summary>
+        /// <param name="applySetResult">Apply set result.</param>
+        internal PSValidateConfigurationSetResult(ApplyConfigurationSetResult applySetResult)
+        {
+            this.ResultCode = applySetResult.ResultCode?.HResult ?? ErrorCodes.S_OK;
+
+            var unitResults = new List<PSValidateConfigurationUnitResult>();
+            foreach (var unitResult in applySetResult.UnitResults)
+            {
+                unitResults.Add(new PSValidateConfigurationUnitResult(unitResult));
+            }
+
+            this.UnitResults = unitResults;
+        }
+
+        /// <summary>
+        /// Gets the result code.
+        /// </summary>
+        public int ResultCode { get; private init; }
+
+        /// <summary>
+        /// Gets the results of the units.
+        /// </summary>
+        public IReadOnlyList<PSValidateConfigurationUnitResult> UnitResults { get; private init; }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSValidateConfigurationUnitResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/PSObjects/PSValidateConfigurationUnitResult.cs
@@ -1,0 +1,25 @@
+﻿// -----------------------------------------------------------------------------
+// <copyright file="PSValidateConfigurationUnitResult.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Configuration.Engine.PSObjects
+{
+    using Microsoft.Management.Configuration;
+
+    /// <summary>
+    /// The validate result of a configuration unit.
+    /// </summary>
+    public class PSValidateConfigurationUnitResult : PSUnitResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PSValidateConfigurationUnitResult"/> class.
+        /// </summary>
+        /// <param name="unitResult">Apply unit result.</param>
+        internal PSValidateConfigurationUnitResult(ApplyConfigurationUnitResult unitResult)
+            : base(unitResult.Unit, unitResult.ResultInformation)
+        {
+        }
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Resources/Resources.Designer.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Resources/Resources.Designer.cs
@@ -504,9 +504,18 @@ namespace Microsoft.WinGet.Configuration.Engine.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Have you reviewed the configuration and would you like to proceed applying it to the system?.
         /// </summary>
-        internal static string ConfigurationWarningPrompt {
+        internal static string ConfigurationWarningPromptApply {
             get {
-                return ResourceManager.GetString("ConfigurationWarningPrompt", resourceCulture);
+                return ResourceManager.GetString("ConfigurationWarningPromptApply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Have you reviewed the configuration and would you like to proceed verifying it against the system?.
+        /// </summary>
+        internal static string ConfigurationWarningPromptTest {
+            get {
+                return ResourceManager.GetString("ConfigurationWarningPromptTest", resourceCulture);
             }
         }
         

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Resources/Resources.resx
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Resources/Resources.resx
@@ -182,7 +182,7 @@
     <value>You are responsible for understanding the configuration settings you are choosing to execute. Microsoft is not responsible for the configuration file you have authored or imported. This configuration may change settings in Windows, install software, change software settings (including security settings), and accept user agreements to third-party packages and services on your behalf.  By running this configuration file, you acknowledge that you understand and agree to these resources and settings. Any applications installed are licensed to you by their owners. Microsoft is not responsible for, nor does it grant any licenses to, third-party packages or services.</value>
     <comment>Legal approved. Do not change without approval.</comment>
   </data>
-  <data name="ConfigurationWarningPrompt" xml:space="preserve">
+  <data name="ConfigurationWarningPromptApply" xml:space="preserve">
     <value>Have you reviewed the configuration and would you like to proceed applying it to the system?</value>
     <comment>PM approved.</comment>
   </data>
@@ -305,5 +305,8 @@
   <data name="ConfigurationModulePathArgError" xml:space="preserve">
     <value>`-ModulePath` value must be `CurrentUser`, `AllUsers`, `Default` or an absolute path.</value>
     <comment>{Locked="{-ModulePath}, {CurrentUser}, {AllUsers}, {Default}}</comment>
+  </data>
+  <data name="ConfigurationWarningPromptTest" xml:space="preserve">
+    <value>Have you reviewed the configuration and would you like to proceed verifying it against the system?</value>
   </data>
 </root>

--- a/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
@@ -20,6 +20,7 @@ CmdletsToExport = @(
     "Get-WinGetConfigurationDetails"
     "Invoke-WinGetConfiguration"
     "Start-WinGetConfiguration"
+    "Test-WinGetConfiguration"
 )
 
 PrivateData = @{

--- a/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
@@ -22,6 +22,7 @@ CmdletsToExport = @(
     "Start-WinGetConfiguration"
     "Test-WinGetConfiguration"
     "Confirm-WinGetConfiguration"
+    "Stop-WinGetConfiguration"
 )
 
 PrivateData = @{

--- a/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
@@ -21,6 +21,7 @@ CmdletsToExport = @(
     "Invoke-WinGetConfiguration"
     "Start-WinGetConfiguration"
     "Test-WinGetConfiguration"
+    "Confirm-WinGetConfiguration"
 )
 
 PrivateData = @{

--- a/src/PowerShell/tests/Microsoft.WinGet.Configuration.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Configuration.Tests.ps1
@@ -54,7 +54,7 @@ BeforeAll {
 
     function DeleteConfigTxtFiles()
     {
-        Get-ChildItem $(GetConfigTestDataPath) -Filter Configure*.txt -Recurse | ForEach-Object { Remove-Item $_ }
+        Get-ChildItem $(GetConfigTestDataPath) -Filter *.txt -Recurse | ForEach-Object { Remove-Item $_ }
     }
 
     function GetConfigTestDataFile([string] $fileName)


### PR DESCRIPTION
- `Test-WinGetConfiguration` to test a configuration. Equivalent of `winget configure test`
- `Confirm-WinGetConfiguration` to validate a configuration. Equivalent of `winget configure validate` except it just calls the configuration APIs without the extra validation winget does.
- Support cancellation via CTRL-C for blocking cmdlets and `Stop-WinGetConfiguration` for configuration stated with `Start-WinGetConfiguration`
- Add tests for `Test-WinGetConfiguration` and `Confirm-WinGetConfiguration` cmdlets.
- Add more tests for `Open-WinGetConfiguration`
- Cancellation verified manually