### PR TITLE
Use correct caller name in Com startup telemetry event

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -173,11 +173,6 @@ namespace AppInstaller::Logging
         m_executionStage = stage;
     }
 
-    void TelemetryTraceLogger::SetUseSummary(bool useSummary) noexcept
-    {
-        m_useSummary = useSummary;
-    }
-
     std::unique_ptr<TelemetryTraceLogger> TelemetryTraceLogger::CreateSubTraceLogger() const
     {
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !this->m_isInitialized);

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -168,8 +168,6 @@ namespace AppInstaller::Logging
 
         void SetExecutionStage(uint32_t stage) noexcept;
 
-        void SetUseSummary(bool useSummary) noexcept;
-
         std::unique_ptr<TelemetryTraceLogger> CreateSubTraceLogger() const;
 
         // Logs the failure info.

--- a/src/Microsoft.Management.Deployment/PackageManager.h
+++ b/src/Microsoft.Management.Deployment/PackageManager.h
@@ -3,7 +3,6 @@
 #pragma once
 #include "PackageManager.g.h"
 #include "Public/ComClsids.h"
-#include <winget/ThreadGlobals.h>
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
 // Forward declaration
@@ -18,7 +17,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     [uuid(WINGET_OUTOFPROC_COM_CLSID_PackageManager)]
     struct PackageManager : PackageManagerT<PackageManager>
     {
-        PackageManager();
+        PackageManager() = default;
 
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Management::Deployment::PackageCatalogReference> GetPackageCatalogs();
         winrt::Microsoft::Management::Deployment::PackageCatalogReference GetPredefinedPackageCatalog(winrt::Microsoft::Management::Deployment::PredefinedPackageCatalog const& predefinedPackageCatalog);
@@ -42,11 +41,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             DownloadPackageAsync(winrt::Microsoft::Management::Deployment::CatalogPackage package, winrt::Microsoft::Management::Deployment::DownloadOptions options);
         winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Management::Deployment::DownloadResult, winrt::Microsoft::Management::Deployment::PackageDownloadProgress>
             GetDownloadProgress(winrt::Microsoft::Management::Deployment::CatalogPackage package, winrt::Microsoft::Management::Deployment::PackageCatalogInfo catalogInfo);
-
-#if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
-    private:
-        AppInstaller::ThreadLocalStorage::WingetThreadGlobals m_threadGlobals;
-#endif
     };
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)


### PR DESCRIPTION
Verified correct caller name is used from inspecting the log.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3711)