### PR TITLE
Ignore corrupted source data

### DIFF
--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -312,14 +312,14 @@ TEST_CASE("RepoSources_InvalidYAML", "[sources]")
 {
     SetSetting(Stream::UserSources, "Name: Value : BAD");
 
-    REQUIRE_THROWS_HR(GetSources(), APPINSTALLER_CLI_ERROR_SOURCES_INVALID);
+    REQUIRE_NOTHROW(GetSources());
 }
 
 TEST_CASE("RepoSources_MissingField", "[sources]")
 {
     SetSetting(Stream::UserSources, s_SingleSource_MissingArg);
 
-    REQUIRE_THROWS_HR(GetSources(), APPINSTALLER_CLI_ERROR_SOURCES_INVALID);
+    REQUIRE_NOTHROW(GetSources());
 }
 
 TEST_CASE("RepoSources_AddSource", "[sources]")

--- a/src/AppInstallerRepositoryCore/SourceList.cpp
+++ b/src/AppInstallerRepositoryCore/SourceList.cpp
@@ -145,7 +145,10 @@ namespace AppInstaller::Repository
             else
             {
                 std::vector<SourceDetailsInternal> result;
-                THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCES_INVALID, !TryReadSourceDetails(setting.GetName(), *sourcesStream, rootName, parse, result));
+                if (!TryReadSourceDetails(setting.GetName(), *sourcesStream, rootName, parse, result))
+                {
+                    AICLI_LOG(YAML, Error, << "Ignoring corrupted source data.");
+                }
                 return result;
             }
         }


### PR DESCRIPTION
## Change
Rather than a failure here, we will treat corrupt source data as simply empty.  The only recourse the user currently has is to delete it anyway, and COM callers have no means to mitigate it.
 
## Validation
Regression tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4291)