### PR TITLE
Show only agreement related info during install

### DIFF
--- a/src/AppInstallerCLICore/Workflows/PromptFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PromptFlow.cpp
@@ -178,7 +178,7 @@ namespace AppInstaller::CLI::Workflow
                     return;
                 }
 
-                context << Workflow::ReportManifestIdentityWithVersion(Resource::String::ReportIdentityForAgreements) << Workflow::ShowPackageInfo;
+                context << Workflow::ReportManifestIdentityWithVersion(Resource::String::ReportIdentityForAgreements) << Workflow::ShowAgreementsInfo;
                 context.Reporter.EmptyLine();
             }
 

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -65,6 +65,23 @@ namespace {
             outputStream << "  "_liv << value << std::endl;
         }
     }
+
+    void ShowAgreementItem(Execution::OutputStream outputStream, AppInstaller::Manifest::Agreement agreement) {
+        if (!agreement.Label.empty())
+        {
+            outputStream << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
+        }
+
+        if (!agreement.AgreementText.empty())
+        {
+            outputStream << agreement.AgreementText << std::endl;
+        }
+
+        if (!agreement.AgreementUrl.empty())
+        {
+            outputStream << agreement.AgreementUrl << std::endl;
+        }
+    }
 }
 
 namespace AppInstaller::CLI::Workflow
@@ -90,26 +107,12 @@ namespace AppInstaller::CLI::Workflow
         const auto& agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
         if (!agreements.empty())
         {
-            context.Reporter.Info() << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
+            info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
             for (const auto& agreement : agreements)
             {
-                if (!agreement.Label.empty())
-                {
-                    info << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
-                }
-
-                if (!agreement.AgreementText.empty())
-                {
-                    info << agreement.AgreementText << std::endl;
-                }
-
-                if (!agreement.AgreementUrl.empty())
-                {
-                    info << agreement.AgreementUrl << std::endl;
-                }
+                ShowAgreementItem(info, agreement);
             }
 
-            info << std::endl;
         }
     }
 
@@ -165,26 +168,12 @@ namespace AppInstaller::CLI::Workflow
         const auto& agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
         if (!agreements.empty())
         {
-            context.Reporter.Info() << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
+            info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
             for (const auto& agreement : agreements)
             {
-                if (!agreement.Label.empty())
-                {
-                    info << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
-                }
-
-                if (!agreement.AgreementText.empty())
-                {
-                    info << agreement.AgreementText << std::endl;
-                }
-
-                if (!agreement.AgreementUrl.empty())
-                {
-                    info << agreement.AgreementUrl << std::endl;
-                }
+                ShowAgreementItem(info, agreement);
             }
 
-            info << std::endl;
         }
     }
 

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -66,7 +66,8 @@ namespace {
         }
     }
 
-    void ShowAgreements(Execution::OutputStream outputStream, std::vector<AppInstaller::Manifest::Agreement> agreements) {
+    void ShowAgreements(Execution::OutputStream outputStream, const std::vector<AppInstaller::Manifest::Agreement>& agreements) {
+
         if (agreements.empty()) {
             return;
         }

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -66,20 +66,28 @@ namespace {
         }
     }
 
-    void ShowAgreementItem(Execution::OutputStream outputStream, AppInstaller::Manifest::Agreement agreement) {
-        if (!agreement.Label.empty())
-        {
-            outputStream << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
+    void ShowAgreements(Execution::OutputStream outputStream, std::vector<AppInstaller::Manifest::Agreement> agreements) {
+        if (agreements.empty()) {
+            return;
         }
 
-        if (!agreement.AgreementText.empty())
-        {
-            outputStream << agreement.AgreementText << std::endl;
-        }
+        outputStream << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
+        for (const auto& agreement : agreements) {
 
-        if (!agreement.AgreementUrl.empty())
-        {
-            outputStream << agreement.AgreementUrl << std::endl;
+            if (!agreement.Label.empty())
+            {
+                outputStream << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
+            }
+
+            if (!agreement.AgreementText.empty())
+            {
+                outputStream << agreement.AgreementText << std::endl;
+            }
+
+            if (!agreement.AgreementUrl.empty())
+            {
+                outputStream << agreement.AgreementUrl << std::endl;
+            }
         }
     }
 }
@@ -103,17 +111,8 @@ namespace AppInstaller::CLI::Workflow
         ShowSingleLineField(info, Resource::String::ShowLabelCopyright, manifest.CurrentLocalization.Get<Manifest::Localization::Copyright>());
         ShowSingleLineField(info, Resource::String::ShowLabelCopyrightUrl, manifest.CurrentLocalization.Get<Manifest::Localization::CopyrightUrl>());
         ShowSingleLineField(info, Resource::String::ShowLabelPurchaseUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PurchaseUrl>());
-
-        const auto& agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
-        if (!agreements.empty())
-        {
-            info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
-            for (const auto& agreement : agreements)
-            {
-                ShowAgreementItem(info, agreement);
-            }
-
-        }
+        ShowAgreements(info, manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>());
+        
     }
 
     void ShowManifestInfo(Execution::Context& context)
@@ -165,16 +164,7 @@ namespace AppInstaller::CLI::Workflow
             }
         }
         ShowMultiValueField(info, Resource::String::ShowLabelTags, manifest.CurrentLocalization.Get<Manifest::Localization::Tags>());
