### PR TITLE
Anonymize display path in download command output

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -549,6 +549,12 @@ namespace AppInstaller::CLI::Workflow
 
             renamedDownloadedInstaller = downloadDirectory / GetInstallerDownloadOnlyFileName(context);
             Filesystem::RenameFile(installerPath, renamedDownloadedInstaller);
+
+            if (Settings::User().Get<Settings::Setting::AnonymizePathForDisplay>())
+            {
+                Runtime::ReplaceProfilePathsWithEnvironmentVariable(renamedDownloadedInstaller);
+            }
+
             context.Reporter.Info() << Resource::String::InstallerDownloaded(Utility::LocIndView{ renamedDownloadedInstaller.u8string() }) << std::endl;
         }
         else

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -12,6 +12,9 @@
 
 namespace AppInstaller::Runtime
 {
+    // Substitutes environment variables if applicable in the given path.
+    void ReplaceProfilePathsWithEnvironmentVariable(std::filesystem::path& path);
+
     // Sets the runtime path state name globally.
     void SetRuntimePathStateName(std::string name);
 

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -217,14 +217,14 @@ namespace AppInstaller::Runtime
             PSID SID;
             TRUSTEE_TYPE TrusteeType;
         };
+    }
 
-        // Try to replace LOCALAPPDATA first as it is the likely location, fall back to trying USERPROFILE.
-        void ReplaceProfilePathsWithEnvironmentVariable(std::filesystem::path& path)
+    // Try to replace LOCALAPPDATA first as it is the likely location, fall back to trying USERPROFILE.
+    void ReplaceProfilePathsWithEnvironmentVariable(std::filesystem::path& path)
+    {
+        if (!ReplaceCommonPathPrefix(path, GetKnownFolderPath(FOLDERID_LocalAppData), s_LocalAppDataEnvironmentVariable))
         {
-            if (!ReplaceCommonPathPrefix(path, GetKnownFolderPath(FOLDERID_LocalAppData), s_LocalAppDataEnvironmentVariable))
-            {
-                ReplaceCommonPathPrefix(path, GetKnownFolderPath(FOLDERID_Profile), s_UserProfileEnvironmentVariable);
-            }
+            ReplaceCommonPathPrefix(path, GetKnownFolderPath(FOLDERID_Profile), s_UserProfileEnvironmentVariable);
         }
     }
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.
    No; Thought it made sense for these paths to also respect `anonymizeDisplayedPaths` user setting


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3856)