### PR TITLE
WinGetCommandLineInterfaces Group Policy Exception for COM API Calls

### DIFF
--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -164,7 +164,7 @@ namespace AppInstaller::CLI
         if (!commandAliases.empty())
         {
             infoOut << Resource::String::AvailableCommandAliases << std::endl;
-            
+
             for (const auto& commandAlias : commandAliases)
             {
                 infoOut << "  "_liv << Execution::HelpCommandEmphasis << commandAlias << std::endl;
@@ -283,7 +283,7 @@ namespace AppInstaller::CLI
             if (
                 Utility::CaseInsensitiveEquals(*itr, command->Name()) ||
                 Utility::CaseInsensitiveContains(command->Aliases(), *itr)
-            )
+                )
             {
                 if (!ExperimentalFeature::IsEnabled(command->Feature()))
                 {
@@ -555,7 +555,7 @@ namespace AppInstaller::CLI
                 if (
                     Utility::CaseInsensitiveEquals(argName, arg.Name()) ||
                     Utility::CaseInsensitiveEquals(argName, arg.AlternateName())
-                   )
+                    )
                 {
                     if (arg.Type() == ArgumentType::Flag)
                     {
@@ -668,7 +668,7 @@ namespace AppInstaller::CLI
         }
 
         if (execArgs.Contains(Execution::Args::Type::CustomHeader) && !execArgs.Contains(Execution::Args::Type::Source) &&
-           !execArgs.Contains(Execution::Args::Type::SourceName))
+            !execArgs.Contains(Execution::Args::Type::SourceName))
         {
             throw CommandException(Resource::String::HeaderArgumentNotApplicableWithoutSource(Argument::ForType(Execution::Args::Type::CustomHeader).Name()));
         }
@@ -864,8 +864,12 @@ namespace AppInstaller::CLI
             throw GroupPolicyException(Settings::TogglePolicy::Policy::WinGet);
         }
 
-        // Block CLI execution if WinGetCommandLineInterfaces is disabled by Policy
-        if (!Settings::GroupPolicies().IsEnabled(Settings::TogglePolicy::Policy::WinGetCommandLineInterfaces))
+        bool comApiCall = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::WinGetCOMApiCall);
+
+        // Block command-line interface operations if WinGetCommandLineInterfaces is turned off by policy,
+        // but maintain access to COM API calls.
+        if (!comApiCall &&
+            !Settings::GroupPolicies().IsEnabled(Settings::TogglePolicy::Policy::WinGetCommandLineInterfaces))
         {
             AICLI_LOG(CLI, Error, << "WinGet is disabled by group policy");
             throw GroupPolicyException(Settings::TogglePolicy::Policy::WinGetCommandLineInterfaces);
@@ -929,7 +933,7 @@ namespace AppInstaller::CLI
         context.Reporter.Error() << Resource::String::CommandDoesNotSupportResumeMessage << std::endl;
         AICLI_TERMINATE_CONTEXT(E_NOTIMPL);
     }
-    
+
     void Command::SelectCurrentCommandIfUnrecognizedSubcommandFound(bool value)
     {
         m_selectCurrentCommandIfUnrecognizedSubcommandFound = value;

--- a/src/AppInstallerCLICore/Commands/COMCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/COMCommand.cpp
@@ -16,6 +16,15 @@ namespace AppInstaller::CLI
     using namespace AppInstaller::Manifest;
     using namespace AppInstaller::Utility::literals;
 
+    // IMPORTANT: This serves as a base interface for all COM commands and should not be used directly.
+    // It allows the COM Command implementations to share and enforce common behavior before invoking the base implementation.
+    // Currently, it sets the WinGetCOMApiCall flag in the context before invoking the base Execute implementation.
+    void COMCommand::Execute(Context& context) const
+    {
+        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
+        Command::Execute(context);
+    }
+
     // IMPORTANT: To use this command, the caller should have already retrieved the package manifest (GetManifest()) and added it to the Context Data
     void COMDownloadCommand::ExecuteInternal(Context& context) const
     {
@@ -30,12 +39,6 @@ namespace AppInstaller::CLI
             Workflow::DownloadInstaller;
     }
 
-    void COMDownloadCommand::Execute(Context& context) const
-    {
-        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
-        Command::Execute(context);
-    }
-
     // IMPORTANT: To use this command, the caller should have already executed the COMDownloadCommand
     void COMInstallCommand::ExecuteInternal(Context& context) const
     {
@@ -45,22 +48,10 @@ namespace AppInstaller::CLI
             Workflow::InstallPackageInstaller;
     }
 
-    void COMInstallCommand::Execute(Context& context) const
-    {
-        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
-        Command::Execute(context);
-    }
-
     // IMPORTANT: To use this command, the caller should have already retrieved the InstalledPackageVersion and added it to the Context Data
     void COMUninstallCommand::ExecuteInternal(Execution::Context& context) const
     {
         context <<
             Workflow::UninstallSinglePackage;
-    }
-
-    void COMUninstallCommand::Execute(Execution::Context& context) const
-    {
-        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
-        Command::Execute(context);
     }
 }

--- a/src/AppInstallerCLICore/Commands/COMCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/COMCommand.cpp
@@ -30,6 +30,12 @@ namespace AppInstaller::CLI
             Workflow::DownloadInstaller;
     }
 
