### PR TITLE
Make manifest retrieval choice more dynamic

### DIFF
--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -18,7 +18,7 @@ namespace TestCommon
         using LocIndString = AppInstaller::Utility::LocIndString;
         using MetadataMap = AppInstaller::Repository::IPackageVersion::Metadata;
 
-        TestPackageVersion(const Manifest& manifest, std::weak_ptr<const ISource> source = {});
+        TestPackageVersion(const Manifest& manifest, std::weak_ptr<const ISource> source = {}, bool hideSystemReferenceStrings = false);
         TestPackageVersion(const Manifest& manifest, MetadataMap installationMetadata, std::weak_ptr<const ISource> source = {});
 
         template <typename... Args>
@@ -36,6 +36,7 @@ namespace TestCommon
         Manifest VersionManifest;
         MetadataMap Metadata;
         std::weak_ptr<const ISource> Source;
+        bool HideSystemReferenceStrings = false;
 
     protected:
         static void AddIfHasValueAndNotPresent(const AppInstaller::Utility::NormalizedString& value, std::vector<LocIndString>& target, bool folded = false);
@@ -52,7 +53,7 @@ namespace TestCommon
         using MetadataMap = TestPackageVersion::MetadataMap;
 
         // Create a package with only available versions using these manifests.
-        TestPackage(const std::vector<Manifest>& available, std::weak_ptr<const ISource> source = {});
+        TestPackage(const std::vector<Manifest>& available, std::weak_ptr<const ISource> source = {}, bool hideSystemReferenceStringsOnVersion = false);
 
         // Create a package with an installed version, metadata, and optionally available versions.
         TestPackage(const Manifest& installed, MetadataMap installationMetadata, const std::vector<Manifest>& available = {}, std::weak_ptr<const ISource> source = {});
@@ -85,6 +86,9 @@ namespace TestCommon
         const AppInstaller::Repository::SourceDetails& GetDetails() const override;
         const std::string& GetIdentifier() const override;
         AppInstaller::Repository::SourceInformation GetInformation() const override;
+
+        bool QueryFeatureFlag(AppInstaller::Repository::SourceFeatureFlag flag) const override;
+        std::function<bool(AppInstaller::Repository::SourceFeatureFlag)> QueryFeatureFlagFunction;
 
         AppInstaller::Repository::SearchResult Search(const AppInstaller::Repository::SearchRequest& request) const override;
         void* CastTo(AppInstaller::Repository::ISourceType type) override;

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -1519,13 +1519,14 @@ namespace AppInstaller::Repository
             }
 
             SearchResult availableResult = result.SearchAndHandleFailures(source, request);
+            bool downloadManifests = source.QueryFeatureFlag(SourceFeatureFlag::ManifestMayContainAdditionalSystemReferenceStrings);
 
             for (auto&& match : availableResult.Matches)
             {
                 // Check for a package already in the result that should have been correlated already.
                 // In cases that PackageData will be created, also download manifests for system reference strings
                 // when search result is small (currently limiting to 1).
-                auto packageData = result.CheckForExistingResultFromAvailablePackageMatch(match, availableResult.Matches.size() == 1);
+                auto packageData = result.CheckForExistingResultFromAvailablePackageMatch(match, downloadManifests && availableResult.Matches.size() == 1);
 
                 // If found existing package in the result, continue
                 if (!packageData)

--- a/src/AppInstallerRepositoryCore/ISource.h
+++ b/src/AppInstallerRepositoryCore/ISource.h
@@ -35,6 +35,10 @@ namespace AppInstaller::Repository
         // Get the source's information after the source is opened.
         virtual SourceInformation GetInformation() const { return {}; };
 
+        // Query the value of the given feature flag.
+        // The default state of any new flag is false.
+        virtual bool QueryFeatureFlag(SourceFeatureFlag) const { return false; }
+
         // Execute a search on the source.
         virtual SearchResult Search(const SearchRequest& request) const = 0;
 

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -168,6 +168,15 @@ namespace AppInstaller::Repository
         std::vector<std::string> RequiredQueryParameters;
     };
 
+    // Allows calling code to inquire about specific features of an ISource implementation.
+    // The default state of any new flag is false.
+    enum class SourceFeatureFlag
+    {
+        // If true, the manifests for this source may contain more data than is available from just the
+        // version information found from a search.
+        ManifestMayContainAdditionalSystemReferenceStrings,
+    };
+
     // Represents a source which would be interacted from outside of repository lib.
     struct Source
     {
@@ -215,6 +224,10 @@ namespace AppInstaller::Repository
 
         // Get the source's information.
         SourceInformation GetInformation() const;
+
+        // Query the value of the given feature flag.
+        // The default state of any new flag is false.
+        bool QueryFeatureFlag(SourceFeatureFlag flag) const;
 
         // Returns true if the origin type can contain available packages.
         bool ContainsAvailablePackages() const;

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -563,6 +563,12 @@ namespace AppInstaller::Repository
         }
     }
 
+    bool Source::QueryFeatureFlag(SourceFeatureFlag flag) const
+    {
+        THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_source);
+        return m_source->QueryFeatureFlag(flag);
+    }
+
     bool Source::ContainsAvailablePackages() const
     {
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), IsComposite());

--- a/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
@@ -436,6 +436,17 @@ namespace AppInstaller::Repository::Rest
         return m_information;
     }
 
+    bool RestSource::QueryFeatureFlag(SourceFeatureFlag flag) const
+    {
+        switch (flag)
+        {
+        case SourceFeatureFlag::ManifestMayContainAdditionalSystemReferenceStrings:
+            return true;
+        }
+
+        return false;
+    }
+
     SearchResult RestSource::Search(const SearchRequest& request) const
     {
         IRestClient::SearchResult results = m_restClient.Search(request);

--- a/src/AppInstallerRepositoryCore/Rest/RestSource.h
+++ b/src/AppInstallerRepositoryCore/Rest/RestSource.h
@@ -31,6 +31,8 @@ namespace AppInstaller::Repository::Rest
 
         SourceInformation GetInformation() const override;
 
+        bool QueryFeatureFlag(SourceFeatureFlag flag) const override;
+
         // Execute a search on the source.
         SearchResult Search(const SearchRequest& request) const override;
 


### PR DESCRIPTION
## Change
This change lets the source implementation indicate whether manifests might contain more information than the search results.  It then only applies that to REST, as the implementation is not under our control.  This should have no net effect on the results quality, but should not attempt to retrieve manifests from the winget source when they are not providing any additional value currently.

## Validation
Manually ensured no manifest retrieved for winget based package lookup in dev when one was done for the current release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3738)