### PR TITLE
Improve the version header detection and logging

### DIFF
--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -168,7 +168,7 @@ namespace AppInstaller::Utility
 
         for (const auto& header : response.Headers())
         {
-            result.emplace(Utility::ConvertToUTF8(header.Key()), Utility::ConvertToUTF8(header.Value()));
+            result.emplace(Utility::FoldCase(static_cast<std::string_view>(Utility::ConvertToUTF8(header.Key()))), Utility::ConvertToUTF8(header.Value()));
         }
 
         return result;

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -161,11 +161,22 @@ namespace AppInstaller::Repository::Microsoft
                             AICLI_LOG(Repo, Verbose, << "Header indicates version is: " << itr->second);
                             return { itr->second };
                         }
+
+                        // We did not find the header we were looking for, log the ones we did find
+                        AICLI_LOG(Repo, Verbose, << "Did not find " << s_PreIndexedPackageSourceFactory_PackageVersionHeader << " in:\n" << [&]()
+                            {
+                                std::ostringstream headerLog;
+                                for (const auto& header : headers)
+                                {
+                                    headerLog << "  " << header.first << " : " << header.second << '\n';
+                                }
+                                return std::move(headerLog).str();
+                            }());
                     }
                     CATCH_LOG();
                 }
 
-                AICLI_LOG(Repo, Verbose, << "No version header, falling back to reading the package data");
+                AICLI_LOG(Repo, Verbose, << "Falling back to reading the package data");
                 Msix::MsixInfo info{ packageLocation };
                 auto manifest = info.GetAppPackageManifests();
 


### PR DESCRIPTION
## Change
I have seen the header detection fall back exactly one time unexpectedly.  It did not fail (no throw in the try/catch block), and I was running Fiddler and saw the header present.

Because it happening to me once could me happening in the wild thousands or millions of times, this change folds the case of the headers to ensure that they are in fact lower case and adds logging to dump the headers to make it easier to diagnose in case it ever happens again.

## Validation
Still works, but since I have no idea why it failed the one time, I can't really say it has been resolved.  Hopefully that means it was a special case.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3680)