### PR TITLE
Add package id, name, and source to install/update/uninstall result for PowerShell cmdlet

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="match">The match option.</param>
         /// <param name="callback">The method to call after retrieving the package and version to operate upon.</param>
         /// <returns>Result of the callback.</returns>
-        protected async Task<TResult?> GetPackageAndExecuteAsync<TResult>(
+        protected async Task<Tuple<TResult, CatalogPackage>?> GetPackageAndExecuteAsync<TResult>(
             CompositeSearchBehavior behavior,
             PackageFieldMatchOption match,
             Func<CatalogPackage, PackageVersionId?, Task<TResult>> callback)
@@ -67,7 +67,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             PackageVersionId? version = this.GetPackageVersionId(package);
             if (this.ShouldProcess(package.ToString(version)))
             {
-                return await callback(package, version);
+                var result = await callback(package, version);
+                return new Tuple<TResult, CatalogPackage>(result, package);
             }
 
             return null;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -117,7 +117,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
             if (result != null)
             {
-
                 this.Write(StreamType.Object, new PSInstallResult(result, catalogPackage));
             }
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -94,8 +94,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             string psPackageInstallMode)
         {
-            CatalogPackage? catalogPackage = null;
-
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs,
@@ -110,14 +108,12 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                         }
 
                         options.PackageInstallScope = PSEnumHelpers.ToPackageInstallScope(psPackageInstallScope);
-
-                        catalogPackage = package;
                         return await this.InstallPackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSInstallResult(result, catalogPackage));
+                this.Write(StreamType.Object, new PSInstallResult(result.Item1, result.Item2));
             }
         }
 
@@ -132,8 +128,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             string psPackageInstallMode)
         {
-            CatalogPackage? catalogPackage = null;
-
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.LocalCatalogs,
@@ -142,13 +136,12 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                     {
                         InstallOptions options = this.GetInstallOptions(version, psPackageInstallMode);
                         options.AllowUpgradeToUnknownVersion = includeUnknown;
-                        catalogPackage = package;
                         return await this.UpgradePackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSInstallResult(result, catalogPackage));
+                this.Write(StreamType.Object, new PSInstallResult(result.Item1, result.Item2));
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -94,6 +94,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             string psPackageInstallMode)
         {
+            CatalogPackage? catalogPackage = null;
+
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.RemotePackagesFromRemoteCatalogs,
@@ -109,12 +111,14 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
                         options.PackageInstallScope = PSEnumHelpers.ToPackageInstallScope(psPackageInstallScope);
 
+                        catalogPackage = package;
                         return await this.InstallPackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSInstallResult(result));
+
+                this.Write(StreamType.Object, new PSInstallResult(result, catalogPackage));
             }
         }
 
