### PR TITLE
Add support for optional limitation set in configuration remote server and processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ The client is built around the concept of sources; a set of packages effectively
   * .NET Desktop Development
   * Desktop Development with C++
   * Universal Windows Platform Development
-* [Windows 10 SDK, version 2004 (10.0.19041.0)](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
-  > **Note**: You can also get it through `winget install Microsoft.WindowsSDK --version 10.0.19041.685` (use --force if you have a newer version installed) or via Visual Studio > Get Tools and Features > Individual Components > Windows 10 SDK (10.0.19041.0)
+* [Windows SDK for Windows 11 (10.0.22000.194)](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
+  > **Note**: You can also get it through `winget install Microsoft.WindowsSDK --version 10.0.22000.832` (use --force if you have a newer version installed) or via Visual Studio > Get Tools and Features > Individual Components > Windows 10 SDK (10.0.22000.0)
 * The following extensions:
   * [Microsoft Visual Studio Installer Projects](https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -413,7 +413,7 @@ jobs:
     inputs:
       SourceFolder: $(buildOutDirAnyCpu)
       Contents: |
-          Microsoft.Management.Configuration.Projection\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.Projection.dll
+          Microsoft.Management.Configuration.Projection\net6.0-windows10.0.22000.0\Microsoft.Management.Configuration.Projection.dll
       TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Configuration\SharedDependencies\$(BuildPlatform)
       flattenFolders: true
     condition: succeededOrFailed()

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
@@ -537,7 +537,7 @@
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorTextNuget)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <PropertyGroup>
       <MicrosoftManagementConfigurationProcessorPath>$(OutputPath)..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.winmd</MicrosoftManagementConfigurationProcessorPath>
-      <MicrosoftManagementConfigurationProcessorPath Condition="!Exists('$(MicrosoftManagementConfigurationProcessorPath)')">$(SolutionDir)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Processor\net6.0-windows10.0.19041.0\win\Microsoft.Management.Configuration.Processor.winmd</MicrosoftManagementConfigurationProcessorPath>
+      <MicrosoftManagementConfigurationProcessorPath Condition="!Exists('$(MicrosoftManagementConfigurationProcessorPath)')">$(SolutionDir)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Processor\net6.0-windows10.0.22000.0\win\Microsoft.Management.Configuration.Processor.winmd</MicrosoftManagementConfigurationProcessorPath>
     </PropertyGroup>
     <Message Importance="high" Text="Microsoft.Management.Configuration.Processor.winmd -&gt; $(MicrosoftManagementConfigurationProcessorPath)" />
     <Error Condition="!Exists('$(MicrosoftManagementConfigurationProcessorPath)')" Text="Microsoft.Management.Configuration.Processor.winmd was not found in $(MicrosoftManagementConfigurationProcessorPath)" />

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
@@ -251,7 +251,7 @@
       <WinGetAdditionalPackageFile Include="$(WinGetAdditonalPackageFileRoot)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Projection\**\Microsoft.Management.Configuration.Projection.dll">
         <PackagePath>ConfigurationRemotingServer\Microsoft.Management.Configuration.Projection.dll</PackagePath>
       </WinGetAdditionalPackageFile>
-      <WinGetAdditionalPackageFile Include="$(WinGetAdditonalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net6.0-windows10.0.19041.0\$(ConfigServerRid)\**\*">
+      <WinGetAdditionalPackageFile Include="$(WinGetAdditonalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net6.0-windows10.0.22000.0\$(ConfigServerRid)\**\*">
         <PackagePath>ConfigurationRemotingServer</PackagePath>
         <Recurse>true</Recurse>
       </WinGetAdditionalPackageFile>

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/src/ConfigurationRemotingServer/Program.cs
+++ b/src/ConfigurationRemotingServer/Program.cs
@@ -18,7 +18,6 @@ namespace ConfigurationRemotingServer
         private const string CommandLineSectionSeparator = "~~~~~~";
         private const string ExternalModulesName = "ExternalModules";
 
-
         static int Main(string[] args)
         {
             ulong memoryHandle = ulong.Parse(args[0]);
@@ -33,12 +32,13 @@ namespace ConfigurationRemotingServer
 
                 // Set default properties.
                 var externalModulesPath = GetExternalModulesPath();
-                if (!string.IsNullOrWhiteSpace(externalModulesPath))
+                if (string.IsNullOrWhiteSpace(externalModulesPath))
                 {
-                    // Set as implicit module paths so it will be always included in AdditionalModulePaths
-                    factory.ImplicitModulePaths = new List<string>() { externalModulesPath };
+                    throw new DirectoryNotFoundException("Failed to get ExternalModules.");
                 }
 
+                // Set as implicit module paths so it will be always included in AdditionalModulePaths
+                factory.ImplicitModulePaths = new List<string>() { externalModulesPath };
                 factory.ProcessorType = PowerShellConfigurationProcessorType.Hosted;
 
                 // Parse limitation set if applicable.

--- a/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
@@ -9,13 +9,13 @@ param(
 
 # Copy the winmd into the unit test directory since it will be needed for marshalling
 $Local:winmdSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd"
-$Local:winmdTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.winmd"
+$Local:winmdTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.22000.0\Microsoft.Management.Configuration.winmd"
 
 Copy-Item $Local:winmdSourcePath $Local:winmdTargetPath -Force
 
 # Copy the OOP helper dll into the unit test directory to make activation look the same as in-proc
 $Local:dllSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.OutOfProc\Microsoft.Management.Configuration.OutOfProc.dll"
-$Local:dllTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.dll"
+$Local:dllTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.22000.0\Microsoft.Management.Configuration.dll"
 
 Copy-Item $Local:dllSourcePath $Local:dllTargetPath -Force
 

--- a/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ValueSetExtensions.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -10,7 +10,6 @@ namespace Microsoft.Management.Configuration.Processor.Extensions
     using System.Collections;
     using System.Collections.Generic;
     using Windows.Foundation.Collections;
-    using WinRT;
 
     /// <summary>
     /// Extensions for ValueSet.
@@ -89,6 +88,89 @@ namespace Microsoft.Management.Configuration.Processor.Extensions
             }
 
             return sortedList.Values;
+        }
+
+        /// <summary>
+        /// Performs a deep compare of the ValueSets.
+        /// </summary>
+        /// <param name="first">First ValueSet.</param>
+        /// <param name="second">Second ValueSet.</param>
+        /// <returns>Whether the two ValueSets equal.</returns>
+        public static bool ContentEquals(this ValueSet first, ValueSet second)
+        {
+            if (first.Count != second.Count)
+            {
+                return false;
+            }
+
+            foreach (var keyValuePair in first)
+            {
+                if (!second.ContainsKey(keyValuePair.Key))
+                {
+                    return false;
+                }
+
+                var firstValue = keyValuePair.Value;
+                var secondValue = second[keyValuePair.Key];
+
+                // Empty value check.
+                if (firstValue == null && secondValue == null)
+                {
+                    continue;
+                }
+                else if ((firstValue == null && secondValue != null) ||
+                    (firstValue != null && secondValue == null))
+                {
+                    return false;
+                }
+
+                // Try as ValueSet.
+                var firstValueSet = firstValue as ValueSet;
+                var secondValueSet = secondValue as ValueSet;
+
+                if (firstValueSet != null && secondValueSet != null)
+                {
+                    if (!firstValueSet.ContentEquals(secondValueSet))
+                    {
+                        return false;
+                    }
+                }
+                else if ((firstValueSet == null && secondValueSet != null) ||
+                    (firstValueSet != null && secondValueSet == null))
+                {
+                    return false;
+                }
+
+                // Try as scalar.
+                if (firstValue is string firstString && secondValue is string secondString)
+                {
+                    if (firstString != secondString)
+                    {
+                        return false;
+                    }
+                }
+                else if (firstValue is long firstLong && secondValue is long secondLong)
+                {
+                    if (firstLong != secondLong)
+                    {
+                        return false;
+                    }
+                }
+                else if (firstValue is bool firstBool && secondValue is bool secondBool)
+                {
+                    if (firstBool != secondBool)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    // Note: DateTime and float are not supported in parser yet.
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
@@ -118,8 +118,7 @@ namespace Microsoft.Management.Configuration.Processor.Extensions
                 {
                     continue;
                 }
-                else if ((firstValue == null && secondValue != null) ||
-                    (firstValue != null && secondValue == null))
+                else if (firstValue == null || secondValue == null)
                 {
                     return false;
                 }
@@ -139,8 +138,7 @@ namespace Microsoft.Management.Configuration.Processor.Extensions
                         continue;
                     }
                 }
-                else if ((firstValueSet == null && secondValueSet != null) ||
-                    (firstValueSet != null && secondValueSet == null))
+                else if (firstValueSet != null || secondValueSet != null)
                 {
                     return false;
                 }

--- a/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Extensions/ValueSetExtensions.cs
@@ -134,6 +134,10 @@ namespace Microsoft.Management.Configuration.Processor.Extensions
                     {
                         return false;
                     }
+                    else
+                    {
+                        continue;
+                    }
                 }
                 else if ((firstValueSet == null && secondValueSet != null) ||
                     (firstValueSet != null && secondValueSet == null))

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <DotNetVersion>net6.0</DotNetVersion>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)-windows10.0.22000.0</TargetFramework>
     <Nullable>enable</Nullable>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
@@ -30,7 +30,7 @@
 
   <PropertyGroup>
     <CsWinRTComponent>true</CsWinRTComponent>
-    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -17,5 +17,5 @@ using System.Runtime.Versioning;
 
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
-[assembly: TargetPlatform("Windows10.0.19041.0")]
+[assembly: TargetPlatform("Windows10.0.22000.0")]
 [assembly: SupportedOSPlatform("Windows10.0.17763.0")]

--- a/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
@@ -400,6 +400,7 @@ namespace Microsoft.Management.Configuration.Processor
 
             if (this.isCreateProcessorInvoked)
             {
+                this.OnDiagnostics(DiagnosticLevel.Error, "CreateSetProcessor is already invoked in limit mode.");
                 throw new InvalidOperationException("CreateSetProcessor is already invoked in limit mode.");
             }
             else

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
                     throw new InvalidOperationException("Configuration set should not be null in limit mode.");
                 }
 
