### PR TITLE
Fix header for AdminSettings

### DIFF
--- a/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
@@ -3,10 +3,7 @@
 #pragma once
 
 #include <string>
-
-#ifndef AICLI_DISABLE_TEST_HOOKS
 #include "winget/GroupPolicy.h"
-#endif
 
 namespace AppInstaller::Settings
 {


### PR DESCRIPTION
Overlooked this extra macro, verified in appinstaller build by disabling test macros