### PR TITLE
Improve packaged source updating

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -429,6 +429,7 @@ SMTO
 sortof
 sourceforge
 SOURCESDIRECTORY
+sourceversion
 spamming
 SPAPI
 Srinivasan

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -145,6 +145,8 @@ namespace AppInstaller::Utility
 
     std::map<std::string, std::string> GetHeaders(std::string_view url)
     {
+        AICLI_LOG(Core, Verbose, << "Retrieving headers from url: " << url);
+
         HttpBaseProtocolFilter filter;
         filter.CacheControl().ReadBehavior(HttpCacheReadBehavior::MostRecent);
 

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 #include "pch.h"
 #include "Public/AppInstallerErrors.h"
 #include "Public/AppInstallerRuntime.h"
@@ -17,6 +16,9 @@
 using namespace AppInstaller::Runtime;
 using namespace AppInstaller::Settings;
 using namespace AppInstaller::Filesystem;
+using namespace winrt::Windows::Web::Http;
+using namespace winrt::Windows::Web::Http::Headers;
+using namespace winrt::Windows::Web::Http::Filters;
 
 namespace AppInstaller::Utility
 {
@@ -137,6 +139,35 @@ namespace AppInstaller::Utility
         AICLI_LOG(Core, Info, << "Download completed.");
 
         #pragma warning(pop)
+
+        return result;
+    }
+
+    std::map<std::string, std::string> GetHeaders(std::string_view url)
+    {
+        HttpBaseProtocolFilter filter;
+        filter.CacheControl().ReadBehavior(HttpCacheReadBehavior::MostRecent);
+
+        HttpClient client(filter);
+        client.DefaultRequestHeaders().Connection().Clear();
+        client.DefaultRequestHeaders().Append(L"Connection", L"close");
+        client.DefaultRequestHeaders().UserAgent().ParseAdd(Utility::ConvertToUTF16(Runtime::GetDefaultUserAgent().get()));
+
+        winrt::Windows::Foundation::Uri uri{ Utility::ConvertToUTF16(url) };
+        HttpRequestMessage request(HttpMethod::Head(), uri);
+
+        HttpResponseMessage response = client.SendRequestAsync(request, HttpCompletionOption::ResponseHeadersRead).get();
+
+        THROW_HR_IF(
+            MAKE_HRESULT(SEVERITY_ERROR, FACILITY_HTTP, response.StatusCode()),
+            response.StatusCode() != HttpStatusCode::Ok);
+
+        std::map<std::string, std::string> result;
+
+        for (const auto& header : response.Headers())
+        {
+            result.emplace(Utility::ConvertToUTF8(header.Key()), Utility::ConvertToUTF8(header.Value()));
+        }
 
         return result;
     }

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -7,6 +7,7 @@
 #include <wrl/client.h>
 
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <ostream>
 #include <string>
@@ -58,6 +59,9 @@ namespace AppInstaller::Utility
         IProgressCallback& progress,
         bool computeHash = false,
         std::optional<DownloadInfo> info = {});
+
+    // Gets the headers for the given URL.
+    std::map<std::string, std::string> GetHeaders(std::string_view url);
 
     // Determines if the given url is a remote location.
     bool IsUrlRemote(std::string_view url);

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -299,16 +299,19 @@ namespace AppInstaller::Repository::Microsoft
                 std::optional<Msix::PackageVersion> currentVersion = GetCurrentVersion(details);
                 PreIndexedPackageUpdateCheck updateCheck(details);
 
