### PR TITLE
Improve MSStore installation success rate by trying Restart or Cancel when applicable

### DIFF
--- a/src/AppInstallerCommonCore/MSStore.cpp
+++ b/src/AppInstallerCommonCore/MSStore.cpp
@@ -282,8 +282,12 @@ namespace AppInstaller::MSStore
         auto cancelIfOperationFailed = wil::scope_exit(
             [&]()
             {
-                AppInstallManager installManager;
-                installManager.Cancel(m_productId);
+                try
+                {    
+                    AppInstallManager installManager;
+                    installManager.Cancel(m_productId);
+                }
+                CATCH_LOG();
             });
 
         for (auto const& installItem : installItems)

--- a/src/AppInstallerCommonCore/MSStore.cpp
+++ b/src/AppInstallerCommonCore/MSStore.cpp
@@ -121,6 +121,7 @@ namespace AppInstaller::MSStore
                 case AppInstallState::PausedLowBattery:
                 case AppInstallState::PausedWiFiRecommended:
                 case AppInstallState::PausedWiFiRequired:
+                case AppInstallState::ReadyToDownload:
                     // For these states, set result to restart and continue the loop to see if future items need cancel.
                     result = CheckExistingItemResult::Restart;
                     break;

--- a/src/AppInstallerSharedLib/AppInstallerStrings.cpp
+++ b/src/AppInstallerSharedLib/AppInstallerStrings.cpp
@@ -104,6 +104,11 @@ namespace AppInstaller::Utility
         return ToLower(a) == ToLower(b);
     }
 
+    bool CaseInsensitiveEquals(std::wstring_view a, std::wstring_view b)
+    {
+        return ToLower(a) == ToLower(b);
+    }
+
     bool CaseInsensitiveContains(const std::vector<std::string_view>& a, std::string_view b)
     {
         auto B = ToLower(b);

--- a/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
@@ -108,6 +108,10 @@ namespace AppInstaller::Utility
     // Use this if one of the values is a known value, and thus ToLower is sufficient.
     bool CaseInsensitiveEquals(std::string_view a, std::string_view b);
 
+    // Compares the two UTF16 strings in a case insensitive manner.
+    // Use this if one of the values is a known value, and thus ToLower is sufficient.
+    bool CaseInsensitiveEquals(std::wstring_view a, std::wstring_view b);
+
     // Returns if a UTF8 string is contained within a vector in a case insensitive manner.
     bool CaseInsensitiveContains(const std::vector<std::string_view>& a, std::string_view b);
 


### PR DESCRIPTION
After calling to InstallProductAsync, try to check status of existing install items and call Restart or Cancel if applicable.
After our operation failed, clean up the installation queue by calling cancel.

I manually validated by opening Store app, install a test app and pause the installation. Then use winget to install the same app. App installation failed before the change and succeeded after the change.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4356)