### PR TITLE
Cherry-Pick from #3937 - Fix pipeline build error

### DIFF
--- a/src/AppInstallerRepositoryCore/CompositeSource.h
+++ b/src/AppInstallerRepositoryCore/CompositeSource.h
@@ -59,6 +59,6 @@ namespace AppInstaller::Repository
         Source m_installedSource;
         std::vector<Source> m_availableSources;
         SourceDetails m_details;
-        CompositeSearchBehavior m_searchBehavior;
+        CompositeSearchBehavior m_searchBehavior = CompositeSearchBehavior::Installed;
     };
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -195,7 +195,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
             catch (RuntimeException e)
             {
                 this.psCmdlet.WriteDebug($"Failed installing bundle via Add-AppxProvisionedPackage {e}");
-                throw e;
+                throw;
             }
         }
 
@@ -219,7 +219,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
             catch (RuntimeException e)
             {
                 this.psCmdlet.WriteDebug($"Failed installing bundle via Add-AppxPackage {e}");
-                throw e;
+                throw;
             }
         }
 
@@ -384,7 +384,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
                 else
                 {
                     this.psCmdlet.WriteError(e.ErrorRecord);
-                    throw e;
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
This fixes the recent build errors in the pipelines. The compiler was complaining about re-throwing an exception with `throw e;` instead of `throw;`, which messes with the stack trace. Presumably it started because of a tool update in the agents.

This also fixes a compilation error I'm seeing locally from a member not being initialized.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4063)