-                if (currentVersion && currentVersion.value() >= updateCheck.AvailableVersion())
+                if (currentVersion)
                 {
-                    AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
-                        ") was not newer than existing (" << currentVersion.value().ToString() << "), no update needed");
-                    return true;
-                }
-                else
-                {
-                    AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
-                        ") was newer than existing (" << currentVersion.value().ToString() << "), updating");
+                    if (currentVersion.value() >= updateCheck.AvailableVersion())
+                    {
+                        AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
+                            ") was not newer than existing (" << currentVersion.value().ToString() << "), no update needed");
+                        return true;
+                    }
+                    else
+                    {
+                        AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
+                            ") was newer than existing (" << currentVersion.value().ToString() << "), updating");
+                    }
                 }
 
                 if (progress.IsCancelledBy(CancelReason::Any))

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -108,7 +108,6 @@ namespace AppInstaller::Repository::Microsoft
         {
             PreIndexedPackageUpdateCheck(const SourceDetails& details)
             {
-                // Get both locations to force the alternate location check
                 m_packageLocation = GetPrimaryPackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
                 std::string alternateLocation = GetAlternatePackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
 
@@ -166,7 +165,7 @@ namespace AppInstaller::Repository::Microsoft
                     CATCH_LOG();
                 }
 
-                // We were not able to retrieve 
+                AICLI_LOG(Repo, Verbose, << "No version header, falling back to reading the package data");
                 Msix::MsixInfo info{ packageLocation };
                 auto manifest = info.GetAppPackageManifests();
 
@@ -302,8 +301,14 @@ namespace AppInstaller::Repository::Microsoft
 
                 if (currentVersion && currentVersion.value() >= updateCheck.AvailableVersion())
                 {
-                    AICLI_LOG(Repo, Info, << "Remote source data was not newer than existing, no update needed");
+                    AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
+                        ") was not newer than existing (" << currentVersion.value().ToString() << "), no update needed");
                     return true;
+                }
+                else
+                {
+                    AICLI_LOG(Repo, Verbose, << "Remote source data (" << updateCheck.AvailableVersion().ToString() <<
+                        ") was newer than existing (" << currentVersion.value().ToString() << "), updating");
                 }
 
                 if (progress.IsCancelledBy(CancelReason::Any))

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -17,20 +17,48 @@ namespace AppInstaller::Repository::Microsoft
     namespace
     {
         static constexpr std::string_view s_PreIndexedPackageSourceFactory_PackageFileName = "source.msix"sv;
+        static constexpr std::string_view s_PreIndexedPackageSourceFactory_VersionFileName = "source.version.txt"sv;
         static constexpr std::string_view s_PreIndexedPackageSourceFactory_IndexFileName = "index.db"sv;
         // TODO: This being hard coded to force using the Public directory name is not ideal.
         static constexpr std::string_view s_PreIndexedPackageSourceFactory_IndexFilePath = "Public\\index.db"sv;
 
+        // Construct the package location from the given details.
+        // Currently expects that the arg is an https uri pointing to the root of the data.
+        std::string GetPackageLocation(const std::string& basePath, std::string_view fileName)
+        {
+            std::string result = basePath;
+            if (result.back() != '/')
+            {
+                result += '/';
+            }
+            result += fileName;
+            return result;
+        }
+
+        std::string GetPrimaryPackageLocation(const SourceDetails& details, std::string_view fileName)
+        {
+            THROW_HR_IF(E_INVALIDARG, details.Arg.empty());
+            return GetPackageLocation(details.Arg, fileName);
+        }
+
+        std::string GetAlternatePackageLocation(const SourceDetails& details, std::string_view fileName)
+        {
+            return (details.AlternateArg.empty() ?
+                std::string{} :
+                GetPackageLocation(details.AlternateArg, fileName));
+        }
+
+        // Abstracts the fallback for package location when the MsixInfo is needed.
         struct PreIndexedPackageInfo
         {
             template <typename LocationCheck>
             PreIndexedPackageInfo(const SourceDetails& details, LocationCheck&& locationCheck)
             {
                 // Get both locations to force the alternate location check
-                m_packageLocation = GetPrimaryPackageLocation(details);
+                m_packageLocation = GetPrimaryPackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
                 locationCheck(m_packageLocation);
 
-                std::string alternateLocation = GetAlternatePackageLocation(details);
+                std::string alternateLocation = GetAlternatePackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
                 if (!alternateLocation.empty())
                 {
                     locationCheck(alternateLocation);
@@ -72,29 +100,58 @@ namespace AppInstaller::Repository::Microsoft
         private:
             std::string m_packageLocation;
             std::unique_ptr<Msix::MsixInfo> m_msixInfo;
+        };
 
-            std::string GetPrimaryPackageLocation(const SourceDetails& details)
+        // Abstracts the fallback for package location when an update is being done.
+        struct PreIndexedPackageUpdateCheck
+        {
+            PreIndexedPackageUpdateCheck(const SourceDetails& details)
             {
-                THROW_HR_IF(E_INVALIDARG, details.Arg.empty());
-                return GetPackageLocation(details.Arg);
-            }
+                // Get both locations to force the alternate location check
+                m_packageLocation = GetPrimaryPackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
+                std::string alternateLocation = GetAlternatePackageLocation(details, s_PreIndexedPackageSourceFactory_PackageFileName);
 
-            std::string GetAlternatePackageLocation(const SourceDetails& details)
-            {
-                return (details.AlternateArg.empty() ? std::string{} : GetPackageLocation(details.AlternateArg));
-            }
+                // Try getting the primary location's info
+                HRESULT primaryHR = S_OK;
 
-            // Construct the package location from the given details.
-            // Currently expects that the arg is an https uri pointing to the root of the data.
-            std::string GetPackageLocation(const std::string& basePath)
-            {
-                std::string result = basePath;
-                if (result.back() != '/')
+                try
                 {
-                    result += '/';
+                    m_availableVersion = GetAvailableVersionFrom(m_packageLocation, GetPrimaryPackageLocation(details, s_PreIndexedPackageSourceFactory_VersionFileName));
+                    return;
                 }
-                result += s_PreIndexedPackageSourceFactory_PackageFileName;
-                return result;
+                catch (...)
+                {
+                    if (alternateLocation.empty())
+                    {
+                        throw;
+                    }
+                    primaryHR = LOG_CAUGHT_EXCEPTION_MSG("PreIndexedPackageUpdateCheck failed on primary location");
+                }
+
+                // Try alternate location
+                m_packageLocation = std::move(alternateLocation);
+
+                try
+                {
+                    m_availableVersion = GetAvailableVersionFrom(m_packageLocation, GetAlternatePackageLocation(details, s_PreIndexedPackageSourceFactory_VersionFileName));
+                    return;
+                }
+                CATCH_LOG_MSG("PreIndexedPackageUpdateCheck failed on alternate location");
+
+                THROW_HR(primaryHR);
+            }
+
+            const std::string& PackageLocation() const { return m_packageLocation; }
+            const Msix::PackageVersion& AvailableVersion() const { return m_availableVersion; }
+
+        private:
+            std::string m_packageLocation;
+            Msix::PackageVersion m_availableVersion;
+
+            Msix::PackageVersion GetAvailableVersionFrom(const std::string& packageLocation, const std::string& versionLocation)
+            {
+                std::ostringstream versionStream;
+                Utility::DownloadToStream(versionLocation, versionStream, Utility::DownloadType::Index)
             }
         };
 
@@ -164,7 +221,7 @@ namespace AppInstaller::Repository::Microsoft
                     return false;
                 }
 
-                return UpdateInternal(packageInfo.PackageLocation(), packageInfo.MsixInfo(), details, progress);
+                return UpdateInternal(packageInfo.PackageLocation(), details, progress);
             }
 
             bool Update(const SourceDetails& details, IProgressCallback& progress) override final
@@ -177,7 +234,10 @@ namespace AppInstaller::Repository::Microsoft
                 return UpdateBase(details, true, progress);
             }
 
