### PR TITLE
Fix mixed elevation integration issue by using MemoryStream (#4413)

### DIFF
--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
@@ -232,8 +232,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             // This is done here to enable easy cancellation propagation to the stream reads.
             uint32_t bufferSize = 1 << 20;
             Windows::Storage::Streams::Buffer buffer(bufferSize);
-            Windows::Storage::Streams::InputStreamOptions readOptions = 
-                Windows::Storage::Streams::InputStreamOptions::Partial | Windows::Storage::Streams::InputStreamOptions::ReadAhead;
+
+            // Memory stream in mixed elevation does not support InputStreamOptions as flags.
+            Windows::Storage::Streams::InputStreamOptions readOptions = Windows::Storage::Streams::InputStreamOptions::Partial;
             std::string inputString;
 
             for (;;)

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.cpp
@@ -128,10 +128,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     {
         std::unique_ptr<ConfigurationSetSerializer> serializer = ConfigurationSetSerializer::CreateSerializer(m_schemaVersion);
         hstring result = serializer->Serialize(this);
+        auto resultUtf8 = winrt::to_string(result);
+        std::vector<uint8_t> bytes(resultUtf8.begin(), resultUtf8.end());
 
         Windows::Storage::Streams::DataWriter dataWriter{ stream };
-        dataWriter.UnicodeEncoding(Windows::Storage::Streams::UnicodeEncoding::Utf8);
-        dataWriter.WriteString(result);
+        dataWriter.WriteBytes(bytes);
         dataWriter.StoreAsync().get();
         dataWriter.DetachStream();
     }


### PR DESCRIPTION
This work is done together with @ryfu-msft 

Tested and validated on both Ryan and my machine.

The issue is when InMemoryRandomAccessStream is used in ConfigurationRemoteServer, marshalling will complain about setting rpc security status too late. We fixed it by not using winrt InMemoryRandomAccessStream. Instead, we'll use System.IO.MemoryStream. ###### Microsoft Reviewers: [Open in
CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4413)

---------

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4414)