### PR TITLE
Enable Microsoft.WinGet.Client arm64 support

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Resolver/ModuleInit.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Resolver/ModuleInit.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ModuleInit.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -23,7 +23,7 @@ namespace Microsoft.WinGet.Resolver
     /// </summary>
     public class ModuleInit : IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
-        private static readonly IEnumerable<Architecture> ValidArchs = new Architecture[] { Architecture.X86, Architecture.X64 };
+        private static readonly IEnumerable<Architecture> ValidArchs = new Architecture[] { Architecture.X86, Architecture.X64, Architecture.Arm64 };
 
         /// <inheritdoc/>
         public void OnImport()

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/OperationWithProgressBase.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/OperationWithProgressBase.cs
@@ -24,8 +24,8 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
 
         static OperationWithProgressBase()
         {
-            // There's an OS bug where COM has never worked properly on arm64, this cause the
-            // progress to AV on that architecture. Fix is in 10.0.26068.0, for build before disable progress.
+            // Progress on arm64 will produce an AV because there's an OS bug where marshaling structs over a certain size fail.
+            // Fix is in 10.0.26068.0, for build before that disable progress.
             if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
             {
                 var minWindowsVersion = new Version(10, 0, 26068, 0);

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
@@ -11,7 +11,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
     using System.IO;
     using System.Linq;
     using System.Management.Automation;
-    using System.Runtime.InteropServices;
     using System.Threading.Tasks;
     using Microsoft.Management.Configuration;
     using Microsoft.Management.Configuration.Processor;
@@ -31,24 +30,6 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
     /// </summary>
     public sealed class ConfigurationCommand : PowerShellCmdlet
     {
-        private static bool isProgressEnabled;
-
-        static ConfigurationCommand()
-        {
-            // There's an OS bug where COM has never worked properly on arm64, this cause the
-            // progress to AV on that architecture. Fix is in 10.0.26068.0, for build before disable progress.
-            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-            {
-                var minWindowsVersion = new Version(10, 0, 26068, 0);
-                var osVersion = Environment.OSVersion.Version;
-                isProgressEnabled = osVersion.CompareTo(minWindowsVersion) >= 0;
-            }
-            else
-            {
-                isProgressEnabled = true;
-            }
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationCommand"/> class.
         /// </summary>
@@ -383,11 +364,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
                 set.Units.Count);
 
             var applyTask = processor.ApplySetAsync(set, flags);
-
-            if (isProgressEnabled)
-            {
-                applyTask.Progress = applyProgressOutput.Progress;
-            }
+            applyTask.Progress = applyProgressOutput.Progress;
 
             try
             {
@@ -421,11 +398,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
                 set.Units.Count);
 
             var testTask = processor.TestSetAsync(set);
-
-            if (isProgressEnabled)
-            {
-                testTask.Progress = testProgressOutput.Progress;
-            }
+            testTask.Progress = testProgressOutput.Progress;
 
             try
             {
@@ -463,11 +436,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
                     totalUnitsCount);
 
                 var detailsTask = processor.GetSetDetailsAsync(set, ConfigurationUnitDetailFlags.ReadOnly);
-
-                if (isProgressEnabled)
-                {
-                    detailsTask.Progress = detailsProgressOutput.Progress;
-                }
+                detailsTask.Progress = detailsProgressOutput.Progress;
 
                 try
                 {


### PR DESCRIPTION
This PR enables arm64 for the Microsoft.WinGet.Client module.

There's an OS bug that causes an AV (see https://github.com/microsoft/winget-cli/pull/4251#issuecomment-1989102892) in arm64 devices that was fixed in a newer Windows build. The AV message is just shown for PowerShell Core. In Windows PowerShell no error message is displayed but it won't display progress either. Regardless, the winget install/uninstall operation still happens as the progress is shown after we asked winget to install the app. The configuration module doesn't get affected by the OS bug, so there's no need to disable progress.

To keep showing progress the module now looks at the OS version. If the processor architecture is arm64 and the OS version is lower than 10.0.26068.0 progress is disabled in the module.

I verified manually on arm64 builds with and without the fix. 

Fixes #4169

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4392)