-            virtual bool UpdateInternal(const std::string& packageLocation, Msix::MsixInfo& packageInfo, const SourceDetails& details, IProgressCallback& progress) = 0;
+            // Retrieves the currently cached version of the package.
+            virtual std::optional<Msix::PackageVersion> GetCurrentVersion(const SourceDetails& details) = 0;
+
+            virtual bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) = 0;
 
             bool Remove(const SourceDetails& details, IProgressCallback& progress) override final
             {
@@ -215,14 +275,14 @@ namespace AppInstaller::Repository::Microsoft
             {
                 THROW_HR_IF(E_INVALIDARG, details.Type != PreIndexedPackageSourceFactory::Type());
 
-                PreIndexedPackageInfo packageInfo(details, [](const std::string&){});
+                std::optional<Msix::PackageVersion> currentVersion = GetCurrentVersion(details);
+                PreIndexedPackageUpdateCheck updateCheck(details);
 
-                // The package should not be a bundle
-                THROW_HR_IF(APPINSTALLER_CLI_ERROR_PACKAGE_IS_BUNDLE, packageInfo.MsixInfo().GetIsBundle());
-
-                // Ensure that family name has not changed
-                THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE,
-                    GetPackageFamilyNameFromDetails(details) != Msix::GetPackageFamilyNameFromFullName(packageInfo.MsixInfo().GetPackageFullName()));
+                if (currentVersion && currentVersion.value() >= updateCheck.AvailableVersion())
+                {
+                    AICLI_LOG(Repo, Info, << "Remote source data was not newer than existing, no update needed");
+                    return true;
+                }
 
                 if (progress.IsCancelledBy(CancelReason::Any))
                 {
@@ -236,7 +296,7 @@ namespace AppInstaller::Repository::Microsoft
                     return false;
                 }
 
-                return UpdateInternal(packageInfo.PackageLocation(), packageInfo.MsixInfo(), details, progress);
+                return UpdateInternal(updateCheck.PackageLocation(), details, progress);
             }
         };
 
