### PR TITLE
Read registry value data on demand

### DIFF
--- a/src/AppInstallerSharedLib/GroupPolicy.cpp
+++ b/src/AppInstallerSharedLib/GroupPolicy.cpp
@@ -136,14 +136,23 @@ namespace AppInstaller::Settings
             typename Mapping::value_t items;
             for (const auto& value : listKey->Values())
             {
-                auto item = Mapping::ReadAndValidateItem(value);
-                if (item.has_value())
+                std::optional<Registry::Value> potentialValue = value.Value();
+
+                if (potentialValue)
                 {
-                    items.emplace_back(std::move(item.value()));
+                    auto item = Mapping::ReadAndValidateItem(potentialValue.value());
+                    if (item.has_value())
+                    {
+                        items.emplace_back(std::move(item.value()));
+                    }
+                    else
+                    {
+                        AICLI_LOG(Core, Warning, << "Failed to read Group Policy list value. Policy [" << Mapping::KeyName << "], Value [" << value.Name() << ']');
+                    }
                 }
                 else
                 {
-                    AICLI_LOG(Core, Warning, << "Failed to read Group Policy list value. Policy [" << Mapping::KeyName << "], Value [" << value.Name() << ']');
+                    AICLI_LOG(Core, Verbose, << "Group Policy list value not found. Policy [" << Mapping::KeyName << "], Value [" << value.Name() << ']');
                 }
             }
 

--- a/src/AppInstallerSharedLib/Public/winget/Registry.h
+++ b/src/AppInstallerSharedLib/Public/winget/Registry.h
@@ -148,16 +148,21 @@ namespace AppInstaller::Registry
 
         struct const_iterator;
 
-        struct ValueRef : Value
+        struct ValueRef
         {
             friend const_iterator;
 
             // Gets the name of the value.
             std::string Name() const;
 
-        private:
-            ValueRef(std::wstring&& valueName, DWORD type, std::vector<BYTE>&& data);
+            // Gets the actual value of the value.
+            // The optional allows for the potential race with the value being removed.
+            std::optional<Value> Value() const;
 
+        private:
+            ValueRef(wil::shared_hkey key, std::wstring&& valueName);
+
+            wil::shared_hkey m_key;
             std::wstring m_valueName;
         };
 


### PR DESCRIPTION
## Change
When enumerating registry keys, move the code that reads the registry value data to be on request rather than during the iterator advancement.  This enables code that doesn't need the data to simply skip it, and code that does to better handle the error if desired.

## Validation
Regression only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3642)