### PR TITLE
Reduce the size of the index

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -103,6 +103,7 @@ DACL
 datetimeoffset
 Dbg
 debian
+dedupe
 deigh
 deleteifnotneeded
 DENYWR
@@ -264,6 +265,7 @@ luffy
 Luffytaro
 maclachlan
 malware
+mapdatafolding
 mapview
 Maxed
 maxvalue

--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -311,6 +311,17 @@ bool AreArpVersionsSupported(const SQLiteIndex& index, const Schema::Version& te
     return (index.GetVersion() >= Schema::Version{ 1, 5 } && testVersion >= Schema::Version{ 1, 5 });
 }
 
+bool IsMapDataFoldingSupported(const SQLiteIndex& index, const Schema::Version& testVersion)
+{
+    UNSCOPED_INFO("Index " << index.GetVersion() << " | Test " << testVersion);
+    return (index.GetVersion() >= Schema::Version{ 1, 7 } && testVersion >= Schema::Version{ 1, 7 });
+}
+
+bool IsMapDataFolded(const SQLiteIndex& index)
+{
+    return (index.GetVersion() >= Schema::Version{ 1, 7 });
+}
+
 std::string GetPropertyStringByKey(const SQLiteIndex& index, SQLite::rowid_t id, PackageVersionProperty property, std::string_view version, std::string_view channel)
 {
     auto manifestId = index.GetManifestIdByKey(id, version, channel);
@@ -3176,4 +3187,153 @@ TEST_CASE("SQLiteIndex_CheckConsistency_FindEmbeddedNull", "[sqliteindex]")
     update.Execute();
 
     REQUIRE(!index.CheckConsistency(true));
+}
+
+TEST_CASE("SQLiteIndex_MapDataFolding_Tags", "[sqliteindex][mapdatafolding]")
+{
+    TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
+    INFO("Using temporary file named: " << tempFile.GetPath());
+
+    std::string tag1 = "Tag1";
+    std::string tag2 = "Tag2";
+
+    SQLiteIndex index = SearchTestSetup(tempFile, {
+        { "Id", "Name", "Publisher", "Moniker", "Version1", "", { tag1 }, { "Command" }, "Path1", {}, { "PC1" } },
+        { "Id", "Name", "Publisher", "Moniker", "Version2", "", { tag2 }, { "Command" }, "Path2", {}, { "PC2" } },
+        });
+
+    // Apply the map data folding if it is present in the created test index.
+    index.PrepareForPackaging();
+
+    Schema::Version testVersion = TestPrepareForRead(index);
+
+    SearchRequest request1;
+    request1.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::Tag, MatchType::Exact, tag1));
+    auto results1 = index.Search(request1);
+
+    SearchRequest request2;
+    request2.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::Tag, MatchType::Exact, tag2));
+    auto results2 = index.Search(request1);
+
+    REQUIRE(results1.Matches.size() == 1);
+    REQUIRE(results2.Matches.size() == 1);
+    REQUIRE(results1.Matches[0].first == results2.Matches[0].first);
+}
+
+TEST_CASE("SQLiteIndex_MapDataFolding_PFNs", "[sqliteindex][mapdatafolding]")
+{
+    TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
+    INFO("Using temporary file named: " << tempFile.GetPath());
+
+    std::string pfn1 = "PFN1";
+    std::string pfn2 = "PFN2";
+
+    SQLiteIndex index = SearchTestSetup(tempFile, {
+        { "Id", "Name", "Publisher", "Moniker", "Version1", "", { }, { "Command" }, "Path1", { pfn1 }, { } },
+        { "Id", "Name", "Publisher", "Moniker", "Version2", "", { }, { "Command" }, "Path2", { pfn2 }, { } },
+        });
+
+    // Apply the map data folding if it is present in the created test index.
+    index.PrepareForPackaging();
+
+    Schema::Version testVersion = TestPrepareForRead(index);
+
+    SearchRequest request1;
+    request1.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::PackageFamilyName, MatchType::Exact, pfn1));
+    auto results1 = index.Search(request1);
+
+    SearchRequest request2;
+    request2.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::PackageFamilyName, MatchType::Exact, pfn2));
+    auto results2 = index.Search(request1);
+
+    REQUIRE(results1.Matches.size() == 1);
+    REQUIRE(results2.Matches.size() == 1);
+    REQUIRE(results1.Matches[0].first == results2.Matches[0].first);
+
+    auto versionKeys = index.GetVersionKeysById(results1.Matches[0].first);
+    REQUIRE(versionKeys.size() == 2);
+
+    auto manifestId1 = index.GetManifestIdByKey(results1.Matches[0].first, versionKeys[0].GetVersion().ToString(), versionKeys[0].GetChannel().ToString());
+    auto manifestId2 = index.GetManifestIdByKey(results1.Matches[0].first, versionKeys[1].GetVersion().ToString(), versionKeys[1].GetChannel().ToString());
+
+    REQUIRE(manifestId1.has_value());
+    REQUIRE(manifestId2.has_value());
+
+    auto pfnValues1 = index.GetMultiPropertyByManifestId(manifestId1.value(), PackageVersionMultiProperty::PackageFamilyName);
+    auto pfnValues2 = index.GetMultiPropertyByManifestId(manifestId2.value(), PackageVersionMultiProperty::PackageFamilyName);
+
+    if (IsMapDataFoldingSupported(index, testVersion))
+    {
+        REQUIRE(pfnValues1.size() == 2);
+        REQUIRE(pfnValues2.size() == 2);
+        REQUIRE(pfnValues1[0] != pfnValues1[1]);
+    }
+    else if (IsMapDataFolded(index))
+    {
+        if (manifestId1 > manifestId2)
+        {
+            REQUIRE(pfnValues1.size() == 2);
+            REQUIRE(pfnValues2.size() == 0);
+            REQUIRE(pfnValues1[0] != pfnValues1[1]);
+        }
+        else
+        {
+            REQUIRE(pfnValues1.size() == 0);
+            REQUIRE(pfnValues2.size() == 2);
+            REQUIRE(pfnValues2[0] != pfnValues2[1]);
+        }
+    }
+    else
+    {
+        REQUIRE(pfnValues1.size() == 1);
+        REQUIRE(pfnValues2.size() == 1);
+        REQUIRE(pfnValues1[0] != pfnValues2[0]);
+    }
+}
+
+TEST_CASE("SQLiteIndex_MapDataFolding_ProductCodes", "[sqliteindex][mapdatafolding]")
+{
+    TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
+    INFO("Using temporary file named: " << tempFile.GetPath());
+
+    std::string pc1 = "PC1";
+    std::string pc2 = "PC2";
+
+    SQLiteIndex index = SearchTestSetup(tempFile, {
+        { "Id", "Name", "Publisher", "Moniker", "Version1", "", { }, { "Command" }, "Path1", { }, { pc1 } },
+        { "Id", "Name", "Publisher", "Moniker", "Version2", "", { }, { "Command" }, "Path2", { }, { pc2 } },
+        });
+
+    // Apply the map data folding if it is present in the created test index.
+    index.PrepareForPackaging();
+
+    Schema::Version testVersion = TestPrepareForRead(index);
+
+    SearchRequest request1;
+    request1.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::Exact, pc1));
+    auto results1 = index.Search(request1);
+
+    SearchRequest request2;
+    request2.Inclusions.emplace_back(PackageMatchFilter(PackageMatchField::ProductCode, MatchType::Exact, pc2));
+    auto results2 = index.Search(request1);
+
+    REQUIRE(results1.Matches.size() == 1);
+    REQUIRE(results2.Matches.size() == 1);
+    REQUIRE(results1.Matches[0].first == results2.Matches[0].first);
+
+    auto versionKeys = index.GetVersionKeysById(results1.Matches[0].first);
+    REQUIRE(versionKeys.size() == 2);
+
+    auto manifestId1 = index.GetManifestIdByKey(results1.Matches[0].first, versionKeys[0].GetVersion().ToString(), versionKeys[0].GetChannel().ToString());
+    auto manifestId2 = index.GetManifestIdByKey(results1.Matches[0].first, versionKeys[1].GetVersion().ToString(), versionKeys[1].GetChannel().ToString());
+
+    REQUIRE(manifestId1.has_value());
+    REQUIRE(manifestId2.has_value());
+
+    auto pcValues1 = index.GetMultiPropertyByManifestId(manifestId1.value(), PackageVersionMultiProperty::ProductCode);
+    auto pcValues2 = index.GetMultiPropertyByManifestId(manifestId2.value(), PackageVersionMultiProperty::ProductCode);
+
+    REQUIRE(pcValues1.size() == 1);
+    REQUIRE(pcValues2.size() == 1);
+    REQUIRE(pcValues1[0] != pcValues2[0]);
 }