@@ -305,46 +365,58 @@ namespace AppInstaller::Repository::Microsoft
                 return std::make_shared<PackagedContextSourceReference>(details);
             }
 
-            bool UpdateInternal(const std::string& packageLocation, Msix::MsixInfo& packageInfo, const SourceDetails& details, IProgressCallback& progress) override
+            std::optional<Msix::PackageVersion> GetCurrentVersion(const SourceDetails& details) override
             {
-                // Check if the package is newer before calling into deployment.
-                // This can save us a lot of time over letting deployment detect same version.
                 auto extension = GetExtensionFromDetails(details);
+
                 if (extension)
                 {
-                    if (!packageInfo.IsNewerThan(extension->GetPackageVersion()))
-                    {
-                        AICLI_LOG(Repo, Info, << "Remote source data was not newer than existing, no update needed");
-                        return true;
-                    }
-                }
-
-                if (progress.IsCancelledBy(CancelReason::Any))
-                {
-                    AICLI_LOG(Repo, Info, << "Cancelling update upon request");
-                    return false;
-                }
-
-                // Due to complications with deployment, download the file and deploy from
-                // a local source while we investigate further.
-                bool download = Utility::IsUrlRemote(packageLocation);
-                std::filesystem::path tempFile;
-                winrt::Windows::Foundation::Uri uri = nullptr;
-
-                if (download)
-                {
-                    tempFile = Runtime::GetPathTo(Runtime::PathName::Temp);
-                    tempFile /= GetPackageFamilyNameFromDetails(details) + ".msix";
-
-                    Utility::Download(packageLocation, tempFile, Utility::DownloadType::Index, progress);
-
-                    uri = winrt::Windows::Foundation::Uri(tempFile.c_str());
+                    auto version = extension->GetPackageVersion();
+                    return Msix::PackageVersion{ version.Major, version.Minor, version.Build, version.Revision };
                 }
                 else
                 {
-                    uri = winrt::Windows::Foundation::Uri(Utility::ConvertToUTF16(packageLocation));
+                    return std::nullopt;
+                }
+            }
+
+            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) override
+            {
+                // Due to complications with deployment, download the file and deploy from
+                // a local source while we investigate further.
+                bool download = Utility::IsUrlRemote(packageLocation);
+                std::filesystem::path localFile;
+
+                if (download)
+                {
+                    localFile = Runtime::GetPathTo(Runtime::PathName::Temp);
+                    localFile /= GetPackageFamilyNameFromDetails(details) + ".msix";
+
+                    Utility::Download(packageLocation, localFile, Utility::DownloadType::Index, progress);
+                }
+                else
+                {
+                    localFile = Utility::ConvertToUTF16(packageLocation);
                 }
 
+                // Verify the local file
+                Msix::WriteLockedMsixFile fileLock{ localFile };
+                Msix::MsixInfo localMsixInfo{ localFile };
+
+                // The package should not be a bundle
+                THROW_HR_IF(APPINSTALLER_CLI_ERROR_PACKAGE_IS_BUNDLE, localMsixInfo.GetIsBundle());
+
+                // Ensure that family name has not changed
+                THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE,
+                    GetPackageFamilyNameFromDetails(details) != Msix::GetPackageFamilyNameFromFullName(localMsixInfo.GetPackageFullName()));
+
+                if (!fileLock.ValidateTrustInfo(WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin)))
+                {
+                    AICLI_LOG(Repo, Error, << "Source update failed. Source package failed trust validation.");
+                    THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE);
+                }
+
+                winrt::Windows::Foundation::Uri uri = winrt::Windows::Foundation::Uri(localFile.c_str());
                 Deployment::AddPackage(
                     uri,
                     winrt::Windows::Management::Deployment::DeploymentOptions::None,
@@ -356,27 +428,9 @@ namespace AppInstaller::Repository::Microsoft
                     try
                     {
                         // If successful, delete the file
-                        std::filesystem::remove(tempFile);
+                        std::filesystem::remove(localFile);
                     }
                     CATCH_LOG();
-                }
-
-                // Ensure origin if necessary
-                // TODO: Move to checking this before deploying it. That requires significant code to be written though
-                //       as there is no public API to check the origin directly.
-                if (WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin))
-                {
-                    std::wstring pfn = packageInfo.GetPackageFullNameWide();
-
-                    PackageOrigin origin = PackageOrigin::PackageOrigin_Unknown;
-                    if (SUCCEEDED_WIN32_LOG(GetStagedPackageOrigin(pfn.c_str(), &origin)))
-                    {
-                        if (origin != PackageOrigin::PackageOrigin_Store)
-                        {
-                            Deployment::RemovePackage(Utility::ConvertToUTF8(pfn), winrt::Windows::Management::Deployment::RemovalOptions::None, progress);
-                            THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE);
-                        }
-                    }
                 }
 
                 return true;
