### PR TITLE
Fix signaling the app shutdown event running as admin

### DIFF
--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -67,12 +67,31 @@ namespace AppInstaller::CLI::Execution
         private:
             SignalTerminationHandler()
             {
-                // Create message only window.
-                m_messageQueueReady.create();
-                m_windowThread = std::thread(&SignalTerminationHandler::CreateWindowAndStartMessageLoop, this);
-                if (!m_messageQueueReady.wait(100))
+                if (Runtime::IsRunningAsAdmin() && Runtime::IsRunningInPackagedContext())
                 {
-                    AICLI_LOG(CLI, Warning, << "Timeout creating winget window");
+                    m_catalog = winrt::Windows::ApplicationModel::PackageCatalog::OpenForCurrentPackage();
+                    m_updatingEvent = m_catalog.PackageUpdating(
+                        winrt::auto_revoke, [this](winrt::Windows::ApplicationModel::PackageCatalog, winrt::Windows::ApplicationModel::PackageUpdatingEventArgs args)
+                        {
+                            // There are 3 events being hit with 0%, 1% and 38%
+                            // Typically the window message is received between the first two.
+                            constexpr double minProgress = 0;
+                            auto progress = args.Progress();
+                            if (progress > minProgress)
+                            {
+                                SignalTerminationHandler::Instance().StartAppShutdown();
+                            }
+                        });
+                }
+                else
+                {
+                    // Create message only window.
+                    m_messageQueueReady.create();
+                    m_windowThread = std::thread(&SignalTerminationHandler::CreateWindowAndStartMessageLoop, this);
+                    if (!m_messageQueueReady.wait(100))
+                    {
+                        AICLI_LOG(CLI, Warning, << "Timeout creating winget window");
+                    }
                 }
 
                 // Set up ctrl-c handler.
@@ -236,6 +255,8 @@ namespace AppInstaller::CLI::Execution
             wil::unique_event m_messageQueueReady;
             wil::unique_hwnd m_windowHandle;
             std::thread m_windowThread;
+            winrt::Windows::ApplicationModel::PackageCatalog m_catalog = nullptr;
+            decltype(winrt::Windows::ApplicationModel::PackageCatalog{ nullptr }.PackageUpdating(winrt::auto_revoke, nullptr)) m_updatingEvent;
         };
 
         void SetSignalTerminationHandlerContext(bool add, Context* context)

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -95,26 +95,5 @@ namespace AppInstallerCLIE2ETests
             // Look for the output.
             Assert.True(testCmdTask.Result.StdOut.Contains("Succeeded waiting for app shutdown event"));
         }
-
-        /// <summary>
-        /// Runs winget test appshutdown --force.
-        /// </summary>
-        [Test]
-        public void RegisterApplicationTest_Force()
-        {
-            if (!TestSetup.Parameters.PackagedContext)
-            {
-                Assert.Ignore("Not packaged context.");
-            }
-
-            if (string.IsNullOrEmpty(TestSetup.Parameters.AICLIPackagePath))
-            {
-                throw new NullReferenceException("AICLIPackagePath");
-            }
-
-            var result = TestCommon.RunAICLICommand("test", "appshutdown --force", timeOut: 300000, throwOnTimeout: false);
-            TestContext.Out.Write(result.StdOut);
-            Assert.True(result.StdOut.Contains("Succeeded waiting for app shutdown event"));
-        }
     }
 }

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -23,12 +23,16 @@ namespace AppInstallerCLIE2ETests
         /// Runs winget test appshutdown and register the application to force a WM_QUERYENDSESSION message.
         /// </summary>
         [Test]