--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -35,7 +35,7 @@ SQLiteIndex CreateTestIndex(const std::string& filePath, std::optional<Schema::V
     // If no specific version requested, then use generator to run against the last 3 versions.
     if (!version)
     {
-        version = GENERATE(Schema::Version{ 1, 2 }, Schema::Version{ 1, 3 }, Schema::Version{ 1, 4 }, Schema::Version::Latest());
+        version = GENERATE(Schema::Version{ 1, 5 }, Schema::Version{ 1, 6 }, Schema::Version::Latest());
     }
 
     return SQLiteIndex::CreateNew(filePath, version.value());
@@ -43,41 +43,31 @@ SQLiteIndex CreateTestIndex(const std::string& filePath, std::optional<Schema::V
 
 Schema::Version TestPrepareForRead(SQLiteIndex& index)
 {
-    if (index.GetVersion() == Schema::Version{ 1, 2 })
+    if (index.GetVersion() == Schema::Version{ 1, 5 })
     {
-        Schema::Version version = GENERATE(Schema::Version{ 1, 2 });
-
-        if (version != Schema::Version{ 1, 2 })
-        {
-            index.ForceVersion(version);
-            return version;
-        }
-    }
-    else if (index.GetVersion() == Schema::Version{ 1, 3 })
-    {
-        Schema::Version version = GENERATE(Schema::Version{ 1, 2 }, Schema::Version{ 1, 3 });
-
-        if (version != Schema::Version{ 1, 3 })
-        {
-            index.ForceVersion(version);
-            return version;
-        }
-    }
-    else if (index.GetVersion() == Schema::Version{ 1, 4 })
-    {
-        Schema::Version version = GENERATE(Schema::Version{ 1, 2 }, Schema::Version{ 1, 3 }, Schema::Version{ 1, 4 });
-
-        if (version != Schema::Version{ 1, 4 })
-        {
-            index.ForceVersion(version);
-            return version;
-        }
-    }
-    else if (index.GetVersion() == Schema::Version{ 1, 5 })
-    {
-        Schema::Version version = GENERATE(Schema::Version{ 1, 2 }, Schema::Version{ 1, 3 }, Schema::Version{ 1, 4 }, Schema::Version{ 1, 5 });
+        Schema::Version version = GENERATE(Schema::Version{ 1, 5 });
 
         if (version != Schema::Version{ 1, 5 })
+        {
+            index.ForceVersion(version);
+            return version;
+        }
+    }
+    else if (index.GetVersion() == Schema::Version{ 1, 6 })
+    {
+        Schema::Version version = GENERATE(Schema::Version{ 1, 5 }, Schema::Version{ 1, 6 });
+
+        if (version != Schema::Version{ 1, 6 })
+        {
+            index.ForceVersion(version);
+            return version;
+        }
+    }
+    else if (index.GetVersion() == Schema::Version{ 1, 7 })
+    {
+        Schema::Version version = GENERATE(Schema::Version{ 1, 5 }, Schema::Version{ 1, 6 }, Schema::Version{ 1, 7 });
+
+        if (version != Schema::Version{ 1, 7 })
         {
             index.ForceVersion(version);
             return version;

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -385,6 +385,7 @@
     <ClInclude Include="Microsoft\Schema\1_6\Interface.h" />
     <ClInclude Include="Microsoft\Schema\1_6\SearchResultsTable.h" />
     <ClInclude Include="Microsoft\Schema\1_6\UpgradeCodeTable.h" />
+    <ClInclude Include="Microsoft\Schema\1_7\Interface.h" />
     <ClInclude Include="Microsoft\Schema\IPinningIndex.h" />
     <ClInclude Include="Microsoft\Schema\IPortableIndex.h" />
     <ClInclude Include="Microsoft\Schema\ISQLiteIndex.h" />
@@ -488,6 +489,7 @@
     <ClCompile Include="Microsoft\Schema\1_5\Interface_1_5.cpp" />
     <ClCompile Include="Microsoft\Schema\1_6\Interface_1_6.cpp" />
     <ClCompile Include="Microsoft\Schema\1_6\SearchResultsTable_1_6.cpp" />
+    <ClCompile Include="Microsoft\Schema\1_7\Interface_1_7.cpp" />
     <ClCompile Include="Microsoft\Schema\MetadataTable.cpp" />
     <ClCompile Include="Microsoft\Schema\Pinning_1_0\PinningIndexInterface_1_0.cpp" />
     <ClCompile Include="Microsoft\Schema\Pinning_1_0\PinTable.cpp" />

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -91,6 +91,9 @@
     <Filter Include="Rest\Schema\1_6\Json">
       <UniqueIdentifier>{b2e78f3d-931e-432c-8485-255b1dbc9db7}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Microsoft\Schema\1_7">
+      <UniqueIdentifier>{f610927a-6f1d-42c5-9ad9-b59790091944}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -387,6 +390,9 @@
     <ClInclude Include="Rest\Schema\1_6\Interface.h">
       <Filter>Rest\Schema\1_6</Filter>
     </ClInclude>
+    <ClInclude Include="Microsoft\Schema\1_7\Interface.h">
+      <Filter>Microsoft\Schema\1_7</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -613,6 +619,9 @@
     </ClCompile>
     <ClCompile Include="Rest\Schema\1_6\RestInterface_1_6.cpp">
       <Filter>Rest\Schema\1_6</Filter>
+    </ClCompile>
+    <ClCompile Include="Microsoft\Schema\1_7\Interface_1_7.cpp">
+      <Filter>Microsoft\Schema\1_7</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -13,6 +13,7 @@
 #include "Schema/1_4/Interface.h"
 #include "Schema/1_5/Interface.h"
 #include "Schema/1_6/Interface.h"
+#include "Schema/1_7/Interface.h"
 
 namespace AppInstaller::Repository::Microsoft
 {
@@ -63,11 +64,15 @@ namespace AppInstaller::Repository::Microsoft
         {
             return std::make_unique<V1_5::Interface>();
         }
-        else if (m_version == Version{ 1, 6 } ||
+        else if (m_version == Version{ 1, 6 })
+        {
+            return std::make_unique<V1_6::Interface>();
+        }
+        else if (m_version == Version{ 1, 7 } ||
             m_version.MajorVersion == 1 ||
             m_version.IsLatest())
         {
-            return std::make_unique<V1_6::Interface>();
+            return std::make_unique<V1_7::Interface>();
         }
 
         // We do not have the capacity to operate on this schema version

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -40,39 +40,22 @@ namespace AppInstaller::Repository::Microsoft
     {
         using namespace Schema;
 
-        if (version == Version{ 1, 0 })
-        {
-            return std::make_unique<V1_0::Interface>();
-        }
-        else if (version == Version{ 1, 1 })
-        {
-            return std::make_unique<V1_1::Interface>();
-        }
-        else if (version == Version{ 1, 2 })
-        {
-            return std::make_unique<V1_2::Interface>();
-        }
-        else if (version == Version{ 1, 3 })
-        {
-            return std::make_unique<V1_3::Interface>();
-        }
-        else if (version == Version{ 1, 4 })
-        {
-            return std::make_unique<V1_4::Interface>();
-        }
-        else if (version == Version{ 1, 5 })
-        {
-            return std::make_unique<V1_5::Interface>();
-        }
-        else if (version == Version{ 1, 6 })
-        {
-            return std::make_unique<V1_6::Interface>();
-        }
-        else if (version == Version{ 1, 7 } ||
-            version.MajorVersion == 1 ||
+        if (version.MajorVersion == 1 ||
             version.IsLatest())
         {
-            return std::make_unique<V1_7::Interface>();
+            constexpr std::array<std::unique_ptr<Schema::ISQLiteIndex>(*)(), 8> versionCreatorMap =
+            {
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_0::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_1::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_2::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_3::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_4::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_5::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_6::Interface>()); },
+                []() { return std::unique_ptr<Schema::ISQLiteIndex>(std::make_unique<V1_7::Interface>()); },
+            };
+
+            return versionCreatorMap[std::min(static_cast<size_t>(version.MinorVersion), versionCreatorMap.size() - 1)]();
         }
 
         // We do not have the capacity to operate on this schema version
@@ -99,6 +82,11 @@ namespace AppInstaller::Repository::Microsoft
     void SQLiteIndex::ForceVersion(const Schema::Version& version)
     {
         m_interface = CreateISQLiteIndex(version);
+    }
+
+    Schema::Version SQLiteIndex::GetLatestVersion()
+    {
+        return CreateISQLiteIndex(Schema::Version::Latest())->GetVersion();
     }
 #endif
 

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -36,41 +36,41 @@ namespace AppInstaller::Repository::Microsoft
         return result;
     }
 
-    std::unique_ptr<Schema::ISQLiteIndex> SQLiteIndex::CreateISQLiteIndex() const
+    std::unique_ptr<Schema::ISQLiteIndex> SQLiteIndex::CreateISQLiteIndex(const Schema::Version& version)
     {
         using namespace Schema;
 
-        if (m_version == Version{ 1, 0 })
+        if (version == Version{ 1, 0 })
         {
             return std::make_unique<V1_0::Interface>();
         }
-        else if (m_version == Version{ 1, 1 })
+        else if (version == Version{ 1, 1 })
         {
             return std::make_unique<V1_1::Interface>();
         }
-        else if (m_version == Version{ 1, 2 })
+        else if (version == Version{ 1, 2 })
         {
             return std::make_unique<V1_2::Interface>();
         }
-        else if (m_version == Version{ 1, 3 })
+        else if (version == Version{ 1, 3 })
         {
             return std::make_unique<V1_3::Interface>();
         }
-        else if (m_version == Version{ 1, 4 })
+        else if (version == Version{ 1, 4 })
         {
             return std::make_unique<V1_4::Interface>();
         }
-        else if (m_version == Version{ 1, 5 })
+        else if (version == Version{ 1, 5 })
         {
             return std::make_unique<V1_5::Interface>();
         }
-        else if (m_version == Version{ 1, 6 })
+        else if (version == Version{ 1, 6 })
         {
             return std::make_unique<V1_6::Interface>();
         }
-        else if (m_version == Version{ 1, 7 } ||
-            m_version.MajorVersion == 1 ||
-            m_version.IsLatest())
+        else if (version == Version{ 1, 7 } ||
+            version.MajorVersion == 1 ||
+            version.IsLatest())
         {
             return std::make_unique<V1_7::Interface>();
         }
@@ -79,10 +79,10 @@ namespace AppInstaller::Repository::Microsoft
         THROW_HR(HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED));
     }
 
-    SQLiteIndex::SQLiteIndex(const std::string& target, Schema::Version version) : SQLiteStorageBase(target, version)
+    SQLiteIndex::SQLiteIndex(const std::string& target, const Schema::Version& version) : SQLiteStorageBase(target, version)
     {
         m_dbconn.EnableICU();
-        m_interface = CreateISQLiteIndex();
+        m_interface = CreateISQLiteIndex(version);
         m_version = m_interface->GetVersion();
     }
 
@@ -91,15 +91,14 @@ namespace AppInstaller::Repository::Microsoft
     {
         m_dbconn.EnableICU();
         AICLI_LOG(Repo, Info, << "Opened SQLite Index with version [" << m_version << "], last write [" << GetLastWriteTime() << "]");
-        m_interface = CreateISQLiteIndex();
+        m_interface = CreateISQLiteIndex(m_version);
         THROW_HR_IF(APPINSTALLER_CLI_ERROR_CANNOT_WRITE_TO_UPLEVEL_INDEX, disposition == SQLiteStorageBase::OpenDisposition::ReadWrite && m_version != m_interface->GetVersion());
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS
     void SQLiteIndex::ForceVersion(const Schema::Version& version)
     {
-        m_version = version;
-        m_interface = CreateISQLiteIndex();
+        m_interface = CreateISQLiteIndex(version);
     }
 #endif
 

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -138,7 +138,7 @@ namespace AppInstaller::Repository::Microsoft
         std::vector<std::pair<SQLite::rowid_t, Utility::NormalizedString>> GetDependentsById(AppInstaller::Manifest::string_t packageId) const;
     private:
         // Constructor used to create a new index.
-        SQLiteIndex(const std::string& target, Schema::Version version);
+        SQLiteIndex(const std::string& target, const Schema::Version& version);
 
         // Constructor used to open an existing index.
         SQLiteIndex(const std::string& target, SQLiteStorageBase::OpenDisposition disposition, Utility::ManagedFile&& indexFile);
@@ -148,7 +148,7 @@ namespace AppInstaller::Repository::Microsoft
         bool UpdateManifestInternal(const Manifest::Manifest& manifest, const std::optional<std::filesystem::path>& relativePath);
 
         // Creates the ISQLiteIndex interface object for this version.
-        std::unique_ptr<Schema::ISQLiteIndex> CreateISQLiteIndex() const;
+        static std::unique_ptr<Schema::ISQLiteIndex> CreateISQLiteIndex(const Schema::Version& version);
 
         std::unique_ptr<Schema::ISQLiteIndex> m_interface;
     };

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -56,6 +56,9 @@ namespace AppInstaller::Repository::Microsoft
         // Changes the version of the interface being used to operate on the database.
         // Should only be used for testing.
         void ForceVersion(const Schema::Version& version);
+
+        // Gets the latest version of the index schema (the actual numbers, not just the latest sentinel values).
+        static Schema::Version GetLatestVersion();
 #endif
 
         // Adds the manifest at the repository relative path to the index.

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteStorageBase.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteStorageBase.cpp
@@ -105,7 +105,7 @@ namespace AppInstaller::Repository::Microsoft
         m_version = Schema::Version::GetSchemaVersion(m_dbconn);
     }
 
-    SQLiteStorageBase::SQLiteStorageBase(const std::string& target, Schema::Version version) :
+    SQLiteStorageBase::SQLiteStorageBase(const std::string& target, const Schema::Version& version) :
         m_dbconn(SQLite::Connection::Create(target, SQLite::Connection::OpenDisposition::Create))
     {
         m_version = version;

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteStorageBase.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteStorageBase.h
@@ -30,7 +30,7 @@ namespace AppInstaller::Repository::Microsoft
         Schema::Version GetVersion() const { return m_version; }
 
     protected:
-        SQLiteStorageBase(const std::string& target, Schema::Version version);
+        SQLiteStorageBase(const std::string& target, const Schema::Version& version);
 
         SQLiteStorageBase(const std::string& filePath, SQLiteStorageBase::OpenDisposition disposition, Utility::ManagedFile&& indexFile);
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "Microsoft/Schema/ISQLiteIndex.h"
 #include "Microsoft/Schema/1_0/SearchResultsTable.h"
+#include "Microsoft/Schema/1_0/OneToManyTable.h"
 
 #include <memory>
 #include <vector>
@@ -54,6 +55,9 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Gets a property already knowing that the manifest id is valid.
         virtual std::optional<std::string> GetPropertyByManifestIdInternal(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionProperty property) const;
+
+        // Gets the one to many table schema to use.
+        virtual OneToManyTableSchema GetOneToManyTableSchema() const;
 
         // Force the database to shrink the file size.
         // This *must* be done outside of an active transaction.

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/Interface_1_0.cpp
@@ -176,8 +176,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             { PathPartTable::ValueName(), false, WI_IsFlagClear(options, CreateOptions::SupportPathless) }
             });
 
-        TagsTable::Create_deprecated(connection);
-        CommandsTable::Create_deprecated(connection);
+        TagsTable::Create(connection, GetOneToManyTableSchema());
+        CommandsTable::Create(connection, GetOneToManyTableSchema());
 
         savepoint.Commit();
     }
@@ -377,8 +377,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             PathPartTable::ValueName(),
             });
 
