### PR TITLE
Fix typo in '#658 - WinGet Download.md' Spec File

### DIFF
--- a/doc/specs/#658 - WinGet Download.md
+++ b/doc/specs/#658 - WinGet Download.md
@@ -97,9 +97,9 @@ usage: winget download [[-q] <query>] [<options>]
 The following items will be included in the WinGet Settings Schema 
 
 ```json
-"DownloadBehavior: {
+"DownloadBehavior": {
         "defaultDownloadDirectory":"%USERPROFILE%/Downloads/"
-}"
+}
 ```
 
 The "defaultDownloadDirectory" setting will be used as the default folder where the package installer and manifest is downloaded to.


### PR DESCRIPTION
There were miss-placed double quotes in the section titled 'WinGet Setting - Default Download Output', see commit patches for exact location of this typo.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4179)