### PR TITLE
Remove x86 platform from fuzzing pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -548,9 +548,6 @@ jobs:
       x64:
         buildConfiguration: 'Fuzzing'
         buildPlatform: 'x64'
-      x86:
-        buildConfiguration: 'Fuzzing'
-        buildPlatform: 'x86'
 
   variables:
     buildOutDir: $(Build.SourcesDirectory)\src\$(buildPlatform)\$(buildConfiguration)


### PR DESCRIPTION
Informed by fuzzing team that only one architecture is required for fuzzing. 
Also starting two fuzzing jobs at the same time seems to cause a conflict where one job cancels the other. This should resolve that issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4195)