### PR TITLE
Explicitly add Microsoft.Management.Configuration as remoting server dependency

### DIFF
--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj" />
+    <ProjectReference Include="..\Microsoft.Management.Configuration\Microsoft.Management.Configuration.vcxproj" />
   </ItemGroup>
 
   <Target Name="PwshFiles" AfterTargets="AfterBuild">


### PR DESCRIPTION
There's some issue with the build toolchain in internal pipeline that deep dependencies (3 level deep) are not picked up by the build. Explicitly adding the dependency fixed the issue. Manually validated the release package produced by internal pipeline and mixed elevation works as expected.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4418)