-                var unitList = useLimitList ? this.configurationSet.Units : this.limitUnitList;
+                var unitList = useLimitList ? this.limitUnitList : this.configurationSet.Units;
 
                 for (int i = unitList.Count - 1; i >= 0; i--)
                 {

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationSetProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -24,16 +24,25 @@ namespace Microsoft.Management.Configuration.Processor.Set
     internal sealed class ConfigurationSetProcessor : IConfigurationSetProcessor
     {
         private readonly ConfigurationSet? configurationSet;
+        private readonly bool isLimitMode;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationSetProcessor"/> class.
         /// </summary>
         /// <param name="processorEnvironment">The processor environment.</param>
         /// <param name="configurationSet">Configuration set.</param>
-        public ConfigurationSetProcessor(IProcessorEnvironment processorEnvironment, ConfigurationSet? configurationSet)
+        /// <param name="isLimitMode">Whether the set processor should work in limitation mode.</param>
+        public ConfigurationSetProcessor(IProcessorEnvironment processorEnvironment, ConfigurationSet? configurationSet, bool isLimitMode = false)
         {
             this.ProcessorEnvironment = processorEnvironment;
             this.configurationSet = configurationSet;
+            this.isLimitMode = isLimitMode;
+
+            // In limit mode, configurationSet is the limitation set to be used. It cannot be null.
+            if (this.isLimitMode && this.configurationSet == null)
+            {
+                throw new ArgumentNullException(nameof(this.configurationSet), "configurationSet is required in limit mode.");
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
     using Microsoft.Management.Configuration.Processor.Helpers;
     using Microsoft.Management.Configuration.Processor.ProcessorEnvironments;
     using Microsoft.Management.Configuration.Processor.Unit;
+    using Windows.Foundation.Collections;
     using Windows.Security.Cryptography.Certificates;
 
     /// <summary>
@@ -209,11 +210,33 @@ namespace Microsoft.Management.Configuration.Processor.Set
             return schemaVersion != null && schemaVersion == "0.1";
         }
 
+        private static bool ValueSetEquals(ValueSet first, ValueSet second)
+        {
+            if (first.Count != second.Count)
+            {
+                return false;
+            }
+
+
+
+            return true;
+        }
+
         private static bool ConfigurationUnitEquals(ConfigurationUnit first, ConfigurationUnit second)
         {
             if (first.Identifier != second.Identifier ||
                 first.Type != second.Type ||
                 first.Intent != second.Intent)
+            {
+                return false;
+            }
+
+            if (!ValueSetEquals(first.Settings, second.Settings))
+            {
+                return false;
+            }
+
+            if (!ValueSetEquals(first.Metadata, second.Metadata))
             {
                 return false;
             }

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
     using System.Collections.Generic;
     using System.IO;
     using System.Management.Automation;
+    using System.Runtime.CompilerServices;
     using Microsoft.Management.Configuration.Processor.DscResourcesInfo;
     using Microsoft.Management.Configuration.Processor.Exceptions;
     using Microsoft.Management.Configuration.Processor.Extensions;
@@ -63,6 +64,17 @@ namespace Microsoft.Management.Configuration.Processor.Set
         /// Gets the processor environment.
         /// </summary>
         internal IProcessorEnvironment ProcessorEnvironment { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the set processor is running in limit mode.
+        /// </summary>
+        internal bool IsLimitMode
+        {
+            get
+            {
+                return this.isLimitMode;
+            }
+        }
 
         /// <summary>
         /// Creates a configuration unit processor for the given unit.
@@ -395,6 +407,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
             this.SetProcessorFactory?.OnDiagnostics(level, message);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         private ConfigurationUnit GetConfigurationUnit(ConfigurationUnit incomingUnit, bool useLimitList = false)
         {
             if (this.isLimitMode)

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -10,13 +10,12 @@ namespace Microsoft.Management.Configuration.Processor.Set
     using System.Collections.Generic;
     using System.IO;
     using System.Management.Automation;
-    using Microsoft.Management.Configuration.Processor.Constants;
     using Microsoft.Management.Configuration.Processor.DscResourcesInfo;
     using Microsoft.Management.Configuration.Processor.Exceptions;
+    using Microsoft.Management.Configuration.Processor.Extensions;
     using Microsoft.Management.Configuration.Processor.Helpers;
     using Microsoft.Management.Configuration.Processor.ProcessorEnvironments;
     using Microsoft.Management.Configuration.Processor.Unit;
-    using Windows.Foundation.Collections;
     using Windows.Security.Cryptography.Certificates;
 
     /// <summary>
@@ -210,18 +209,6 @@ namespace Microsoft.Management.Configuration.Processor.Set
             return schemaVersion != null && schemaVersion == "0.1";
         }
 
-        private static bool ValueSetEquals(ValueSet first, ValueSet second)
-        {
-            if (first.Count != second.Count)
-            {
-                return false;
-            }
-
-
-
-            return true;
-        }
-
         private static bool ConfigurationUnitEquals(ConfigurationUnit first, ConfigurationUnit second)
         {
             if (first.Identifier != second.Identifier ||
@@ -231,17 +218,17 @@ namespace Microsoft.Management.Configuration.Processor.Set
                 return false;
             }
 
-            if (!ValueSetEquals(first.Settings, second.Settings))
+            if (!first.Settings.ContentEquals(second.Settings))
             {
                 return false;
             }
 
-            if (!ValueSetEquals(first.Metadata, second.Metadata))
+            if (!first.Metadata.ContentEquals(second.Metadata))
             {
                 return false;
             }
 
-            // Consider group units logic when group units are supported.
+            // Note: Consider group units logic when group units are supported.
             return true;
         }
 
@@ -432,7 +419,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
                         return unit;
                     }
 
-                    // Consider group units logic when group units are supported.
+                    // Note: Consider group units logic when group units are supported.
                 }
 
                 throw new InvalidOperationException("Configuration unit not found in limit mode.");

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
@@ -190,6 +190,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
             {
                 if (this.isTestInvoked)
                 {
+                    this.OnDiagnostics(DiagnosticLevel.Error, "TestSettings is already invoked in limit mode.");
                     throw new InvalidOperationException("TestSettings is already invoked in limit mode.");
                 }
                 else
@@ -202,6 +203,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
             {
                 if (this.isApplyInvoked)
                 {
+                    this.OnDiagnostics(DiagnosticLevel.Error, "ApplySettings is already invoked in limit mode.");
                     throw new InvalidOperationException("ApplySettings is already invoked in limit mode.");
                 }
                 else

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationUnitProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -7,6 +7,8 @@
 namespace Microsoft.Management.Configuration.Processor.Unit
 {
     using System;
+    using System.ComponentModel;
+    using System.Runtime.CompilerServices;
     using Microsoft.Management.Configuration;
     using Microsoft.Management.Configuration.Processor.Exceptions;
     using Microsoft.Management.Configuration.Processor.Extensions;
@@ -20,18 +22,25 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     {
         private readonly IProcessorEnvironment processorEnvironment;
         private readonly ConfigurationUnitAndResource unitResource;
+        private readonly bool isLimitMode;
+
+        private bool isTestInvoked = false;
+        private bool isApplyInvoked = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationUnitProcessor"/> class.
         /// </summary>
         /// <param name="processorEnvironment">Processor environment.</param>
         /// <param name="unitResource">UnitResource.</param>
+        /// <param name="isLimitMode">Whether it is under limit mode.</param>
         internal ConfigurationUnitProcessor(
             IProcessorEnvironment processorEnvironment,
-            ConfigurationUnitAndResource unitResource)
+            ConfigurationUnitAndResource unitResource,
+            bool isLimitMode = false)
         {
             this.processorEnvironment = processorEnvironment;
             this.unitResource = unitResource;
+            this.isLimitMode = isLimitMode;
         }
 
         /// <summary>
@@ -53,6 +62,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
         {
             this.OnDiagnostics(DiagnosticLevel.Verbose, $"Invoking `Get` for resource: {this.unitResource.UnitInternal.QualifiedName}...");
 
+            this.CheckLimitMode(ConfigurationUnitIntent.Inform);
             var result = new GetSettingsResult(this.Unit);
 
             try
@@ -86,6 +96,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
                 throw new NotSupportedException();
             }
 
+            this.CheckLimitMode(ConfigurationUnitIntent.Assert);
             var result = new TestSettingsResult(this.Unit);
             result.TestResult = ConfigurationTestResult.Failed;
             try
@@ -122,6 +133,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
                 throw new NotSupportedException();
             }
 
+            this.CheckLimitMode(ConfigurationUnitIntent.Apply);
             var result = new ApplySettingsResult(this.Unit);
             try
             {
@@ -159,6 +171,46 @@ namespace Microsoft.Management.Configuration.Processor.Unit
                 resultInformation.Details = e.ToString();
                 resultInformation.ResultSource = ConfigurationUnitResultSource.Internal;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private void CheckLimitMode(ConfigurationUnitIntent intent)
+        {
+            if (!this.isLimitMode)
+            {
+                return;
+            }
+
+            if (intent == ConfigurationUnitIntent.Unknown)
+            {
+                throw new InvalidEnumArgumentException(nameof(ConfigurationUnitIntent.Unknown));
+            }
+
+            if (intent == ConfigurationUnitIntent.Assert)
+            {
+                if (this.isTestInvoked)
+                {
+                    throw new InvalidOperationException("TestSettings is already invoked in limit mode.");
+                }
+                else
+                {
+                    this.isTestInvoked = true;
+                }
+            }
+
+            if (intent == ConfigurationUnitIntent.Apply)
+            {
+                if (this.isApplyInvoked)
+                {
+                    throw new InvalidOperationException("ApplySettings is already invoked in limit mode.");
+                }
+                else
+                {
+                    this.isApplyInvoked = true;
+                }
+            }
+
+            // Get is always allowed now.
         }
 
         private void OnDiagnostics(DiagnosticLevel level, string message)

--- a/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
+++ b/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <Platform>AnyCpu</Platform>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <CsWinRTIncludes>Microsoft.Management.Configuration</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-    <CsWinRTWindowsMetadata>10.0.19041.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/Errors.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/Errors.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="Errors.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -7,7 +7,7 @@
 namespace Microsoft.Management.Configuration.UnitTests.Helpers
 {
     /// <summary>
-    /// Contains the error codes used by Microsoft.Management.Configuration
+    /// Contains the error codes used by Microsoft.Management.Configuration.
     /// </summary>
     internal static class Errors
     {

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="OutOfProcAttribute.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -27,7 +27,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
             // The test runner is located somewhere like this:
             //  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform
             // and the command line from there is:
-            //  .\vstest.console.exe "<location of your repo>\src\x64\Debug\Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.UnitTests.dll" --TestCaseFilter:Category=OutOfProc
+            //  .\vstest.console.exe "<location of your repo>\src\x64\Debug\Microsoft.Management.Configuration.UnitTests\net6.0-windows10.0.22000.0\Microsoft.Management.Configuration.UnitTests.dll" --TestCaseFilter:Category=OutOfProc
         }
     }
 }

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <Nullable>enable</Nullable>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Platforms>x64;x86;arm64</Platforms>

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationProcessorFactoryTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
             configurationProcessorFactory.ImplicitModulePaths = new List<string> { @"c:\this\is\implicit" };
             Assert.Equal(configurationProcessorFactory.AdditionalModulePaths, new List<string> { @"c:\this\is\additional", @"c:\this\is\implicit" });
 
-            // Set AdditiionalModulePaths when ImplicitModulePaths module paths are set
+            // Set AdditionalModulePaths when ImplicitModulePaths module paths are set
             configurationProcessorFactory.AdditionalModulePaths = new List<string> { @"c:\this\is\additional\2" };
             Assert.Equal(configurationProcessorFactory.AdditionalModulePaths, new List<string> { @"c:\this\is\additional\2", @"c:\this\is\implicit" });
         }

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorFactoryTests.cs
@@ -135,5 +135,52 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
             var modulePath = setProcessor.ProcessorEnvironment.GetVariable<string>(Variables.PSModulePath);
             Assert.Contains($"{properties.CustomLocation};", modulePath);
         }
+
+        /// <summary>
+        /// Tests the configuration set processor in limitation mode.
+        /// </summary>
+        [Fact]
+        public void CreateSetProcessor_LimitMode()
+        {
+            var configurationProcessorFactory = new PowerShellConfigurationSetProcessorFactory();
+            var configurationSet = new ConfigurationSet();
+            configurationProcessorFactory.LimitationSet = configurationSet;
+
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.LimitationSet = configurationSet);
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.ProcessorType = PowerShellConfigurationProcessorType.Default);
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.AdditionalModulePaths = new List<string>());
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.ImplicitModulePaths = new List<string>());
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.Policy = PowerShellConfigurationProcessorPolicy.Unrestricted);
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.Location = PowerShellConfigurationProcessorLocation.Custom);
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.CustomLocation = @"c:\this\is\a\module\path");
+
+            var setProcessor = configurationProcessorFactory.CreateSetProcessor(configurationSet) as ConfigurationSetProcessor;
+            Assert.NotNull(setProcessor);
+            Assert.True(setProcessor.IsLimitMode);
+
+            // Create processor again in limit mode should fail
+            Assert.Throws<System.InvalidOperationException>(() => configurationProcessorFactory.CreateSetProcessor(configurationSet));
+        }
+
+        /// <summary>
+        /// Tests the configuration set processor factory with ImplicitModulePaths.
+        /// </summary>
+        [Fact]
+        public void ImplicitModulePaths()
+        {
+            var configurationProcessorFactory = new PowerShellConfigurationSetProcessorFactory();
+
+            // When ImplicitModulePaths module paths are not set
+            configurationProcessorFactory.AdditionalModulePaths = new List<string> { @"c:\this\is\additional" };
+            Assert.Equal(configurationProcessorFactory.AdditionalModulePaths, new List<string> { @"c:\this\is\additional" });
+
+            // Implicit ModulePaths are set, it automatically populates AdditionalModulePaths
+            configurationProcessorFactory.ImplicitModulePaths = new List<string> { @"c:\this\is\implicit" };
+            Assert.Equal(configurationProcessorFactory.AdditionalModulePaths, new List<string> { @"c:\this\is\additional", @"c:\this\is\implicit" });
+
+            // Set AdditiionalModulePaths when ImplicitModulePaths module paths are set
+            configurationProcessorFactory.AdditionalModulePaths = new List<string> { @"c:\this\is\additional\2" };
+            Assert.Equal(configurationProcessorFactory.AdditionalModulePaths, new List<string> { @"c:\this\is\additional\2", @"c:\this\is\implicit" });
+        }
     }
 }

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationUnitProcessorTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationUnitProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationUnitProcessorTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -351,6 +351,44 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
             Assert.Equal(thrownException.HResult, result.ResultInformation.ResultCode.HResult);
             Assert.True(!string.IsNullOrWhiteSpace(result.ResultInformation.Description));
             Assert.Equal(ConfigurationUnitResultSource.Internal, result.ResultInformation.ResultSource);
