### PR TITLE
CodeCoverage pipeline for submission to onefuzz.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,6 +34,7 @@ Atest
 ATL
 AUrl
 Authenticode
+azcopy
 azurewebsites
 bcp
 BEFACEF
@@ -66,6 +67,7 @@ CLOSEAPP
 cloudapp
 clsctx
 clsid
+cobertura
 CODEOWNERS
 COINIT
 COMGLB
@@ -386,6 +388,7 @@ runtimeclass
 ryfu
 rzkzqaqjwj
 SARL
+SASURL
 schematab
 sddl
 SECUREFILEPATH

--- a/azure-pipelines.coverage.yml
+++ b/azure-pipelines.coverage.yml
@@ -1,0 +1,70 @@
+# Code coverage pipeline required by OneFuzz
+pr: none
+trigger: none
+
+pool:
+  vmImage: windows-latest
+
+parameters:
+  - name: sasUrl
+    type: string
+    displayName: SAS URL
+  - name: branch
+    type: string
+    displayName: Branch
+  - name: jobID
+    type: string
+    displayName: OneFuzz Job ID
+  - name: buildDate
+    type: string
+    displayName: Build Date
+  - name: commitID
+    type: string
+    displayName: Commit ID
+
+variables:
+  - name: coverage-file
+    value: cobertura-coverage.xml
+  - name: job-ID 
+    value: ${{ parameters.jobID }}
+  - name: build-date 
+    value: ${{ parameters.buildDate }}
+  - name: branch
+    value: ${{ parameters.branch }}
+  - name: sas-url
+    value: ${{ parameters.sasUrl }}
+  - name: commit-ID
+    value: ${{ parameters.commitID }}
+
+jobs:
+- job: prod
+  displayName: Prod Task
+  steps:
+  # Get source code
+  - script: |
+        git clone https://github.com/microsoft/winget-cli.git
+        git checkout $(commit-ID)
+    displayName: 'Clone winget-cli'
+
+  # Get code coverage from OneFuzz for the job
+  - powershell: |
+      Write-Host "Job ID: $(job-ID), Build Date: $(build-date), Branch: $(branch)"
+      $SASUrl = [System.Uri]::new("$(sas-url)")
+      azcopy cp $SASUrl.AbsoluteUri ./ --recursive
+      $ContainerName = $SASURL.LocalPath.Split("/")[1]
+      Write-Host "##vso[task.setvariable variable=container-name;]$ContainerName"
+      cd $ContainerName
+      $size = ((Get-Item .\$(coverage-file)).length)
+      if ($size -eq 0) {
+        Write-Host "Cobertura coverage XML is empty."
+        exit 1
+      }
+    displayName: PowerShell script to get coverage
+
+  # Use Cobertura report generator
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: ./$(container-name)\$(coverage-file)
+      pathToSources: $(System.DefaultWorkingDirectory)
+    displayName: Built in ADO Task that uses ReportGenerator

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -592,3 +592,4 @@ jobs:
       onefuzzDropDirectory: '$(buildOutDir)\WinGetYamlFuzzing'
       onefuzzDropPAT: $(onefuzzDropPAT)
       onefuzzFilingBugPAT: $(onefuzzBugFilingPAT)
+      onefuzzCodeCoveragePAT: $(onefuzzCodeCoveragePAT)

--- a/src/WinGetYamlFuzzing/OneFuzzConfig.json
+++ b/src/WinGetYamlFuzzing/OneFuzzConfig.json
@@ -26,6 +26,11 @@
         "AssignedTo": "ryfu@microsoft.com",
         "AreaPath": "OS\\Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\InstaDev",
         "IterationPath": "OS"
+      },
+      "codeCoverage": {
+        "org": "ms",
+        "project": "winget-cli",
+        "pipelineId": "Pipeline ID"
       }
     }
   ]


### PR DESCRIPTION
This pipeline will be triggered after a onefuzz job is completed. That way the code coverage results can be reported back to the one fuzz team for analysis. 

I will need to check this in first before I can create the corresponding ADO pipeline. Then update the onfuzzconfig to point to the correct pipeline id. Once that is completed, this pipeline should work and submit our code coverage results.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4177)