### PR TITLE
Add a bit of randomness to the wait time after source update failure

### DIFF
--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -53,7 +53,12 @@ namespace AppInstaller::Repository
             CATCH_LOG();
 
             AICLI_LOG(Repo, Info, << "Source add/update failed, waiting a bit and retrying: " << details.Name);
-            std::this_thread::sleep_for(2s);
+
+            // Add a bit of randomness to the retry wait time
+            std::default_random_engine randomEngine(std::random_device{}());
+            std::uniform_int_distribution<long long> distribution(2000, 10000);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(distribution(randomEngine)));
 
             // If this one fails, maybe the problem is persistent.
             result = (factory.get()->*member)(details, progress);

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -55,6 +55,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <random>
 #include <set>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
## Change
When we fail to add/update a source, make the retry time random rather than fixed.

## Validation
Manually tried adding an invalid URL a few times to observe the effective wait time via logs.  Was always in the distribution specified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3661)