### PR TITLE
Broadcast WM_SETTINGCHANGE on change of path

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -419,6 +419,7 @@ seof
 servercert
 servercertificate
 setmetadatabymanifestid
+SETTINGCHANGE
 SETTINGMAPPING
 SHCONTF
 SHGDN

--- a/src/AppInstallerCommonCore/PathVariable.cpp
+++ b/src/AppInstallerCommonCore/PathVariable.cpp
@@ -121,6 +121,7 @@ namespace AppInstaller::Registry::Environment
 
         std::wstring pathName = std::wstring{ s_PathName };
         m_key.SetValue(pathName, ConvertToUTF16(value), REG_EXPAND_SZ);
+        SendNotifyMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
     }
 
     bool RefreshPathVariableForCurrentProcess()

--- a/src/AppInstallerCommonCore/PathVariable.cpp
+++ b/src/AppInstallerCommonCore/PathVariable.cpp
@@ -121,7 +121,8 @@ namespace AppInstaller::Registry::Environment
 
         std::wstring pathName = std::wstring{ s_PathName };
         m_key.SetValue(pathName, ConvertToUTF16(value), REG_EXPAND_SZ);
-        SendNotifyMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
+        SendNotifyMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, (LPARAM)TEXT("Environment"));
+
     }
 
     bool RefreshPathVariableForCurrentProcess()


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).

When the Path variable is updated, the changes are not always picked up by the shell. Even when all CMD, Terminal, Powershell, and Bash windows are closed, it may rarely happen that the new values of the environment variable are not used. There is a workaround for this where users can go to edit the Path variable, make no changes, and click "Okay" to force the refresh.

According to [Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange?wt.mc_id=WDIT-MVP-5005084) - the `WM-SETTINGCHANGE` message should be broadcast when policy settings have changed. And, looking specifically at the page on [Environment Variables](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables?wt.mc_id=WDIT-MVP-5005084) it says -

> To programmatically add or modify system environment variables, add them to the HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment registry key, then broadcast a [WM_SETTINGCHANGE](https://learn.microsoft.com/en-us/windows/desktop/winmsg/wm-settingchange) message with lParam set to the string "Environment". This allows applications, such as the shell, to pick up your updates.

In the case of WinGet, the PATH environment variable is being set, but the `WM-SETTINGCHANGE` message is not being broadcast. This change adds the broadcast to notify the system of the change to the environment variables.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3751)