### PR TITLE
Platform source should not be blocked by policy check

### DIFF
--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -1294,3 +1294,9 @@ TEST_CASE("RepoSources_GroupPolicy_BypassCertificatePinningForMicrosoftStore", "
         REQUIRE_FALSE(source.GetDetails().CertificatePinningConfiguration.IsEmpty());
     }
 }
+
+TEST_CASE("RepoSources_BuiltInDesktopFrameworkSourceAlwaysCreatable", "[sources]")
+{
+    Source source(WellKnownSource::DesktopFrameworks);
+    REQUIRE(source);
+}

--- a/src/AppInstallerRepositoryCore/SourcePolicy.cpp
+++ b/src/AppInstallerRepositoryCore/SourcePolicy.cpp
@@ -173,6 +173,9 @@ namespace AppInstaller::Repository
             return IsDefaultSourceEnabled(source, ExperimentalFeature::Feature::None, onlyExplicit, TogglePolicy::Policy::DefaultSource);
         case AppInstaller::Repository::WellKnownSource::MicrosoftStore:
             return IsDefaultSourceEnabled(source, ExperimentalFeature::Feature::None, onlyExplicit, TogglePolicy::Policy::MSStoreSource);
+        case AppInstaller::Repository::WellKnownSource::DesktopFrameworks:
+            // No corresponding policy available for this source.
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Validation: verified locally with the fix, AppInstaller was able to open external dependency source and test package can be successfully installed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3725)