-        TagsTable::PrepareForPackaging_deprecated(connection);
-        CommandsTable::PrepareForPackaging_deprecated(connection);
+        TagsTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), false, false);
+        CommandsTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), false, false);
 
         savepoint.Commit();
 
@@ -639,6 +639,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         default:
             return {};
         }
+    }
+
+    OneToManyTableSchema Interface::GetOneToManyTableSchema() const
+    {
+        return OneToManyTableSchema::Version_1_0;
     }
 
     void Interface::Vacuum(const SQLite::Connection& connection)

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToManyTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToManyTable.h
@@ -63,7 +63,13 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
 
         // Determines if the table is empty.
         bool OneToManyTableIsEmpty(SQLite::Connection& connection, std::string_view tableName);
+
+        // Prepares a statement for replacing all of the map data to point to a single manifest for a given id.
+        SQLite::Statement OneToManyTablePrepareMapDataFoldingStatement(const SQLite::Connection& connection, std::string_view tableName);
     }
+
+    // Gets the manifest id that the PrepareMapDataFoldingStatement will fold to for the given manifest id.
+    std::optional<SQLite::rowid_t> OneToManyTableGetMapDataFoldingManifestTargetId(const SQLite::Connection& connection, SQLite::rowid_t manifestId);
 
     // A table that represents a value that is 1:N with a primary entry.
     template <typename TableInfo>
