### PR TITLE
Allow user settings to control logging channels

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -194,14 +194,31 @@ If set to true, the `telemetry.disable` setting will prevent any event from bein
 
 ## Logging
 
-The `logging` settings control the level of detail in log files. `--verbose-logs` will override this setting and always creates a verbose log.
-Defaults to `info` if value is not set or is invalid
+The `logging` settings control the level of detail in log files.
 
 ### level
 
+ `--verbose-logs` will override this setting and always creates a verbose log.
+Defaults to `info` if value is not set or is invalid.
+
 ```json
     "logging": {
-        "level": ["verbose", "info", "warning", "error", "critical"]
+        "level": "verbose" | "info" | "warning" | "error" | "critical"
+    },
+```
+
+### channels
+
+The valid values in this array are defined in the function `GetChannelFromName` in the [logging code](../src/AppInstallerSharedLib/AppInstallerLogging.cpp).  These align with the ***channel identifier*** found in the log files.  For example, ***`CORE`*** in:
+```
+2023-12-06 19:17:07.988 [CORE] WinGet, version [1.7.0-preview], activity [{24A91EA8-46BE-47A1-B65C-CEBCE90B8675}]
+```
+
+In addition, there are special values that cover multiple channels.  `default` is the default set of channels, while `all` is all of the channels.  Invalid values are ignored.
+
+```json
+    "logging": {
+        "channels": ["default"]
     },
 ```
 

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -41,26 +41,39 @@
       "type": "object",
       "properties": {
         "level": {
-            "description": "Preferred logging level",
-            "type": "string",
-            "enum": [
-                "verbose",
-                "info",
-                "warning",
-                "error",
-                "critical"
-            ]
+          "description": "Preferred logging level",
+          "type": "string",
+          "enum": [
+            "verbose",
+            "info",
+            "warning",
+            "error",
+            "critical"
+          ]
         },
         "channels": {
           "description": "The logging channels to enable",
           "type": "array",
           "items": {
+            "uniqueItems": "true",
             "type": "string",
+            "enum": [
+              "fail",
+              "cli",
+              "sql",
+              "repo",
+              "yaml",
+              "core",
+              "test",
+              "config",
+              "default",
+              "all"
+            ],
             "maxLength": 20
           },
           "minItems": 0,
           "maxItems": 20
-        },
+        }
       }
     },
     "InstallPrefReq": {

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -41,16 +41,26 @@
       "type": "object",
       "properties": {
         "level": {
-          "description": "Preferred logging level",
-          "type": "string",
-          "enum": [
-            "verbose",
-            "info",
-            "warning",
-            "error",
-            "critical"
-          ]
-        }
+            "description": "Preferred logging level",
+            "type": "string",
+            "enum": [
+                "verbose",
+                "info",
+                "warning",
+                "error",
+                "critical"
+            ]
+        },
+        "channels": {
+          "description": "The logging channels to enable",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 20
+          },
+          "minItems": 0,
+          "maxItems": 20
+        },
       }
     },
     "InstallPrefReq": {

--- a/src/AppInstallerCLICore/COMContext.cpp
+++ b/src/AppInstallerCLICore/COMContext.cpp
@@ -77,8 +77,8 @@ namespace AppInstaller::CLI::Execution
 
     void COMContext::SetLoggers()
     {
-        Logging::Log().SetLevel(Logging::Level::Info);
-        Logging::Log().EnableChannel(Logging::Channel::All);
+        Logging::Log().EnableChannelsByBitmask(Settings::User().Get<Settings::Setting::LoggingChannelPreference>());
+        Logging::Log().SetLevel(Settings::User().Get<Settings::Setting::LoggingLevelPreference>());
 
         // TODO: Log to file for COM API calls only when debugging in visual studio
         Logging::FileLogger::Add(s_comLogFileNamePrefix);

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -65,7 +65,7 @@ namespace AppInstaller::CLI
         auto previousThreadGlobals = context.SetForCurrentThread();
 
         // Enable all logging for this phase; we will update once we have the arguments
-        Logging::Log().EnableChannel(Logging::Channel::All);
+        Logging::Log().EnableChannelsByBitmask(Settings::User().Get<Settings::Setting::LoggingChannelPreference>());
         Logging::Log().SetLevel(Settings::User().Get<Settings::Setting::LoggingLevelPreference>());
         Logging::FileLogger::Add();
         Logging::EnableWilFailureTelemetry();

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -576,3 +576,34 @@ TEST_CASE("SettingsMaxResumes", "[settings]")
         REQUIRE(userSettingTest.Get<Setting::MaxResumes>() == 5);
     }
 }