@@ -480,7 +534,31 @@ namespace AppInstaller::Repository::Microsoft
                 return std::make_shared<DesktopContextSourceReference>(details);
             }
 
-            bool UpdateInternal(const std::string& packageLocation, Msix::MsixInfo& packageInfo, const SourceDetails& details, IProgressCallback& progress) override
+            std::optional<Msix::PackageVersion> GetCurrentVersion(const SourceDetails& details) override
+            {
+                std::filesystem::path packageState = GetStatePathFromDetails(details);
+                std::filesystem::path packagePath = packageState / s_PreIndexedPackageSourceFactory_PackageFileName;
+
+                if (std::filesystem::exists(packagePath))
+                {
+                    // If we already have a trusted index package, use it to determine if we need to update or not.
+                    Msix::WriteLockedMsixFile indexPackage{ packagePath };
+                    if (indexPackage.ValidateTrustInfo(WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin)))
+                    {
+                        Msix::MsixInfo msixInfo{ packagePath };
+                        auto manifest = msixInfo.GetAppPackageManifests();
+
+                        if (manifest.size() == 1)
+                        {
+                            return manifest[0].GetIdentity().GetVersion();
+                        }
+                    }
+                }
+
+                return std::nullopt;
+            }
+
+            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) override
             {
                 // We will extract the manifest and index files directly to this location
                 std::filesystem::path packageState = GetStatePathFromDetails(details);
@@ -488,19 +566,19 @@ namespace AppInstaller::Repository::Microsoft
 
                 std::filesystem::path packagePath = packageState / s_PreIndexedPackageSourceFactory_PackageFileName;
 
-                if (std::filesystem::exists(packagePath))
-                {
-                    // If we already have a trusted index package, use it to determine if we need to update or not.
-                    Msix::WriteLockedMsixFile indexPackage{ packagePath };
-                    if (indexPackage.ValidateTrustInfo(WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin)) &&
-                        !packageInfo.IsNewerThan(packagePath))
-                    {
-                        AICLI_LOG(Repo, Info, << "Remote source data was not newer than existing, no update needed");
-                        return true;
-                    }
-                }
-
                 std::filesystem::path tempPackagePath = packagePath.u8string() + ".dnld.msix";
+                auto removeTempFileOnExit = wil::scope_exit([&]()
+                    {
+                        try
+                        {
+                            std::filesystem::remove(tempPackagePath);
+                        }
+                        catch (...)
+                        {
+                            AICLI_LOG(Repo, Info, << "Failed to remove temp index file at: " << tempPackagePath);
+                        }
+                    });
+
                 if (Utility::IsUrlRemote(packageLocation))
                 {
                     AppInstaller::Utility::Download(packageLocation, tempPackagePath, AppInstaller::Utility::DownloadType::Index, progress);
@@ -511,46 +589,37 @@ namespace AppInstaller::Repository::Microsoft
                     progress.OnProgress(100, 100, ProgressType::Percent);
                 }
 
-                bool updateSuccess = false;
                 if (progress.IsCancelledBy(CancelReason::Any))
                 {
                     AICLI_LOG(Repo, Info, << "Cancelling update upon request");
+                    return false;
                 }
-                else
+
                 {
-                    bool tempIndexPackageTrusted = false;
+                    // Extra scope to release the file lock right after trust validation.
+                    Msix::WriteLockedMsixFile tempIndexPackage{ tempPackagePath };
+                    Msix::MsixInfo tempMsixInfo{ tempPackagePath };
 
-                    {
-                        // Extra scope to release the file lock right after trust validation.
-                        Msix::WriteLockedMsixFile tempIndexPackage{ tempPackagePath };
-                        tempIndexPackageTrusted = tempIndexPackage.ValidateTrustInfo(WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin));
-                    }
+                    // The package should not be a bundle
+                    THROW_HR_IF(APPINSTALLER_CLI_ERROR_PACKAGE_IS_BUNDLE, tempMsixInfo.GetIsBundle());
 
