### PR TITLE
Add missing condition for using toolset v143 when building JsonCppLib for arm

### DIFF
--- a/src/JsonCppLib/JsonCppLib.vcxproj
+++ b/src/JsonCppLib/JsonCppLib.vcxproj
@@ -127,12 +127,14 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|ARM'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">


### PR DESCRIPTION
The .vcxproj file is missing a conditional property to use the toolset v143 when building with VS v17.0 for arm. This causes the build to always use v142 for arm, which would fail if we only have VS v17.0 available and we don't have toolset v142.

Added the conditional property following the same pattern as all other architectures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3773)