### PR TITLE
Improve behavior of 'UpgradeBehavior: deny'

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -601,6 +601,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(UpdateNotApplicableReason);
         WINGET_DEFINE_RESOURCE_STRINGID(UpgradeArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(UpgradeAvailableForPinned);
+        WINGET_DEFINE_RESOURCE_STRINGID(UpgradeBehaviorDenyCount);
         WINGET_DEFINE_RESOURCE_STRINGID(UpgradeBlockedByManifest);
         WINGET_DEFINE_RESOURCE_STRINGID(UpgradeBlockedByPinCount);
         WINGET_DEFINE_RESOURCE_STRINGID(UpgradeCommandLongDescription);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1723,6 +1723,10 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="UpgradePinnedByUserCount" xml:space="preserve">
     <value>{0} package(s) have pins that prevent upgrade. Use the 'winget pin' command to view and edit pins. Using the --include-pinned argument may show more results.</value>
     <comment>{Locked="winget pin","--include-pinned"} {0} is a placeholder replaced by an integer number of packages</comment>
+  </data>
+  <data name="UpgradeBehaviorDenyCount" xml:space="preserve">
+    <value>{0} package(s) cannot be upgraded using winget. Please use the method provided by the publisher for upgrading these packages.</value>
+    <comment>{0} is a placeholder replaced by an integer number of packages</comment>
   </data>
   <data name="ConfigureCommandLongDescription" xml:space="preserve">
     <value>Ensures that the system matches the desired state as described by the provided configuration. May download/execute processors in order to achieve the desired state. The configuration and the processors should be checked to ensure that they are trustworthy before applying them.</value>

--- a/src/AppInstallerCommonCore/Pin.cpp
+++ b/src/AppInstallerCommonCore/Pin.cpp
@@ -35,6 +35,10 @@ namespace AppInstaller::Pinning
         {
             return PinType::PinnedByManifest;
         }
+        else if (Utility::CaseInsensitiveEquals(in, "BlockedByManifest"sv))
+        {
+            return PinType::BlockedByManifest;
+        }
         else
         {
             return PinType::Unknown;
@@ -53,6 +57,8 @@ namespace AppInstaller::Pinning
             return "Gating"sv;
         case PinType::PinnedByManifest:
             return "PinnedByManifest"sv;
+        case PinType::BlockedByManifest:
+            return "BlockedByManifest"sv;
         case PinType::Unknown:
         default:
             return "Unknown";

--- a/src/AppInstallerCommonCore/Public/winget/Pin.h
+++ b/src/AppInstallerCommonCore/Public/winget/Pin.h
@@ -24,6 +24,9 @@ namespace AppInstaller::Pinning
         // The package is blocked from 'upgrade --all' and 'upgrade <package>'.
         // User has to unblock to allow update.
         Blocking,
+        // The package is blocked from 'upgrade --all' and 'upgrade <package>'.
+        // The user cannot unblock the package
+        BlockedByManifest,
     };
 
     std::string_view ToString(PinType type);

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -242,7 +242,11 @@ namespace AppInstaller::Repository
         strstr << Utility::GetCurrentUnixEpoch();
         index.SetMetadataByManifestId(manifestId, PackageVersionMetadata::TrackingWriteTime, strstr.str());
 
-        if (installer.RequireExplicitUpgrade)
+        if (installer.UpdateBehavior == Manifest::UpdateBehaviorEnum::Deny)
+        {
+            index.SetMetadataByManifestId(manifestId, PackageVersionMetadata::PinnedState, ToString(Pinning::PinType::BlockedByManifest));
+        }
+        else if (installer.RequireExplicitUpgrade)
         {
             index.SetMetadataByManifestId(manifestId, PackageVersionMetadata::PinnedState, ToString(Pinning::PinType::PinnedByManifest));
         }


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - Resolves #4298 
  - Resolves #4299 
-----

This PR extends the behavior of `UpgradeBehavior: deny` to the PackageTrackingCatalog so that packages which cannot be upgraded via winget are not included with `winget upgrade --all`. However, the package is still checked for whether or not an upgrade is available. If an upgrade is available, the user will be informed of the upgrade through a new table added at the end of the upgrade list. If the package is up to date, the table will not be shown.

```
PS D:\Git\winget-pkgs> wingetdev upgrade
Name           Id                   Version Available Source
------------------------------------------------------------
GitHub Desktop GitHub.GitHubDesktop 3.3.11  3.3.12    winget
1 upgrades available.

1 package(s) cannot be upgraded using winget. Please use the method provided by the publisher for upgrading these packages.
Name    Id              Version  Available Source
-------------------------------------------------
Discord Discord.Discord 1.0.9034 1.0.9035  winget

6 package(s) have pins that prevent upgrade. Use the 'winget pin' command to view and edit pins. Using the --include-pinned argument may show more results.
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4300)