### PR TITLE
Copy semver.dll to direct dependencies

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -113,6 +113,7 @@
       <ManagedDependency Include="$(OutputPath)Microsoft.Windows.SDK.NET.dll" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
       <ManagedDependency Include="$(OutputPath)WinRT.Runtime.dll" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
       <ManagedDependency Include="$(OutputPath)Microsoft.Win32.Registry.dll" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
+      <ManagedDependency Include="$(OutputPath)Semver.dll" />
     </ItemGroup>
     <Message Importance="high" Text="Copying managed shared dependencies: '@(ManagedDependency)'" />
     <Copy SourceFiles="@(ManagedDependency)" DestinationFolder="$(PowerShellModuleSharedDependencies)" />


### PR DESCRIPTION
Forgot to declare semver as one of the copied dependencies which is required for Repair-WinGetPackageManager

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4226)