### PR TITLE
Enable COM API access to correlate with the tracking database only

### DIFF
--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -1412,15 +1412,12 @@ namespace AppInstaller::Repository
                         }
                     }
 
-                    bool addedAvailablePackage = false;
-
                     // Directly search for the available package from tracking information.
                     if (trackingPackage)
                     {
                         auto availablePackage = GetTrackedPackageFromAvailableSource(result, trackedSource, trackingPackage->GetProperty(PackageProperty::Id));
                         if (availablePackage)
                         {
-                            addedAvailablePackage = true;
                             compositePackage->AddAvailablePackage(std::move(availablePackage));
                         }
                         compositePackage->SetTracking(std::move(trackedSource), std::move(trackingPackage), std::move(trackingPackageVersion));
@@ -1453,7 +1450,6 @@ namespace AppInstaller::Repository
                             });
 
                         // For non pinning cases. We found some matching packages here, don't keep going.
-                        addedAvailablePackage = true;
                         compositePackage->AddAvailablePackage(std::move(availablePackage));
                     }
                 }

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -219,6 +219,10 @@ namespace AppInstaller::Repository
         // Set caller.
         void SetCaller(std::string caller);
 
+        // Indicates that we are only interested in the PackageTrackingCatalog for the source.
+        // Must be set before Open to have effect, and will prevent the underlying source from being updated or opened.
+        void InstalledPackageInformationOnly(bool value);
+
         // Execute a search on the source.
         SearchResult Search(const SearchRequest& request) const;
 
@@ -280,6 +284,7 @@ namespace AppInstaller::Repository
         std::shared_ptr<ISource> m_source;
         bool m_isSourceToBeAdded = false;
         bool m_isComposite = false;
+        bool m_installedPackageInformationOnly = false;
         mutable PackageTrackingCatalog m_trackingCatalog;
     };
 }

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -195,6 +195,39 @@ namespace AppInstaller::Repository
             SourceDetails m_details;
             std::exception_ptr m_exception;
         };
+
+        // A wrapper that doesn't actually forward the search requests.
+        struct TrackingOnlySourceWrapper : public ISource
+        {
+            TrackingOnlySourceWrapper(std::shared_ptr<ISourceReference> wrapped) : m_wrapped(std::move(wrapped)) {}
+
+        private:
+            std::shared_ptr<ISourceReference> m_wrapped;
+        };
+
+        // A wrapper to create another wrapper.
+        struct TrackingOnlyReferenceWrapper : public ISourceReference
+        {
+            TrackingOnlyReferenceWrapper(std::shared_ptr<ISourceReference> wrapped) : m_wrapped(std::move(wrapped)) {}
+
+            std::string GetIdentifier() override { return m_wrapped->GetIdentifier(); }
+
+            SourceDetails& GetDetails() override { return m_wrapped->GetDetails(); }
+
+            SourceInformation GetInformation() override { return m_wrapped->GetInformation(); }
+
+            bool SetCustomHeader(std::optional<std::string>) override { return false; }
+
+            void SetCaller(std::string caller) override { m_wrapped->SetCaller(std::move(caller)); }
+
+            std::shared_ptr<ISource> Open(IProgressCallback& progress) override
+            {
+                return std::make_shared<TrackingOnlySourceWrapper>(m_wrapped);
+            }
+
+        private:
+            std::shared_ptr<ISourceReference> m_wrapped;
+        };
     }
 
     std::unique_ptr<ISourceFactory> ISourceFactory::GetForType(std::string_view type)