-        [Ignore("This test won't work on Window Server")]
         public void RegisterApplicationTest()
         {
             if (!TestSetup.Parameters.PackagedContext)
             {
                 Assert.Ignore("Not packaged context.");
+            }
+
+            if (!TestCommon.ExecutingAsAdministrator && TestCommon.IsCIEnvironment)
+            {
+                Assert.Ignore("This test won't work on Window Server as non-admin");
             }
 
             if (string.IsNullOrEmpty(TestSetup.Parameters.AICLIPackagePath))

--- a/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
@@ -13,6 +13,7 @@ namespace AppInstallerCLIE2ETests.Helpers
     using System.Linq;
     using System.Management.Automation;
     using System.Reflection;
+    using System.Security.Principal;
     using System.Text;
     using System.Threading;
     using AppInstallerCLIE2ETests;
@@ -76,6 +77,31 @@ namespace AppInstallerCLIE2ETests.Helpers
             /// Default winget configure.
             /// </summary>
             Default,
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current assembly is executing in an administrative context.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Windows only API")]
+        public static bool ExecutingAsAdministrator
+        {
+            get
+            {
+                WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                WindowsPrincipal principal = new (identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the test is running in the CI build.
+        /// </summary>
+        public static bool IsCIEnvironment
+        {
+            get
+            {
+                return Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER") != null;
+            }
         }
 
         /// <summary>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -194,6 +194,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AdminSettings.cpp" />
+    <ClCompile Include="AppShutdown.cpp" />
     <ClCompile Include="Archive.cpp" />
     <ClCompile Include="Argument.cpp" />
     <ClCompile Include="ARPChanges.cpp" />

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -329,6 +329,9 @@
     <ClCompile Include="ArpHelper.cpp">
       <Filter>Source Files\Repository</Filter>
     </ClCompile>
+    <ClCompile Include="AppShutdown.cpp">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="PropertySheet.props" />

--- a/src/AppInstallerCLITests/AppShutdown.cpp
+++ b/src/AppInstallerCLITests/AppShutdown.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Commands/TestCommand.h"
+
+using namespace AppInstaller::CLI;
+
+TEST_CASE("AppShutdown_WindowMessage", "[appShutdown]")
+{
+    {
+        std::ostringstream output;
+        Execution::Context context{ output, std::cin };
+        context.Args.AddArg(Execution::Args::Type::Force);
+
+        TestAppShutdownCommand appShutdownCmd({});
+        appShutdownCmd.Execute(context);
+
+        REQUIRE(context.IsTerminated());
+        REQUIRE(S_OK == context.GetTerminationHR());
+    }
+}

--- a/src/AppInstallerCLITests/AppShutdown.cpp
+++ b/src/AppInstallerCLITests/AppShutdown.cpp
@@ -1,21 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
+#include <winget/Runtime.h>
 #include "Commands/TestCommand.h"
 
 using namespace AppInstaller::CLI;
 
 TEST_CASE("AppShutdown_WindowMessage", "[appShutdown]")
 {
+    if (AppInstaller::Runtime::IsRunningAsAdmin() && AppInstaller::Runtime::IsRunningInPackagedContext())
     {
-        std::ostringstream output;
-        Execution::Context context{ output, std::cin };
-        context.Args.AddArg(Execution::Args::Type::Force);
-
-        TestAppShutdownCommand appShutdownCmd({});
-        appShutdownCmd.Execute(context);
-
-        REQUIRE(context.IsTerminated());
-        REQUIRE(S_OK == context.GetTerminationHR());
+        WARN("Test can't run as admin in package context");
+        return;
     }
+
+    std::ostringstream output;
+    Execution::Context context{ output, std::cin };
+    context.Args.AddArg(Execution::Args::Type::Force);
+
+    TestAppShutdownCommand appShutdownCmd({});
+    appShutdownCmd.Execute(context);
+
+    REQUIRE(context.IsTerminated());
+    REQUIRE(S_OK == context.GetTerminationHR());
 }


### PR DESCRIPTION
There's bug in the OS where the WM_QUERYENDSESSION message is not send when a package is being updated if the package is running elevated. This makes `winget configure --enable` to stop at 95% and eventually get terminated by the system for an update. The update is successful, but the experience is not the best. It also makes it harder to use `IConfigurationStatics::IConfigurationStatics` in an elevated context.

The fix is to use the `PackageCatalog` APIs and register for `PackageUpdating` events when winget is running elevated and in a package context and signal the competition event if the progress is more than 0. Otherwise create the window and listen to messages.

Enable test where a new update is being registered since now it will work and move test to force the WM_QUERYENDSESSION to UTs

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3874)