-                    if (tempIndexPackageTrusted)
-                    {
-                        std::filesystem::rename(tempPackagePath, packagePath);
-                        AICLI_LOG(Repo, Info, << "Source update success.");
-                        updateSuccess = true;
-                    }
-                    else
+                    // Ensure that family name has not changed
+                    THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE,
+                        GetPackageFamilyNameFromDetails(details) != Msix::GetPackageFamilyNameFromFullName(tempMsixInfo.GetPackageFullName()));
+
+                    if (!tempIndexPackage.ValidateTrustInfo(WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::StoreOrigin)))
                     {
                         AICLI_LOG(Repo, Error, << "Source update failed. Source package failed trust validation.");
+                        THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_INTEGRITY_FAILURE);
                     }
                 }
 
-                if (!updateSuccess)
-                {
-                    try
-                    {
-                        std::filesystem::remove(tempPackagePath);
-                    }
-                    catch (...)
-                    {
-                        AICLI_LOG(Repo, Info, << "Failed to remove temp index file at: " << tempPackagePath);
-                    }
-                }
+                std::filesystem::rename(tempPackagePath, packagePath);
+                AICLI_LOG(Repo, Info, << "Source update success.");
 
-                return updateSuccess;
+                removeTempFileOnExit.release();
+
+                return true;
             }
 
             bool RemoveInternal(const SourceDetails& details, IProgressCallback&) override

--- a/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
@@ -127,12 +127,14 @@ namespace AppInstaller::Utility
     {
         UInt64Version() = default;
         UInt64Version(UINT64 version);
+        UInt64Version(uint16_t major, uint16_t minor, uint16_t build, uint16_t revision);
         UInt64Version(std::string&& version, std::string_view splitChars = DefaultSplitChars);
         UInt64Version(const std::string& version, std::string_view splitChars = DefaultSplitChars) :
             UInt64Version(std::string(version), splitChars) {}
 
         void Assign(std::string version, std::string_view splitChars = DefaultSplitChars) override;
         void Assign(UINT64 version);
+        void Assign(uint16_t major, uint16_t minor, uint16_t build, uint16_t revision);
 
         UINT64 Major() const { return m_parts.size() > 0 ? m_parts[0].Integer : 0; }
         UINT64 Minor() const { return m_parts.size() > 1 ? m_parts[1].Integer : 0; }

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -396,14 +396,24 @@ namespace AppInstaller::Utility
         Assign(version);
     }
 
+    UInt64Version::UInt64Version(uint16_t major, uint16_t minor, uint16_t build, uint16_t revision)
+    {
+        Assign(major, minor, build, revision);
+    }
+
     void UInt64Version::Assign(UINT64 version)
     {
-        const UINT64 mask16 = (1 << 16) - 1;
-        UINT64 revision = version & mask16;
-        UINT64 build = (version >> 0x10) & mask16;
-        UINT64 minor = (version >> 0x20) & mask16;
-        UINT64 major = (version >> 0x30) & mask16;
+        constexpr UINT64 mask16 = (1 << 16) - 1;
+        uint16_t revision = version & mask16;
+        uint16_t build = (version >> 0x10) & mask16;
+        uint16_t minor = (version >> 0x20) & mask16;
+        uint16_t major = (version >> 0x30) & mask16;
 
+        Assign(major, minor, build, revision);
+    }
+
+    void UInt64Version::Assign(uint16_t major, uint16_t minor, uint16_t build, uint16_t revision)
+    {
         // Construct a string representation of the provided version
         std::stringstream ssVersion;
         ssVersion << major


### PR DESCRIPTION
## Change
This change refactors the index package updating to enable an optimization; using an HTTP header to determine the available version rather than reading the package contents remotely.  If the header is present, containing a valid package version string, it will be used as the available version.  If not, the existing package content examination will be used.

The refactoring was required to do all package inspection steps after downloading the package, rather than before.  This enables the single version value to be sufficient until we decide to update, and then in the very unlikely event of the package not meeting criteria we will delete it after having downloaded it.

This also implemented the `TODO` of checking the origin of the package before deploying it rather than after.

## Validation
Manually verified version check fallback and deployment of the package in production.
Manually verified version header detection and use in pre-production.
Open to automated test ideas, but I could not come up with anything that had reasonable ROI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3657)