+
+TEST_CASE("LoggingChannels", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("No channels")
+    {
+        std::string_view json = R"({ "logging": { "channels": [] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingChannelPreference>() == 0);
+    }
+    SECTION("Default")
+    {
+        std::string_view json = R"({ "logging": { "channels": ["default"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingChannelPreference>() == DiagnosticLogger::ConvertChannelToBitmask(Channel::Defaults));
+    }
+    SECTION("Multiple")
+    {
+        std::string_view json = R"({ "logging": { "channels": ["core","Repo","YAML"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::LoggingChannelPreference>() ==
+            (DiagnosticLogger::ConvertChannelToBitmask(Channel::Core) | DiagnosticLogger::ConvertChannelToBitmask(Channel::Repo) | DiagnosticLogger::ConvertChannelToBitmask(Channel::YAML)));
+    }
+}

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -97,6 +97,7 @@ namespace AppInstaller::Settings
         NetworkWingetAlternateSourceURL,
         // Logging
         LoggingLevelPreference,
+        LoggingChannelPreference,
         // Uninstall behavior
         UninstallPurgePortablePackage,
         // Download behavior
@@ -187,6 +188,7 @@ namespace AppInstaller::Settings
 #endif
         // Logging
         SETTINGMAPPING_SPECIALIZATION(Setting::LoggingLevelPreference, std::string, Logging::Level, Logging::Level::Info, ".logging.level"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::LoggingChannelPreference, std::vector<std::string>, uint64_t, Logging::DiagnosticLogger::ConvertChannelToBitmask(Logging::Channel::Defaults), ".logging.channels"sv);
         // Interactivity
         SETTINGMAPPING_SPECIALIZATION(Setting::InteractivityDisable, bool, bool, false, ".interactivity.disable"sv);
         

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -435,6 +435,18 @@ namespace AppInstaller::Settings
             }
             return {};
         }
+
+        WINGET_VALIDATE_SIGNATURE(LoggingChannelPreference)
+        {
+            uint64_t result = 0;
+
+            for (auto const& entry : value)
+            {
+                result |= Logging::DiagnosticLogger::ConvertChannelToBitmask(GetChannelFromName(entry));
+            }
+
+            return result;
+        }
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/AppInstallerSharedLib/Public/AppInstallerLogging.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerLogging.h
@@ -56,11 +56,17 @@ namespace AppInstaller::Logging
         Core,
         Test,
         Config,
+        // Put special channel semantics at the end to preserve the bitspace.
+        None,
+        Defaults,
         All,
     };
 
     // Gets the channel's name as a string.
-    char const* GetChannelName(Channel channel);
+    std::string_view GetChannelName(Channel channel);
+
+    // Gets the channel from it's name.
+    Channel GetChannelFromName(std::string_view channel);
 
     // Gets the maximum channel name length in characters.
     size_t GetMaxChannelNameLength();
@@ -131,6 +137,12 @@ namespace AppInstaller::Logging
 
         // Disables the given channel.
         void DisableChannel(Channel channel);
+
+        // Converts the channel to its mask representation.
+        static uint64_t ConvertChannelToBitmask(Channel channel);
+
+        // Enables the channels per the given mask.
+        void EnableChannelsByBitmask(uint64_t mask);
 
         // Sets the enabled level.
         // All levels higher than this level will be enabled.


### PR DESCRIPTION
## Change
Add a user setting to control the enabled logging channels, then disable the `SQL` by default.  This channel is responsible for 95% of the log lines in a verbose file, yet they are only helpful when debugging a very specific set of issues that does not occur often.

Additionally, make the COM logging use the settings for logging (both channels and level).

## Validation
Added tests to ensure settings parsing.
Manually validated various settings values.