### PR TITLE
Allow all packages to check for a version

### DIFF
--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -433,7 +433,11 @@ namespace AppInstaller::Repository
                         }
                     }
 
-                    return availablePackage->GetAvailableVersion(versionKey);
+                    auto result = availablePackage->GetAvailableVersion(versionKey);
+                    if (result)
+                    {
+                        return result;
+                    }
                 }
 
                 return {};


### PR DESCRIPTION
Related to #4217

## Change
Rather than only the first package that matches the source criteria, return the first version that exists on a package matching the source.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4227)