+        }
+
+        /// <summary>
+        /// Tests ApplySettings in limit mode.
+        /// </summary>
+        [Fact]
+        public void ApplySettings_Test_LimitMode()
+        {
+            string theKey = "key";
+            string theValue = "value";
+            var valueGetResult = new ValueSet
+            {
+                { theKey, theValue },
+            };
+
+            var processorEnvMock = new Mock<IProcessorEnvironment>();
+            processorEnvMock.Setup(m => m.InvokeGetResource(
+                It.IsAny<ValueSet>(),
+                It.IsAny<string>(),
+                It.IsAny<ModuleSpecification?>()))
+                .Returns(valueGetResult)
+                .Verifiable();
+
+            var unitResource = this.CreateUnitResource(ConfigurationUnitIntent.Apply);
+
+            var unitProcessor = new ConfigurationUnitProcessor(processorEnvMock.Object, unitResource, true);
+
+            // GetSettings can be called multiple times.
+            var getResult = unitProcessor.GetSettings();
+            getResult = unitProcessor.GetSettings();
+
+            // TestSettings can be called only once.
+            var testResult = unitProcessor.TestSettings();
+            Assert.Throws<System.InvalidOperationException>(() => unitProcessor.TestSettings());
+
+            // ApplySettings can be called only once.
+            var applyResult = unitProcessor.ApplySettings();
+            Assert.Throws<System.InvalidOperationException>(() => unitProcessor.ApplySettings());
         }
 
         private ConfigurationUnitAndResource CreateUnitResource(ConfigurationUnitIntent intent)

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ValueSetExtensionsTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ValueSetExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ValueSetExtensionsTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -339,6 +339,121 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
             };
 
             Assert.Throws<InvalidOperationException>(() => valueSetArray.ToArray());