@@ -136,6 +142,12 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         static bool IsEmpty(SQLite::Connection& connection)
         {
             return details::OneToManyTableIsEmpty(connection, TableInfo::TableName());
+        }
+
+        // Prepares a statement for replacing all of the map data to point to a single manifest for a given id.
+        static SQLite::Statement PrepareMapDataFoldingStatement(const SQLite::Connection& connection)
+        {
+            return details::OneToManyTablePrepareMapDataFoldingStatement(connection, TableInfo::TableName());
         }
     };
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/OneToOneTable.h
@@ -113,6 +113,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
         }
 
         // Removes data that is no longer needed for an index that is to be published.
+        // Preserving the values index will improve searching when it is primarily done by equality.
         static void PrepareForPackaging(SQLite::Connection& connection, bool preserveValuesIndex = false)
         {
             details::OneToOneTablePrepareForPackaging(connection, TableInfo::TableName(), true, preserveValuesIndex);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface.h
@@ -28,6 +28,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
     protected:
         std::unique_ptr<V1_0::SearchResultsTable> CreateSearchResultsTable(const SQLite::Connection& connection) const override;
         void PerformQuerySearch(V1_0::SearchResultsTable& resultsTable, const RequestMatch& query) const override;
+        V1_0::OneToManyTableSchema GetOneToManyTableSchema() const override;
+
         virtual SearchResult SearchInternal(const SQLite::Connection& connection, SearchRequest& request) const;
         virtual void PrepareForPackaging(SQLite::Connection& connection, bool vacuum);
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_1/Interface_1_1.cpp
@@ -51,10 +51,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
             { V1_0::PathPartTable::ValueName(), false, WI_IsFlagClear(options, CreateOptions::SupportPathless) }
             });
 
