### PR TITLE
Introduce strong and weak comparisons between installers

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.h
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.h
@@ -53,6 +53,18 @@ namespace AppInstaller::CLI::Workflow
             std::string_view m_name;
         };
 
+        // The result of ComparisonField::IsFirstBetter
+        enum class ComparisonResult
+        {
+            // The first input is not better than the second input.
+            Negative,
+            // The first input is somewhat better than the second input.
+            // If another comparison has a strong positive result, it will override a weak result.
+            WeakPositive,
+            // The first input is definitely better than the second input.
+            StrongPositive,
+        };
+
         // An interface for defining new comparisons based on user inputs.
         struct ComparisonField : public FilterField
         {
@@ -61,7 +73,7 @@ namespace AppInstaller::CLI::Workflow
             virtual ~ComparisonField() = default;
 
             // Determines if the first installer is a better choice based on this field alone.
-            virtual bool IsFirstBetter(const Manifest::ManifestInstaller& first, const Manifest::ManifestInstaller& second) = 0;
+            virtual ComparisonResult IsFirstBetter(const Manifest::ManifestInstaller& first, const Manifest::ManifestInstaller& second) = 0;
         };
     }
 

--- a/src/AppInstallerCLITests/ManifestComparator.cpp
+++ b/src/AppInstallerCLITests/ManifestComparator.cpp
@@ -846,3 +846,17 @@ TEST_CASE("ManifestComparator_InstallerType", "[manifest_comparator]")
         RequireInapplicabilities(inapplicabilities, { InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType, InapplicabilityFlags::InstallerType });
     }
 }
+
+TEST_CASE("ManifestComparator_MachineArchitecture_Strong_Scope_Weak", "[manifest_comparator]")
+{
+    Manifest manifest;
+    ManifestInstaller system = AddInstaller(manifest, GetSystemArchitecture(), InstallerTypeEnum::Msi, ScopeEnum::Unknown, "", "");
+    ManifestInstaller user = AddInstaller(manifest, Architecture::Neutral, InstallerTypeEnum::Msi, ScopeEnum::User, "", "");
+
+    ManifestComparatorTestContext context;
+
+    ManifestComparator mc(context, {});
+    auto [result, inapplicabilities] = mc.GetPreferredInstaller(manifest);
+
+    RequireInstaller(result, system);
+}

--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -469,7 +469,7 @@ namespace AppInstaller::Logging
             }
         }
 
-        AICLI_LOG(CLI, Info, << "Completed installer selection.");
+        AICLI_LOG(CLI, Verbose, << "Completed installer selection.");
         AICLI_LOG(CLI, Verbose, << "Selected installer Architecture: " << arch);
         AICLI_LOG(CLI, Verbose, << "Selected installer URL: " << url);
         AICLI_LOG(CLI, Verbose, << "Selected installer InstallerType: " << installerType);


### PR DESCRIPTION
## Change
Rather than a `bool`, the installer comparison function now returns one of three values: negative, weak positive, and strong positive.  The comparison functions are updated to choose between weak and strong positive results as appropriate.  For instance, matching the system architecture when the alternative does not is a strong positive result.  Simply being "better" in the list of emulated architectures is a weak positive result.

The function that used these comparators in our priority order is updated to effectively do multiple passes, one looking for strong results and then one looking for weak results (in reality it is implemented with one pass as an optimization).

## Validation
Added a test to ensure that { System Architecture, Unknown Scope } is chosen over { Emulated Architecture, User Scope } by default.
Manually validated that the packages with this setup were now selecting the proper system architecture package as desired.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3956)