### PR TITLE
Fix PowerShellCmdlet

### DIFF
--- a/src/PowerShell/CommonFiles/PowerShellCmdlet.cs
+++ b/src/PowerShell/CommonFiles/PowerShellCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="PowerShellCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -281,6 +281,7 @@ namespace Microsoft.WinGet.Common.Command
                     {
                         try
                         {
+                            this.pwshThreadEdi = null;
                             this.pwshThreadAction();
                         }
                         catch (Exception e)
@@ -596,12 +597,17 @@ namespace Microsoft.WinGet.Common.Command
                 this.pwshThreadActionCompleted.WaitHandle,
             });
 
-            if (this.pwshThreadEdi != null)
+            try
             {
-                this.pwshThreadEdi.Throw();
+                if (this.pwshThreadEdi != null)
+                {
+                    this.pwshThreadEdi.Throw();
+                }
             }
-
-            this.semaphore.Release();
+            finally
+            {
+                this.semaphore.Release();
+            }
         }
 
         private class QueuedStream


### PR DESCRIPTION
A cmdlet can use `PowerShellCmdlet.ExecuteInPowerShellThread` to request operations to run in the PowerShell thread and wait for it to be completed. Internally, the action gets executed and we store the exception in the `ExceptionDispatchInfo` member object instead of throwing it immediately. This is to preserve the stack properly and facilitate diagnostics via Get-Error.

If the cmdlet catches that exception and attempts to use the PowerShell thread again, it will end up in a deadlock because the semaphore was never released. This PR release semaphore after throwing the stored exception.

This was the case in `AppxModuleHelper.AddAppxPackageAsUriAsync` when `Add-AppxPackage` failed installing the package from a url. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4247)