### PR TITLE
Update Repair-WinGetPackageManager with UiXaml 2.8

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -73,12 +73,12 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         private const string VCLibsUWPDesktopArm64 = "https://aka.ms/Microsoft.VCLibs.arm64.14.00.Desktop.appx";
 
         // Xaml
-        private const string XamlPackage27 = "Microsoft.UI.Xaml.2.7";
-        private const string XamlReleaseTag273 = "v2.7.3";
-        private const string XamlAssetX64 = "Microsoft.UI.Xaml.2.7.x64.appx";
-        private const string XamlAssetX86 = "Microsoft.UI.Xaml.2.7.x86.appx";
-        private const string XamlAssetArm = "Microsoft.UI.Xaml.2.7.arm.appx";
-        private const string XamlAssetArm64 = "Microsoft.UI.Xaml.2.7.arm64.appx";
+        private const string XamlPackage28 = "Microsoft.UI.Xaml.2.8";
+        private const string XamlReleaseTag286 = "v2.8.6";
+        private const string XamlAssetX64 = "Microsoft.UI.Xaml.2.8.x64.appx";
+        private const string XamlAssetX86 = "Microsoft.UI.Xaml.2.8.x86.appx";
+        private const string XamlAssetArm = "Microsoft.UI.Xaml.2.8.arm.appx";
+        private const string XamlAssetArm64 = "Microsoft.UI.Xaml.2.8.arm64.appx";
 
         private readonly PowerShellCmdlet pwshCmdlet;
         private readonly HttpClientHelper httpClientHelper;
@@ -358,12 +358,12 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
 
         private async Task InstallUiXamlAsync()
         {
-            var uiXamlObjs = this.GetAppxObject(XamlPackage27);
+            var uiXamlObjs = this.GetAppxObject(XamlPackage28);
             if (uiXamlObjs is null)
             {
                 var githubRelease = new GitHubClient(RepositoryOwner.Microsoft, RepositoryName.UiXaml);
 
-                var xamlRelease = await githubRelease.GetReleaseAsync(XamlReleaseTag273);
+                var xamlRelease = await githubRelease.GetReleaseAsync(XamlReleaseTag286);
 
                 var packagesToInstall = new List<ReleaseAsset>();
                 var arch = RuntimeInformation.OSArchitecture;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Octokit" Version="4.0.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
+    <PackageReference Include="Semver" Version="2.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -50,7 +51,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22000.196" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == '$(DesktopFramework)'"/>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
@@ -214,11 +214,11 @@ namespace Microsoft.WinGet.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Microsoft.UI.Xaml.2.7 package is not installed.
+        ///   Looks up a localized string similar to Microsoft.UI.Xaml.2.8 package is not installed.
         /// </summary>
-        internal static string MicrosoftUIXaml27Message {
+        internal static string MicrosoftUIXaml28Message {
             get {
-                return ResourceManager.GetString("MicrosoftUIXaml27Message", resourceCulture);
+                return ResourceManager.GetString("MicrosoftUIXaml28Message", resourceCulture);
             }
         }
         

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.Designer.cs
@@ -214,15 +214,6 @@ namespace Microsoft.WinGet.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Microsoft.UI.Xaml.2.8 package is not installed.
-        /// </summary>
-        internal static string MicrosoftUIXaml28Message {
-            get {
-                return ResourceManager.GetString("MicrosoftUIXaml28Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to No packages matched the given input criteria..
         /// </summary>
         internal static string NoPackageFoundExceptionMessage {
@@ -381,15 +372,6 @@ namespace Microsoft.WinGet.Resources {
         internal static string WinGetCLITimeoutExceptionMessage {
             get {
                 return ResourceManager.GetString("WinGetCLITimeoutExceptionMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Windows Package Manager not supported..
-        /// </summary>
-        internal static string WinGetNotSupportedMessage {
-            get {
-                return ResourceManager.GetString("WinGetNotSupportedMessage", resourceCulture);
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
@@ -189,13 +189,6 @@
   <data name="RepairAppExecutionAliasMessage" xml:space="preserve">
     <value>The App Execution Alias for the Windows Package Manager is disabled. You should enable the App Execution Alias for the Windows Package Manager. Go to App execution aliases option in Apps &amp; features Settings to enable it.</value>
   </data>
-  <data name="MicrosoftUIXaml28Message" xml:space="preserve">
-    <value>Microsoft.UI.Xaml.2.8 package is not installed</value>
-    <comment>{Locked="Microsoft.UI.Xaml.2.8"}</comment>
-  </data>
-  <data name="WinGetNotSupportedMessage" xml:space="preserve">
-    <value>Windows Package Manager not supported.</value>
-  </data>
   <data name="IntegrityUnexpectedVersionMessage" xml:space="preserve">
     <value>The installed winget version doesn't match the expectation. Installer version '{0}' Expected version '{1}'</value>
     <comment>{Locked="{0}","{1}"} {0} - The winget current installed winget version. {1} - The expected winget version.</comment>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Properties/Resources.resx
@@ -189,9 +189,9 @@
   <data name="RepairAppExecutionAliasMessage" xml:space="preserve">
     <value>The App Execution Alias for the Windows Package Manager is disabled. You should enable the App Execution Alias for the Windows Package Manager. Go to App execution aliases option in Apps &amp; features Settings to enable it.</value>
   </data>
-  <data name="MicrosoftUIXaml27Message" xml:space="preserve">
-    <value>Microsoft.UI.Xaml.2.7 package is not installed</value>
-    <comment>{Locked="Microsoft.UI.Xaml.2.7"}</comment>
+  <data name="MicrosoftUIXaml28Message" xml:space="preserve">
+    <value>Microsoft.UI.Xaml.2.8 package is not installed</value>
+    <comment>{Locked="Microsoft.UI.Xaml.2.8"}</comment>
   </data>
   <data name="WinGetNotSupportedMessage" xml:space="preserve">
     <value>Windows Package Manager not supported.</value>


### PR DESCRIPTION
Fixes an issue with Repair-WinGetPackageManager not installing the correct version of Ui.Xaml (2.8.6) which is required by the latest release (1.7.10582)

Also I checked the commit history and the minimum version that has the update to v2.8.6 for UI.Xaml is our RC candidate 1.7.10514
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4218)