+        }
+
+        /// <summary>
+        /// Tests ValueSet simple types content equals.
+        /// </summary>
+        [Fact]
+        public void ValueSet_SimpleTypes_ContentEquals()
+        {
+            string stringProperty = "stringProperty";
+            string stringPropertyValue = "string";
+
+            string intProperty = "intProperty";
+            long intPropertyValue = 64;
+
+            string boolProperty = "boolProperty";
+            bool boolPropertyValue = true;
+
+            var valueSet = new ValueSet
+            {
+                { stringProperty, stringPropertyValue },
+                { intProperty, intPropertyValue },
+                { boolProperty, boolPropertyValue },
+            };
+
+            // Same content different order
+            var valueSetDifferentOrder = new ValueSet
+            {
+                { boolProperty, boolPropertyValue },
+                { stringProperty, stringPropertyValue },
+                { intProperty, intPropertyValue },
+            };
+
+            Assert.True(valueSet.ContentEquals(valueSetDifferentOrder));
+
+            // Entry missing
+            var valueSetEntryMissing = new ValueSet
+            {
+                { stringProperty, stringPropertyValue },
+                { intProperty, intPropertyValue },
+            };
+
+            Assert.False(valueSet.ContentEquals(valueSetEntryMissing));
+
+            // Different entry
+            var valueSetEntryDifferent = new ValueSet
+            {
+                { stringProperty, stringPropertyValue },
+                { intProperty, intPropertyValue },
+                { "Another", "AnotherValue" },
+            };
+
+            Assert.False(valueSet.ContentEquals(valueSetEntryDifferent));
+
+            // Different value
+            var valueSetDifferentValue = new ValueSet
+            {
+                { boolProperty, boolPropertyValue },
+                { stringProperty, stringPropertyValue },
+                { intProperty, 0 },
+            };
+
+            Assert.False(valueSet.ContentEquals(valueSetDifferentValue));
+        }
+
+        /// <summary>
+        /// Tests when a ValueSet has inner value sets.
+        /// </summary>
+        [Fact]
+        public void ValueSet_NestedValueSets_ContentEquals()
+        {
+            string boolPropertyInner = "boolPropertyInner";
+            bool boolPropertyValueInner = true;
+            var valueSetInner = new ValueSet()
+            {
+                { boolPropertyInner, boolPropertyValueInner },
+            };
+
+            string stringPropertyInnerInner = "stringPropertyInnerInner";
+            string stringPropertyValueInnerInner = "stringInnerInner";
+            var valueSetInnerInner = new ValueSet()
+            {
+                { stringPropertyInnerInner, stringPropertyValueInnerInner },
+            };
+
+            string inner2Key = "InnerKey2";
+            var valueSetInner2 = new ValueSet()
+            {
+                { inner2Key, valueSetInnerInner },
+            };
+
+            string key1 = "key1";
+            string key2 = "key2";
+            var valueSet = new ValueSet()
+            {
+                { key1, valueSetInner },
+                { key2, valueSetInner2 },
+            };
+
+            // Same content different order
+            var valueSetDifferentOrder = new ValueSet()
+            {
+                { key2, valueSetInner2 },
+                { key1, valueSetInner },
+            };
+
+            Assert.True(valueSet.ContentEquals(valueSetDifferentOrder));
+
+            // Different nested content
+            var valueSetDifferentContent = new ValueSet()
+            {
+                { key2, valueSetInner },
+                { key1, valueSetInner2 },
+            };
+
+            Assert.False(valueSet.ContentEquals(valueSetDifferentContent));
         }
     }
 }

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>net6.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Properties/AssemblyInfo.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -10,7 +10,7 @@ using System.Runtime.Versioning;
 
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
-[assembly: TargetPlatform("Windows10.0.19041.0")]
+[assembly: TargetPlatform("Windows10.0.22000.0")]
 [assembly: SupportedOSPlatform("Windows10.0.18362.0")]
 
 #endif

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>net6.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Properties/AssemblyInfo.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AssemblyInfo.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -10,7 +10,7 @@ using System.Runtime.Versioning;
 
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
-[assembly: TargetPlatform("Windows10.0.19041.0")]
+[assembly: TargetPlatform("Windows10.0.22000.0")]
 [assembly: SupportedOSPlatform("Windows10.0.18362.0")]
 
 #endif

--- a/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
+++ b/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
@@ -207,7 +207,7 @@ if ($moduleToConfigure.HasFlag([ModuleType]::Configuration))
     )
     $module.AddArchSpecificFiles($additionalFiles, "SharedDependencies", $BuildRoot, $Configuration)
     $additionalFiles = @(
-        "Microsoft.Management.Configuration.Projection\net6.0-windows10.0.19041.0\Microsoft.Management.Configuration.Projection.dll"
+        "Microsoft.Management.Configuration.Projection\net6.0-windows10.0.22000.0\Microsoft.Management.Configuration.Projection.dll"
     )
     $module.AddAnyCpuSpecificFilesToArch($additionalFiles, "SharedDependencies", $BuildRoot, $Configuration)
     $modules += $module

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj
@@ -15,7 +15,7 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.19041.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">


### PR DESCRIPTION
Added support for optional limitation set in configuration remote server and processors. When running in limitation mode, incoming units would need to match units in limitation set. And units can only be asserted or applied once.

Added tests. And some hacky manual verification. E2E tests will come along when calling side is updated in separate pr.

Also updated .net target OS version to 22000 to match other parts. (I thought there was a bug in IInputStreamAdaptor for MemoryStream)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4349)