@@ -129,6 +133,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             string psPackageInstallMode)
         {
+            CatalogPackage? catalogPackage = null;
+
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.LocalCatalogs,
@@ -137,12 +143,13 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                     {
                         InstallOptions options = this.GetInstallOptions(version, psPackageInstallMode);
                         options.AllowUpgradeToUnknownVersion = includeUnknown;
+                        catalogPackage = package;
                         return await this.UpgradePackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSInstallResult(result));
+                this.Write(StreamType.Object, new PSInstallResult(result, catalogPackage));
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
@@ -72,6 +72,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             bool force)
         {
+            CatalogPackage? catalogPackage = null;
+
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.LocalCatalogs,
@@ -79,12 +81,13 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                     async (package, version) =>
                     {
                         UninstallOptions options = this.GetUninstallOptions(version, PSEnumHelpers.ToPackageUninstallMode(psPackageUninstallMode), force);
+                        catalogPackage = package;
                         return await this.UninstallPackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSUninstallResult(result));
+                this.Write(StreamType.Object, new PSUninstallResult(result, catalogPackage));
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UninstallPackageCommand.cs
@@ -72,8 +72,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string psPackageFieldMatchOption,
             bool force)
         {
-            CatalogPackage? catalogPackage = null;
-
             var result = this.Execute(
                 async () => await this.GetPackageAndExecuteAsync(
                     CompositeSearchBehavior.LocalCatalogs,
@@ -81,13 +79,12 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                     async (package, version) =>
                     {
                         UninstallOptions options = this.GetUninstallOptions(version, PSEnumHelpers.ToPackageUninstallMode(psPackageUninstallMode), force);
-                        catalogPackage = package;
                         return await this.UninstallPackageAsync(package, options);
                     }));
 
             if (result != null)
             {
-                this.Write(StreamType.Object, new PSUninstallResult(result, catalogPackage));
+                this.Write(StreamType.Object, new PSUninstallResult(result.Item1, result.Item2));
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
@@ -35,7 +35,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.Id : string.Empty;
+                return this.catalogPackage?.Id ?? string.Empty;
             }
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.Name : string.Empty;
+                return this.catalogPackage?.Name ?? string.Empty;
             }
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name : string.Empty;
+                return this.catalogPackage?.DefaultInstallVersion.PackageCatalog.Info.Name ?? string.Empty;
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
@@ -15,14 +15,14 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
     public sealed class PSInstallResult
     {
         private readonly InstallResult installResult;
-        private readonly CatalogPackage? catalogPackage;
+        private readonly CatalogPackage catalogPackage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSInstallResult"/> class.
         /// </summary>
         /// <param name="installResult">The install result COM object.</param>
         /// <param name="catalogPackage">The catalog package COM object.</param>
-        internal PSInstallResult(InstallResult installResult, CatalogPackage? catalogPackage)
+        internal PSInstallResult(InstallResult installResult, CatalogPackage catalogPackage)
         {
             this.installResult = installResult;
             this.catalogPackage = catalogPackage;
@@ -35,7 +35,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.Id ?? string.Empty;
+                return this.catalogPackage.Id;
             }
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.Name ?? string.Empty;
+                return this.catalogPackage.Name;
             }
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.DefaultInstallVersion.PackageCatalog.Info.Name ?? string.Empty;
+                return this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name;
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSInstallResult.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.WinGet.Client.Engine.PSObjects
 {
     using System;
-    using System.Management.Automation;
     using Microsoft.Management.Deployment;
 
     /// <summary>
@@ -16,14 +15,50 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
     public sealed class PSInstallResult
     {
         private readonly InstallResult installResult;
+        private readonly CatalogPackage? catalogPackage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSInstallResult"/> class.
         /// </summary>
         /// <param name="installResult">The install result COM object.</param>
-        internal PSInstallResult(InstallResult installResult)
+        /// <param name="catalogPackage">The catalog package COM object.</param>
+        internal PSInstallResult(InstallResult installResult, CatalogPackage? catalogPackage)
         {
             this.installResult = installResult;
+            this.catalogPackage = catalogPackage;
+        }
+
+        /// <summary>
+        /// Gets the id of the installed package.
+        /// </summary>
+        public string Id
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.Id : string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the installed package.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.Name : string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the source name of the installed package.
+        /// </summary>
+        public string Source
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name : string.Empty;
+            }
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
@@ -16,14 +16,50 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
     public sealed class PSUninstallResult
     {
         private readonly Management.Deployment.UninstallResult uninstallResult;
+        private readonly CatalogPackage? catalogPackage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSUninstallResult"/> class.
         /// </summary>
         /// <param name="uninstallResult">The uninstall result COM object.</param>
-        internal PSUninstallResult(Management.Deployment.UninstallResult uninstallResult)
+        /// <param name="catalogPackage">The catalog package COM object.</param>
+        internal PSUninstallResult(Management.Deployment.UninstallResult uninstallResult, CatalogPackage? catalogPackage)
         {
             this.uninstallResult = uninstallResult;
+            this.catalogPackage = catalogPackage;
+        }
+
+        /// <summary>
+        /// Gets the id of the uninstalled package.
+        /// </summary>
+        public string Id
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.Id : string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the uninstalled package.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.Name : string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the source name of the uninstalled package.
+        /// </summary>
+        public string Source
+        {
+            get
+            {
+                return this.catalogPackage != null ? this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name : string.Empty;
+            }
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.WinGet.Client.Engine.PSObjects
 {
     using System;
-    using System.Management.Automation;
     using Microsoft.Management.Deployment;
 
     /// <summary>
@@ -15,15 +14,15 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
     /// </summary>
     public sealed class PSUninstallResult
     {
-        private readonly Management.Deployment.UninstallResult uninstallResult;
-        private readonly CatalogPackage? catalogPackage;
+        private readonly UninstallResult uninstallResult;
+        private readonly CatalogPackage catalogPackage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PSUninstallResult"/> class.
         /// </summary>
         /// <param name="uninstallResult">The uninstall result COM object.</param>
         /// <param name="catalogPackage">The catalog package COM object.</param>
-        internal PSUninstallResult(Management.Deployment.UninstallResult uninstallResult, CatalogPackage? catalogPackage)
+        internal PSUninstallResult(UninstallResult uninstallResult, CatalogPackage catalogPackage)
         {
             this.uninstallResult = uninstallResult;
             this.catalogPackage = catalogPackage;
@@ -36,7 +35,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.Id ?? string.Empty;
+                return this.catalogPackage.Id;
             }
         }
 
@@ -47,7 +46,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.Name ?? string.Empty;
+                return this.catalogPackage.Name;
             }
         }
 
@@ -58,7 +57,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage?.DefaultInstallVersion.PackageCatalog.Info.Name ?? string.Empty;
+                return this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name;
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSUninstallResult.cs
@@ -36,7 +36,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.Id : string.Empty;
+                return this.catalogPackage?.Id ?? string.Empty;
             }
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.Name : string.Empty;
+                return this.catalogPackage?.Name ?? string.Empty;
             }
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         {
             get
             {
-                return this.catalogPackage != null ? this.catalogPackage.DefaultInstallVersion.PackageCatalog.Info.Name : string.Empty;
+                return this.catalogPackage?.DefaultInstallVersion.PackageCatalog.Info.Name ?? string.Empty;
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
+++ b/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
@@ -95,6 +95,15 @@
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
+            <Label>Id</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Source</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
             <Label>InstallerErrorCode</Label>
           </TableColumnHeader>
           <TableColumnHeader>
@@ -113,6 +122,15 @@
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
+              <TableColumnItem>
+                <ScriptBlock>$_.Id</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Name</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Source</ScriptBlock>
+              </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>$_.InstallerErrorCode</ScriptBlock>
               </TableColumnItem>
@@ -141,6 +159,15 @@
       <TableControl>
         <TableHeaders>
           <TableColumnHeader>
+            <Label>Id</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Name</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Source</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
             <Label>UninstallerErrorCode</Label>
           </TableColumnHeader>
           <TableColumnHeader>
@@ -159,6 +186,15 @@
         <TableRowEntries>
           <TableRowEntry>
             <TableColumnItems>
+              <TableColumnItem>
+                <ScriptBlock>$_.Id</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Name</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Source</ScriptBlock>
+              </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>$_.UninstallerErrorCode</ScriptBlock>
               </TableColumnItem>

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -213,6 +213,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Install-WinGetPackage -Id AppInstallerTest.TestExeInstaller -Version '1.0.0.0'
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestExeInstaller"
+        $result.Name | Should -Be "TestExeInstaller"
+        $result.Source | Should -Be "TestSource"
         $result.InstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -222,6 +225,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Install-WinGetPackage -Name TestPortableExe -Version '2.0.0.0' -MatchOption Equals
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestPortableExe"
+        $result.Name | Should -Be "TestPortableExe"
+        $result.Source | Should -Be "TestSource"
         $result.InstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -231,6 +237,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Update-WinGetPackage -Id AppInstallerTest.TestExeInstaller
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestExeInstaller"
+        $result.Name | Should -Be "TestExeInstaller"
+        $result.Source | Should -Be "TestSource"
         $result.InstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -240,6 +249,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Update-WinGetPackage -Name TestPortableExe
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestPortableExe"
+        $result.Name | Should -Be "TestPortableExe"
+        $result.Source | Should -Be "TestSource"
         $result.InstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -249,6 +261,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Uninstall-WinGetPackage -Id AppInstallerTest.TestExeInstaller
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestExeInstaller"
+        $result.Name | Should -Be "TestExeInstaller"
+        $result.Source | Should -Be "TestSource"
         $result.UninstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -258,6 +273,9 @@ Describe 'Install|Update|Uninstall-WinGetPackage' -Skip:($PSEdition -eq "Desktop
         $result = Uninstall-WinGetPackage -Name TestPortableExe
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestPortableExe"
+        $result.Name | Should -Be "TestPortableExe"
+        $result.Source | Should -Be "TestSource"
         $result.UninstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'
@@ -289,6 +307,9 @@ Describe 'Get-WinGetPackage' -Skip:($PSEdition -eq "Desktop") {
         $result = Install-WinGetPackage -Id AppInstallerTest.TestExeInstaller -Version '1.0.0.0'
 
         $result | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $result.Id | Should -Be "AppInstallerTest.TestExeInstaller"
+        $result.Name | Should -Be "TestExeInstaller"
+        $result.Source | Should -Be "TestSource"
         $result.InstallerErrorCode | Should -Be 0
         $result.Status | Should -Be 'Ok'
         $result.RebootRequired | Should -Be 'False'


### PR DESCRIPTION
Resolves: #3824 

Modifies the output of the install/update/uninstall result to display the id, name, and source of the package so that it is easier to correlate the result with the package. I wanted to also display the installed version but that would require calling the Get-WinGetPackage command and passing in the arguments. 