-        V1_0::TagsTable::Create(connection);
-        V1_0::CommandsTable::Create(connection);
-        PackageFamilyNameTable::Create(connection);
-        ProductCodeTable::Create(connection);
+        V1_0::TagsTable::Create(connection, GetOneToManyTableSchema());
+        V1_0::CommandsTable::Create(connection, GetOneToManyTableSchema());
+        PackageFamilyNameTable::Create(connection, GetOneToManyTableSchema());
+        ProductCodeTable::Create(connection, GetOneToManyTableSchema());
 
         savepoint.Commit();
     }
@@ -196,6 +196,11 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
         V1_0::Interface::PerformQuerySearch(resultsTable, query);
     }
 
+    V1_0::OneToManyTableSchema Interface::GetOneToManyTableSchema() const
+    {
+        return V1_0::OneToManyTableSchema::Version_1_1;
+    }
+
     ISQLiteIndex::SearchResult Interface::SearchInternal(const SQLite::Connection& connection, SearchRequest& request) const
     {
         // Update any system reference strings to be folded
@@ -239,10 +244,10 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_1
             V1_0::PathPartTable::ValueName(),
             });
 
-        V1_0::TagsTable::PrepareForPackaging(connection, false);
-        V1_0::CommandsTable::PrepareForPackaging(connection, false);
-        PackageFamilyNameTable::PrepareForPackaging(connection, true, true);
-        ProductCodeTable::PrepareForPackaging(connection, true, true);
+        V1_0::TagsTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), false, false);
+        V1_0::CommandsTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), false, false);
+        PackageFamilyNameTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), true, true);
+        ProductCodeTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), true, true);
 
         savepoint.Commit();
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_2/Interface_1_2.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_2/Interface_1_2.cpp
@@ -165,8 +165,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_2
         // This will mean that one can match cross locale name and publisher, but the chance that this
         // leads to a confusion between packages is very small. More likely would be intentional attempts
         // to confuse the correlation, which could be fairly easily carried out even with linked values.
