### PR TITLE
Fix settings.schema.0.2.json not validating against schema

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -55,7 +55,7 @@
           "description": "The logging channels to enable",
           "type": "array",
           "items": {
-            "uniqueItems": "true",
+            "uniqueItems": true,
             "type": "string",
             "enum": [
               "fail",
@@ -104,7 +104,7 @@
           "description": "The architecture(s) to use for a package install",
           "type": "array",
           "items": {
-            "uniqueItems": "true",
+            "uniqueItems": true,
             "type": "string",
             "enum": [
               "neutral",
@@ -121,7 +121,7 @@
           "description": "The installerType(s) to use for a package install",
           "type": "array",
           "items": {
-            "uniqueItems": "true",
+            "uniqueItems": true,
             "type": "string",
             "enum": [
               "inno",
@@ -170,7 +170,7 @@
         "defaultInstallRoot": {
           "description": "Default install location to use for packages that require it when not specified",
           "type": "string",
-          "maxLength": "32767"
+          "maxLength": 32767
         },
         "maxResumes": {
           "description": "The maximum number of resumes allowed for a single resume id. This is to prevent continuous reboots if an install that requires a reboot is not properly detected.",


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

settings.schema.0.2.json does currently not validate against the JSON 2019-09 schema draft, although it claims it does.
uniqueItems should be a boolean, not a string: https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.6.4.3
maxLength should be an integer, not a string: https://json-schema.org/draft/2019-09/json-schema-validation#rfc.section.6.3.1
After these changes, it does validate.
Tested before/after with https://www.jsonschemavalidator.net/
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4200)