@@ -533,51 +566,68 @@ namespace AppInstaller::Repository
 
         if (!m_source)
         {
+            std::vector<std::shared_ptr<ISourceReference>>* sourceReferencesToOpen = nullptr;
+            std::vector<std::shared_ptr<ISourceReference>> sourceReferencesForTrackingOnly;
             std::unique_ptr<SourceList> sourceList;
 
-            // Check for updates before opening.
-            for (auto& sourceReference : m_sourceReferences)
+            if (m_installedPackageInformationOnly)
             {
-                auto& details = sourceReference->GetDetails();
-                if (ShouldUpdateBeforeOpen(details))
-                {
-                    try
-                    {
-                        // TODO: Consider adding a context callback to indicate we are doing the same action
-                        // to avoid the progress bar fill up multiple times.
-                        if (BackgroundUpdateSourceFromDetails(details, progress))
-                        {
-                            if (sourceList == nullptr)
-                            {
-                                sourceList = std::make_unique<SourceList>();
-                            }
+                sourceReferencesToOpen = &sourceReferencesForTrackingOnly;
 
-                            auto detailsInternal = sourceList->GetSource(details.Name);
-                            detailsInternal->LastUpdateTime = details.LastUpdateTime;
-                            sourceList->SaveMetadata(*detailsInternal);
-                        }
-                        else
+                // Create a wrapper for each reference
+                for (auto& sourceReference : m_sourceReferences)
+                {
+                    sourceReferencesForTrackingOnly.emplace_back(std::make_shared<TrackingOnlyReferenceWrapper>(sourceReference));
+                }
+            }
+            else
+            {
+                // Check for updates before opening.
+                for (auto& sourceReference : m_sourceReferences)
+                {
+                    auto& details = sourceReference->GetDetails();
+                    if (ShouldUpdateBeforeOpen(details))
+                    {
+                        try
                         {
-                            AICLI_LOG(Repo, Error, << "Failed to update source: " << details.Name);
+                            // TODO: Consider adding a context callback to indicate we are doing the same action
+                            // to avoid the progress bar fill up multiple times.
+                            if (BackgroundUpdateSourceFromDetails(details, progress))
+                            {
+                                if (sourceList == nullptr)
+                                {
+                                    sourceList = std::make_unique<SourceList>();
+                                }
+
+                                auto detailsInternal = sourceList->GetSource(details.Name);
+                                detailsInternal->LastUpdateTime = details.LastUpdateTime;
+                                sourceList->SaveMetadata(*detailsInternal);
+                            }
+                            else
+                            {
+                                AICLI_LOG(Repo, Error, << "Failed to update source: " << details.Name);
+                                result.emplace_back(details);
+                            }
+                        }
+                        catch (...)
+                        {
+                            LOG_CAUGHT_EXCEPTION();
+                            AICLI_LOG(Repo, Warning, << "Failed to update source: " << details.Name);
                             result.emplace_back(details);
                         }
                     }
-                    catch (...)
-                    {
-                        LOG_CAUGHT_EXCEPTION();
-                        AICLI_LOG(Repo, Warning, << "Failed to update source: " << details.Name);
-                        result.emplace_back(details);
-                    }
                 }
+
+                sourceReferencesToOpen = &m_sourceReferences;
             }
 
-            if (m_sourceReferences.size() > 1)
+            if (sourceReferencesToOpen->size() > 1)
             {
                 AICLI_LOG(Repo, Info, << "Multiple sources available, creating aggregated source.");
                 auto aggregatedSource = std::make_shared<CompositeSource>("*DefaultSource");
                 std::vector<std::shared_ptr<OpenExceptionProxy>> openExceptionProxies;
 
-                for (auto& sourceReference : m_sourceReferences)
+                for (auto& sourceReference : *sourceReferencesToOpen)
                 {
                     AICLI_LOG(Repo, Info, << "Adding to aggregated source: " << sourceReference->GetDetails().Name);
 
@@ -607,7 +657,7 @@ namespace AppInstaller::Repository
             }
             else
             {
-                m_source = m_sourceReferences[0]->Open(progress);
+                m_source = (*sourceReferencesToOpen)[0]->Open(progress);
             }
         }
 

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -28,6 +28,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
         if (IsBackgroundProcessForPolicy())
         {
+            // Delay the default update interval for these background processes
             static constexpr winrt::Windows::Foundation::TimeSpan s_PackageCatalogUpdateIntervalDelay_Base = 168h; //1 week
 
             // Add a bit of randomness to the default interval time
@@ -35,6 +36,9 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             std::uniform_int_distribution<long long> distribution(0, 604800);
 
             m_packageCatalogBackgroundUpdateInterval = s_PackageCatalogUpdateIntervalDelay_Base + std::chrono::seconds(distribution(randomEngine));
+
+            // Prevent any update / data processing by default for these background processes
+            m_installedPackageInformationOnly = true;
         }
     }
     void PackageCatalogReference::Initialize(winrt::Microsoft::Management::Deployment::CreateCompositePackageCatalogOptions options)

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -106,6 +106,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                     winrt::Microsoft::Management::Deployment::implementation::PackageCatalogReference* catalogImpl = get_self<winrt::Microsoft::Management::Deployment::implementation::PackageCatalogReference>(catalog);
                     auto copy = catalogImpl->m_sourceReference;
                     copy.SetCaller(GetCallerName());
+                    source.InstalledPackageInformationOnly(catalog.InstalledPackageInformationOnly());
                     copy.Open(progress);
                     remoteSources.emplace_back(std::move(copy));
                 }
@@ -142,6 +143,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             {
                 source = m_sourceReference;
                 source.SetCaller(GetCallerName());
+                source.InstalledPackageInformationOnly(m_installedPackageInformationOnly);
                 source.Open(progress);
             }
 
@@ -212,5 +214,20 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     bool PackageCatalogReference::AcceptSourceAgreements()
     {
         return m_acceptSourceAgreements;
+    }
+
+    bool PackageCatalogReference::InstalledPackageInformationOnly()
+    {
+        return m_installedPackageInformationOnly;
+    }
+
+    void PackageCatalogReference::InstalledPackageInformationOnly(bool value)
+    {
+        if (IsComposite())
+        {
+            throw winrt::hresult_illegal_state_change();
+        }
+
+        m_installedPackageInformationOnly = value;
     }
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.h
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.h
@@ -22,9 +22,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Management::Deployment::SourceAgreement> SourceAgreements();
         hstring AdditionalPackageCatalogArguments();
         void AdditionalPackageCatalogArguments(hstring const& value);
-        // Contract 6.0
+        // Contract 6
         bool AcceptSourceAgreements();
         void AcceptSourceAgreements(bool value);
+        // Contract 7
+        bool InstalledPackageInformationOnly();
+        void InstalledPackageInformationOnly(bool value);
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
@@ -34,6 +37,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         ::AppInstaller::Repository::Source m_sourceReference;
         std::optional<std::string> m_additionalPackageCatalogArguments;
         bool m_acceptSourceAgreements = true;
+        bool m_installedPackageInformationOnly = false;
         std::once_flag m_sourceAgreementsOnceFlag;
 #endif
     };

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -749,6 +749,13 @@ namespace Microsoft.Management.Deployment
 
             Boolean AcceptSourceAgreements;
         }
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 7)]
+        {
+            // When set to true, the opened catalog will only provide the information regarding packages installed from this catalog.
+            // In this mode, no external resources should be required.
+            Boolean InstalledPackageInformationOnly;
+        }
     }
 
     /// Catalogs with PackageCatalogOrigin Predefined


### PR DESCRIPTION
## Change
This change adds a flag that lets the caller specify that they are only interested in the installed tracking data, not the available packages.  With it set, one can correlate to the catalog via the tracking database without ever needing to access the remote source information.

## Validation
Code inspection and manually confirmed that remote search results are not required to have a correlated package signature.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3670)