-        NormalizedPackageNameTable::Create(connection);
-        NormalizedPackagePublisherTable::Create(connection);
+        NormalizedPackageNameTable::Create(connection, GetOneToManyTableSchema());
+        NormalizedPackagePublisherTable::Create(connection, GetOneToManyTableSchema());
 
         savepoint.Commit();
     }
@@ -320,8 +320,8 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_2
 
         V1_1::Interface::PrepareForPackaging(connection, false);
 
-        NormalizedPackageNameTable::PrepareForPackaging(connection, true, true);
-        NormalizedPackagePublisherTable::PrepareForPackaging(connection, true, true);
+        NormalizedPackageNameTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), true, true);
+        NormalizedPackagePublisherTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), true, true);
 
         savepoint.Commit();
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_6/Interface_1_6.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_6/Interface_1_6.cpp
@@ -24,7 +24,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_6
 
         V1_5::Interface::CreateTables(connection, options);
 
-        UpgradeCodeTable::Create(connection);
+        UpgradeCodeTable::Create(connection, GetOneToManyTableSchema());
 
         savepoint.Commit();
     }
@@ -142,7 +142,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_6
 
         V1_5::Interface::PrepareForPackaging(connection, false);
 
-        UpgradeCodeTable::PrepareForPackaging(connection, true, true);
+        UpgradeCodeTable::PrepareForPackaging(connection, GetOneToManyTableSchema(), true, true);
 
         savepoint.Commit();
 

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Microsoft/Schema/ISQLiteIndex.h"
+#include "Microsoft/Schema/1_6/Interface.h"
+
+namespace AppInstaller::Repository::Microsoft::Schema::V1_7
+{
+    // Interface to this schema version exposed through ISQLiteIndex.
+    struct Interface : public V1_6::Interface
+    {
+        Interface(Utility::NormalizationVersion normVersion = Utility::NormalizationVersion::Initial);
+
+        // Version 1.0
+        Schema::Version GetVersion() const override;
+
+    protected:
+        V1_0::OneToManyTableSchema GetOneToManyTableSchema() const override;
+    };
+}

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface.h
@@ -6,15 +6,21 @@
 
 namespace AppInstaller::Repository::Microsoft::Schema::V1_7
 {
+    using namespace std::string_view_literals;
+
     // Interface to this schema version exposed through ISQLiteIndex.
     struct Interface : public V1_6::Interface
     {
+        static constexpr std::string_view MapDataFolded_VersionSpecifier = "1.7"sv;
+
         Interface(Utility::NormalizationVersion normVersion = Utility::NormalizationVersion::Initial);
 
         // Version 1.0
         Schema::Version GetVersion() const override;
+        std::vector<std::string> GetMultiPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionMultiProperty property) const override;
 
     protected:
+        void PrepareForPackaging(SQLite::Connection& connection, bool vacuum) override;
         V1_0::OneToManyTableSchema GetOneToManyTableSchema() const override;
     };
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface_1_7.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface_1_7.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Microsoft/Schema/1_7/Interface.h"
+#include "Microsoft/Schema/1_6/UpgradeCodeTable.h"
+#include "Microsoft/Schema/1_6/SearchResultsTable.h"
+#include "Microsoft/Schema/1_0/ManifestTable.h"
+#include "Microsoft/Schema/1_0/VersionTable.h"
+
+namespace AppInstaller::Repository::Microsoft::Schema::V1_7
+{
+    Interface::Interface(Utility::NormalizationVersion normVersion) : V1_6::Interface(normVersion)
+    {
+    }
+
+    Schema::Version Interface::GetVersion() const
+    {
+        return { 1, 7 };
+    }
+
+    V1_0::OneToManyTableSchema Interface::GetOneToManyTableSchema() const
+    {
+        return V1_0::OneToManyTableSchema::Version_1_7;
+    }
+}

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface_1_7.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_7/Interface_1_7.cpp
@@ -2,13 +2,43 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "Microsoft/Schema/1_7/Interface.h"
+#include "Microsoft/Schema/MetadataTable.h"
+#include "Microsoft/Schema/1_0/CommandsTable.h"
+#include "Microsoft/Schema/1_0/IdTable.h"
+#include "Microsoft/Schema/1_0/TagsTable.h"
+#include "Microsoft/Schema/1_1/PackageFamilyNameTable.h"
+#include "Microsoft/Schema/1_2/NormalizedPackageNameTable.h"
+#include "Microsoft/Schema/1_2/NormalizedPackagePublisherTable.h"
 #include "Microsoft/Schema/1_6/UpgradeCodeTable.h"
