### PR TITLE
Allow higher versions to satisfy the VCLibs dependency in Repair

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.WinGet.Client.Engine.Helpers
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
@@ -254,15 +255,28 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
                     { Name, VCLibsUWPDesktop },
                 });
 
-            // See if the required version is installed.
+            // See if the minimum (or greater) version is installed.
+            // TODO: Pull the minimum version from the target package
+            // TODO: This does not check architecture of the package
+            Version minimumVersion = new Version(VCLibsUWPDesktopVersion);
+
             bool isInstalled = false;
             if (result != null &&
                 result.Count > 0)
             {
                 foreach (dynamic psobject in result)
                 {
-                    if (psobject?.Version == VCLibsUWPDesktopVersion)
+                    string versionString = psobject?.Version?.ToString();
+                    if (versionString == null)
                     {
+                        continue;
+                    }
+
+                    Version packageVersion = new Version(versionString);
+
+                    if (packageVersion >= minimumVersion)
+                    {
+                        this.psCmdlet.WriteDebug($"VCLibs dependency satisfied by: {psobject?.PackageFullName ?? "<null>"}");
                         isInstalled = true;
                         break;
                     }

--- a/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
+++ b/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
@@ -59,16 +59,16 @@ if ($BuildRoot -eq "")
     $BuildRoot = "$PSScriptRoot\..\..";
 }
 
-# Add here new modules
+# Modules, they should be in dependency order so that when importing we don't pick up the release modules.
 [WinGetModule[]]$local:modules = 
-    [WinGetModule]::new(
-        "Microsoft.WinGet.DSC",
-        "$PSScriptRoot\..\Microsoft.WinGet.DSC\",
-        $false),
     [WinGetModule]::new(
         "Microsoft.WinGet.Client",
         "$PSScriptRoot\..\Microsoft.WinGet.Client\ModuleFiles\",
         $true),
+    [WinGetModule]::new(
+        "Microsoft.WinGet.DSC",
+        "$PSScriptRoot\..\Microsoft.WinGet.DSC\",
+        $false),
     [WinGetModule]::new(
         "Microsoft.WinGet.Configuration",
         "$PSScriptRoot\..\Microsoft.WinGet.Configuration\ModuleFiles\",
@@ -111,6 +111,6 @@ if (-not $SkipImportModule)
     foreach($module in $modules)
     {
         Write-Host "Importing module $($module.Name)" -ForegroundColor Green
-        Import-Module $module.Name -Force
+        Import-Module "$moduleRootOutput\$($module.Name)\" -Force
     }
 }


### PR DESCRIPTION
## Change
Rather than looking for the explicit version of the VCLibs dependency, this change allows any version greater than or equal to satisfy the installed check.

This does not resolve the fact that we are using a hardcoded version, nor that we are not checking for the same set of architectures that we would install.

Also fixes the helper script to import the dev modules directly so that it can be used even when the release modules are present in the module path.

## Validation
Stepped through to confirm, added debug output as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3763)