-        const auto& agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
-        if (!agreements.empty())
-        {
-            info << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
-            for (const auto& agreement : agreements)
-            {
-                ShowAgreementItem(info, agreement);
-            }
-
-        }
+        ShowAgreements(info, manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>());
     }
 
     void ShowInstallerInfo(Execution::Context& context)

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.cpp
@@ -69,6 +69,50 @@ namespace {
 
 namespace AppInstaller::CLI::Workflow
 {
+    void ShowAgreementsInfo(Execution::Context& context)
+    {
+        const auto& manifest = context.Get<Execution::Data::Manifest>();
+        auto info = context.Reporter.Info();
+
+        ShowSingleLineField(info, Resource::String::ShowLabelVersion, manifest.Version);
+        ShowSingleLineField(info, Resource::String::ShowLabelPublisher, manifest.CurrentLocalization.Get<Manifest::Localization::Publisher>());
+        ShowSingleLineField(info, Resource::String::ShowLabelPublisherUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PublisherUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelPublisherSupportUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PublisherSupportUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelAuthor, manifest.CurrentLocalization.Get<Manifest::Localization::Author>());
+        ShowSingleLineField(info, Resource::String::ShowLabelPackageUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PackageUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelLicense, manifest.CurrentLocalization.Get<Manifest::Localization::License>());
+        ShowSingleLineField(info, Resource::String::ShowLabelLicenseUrl, manifest.CurrentLocalization.Get<Manifest::Localization::LicenseUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelPrivacyUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PrivacyUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelCopyright, manifest.CurrentLocalization.Get<Manifest::Localization::Copyright>());
+        ShowSingleLineField(info, Resource::String::ShowLabelCopyrightUrl, manifest.CurrentLocalization.Get<Manifest::Localization::CopyrightUrl>());
+        ShowSingleLineField(info, Resource::String::ShowLabelPurchaseUrl, manifest.CurrentLocalization.Get<Manifest::Localization::PurchaseUrl>());
+
+        const auto& agreements = manifest.CurrentLocalization.Get<Manifest::Localization::Agreements>();
+        if (!agreements.empty())
+        {
+            context.Reporter.Info() << Execution::ManifestInfoEmphasis << Resource::String::ShowLabelAgreements << std::endl;
+            for (const auto& agreement : agreements)
+            {
+                if (!agreement.Label.empty())
+                {
+                    info << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
+                }
+
+                if (!agreement.AgreementText.empty())
+                {
+                    info << agreement.AgreementText << std::endl;
+                }
+
+                if (!agreement.AgreementUrl.empty())
+                {
+                    info << agreement.AgreementUrl << std::endl;
+                }
+            }
+
+            info << std::endl;
+        }
+    }
+
     void ShowManifestInfo(Execution::Context& context)
     {
         context << ShowPackageInfo << ShowInstallerInfo;
@@ -126,7 +170,7 @@ namespace AppInstaller::CLI::Workflow
             {
                 if (!agreement.Label.empty())
                 {
-                    info << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
+                    info << "  "_liv << Execution::ManifestInfoEmphasis << agreement.Label << ": "_liv;
                 }
 
                 if (!agreement.AgreementText.empty())

--- a/src/AppInstallerCLICore/Workflows/ShowFlow.h
+++ b/src/AppInstallerCLICore/Workflows/ShowFlow.h
@@ -5,6 +5,12 @@
 
 namespace AppInstaller::CLI::Workflow
 {
+    // Shows information on an application; this is only the information for package agreements
+    // Required Args: None
+    // Inputs: Manifest
+    // Outputs: None
+    void ShowAgreementsInfo(Execution::Context& context);
+
     // Shows information on an application.
     // Required Args: None
     // Inputs: Manifest, Installer


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

This PR  cleans up the install flow to make it easier for a user to see the agreements of the package. It does this by changing the install flow to not show fields that are unrelated to package agreements such as
- Moniker
- Description
- PackageUrl
- ReleaseNotes
- ReleaseNotesUrl
- InstallationNotes
- Documentations
- Tags

-----
Screenshots included below to show difference between old and new

<details>
<summary>Old MSStore Agreements Shown</summary>

![image](https://github.com/microsoft/winget-cli/assets/12611259/81c4638d-fe9a-4d3b-8054-c1b64cbedbdb)
</details>

<details>
<summary>New MSStore Agreements Shown</summary>

![image](https://github.com/microsoft/winget-cli/assets/12611259/2fb040a0-2a03-433d-93b3-359aabc68cac)
</details>

<details>
<summary>Old Local Manifest Agreements Shown</summary>

![image](https://github.com/microsoft/winget-cli/assets/12611259/e68e9470-dc6e-4022-aa36-12c974648cdc)
</details>

<details>
<summary>New Local Manifest Agreements Shown</summary>

![image](https://github.com/microsoft/winget-cli/assets/12611259/f595c9d4-09dc-4f9d-82d6-5ff01d81d14c)
</details>

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/3999)