### PR TITLE
Remove macro condition for GetAdminSettingPolicy

### DIFF
--- a/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
@@ -48,8 +48,5 @@ namespace AppInstaller::Settings
     std::vector<BoolAdminSetting> GetAllBoolAdminSettings();
     std::vector<StringAdminSetting> GetAllStringAdminSettings();
 
-#ifndef AICLI_DISABLE_TEST_HOOKS
-    // Only exposed for tests to validate that all admin settings have a corresponding policy
     TogglePolicy::Policy GetAdminSettingPolicy(BoolAdminSetting setting);
-#endif
 }


### PR DESCRIPTION
There was an issue with the AppInstaller build because the header definition for GetAdminSettingPolicy is not defined because of the macro. Removing the macro as this is the simplest fix to resolve this issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4314)