-#include "Microsoft/Schema/1_6/SearchResultsTable.h"
-#include "Microsoft/Schema/1_0/ManifestTable.h"
-#include "Microsoft/Schema/1_0/VersionTable.h"
 
 namespace AppInstaller::Repository::Microsoft::Schema::V1_7
 {
+    namespace
+    {
+        bool ShouldFoldPropertyLookup(const SQLite::Connection& connection)
+        {
+            // Get the metadata indicator that we folded these multi properties.
+            // If it contains the value for folding these properties in the 1.7 manner, also fold the incoming manifest
+            // to the same value that it would have been folded to so that all manifest entries will have all of these properties.
+            std::optional<std::string> mapDataFolded = MetadataTable::TryGetNamedValue<std::string>(connection, s_MetadataValueName_MapDataFolded);
+
+            if (mapDataFolded)
+            {
+                std::vector<std::string> foldedSplit = Utility::Split(mapDataFolded.value(), s_MetadataValue_MapDataFolded_Separator);
+
+                for (const std::string& splitValue : foldedSplit)
+                {
+                    if (splitValue == Interface::MapDataFolded_VersionSpecifier)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+
     Interface::Interface(Utility::NormalizationVersion normVersion) : V1_6::Interface(normVersion)
     {
     }
@@ -16,6 +46,65 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_7
     Schema::Version Interface::GetVersion() const
     {
         return { 1, 7 };
+    }
+
+    std::vector<std::string> Interface::GetMultiPropertyByManifestId(const SQLite::Connection& connection, SQLite::rowid_t manifestId, PackageVersionMultiProperty property) const
+    {
+        if (property == PackageVersionMultiProperty::PackageFamilyName ||
+            property == PackageVersionMultiProperty::Name ||
+            property == PackageVersionMultiProperty::Publisher ||
+            property == PackageVersionMultiProperty::UpgradeCode)
+        {
+            if (ShouldFoldPropertyLookup(connection))
+            {
+                std::optional<SQLite::rowid_t> maximumManifestId = V1_0::OneToManyTableGetMapDataFoldingManifestTargetId(connection, manifestId);
+                if (maximumManifestId)
+                {
+                    manifestId = maximumManifestId.value();
+                }
+            }
+        }
+
+        return V1_6::Interface::GetMultiPropertyByManifestId(connection, manifestId, property);
+    }
+
+    void Interface::PrepareForPackaging(SQLite::Connection& connection, bool vacuum)
+    {
+        SQLite::Savepoint savepoint = SQLite::Savepoint::Create(connection, "prepareforpackaging_v1_7");
+
+        // Remove data that is not particularly interesting per-manifest
+        std::array<SQLite::Statement, 6> dataRemovalStatements{
+            V1_0::CommandsTable::PrepareMapDataFoldingStatement(connection),
+            V1_0::TagsTable::PrepareMapDataFoldingStatement(connection),
+            V1_1::PackageFamilyNameTable::PrepareMapDataFoldingStatement(connection),
+            V1_2::NormalizedPackageNameTable::PrepareMapDataFoldingStatement(connection),
+            V1_2::NormalizedPackagePublisherTable::PrepareMapDataFoldingStatement(connection),
+            V1_6::UpgradeCodeTable::PrepareMapDataFoldingStatement(connection),
+        };
+
+        std::vector<SQLite::rowid_t> allIdentifiers = V1_0::IdTable::GetAllRowIds(connection);
+
+        for (SQLite::rowid_t id : allIdentifiers)
+        {
+            for (SQLite::Statement& statement : dataRemovalStatements)
+            {
+                statement.Reset();
+                statement.Bind(1, id);
+
+                statement.Execute();
+            }
+        }
+
+        MetadataTable::SetNamedValue(connection, s_MetadataValueName_MapDataFolded, MapDataFolded_VersionSpecifier);
+
+        V1_6::Interface::PrepareForPackaging(connection, false);
+
+        savepoint.Commit();
+
+        if (vacuum)
+        {
+            Vacuum(connection);
+        }
     }
 
     V1_0::OneToManyTableSchema Interface::GetOneToManyTableSchema() const

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -819,6 +819,13 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
+    StatementBuilder& StatementBuilder::WithoutRowID()
+    {
+        m_stream << " WITHOUT ROWID";
+        return *this;
+    }
+
+
     StatementBuilder& StatementBuilder::As(std::string_view alias)
     {
         OutputOperationAndTable(m_stream, " AS", alias);

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.cpp
@@ -84,6 +84,9 @@ namespace AppInstaller::Repository::SQLite::Builder
             case Aggregate::Min:
                 out << "MIN";
                 break;
+            case Aggregate::Max:
+                out << "MAX";
+                break;
             default:
                 THROW_HR(E_UNEXPECTED);
             }
@@ -330,9 +333,23 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
-    StatementBuilder& StatementBuilder::Equals(details::unbound_t)
+    StatementBuilder& StatementBuilder::Equals(details::unbound_t, std::optional<size_t> index)
     {
-        AppendOpAndBinder(Op::Equals);
+        AppendOpAndBinder(Op::Equals, index);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::Equals(std::nullptr_t)
+    {
+        // This is almost certainly not what you want.
+        // In SQL, value = NULL is always false.
+        // Use StatementBuilder::IsNull instead.
+        THROW_HR(E_NOTIMPL);
+    }
+
+    StatementBuilder& StatementBuilder::Equals()
+    {
+        m_stream << " =";
         return *this;
     }
 
@@ -364,14 +381,6 @@ namespace AppInstaller::Repository::SQLite::Builder
         THROW_HR_IF(E_INVALIDARG, escapeChar.length() != 1);
         AddBindFunctor(AppendOpAndBinder(Op::Escape), escapeChar);
         return *this;
-    }
-
-    StatementBuilder& StatementBuilder::Equals(std::nullptr_t)
-    {
-        // This is almost certainly not what you want.
-        // In SQL, value = NULL is always false.
-        // Use StatementBuilder::IsNull instead.
-        THROW_HR(E_NOTIMPL);
     }
 
     StatementBuilder& StatementBuilder::Not()
@@ -794,6 +803,24 @@ namespace AppInstaller::Repository::SQLite::Builder
         return *this;
     }
 
+    StatementBuilder& StatementBuilder::UpdateOrReplace(std::string_view table)
+    {
+        OutputOperationAndTable(m_stream, "UPDATE OR REPLACE", table);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::UpdateOrReplace(QualifiedTable table)
+    {
+        OutputOperationAndTable(m_stream, "UPDATE OR REPLACE", table);
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::UpdateOrReplace(std::initializer_list<std::string_view> table)
+    {
+        OutputOperationAndTable(m_stream, "UPDATE OR REPLACE", table);
+        return *this;
+    }
+
     StatementBuilder& StatementBuilder::Set()
     {
         m_stream << " SET ";
@@ -847,7 +874,7 @@ namespace AppInstaller::Repository::SQLite::Builder
         Prepare(connection).Execute();
     }
 
-    int StatementBuilder::AppendOpAndBinder(Op op)
+    int StatementBuilder::AppendOpAndBinder(Op op, std::optional<size_t> index)
     {
         switch (op)
         {
@@ -865,6 +892,11 @@ namespace AppInstaller::Repository::SQLite::Builder
             break;
         default:
             THROW_HR(E_UNEXPECTED);
+        }
+
+        if (index)
+        {
+            m_stream << index.value();
         }
 
         return m_bindIndex++;

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -116,7 +116,8 @@ namespace AppInstaller::Repository::SQLite::Builder
     // Aggregate functions.
     enum class Aggregate
     {
-        Min
+        Min,
+        Max,
     };
 
     // Helper to mark create an integer primary key for rowid, making it stable across vacuum.
@@ -246,8 +247,10 @@ namespace AppInstaller::Repository::SQLite::Builder
                 return IsNull();
             }
         }
-        StatementBuilder& Equals(details::unbound_t);
+        // The optional index value can be used to specify the parameter index.
+        StatementBuilder& Equals(details::unbound_t, std::optional<size_t> index = {});
         StatementBuilder& Equals(std::nullptr_t);
+        StatementBuilder& Equals();
 
         StatementBuilder& LikeWithEscape(std::string_view value);
         StatementBuilder& Like(details::unbound_t);
@@ -258,8 +261,8 @@ namespace AppInstaller::Repository::SQLite::Builder
 
         StatementBuilder& Not();
         StatementBuilder& In();
-        
-        //Appends a set of value binders for the In clause.
+
+        // Appends a set of value binders for the In clause.
         StatementBuilder& In(size_t count);
 
         // IsNull(true) means the value is null; IsNull(false) means the value is not null.
@@ -394,6 +397,12 @@ namespace AppInstaller::Repository::SQLite::Builder
         StatementBuilder& Update(QualifiedTable table);
         StatementBuilder& Update(std::initializer_list<std::string_view> table);
 
+        // Begin an `update or replace` statement.
+        // The initializer_list form enables the table name to be constructed from multiple parts.
+        StatementBuilder& UpdateOrReplace(std::string_view table);
+        StatementBuilder& UpdateOrReplace(QualifiedTable table);
+        StatementBuilder& UpdateOrReplace(std::initializer_list<std::string_view> table);
+
         // Output the set portion of an update statement.
         StatementBuilder& Set();
 
@@ -430,7 +439,8 @@ namespace AppInstaller::Repository::SQLite::Builder
         };
 
         // Appends given the operation.
-        int AppendOpAndBinder(Op op);
+        // The optional index value can be used to specify the parameter index.
+        int AppendOpAndBinder(Op op, std::optional<size_t> index = {});
 
         // Appends a set of binders for the values clause of an insert.
         int AppendValuesAndBinders(size_t count);

--- a/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
+++ b/src/AppInstallerRepositoryCore/SQLiteStatementBuilder.h
@@ -404,6 +404,9 @@ namespace AppInstaller::Repository::SQLite::Builder
         StatementBuilder& BeginParenthetical();
         StatementBuilder& EndParenthetical();
 
+        // Adds the `without rowid` clause.
+        StatementBuilder& WithoutRowID();
+
         // Assign an alias to the previous item.
         StatementBuilder& As(std::string_view alias);
 

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -46,6 +46,7 @@
 #include <wrl/client.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
## Change
This change seeks to reduce the size of the index in two ways:
1. Better schema design for the 1:N mapping tables
2. Dropping some of the mapping data that is not particularly interesting per manifest (aka per version)

### Better schema design
This is achieved by the map table having no `rowid` and using a primary key with the value first.  This makes the table already sorted by the value, thus the reverse lookups are fast.  It also drops a fair amount of the data in the table itself to remove the `rowid`, given that it was ~1/3 of the rows.

### Dropping map data
We don't actually use the fact that we know that different versions have different tags (or any other data).  Thus, we can simply have one manifest entry per package identifier have all of the values and maintain the same functionality.  There is a slight loss of fidelity if one is reading through the values via API, but this is deemed acceptable given the large data savings.  I explicitly left the product codes alone, as this does have value to keep per version (even if we are not using it currently).

### Size comparison
| State | Size (bytes) | Percentage | Delta (relative) |
| --- | --- | --- | --- |
| Original | 18141184 | 100% | |
| Better schema | 12673024 | 70% | -30% |
| Map folding | 9256960 | 51% | -19% (-27%) |
| File name shortened | 8306688 | 45.8% | -5.2% (-10.3%) |

As a bonus, we plan to also shorten the file names of the manifests, but this is a service only change.

## Validation
Tests are added to verify the behavior is as expected for the various folded data.
The regression tests should help ensure that the schema changes are not functionally impactful.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3666)