+    void COMDownloadCommand::Execute(Context& context) const
+    {
+        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
+        Command::Execute(context);
+    }
+
     // IMPORTANT: To use this command, the caller should have already executed the COMDownloadCommand
     void COMInstallCommand::ExecuteInternal(Context& context) const
     {
@@ -39,10 +45,22 @@ namespace AppInstaller::CLI
             Workflow::InstallPackageInstaller;
     }
 
+    void COMInstallCommand::Execute(Context& context) const
+    {
+        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
+        Command::Execute(context);
+    }
+
     // IMPORTANT: To use this command, the caller should have already retrieved the InstalledPackageVersion and added it to the Context Data
     void COMUninstallCommand::ExecuteInternal(Execution::Context& context) const
     {
         context <<
             Workflow::UninstallSinglePackage;
+    }
+
+    void COMUninstallCommand::Execute(Execution::Context& context) const
+    {
+        context.SetFlags(Execution::ContextFlag::WinGetCOMApiCall);
+        Command::Execute(context);
     }
 }

--- a/src/AppInstallerCLICore/Commands/COMCommand.h
+++ b/src/AppInstallerCLICore/Commands/COMCommand.h
@@ -5,37 +5,43 @@
 
 namespace AppInstaller::CLI
 {
+    // IMPORTANT: This acts as a base interface for all COM commands, and should not be used directly
+    // This will only all the COM Command implementations to share and enforce common behavior before invoking based implementation.
+    // Right now, it sets the WinGetCOMApiCall flag to the context before invoking the base Execute implementation.
+    struct COMCommand : public Command
+    {
+    protected:
+        COMCommand(std::string_view name, std::string_view parent) : Command(name, parent) {}
+
+    public:
+        void Execute(Execution::Context& context) const override;
+    };
+
     // IMPORTANT: To use this command, the caller should have already retrieved the package manifest (GetManifest()) and added it to the Context Data
-    struct COMDownloadCommand final : public Command
+    struct COMDownloadCommand final : public COMCommand
     {
         constexpr static std::string_view CommandName = "download"sv;
-        COMDownloadCommand(std::string_view parent) : Command(CommandName, parent) {}
-
-        void Execute(Execution::Context& context) const override;
+        COMDownloadCommand(std::string_view parent) : COMCommand(CommandName, parent) {}
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };
 
     // IMPORTANT: To use this command, the caller should have already retrieved the package manifest (GetManifest()) and added it to the Context Data
-    struct COMInstallCommand final : public Command
+    struct COMInstallCommand final : public COMCommand
     {
         constexpr static std::string_view CommandName = "install"sv;
-        COMInstallCommand(std::string_view parent) : Command(CommandName, parent) {}
-
-        void Execute(Execution::Context& context) const override;
+        COMInstallCommand(std::string_view parent) : COMCommand(CommandName, parent) {}
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };
 
     // IMPORTANT: To use this command, the caller should have already retrieved the InstalledPackageVersion and added it to the Context Data
-    struct COMUninstallCommand final : public Command
+    struct COMUninstallCommand final : public COMCommand
     {
         constexpr static std::string_view CommandName = "uninstall"sv;
-        COMUninstallCommand(std::string_view parent) : Command(CommandName, parent) {}
-
-        void Execute(Execution::Context& context) const override;
+        COMUninstallCommand(std::string_view parent) : COMCommand(CommandName, parent) {}
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/Commands/COMCommand.h
+++ b/src/AppInstallerCLICore/Commands/COMCommand.h
@@ -11,6 +11,8 @@ namespace AppInstaller::CLI
         constexpr static std::string_view CommandName = "download"sv;
         COMDownloadCommand(std::string_view parent) : Command(CommandName, parent) {}
 
+        void Execute(Execution::Context& context) const override;
+
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };
@@ -21,6 +23,8 @@ namespace AppInstaller::CLI
         constexpr static std::string_view CommandName = "install"sv;
         COMInstallCommand(std::string_view parent) : Command(CommandName, parent) {}
 
+        void Execute(Execution::Context& context) const override;
+
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };
@@ -30,6 +34,8 @@ namespace AppInstaller::CLI
     {
         constexpr static std::string_view CommandName = "uninstall"sv;
         COMUninstallCommand(std::string_view parent) : Command(CommandName, parent) {}
+
+        void Execute(Execution::Context& context) const override;
 
     protected:
         void ExecuteInternal(Execution::Context& context) const override;

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -75,6 +75,7 @@ namespace AppInstaller::CLI::Execution
         RebootRequired = 0x400,
         RegisterResume = 0x800,
         InstallerExecutionUseRepair = 0x1000,
+        WinGetCOMApiCall = 0x2000,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ContextFlag);


### PR DESCRIPTION
[WHY:]
Currently, the policy check within Command::Execute, which is executed for all command implementations, also inadvertently blocks COM API calls due to inheritance from the command class.

[FIX:]
Allow COM API calls while the WinGetCommandLineInterfaces group policy is disabled.

The fix involves bypassing the policy check for calls originating from COM API, identified by a context flag set in the overridden Execute method in COMCommand.

This pull request is being closed as there is another one addressing the same issue https://github.com/microsoft/winget-cli/pull/4293/:

[TODOs:]
- Test run to make sure fix works as expected

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4287)