### PR TITLE
Add try/catch when reading upgrade codes

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/ARPHelper.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/ARPHelper.cpp
@@ -77,28 +77,39 @@ namespace AppInstaller::Repository::Microsoft
             AICLI_LOG(Repo, Info, << "Reading MSI UpgradeCodes");
             std::map<std::string, std::string> upgradeCodes;
 
-            // There is no UpgradeCodes key on the x86 view of the registry
-            Registry::Key upgradeCodesKey = Registry::Key::OpenIfExists(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Installer\\UpgradeCodes", 0, KEY_READ | KEY_WOW64_64KEY);
-
-            if (upgradeCodesKey)
+            try
             {
-                for (const auto& upgradeCodeKeyRef : upgradeCodesKey)
+                // There is no UpgradeCodes key on the x86 view of the registry
+                Registry::Key upgradeCodesKey = Registry::Key::OpenIfExists(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Installer\\UpgradeCodes", 0, KEY_READ | KEY_WOW64_64KEY);
+
+                if (upgradeCodesKey)
                 {
-                    auto upgradeCode = TryUnpackUpgradeCodeGuid(upgradeCodeKeyRef.Name());
-                    if (upgradeCode)
+                    for (const auto& upgradeCodeKeyRef : upgradeCodesKey)
                     {
-                        auto upgradeCodeKey = upgradeCodeKeyRef.Open();
-                        for (const auto& productCodeValue : upgradeCodeKey.Values())
+                        std::string keyName;
+
+                        try
                         {
-                            auto productCode = TryUnpackUpgradeCodeGuid(productCodeValue.Name());
-                            if (productCode)
+                            keyName = upgradeCodeKeyRef.Name();
+                            auto upgradeCode = TryUnpackUpgradeCodeGuid(keyName);
+                            if (upgradeCode)
                             {
-                                upgradeCodes[*productCode] = *upgradeCode;
+                                auto upgradeCodeKey = upgradeCodeKeyRef.Open();
+                                for (const auto& productCodeValue : upgradeCodeKey.Values())
+                                {
+                                    auto productCode = TryUnpackUpgradeCodeGuid(productCodeValue.Name());
+                                    if (productCode)
+                                    {
+                                        upgradeCodes[*productCode] = *upgradeCode;
+                                    }
+                                }
                             }
                         }
+                        CATCH_LOG_MSG("Failed to read upgrade code: %hs", keyName.c_str());
                     }
                 }
             }
+            CATCH_LOG_MSG("Failed to read upgrade codes.");
 
             return upgradeCodes;
         }


### PR DESCRIPTION
## Change
Despite the look of the diff on github, this change only adds two try/catch blocks to the upgrade code parsing code to prevent failures from propagating out.  The upgrade codes are just additional data to help with correlations and should not cause additional user impact beyond not being present.

The outer block protects against the primary key throwing, as well as the subkey enumeration.

The inner block protects against a single upgrade code key throwing, while allowing the loop to potentially continue.

## Validation
Code inspection only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3637)