### PR TITLE
Improve progress handling for group processor

### DIFF
--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetGroupProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetGroupProcessor.cs
@@ -50,10 +50,11 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// <summary>
         /// Apply settings for the group.
         /// </summary>
+        /// <param name="progressHandler">The progress handler.</param>
         /// <returns>The operation to apply settings.</returns>
-        public IAsyncOperationWithProgress<IApplyGroupSettingsResult, IApplyGroupMemberSettingsResult> ApplyGroupSettingsAsync()
+        public IAsyncOperation<IApplyGroupSettingsResult> ApplyGroupSettingsAsync(EventHandler<IApplyGroupMemberSettingsResult> progressHandler)
         {
-            return AsyncInfo.Run((CancellationToken cancellationToken, IProgress<IApplyGroupMemberSettingsResult> progress) => Task.Run<IApplyGroupSettingsResult>(() =>
+            return AsyncInfo.Run((CancellationToken cancellationToken) => Task.Run<IApplyGroupSettingsResult>(() =>
             {
                 this.WaitOnAsyncEvent(cancellationToken);
 
@@ -62,7 +63,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
 
                 if (this.Set != null)
                 {
-                    TestConfigurationUnitGroupProcessor.ApplyGroupSettings(this.Set.Units, progress, result);
+                    TestConfigurationUnitGroupProcessor.ApplyGroupSettings(this.Set.Units, progressHandler, result);
                 }
 
                 return result;
@@ -72,10 +73,11 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// <summary>
         /// Test settings for the group.
         /// </summary>
+        /// <param name="progressHandler">The progress handler.</param>
         /// <returns>The operation to test settings.</returns>
-        public IAsyncOperationWithProgress<ITestGroupSettingsResult, ITestSettingsResult> TestGroupSettingsAsync()
+        public IAsyncOperation<ITestGroupSettingsResult> TestGroupSettingsAsync(EventHandler<ITestSettingsResult> progressHandler)
         {
-            return AsyncInfo.Run((CancellationToken cancellationToken, IProgress<ITestSettingsResult> progress) => Task.Run<ITestGroupSettingsResult>(() =>
+            return AsyncInfo.Run((CancellationToken cancellationToken) => Task.Run<ITestGroupSettingsResult>(() =>
             {
                 this.WaitOnAsyncEvent(cancellationToken);
 
@@ -85,7 +87,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
                 if (this.Set != null)
                 {
                     result.TestResult = TestConfigurationUnitGroupProcessor.GetTestResult(this.Set.Metadata);
-                    TestConfigurationUnitGroupProcessor.TestGroupSettings(this.Set.Units, progress, result);
+                    TestConfigurationUnitGroupProcessor.TestGroupSettings(this.Set.Units, progressHandler, result);
                 }
 
                 return result;

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorGroupTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorGroupTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using Microsoft.Management.Configuration.UnitTests.Fixtures;
     using Microsoft.Management.Configuration.UnitTests.Helpers;
     using Xunit;
@@ -416,16 +417,19 @@ resources:
             configurationSet.Units = new ConfigurationUnit[] { configurationUnitNegative, configurationUnitPositive };
 
             TestConfigurationProcessorFactory factory = new TestConfigurationProcessorFactory();
-            TestConfigurationSetGroupProcessor setProcessor = factory.CreateTestGroupProcessor(configurationSet);
-            setProcessor.ShouldWaitOnAsyncEvent = true;
-
             ConfigurationProcessor processor = this.CreateConfigurationProcessorWithDiagnostics(factory);
-            List<ConfigurationSetChangeData> progressValues = new List<ConfigurationSetChangeData>();
+            ManualResetEvent startProcessing = new ManualResetEvent(false);
+            factory.CreateSetProcessorDelegate = (f, c) =>
+            {
+                startProcessing.WaitOne();
+                return f.CreateTestGroupProcessor(c);
+            };
 
             var operation = processor.ApplySetAsync(configurationSet, ApplyConfigurationSetFlags.None);
-            operation.Progress = (Windows.Foundation.IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> op, ConfigurationSetChangeData unitResult) => { progressValues.Add(unitResult); };
-            setProcessor.SignalAsyncEvent();
 
+            List<ConfigurationSetChangeData> progressValues = new List<ConfigurationSetChangeData>();
+            operation.Progress = (Windows.Foundation.IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> op, ConfigurationSetChangeData unitResult) => { progressValues.Add(unitResult); };
+            startProcessing.Set();
             operation.AsTask().Wait();
             ApplyConfigurationSetResult result = operation.GetResults();
 
@@ -433,7 +437,7 @@ resources:
             Assert.Null(result.ResultCode);
             Assert.NotNull(result.UnitResults);
             Assert.Equal(configurationSet.Units.Count, result.UnitResults.Count);
-            Assert.True((configurationSet.Units.Count * 2) + 2 >= progressValues.Count);
+            Assert.Equal((configurationSet.Units.Count * 2) + 2, progressValues.Count);
 
             ApplyConfigurationUnitResult negativeResult = result.UnitResults.First(x => x.Unit == configurationUnitNegative);
 
@@ -505,16 +509,19 @@ resources:
             configurationUnitGroup.Units = new ConfigurationUnit[] { configurationUnitGroupMember };
 
             TestConfigurationProcessorFactory factory = new TestConfigurationProcessorFactory();
-            TestConfigurationSetGroupProcessor setProcessor = factory.CreateTestGroupProcessor(configurationSet);
-            setProcessor.ShouldWaitOnAsyncEvent = true;
-
             ConfigurationProcessor processor = this.CreateConfigurationProcessorWithDiagnostics(factory);
-            List<ConfigurationSetChangeData> progressValues = new List<ConfigurationSetChangeData>();
+            ManualResetEvent startProcessing = new ManualResetEvent(false);
+            factory.CreateSetProcessorDelegate = (f, c) =>
+            {
+                startProcessing.WaitOne();
+                return f.CreateTestGroupProcessor(c);
+            };
 
             var operation = processor.ApplySetAsync(configurationSet, ApplyConfigurationSetFlags.None);
-            operation.Progress = (Windows.Foundation.IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> op, ConfigurationSetChangeData unitResult) => { progressValues.Add(unitResult); };
-            setProcessor.SignalAsyncEvent();
 
+            List<ConfigurationSetChangeData> progressValues = new List<ConfigurationSetChangeData>();
+            operation.Progress = (Windows.Foundation.IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> op, ConfigurationSetChangeData unitResult) => { progressValues.Add(unitResult); };
+            startProcessing.Set();
             operation.AsTask().Wait();
             ApplyConfigurationSetResult result = operation.GetResults();
 
@@ -522,7 +529,7 @@ resources:
             Assert.Null(result.ResultCode);
             Assert.NotNull(result.UnitResults);
             Assert.Equal(3, result.UnitResults.Count);
-            Assert.True(progressValues.Count <= 2 + (3 * 2));
+            Assert.Equal(2 + (3 * 2), progressValues.Count);
 
             foreach (ConfigurationUnit unit in new ConfigurationUnit[] { configurationUnit, configurationUnitGroup, configurationUnitGroupMember })
             {
@@ -536,7 +543,7 @@ resources:
                 Assert.True(unitResult.PreviouslyInDesiredState);
 
                 IEnumerable<ConfigurationSetChangeData> unitProgress = progressValues.Where(x => x.Unit == unit);
-                Assert.True(unitProgress.Count() <= 2);
+                Assert.Equal(2, unitProgress.Count());
 
                 foreach (ConfigurationSetChangeData change in unitProgress)
                 {

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTestTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTestTests.cs
@@ -7,8 +7,10 @@
 namespace Microsoft.Management.Configuration.UnitTests.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using Microsoft.Management.Configuration.UnitTests.Fixtures;
     using Microsoft.Management.Configuration.UnitTests.Helpers;
     using Microsoft.VisualBasic;

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTestTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTestTests.cs
@@ -7,10 +7,8 @@
 namespace Microsoft.Management.Configuration.UnitTests.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Threading;
     using Microsoft.Management.Configuration.UnitTests.Fixtures;
     using Microsoft.Management.Configuration.UnitTests.Helpers;
     using Microsoft.VisualBasic;

--- a/src/Microsoft.Management.Configuration/ConfigurationSetApplyProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationSetApplyProcessor.cpp
@@ -423,9 +423,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
                 if (groupProcessor)
                 {
-                    auto applyOperation = groupProcessor.ApplyGroupSettingsAsync();
-
-                    applyOperation.Progress([&](const auto&, const IApplyGroupMemberSettingsResult& unitResult)
+                    auto applyOperation = groupProcessor.ApplyGroupSettingsAsync([&](const auto&, const IApplyGroupMemberSettingsResult& unitResult)
                         {
                             m_progress.Progress(unitResult);
                         });

--- a/src/Microsoft.Management.Configuration/DefaultSetGroupProcessor.h
+++ b/src/Microsoft.Management.Configuration/DefaultSetGroupProcessor.h
@@ -17,9 +17,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         IInspectable Group();
 
-        Windows::Foundation::IAsyncOperationWithProgress<ITestGroupSettingsResult, ITestSettingsResult> TestGroupSettingsAsync();
+        Windows::Foundation::IAsyncOperation<ITestGroupSettingsResult> TestGroupSettingsAsync(Windows::Foundation::EventHandler<ITestSettingsResult> progressHandler);
 
-        Windows::Foundation::IAsyncOperationWithProgress<IApplyGroupSettingsResult, IApplyGroupMemberSettingsResult> ApplyGroupSettingsAsync();
+        Windows::Foundation::IAsyncOperation<IApplyGroupSettingsResult> ApplyGroupSettingsAsync(Windows::Foundation::EventHandler<IApplyGroupMemberSettingsResult> progressHandler);
 
     private:
         void ThrowIf(bool cancellation);

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -572,11 +572,11 @@ namespace Microsoft.Management.Configuration
 
         // Determines if the system is already in the state described by the configuration unit group.
         // Progress is expected for every descendant unit and finally the group unit itself.
-        Windows.Foundation.IAsyncOperationWithProgress<ITestGroupSettingsResult, ITestSettingsResult> TestGroupSettingsAsync();
+        Windows.Foundation.IAsyncOperation<ITestGroupSettingsResult> TestGroupSettingsAsync(Windows.Foundation.EventHandler<ITestSettingsResult> progressHandler);
 
         // Applies the state described in the configuration unit group.
         // Progress is expected for every descendant unit and finally the group unit itself.
-        Windows.Foundation.IAsyncOperationWithProgress<IApplyGroupSettingsResult, IApplyGroupMemberSettingsResult> ApplyGroupSettingsAsync();
+        Windows.Foundation.IAsyncOperation<IApplyGroupSettingsResult> ApplyGroupSettingsAsync(Windows.Foundation.EventHandler<IApplyGroupMemberSettingsResult> progressHandler);
     }
 
     // The level of the diagnostic information.


### PR DESCRIPTION
## Change
To prevent the loss of progress events between the group processor and the caller, move to a model where these internal interfaces take in an `EventHandler` parameter rather than using `...WithProgress`.  This will make it possible to be confident that no progress events occurred between the async method starting and the progress handler being attached.

This fixes the flakiness of the tests that were verifying progress events.

## Validation
Using the existing tests, including making them strict again on the number of progress events expected.