### PR TITLE
Apply MotW when installer hash does not match

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -458,11 +458,11 @@ namespace AppInstaller::CLI::Workflow
     {
         if (context.Contains(Execution::Data::InstallerPath))
         {
-            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerTrusted))
+            if (WI_AreAllFlagsSet(context.GetFlags(), Execution::ContextFlag::InstallerTrusted | Execution::ContextFlag::InstallerHashMatched))
             {
                 Utility::ApplyMotwIfApplicable(context.Get<Execution::Data::InstallerPath>(), URLZONE_TRUSTED);
             }
-            else if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerHashMatched))
+            else
             {
                 const auto& installer = context.Get<Execution::Data::Installer>();
                 HRESULT hr = Utility::ApplyMotwUsingIAttachmentExecuteIfApplicable(context.Get<Execution::Data::InstallerPath>(), installer.value().Url, URLZONE_INTERNET);


### PR DESCRIPTION
Current code sets MotW to trusted if an installer is from a trusted source, even if the hash does not match. And for untrusted sources, it does not set the MotW on hash mismatch.

Changing to always set MotW to "internet" for hash mismatch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3978)