### PR TITLE
Add Workflow logs and fix installed version workflow bug

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -375,6 +375,7 @@ wcsicmp
 webpage
 WHOLECHAIN
 wil
+windbg
 wincrypt
 WINEVENT
 winget

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -127,7 +127,6 @@ ESRB
 ests
 etest
 etl
-etting
 execustom
 EXEHASH
 experimentalfeatures

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -127,6 +127,7 @@ ESRB
 ests
 etest
 etl
+etting
 execustom
 EXEHASH
 experimentalfeatures

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -487,6 +487,11 @@ namespace AppInstaller::CLI::Execution
     }
 #endif
 
+    void ContextEnumBasedVariantMapActionCallback(Data data, bool isAdd)
+    {
+        AICLI_LOG(Workflow, Info, << (isAdd ? 'S' : 'G') << "etting data item: " << data);
+    }
+
     std::string Context::GetResumeId()
     {
         return m_checkpointManager->GetResumeId();

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -487,9 +487,22 @@ namespace AppInstaller::CLI::Execution
     }
 #endif
 
-    void ContextEnumBasedVariantMapActionCallback(Data data, bool isAdd)
+    void ContextEnumBasedVariantMapActionCallback(const void* map, Data data, EnumBasedVariantMapAction action)
     {
-        AICLI_LOG(Workflow, Info, << (isAdd ? 'S' : 'G') << "etting data item: " << data);
+        switch (action)
+        {
+        case EnumBasedVariantMapAction::Add:
+            AICLI_LOG(Workflow, Info, << "Setting data item: " << data);
+            break;
+        case EnumBasedVariantMapAction::Contains:
+            AICLI_LOG(Workflow, Info, << "Checking data item: " << data);
+            break;
+        case EnumBasedVariantMapAction::Get:
+            AICLI_LOG(Workflow, Info, << "Getting data item: " << data);
+            break;
+        }
+
+        UNREFERENCED_PARAMETER(map);
     }
 
     std::string Context::GetResumeId()

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -85,10 +85,13 @@ namespace AppInstaller::CLI::Execution
     bool WaitForAppShutdownEvent();
 #endif
 
+    // Callback to log data actions.
+    void ContextEnumBasedVariantMapActionCallback(Data data, bool isAdd);
+
     // The context within which all commands execute.
     // Contains input/output via Execution::Reporter and
     // arguments via Execution::Args.
-    struct Context : EnumBasedVariantMap<Data, details::DataMapping>
+    struct Context : EnumBasedVariantMap<Data, details::DataMapping, ContextEnumBasedVariantMapActionCallback>
     {
         Context(std::ostream& out, std::istream& in) : Reporter(out, in) {}
 

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -86,7 +86,7 @@ namespace AppInstaller::CLI::Execution
 #endif
 
     // Callback to log data actions.
-    void ContextEnumBasedVariantMapActionCallback(Data data, bool isAdd);
+    void ContextEnumBasedVariantMapActionCallback(const void* map, Data data, EnumBasedVariantMapAction action);
 
     // The context within which all commands execute.
     // Contains input/output via Execution::Reporter and

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -13,6 +13,8 @@
 #include <winget/Runtime.h>
 #include <winget/PackageVersionSelection.h>
 
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+
 using namespace std::string_literals;
 using namespace AppInstaller::Utility::literals;
 using namespace AppInstaller::Pinning;
@@ -257,6 +259,18 @@ namespace AppInstaller::CLI::Workflow
     {
         THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), !m_isFunc);
         m_func(context);
+    }
+
+    void WorkflowTask::Log() const
+    {
+        if (m_isFunc)
+        {
+            AICLI_LOG(Workflow, Info, << "Running task: 0x" << m_func << "[ln WindowsPackageManager!" << (reinterpret_cast<char*>(m_func) - reinterpret_cast<char*>(&__ImageBase)) << "]");
+        }
+        else
+        {
+            AICLI_LOG(Workflow, Info, << "Running task: " << m_name);
+        }
     }
 
     Repository::PredefinedSource DetermineInstalledSource(const Execution::Context& context)
@@ -1433,6 +1447,7 @@ AppInstaller::CLI::Execution::Context& operator<<(AppInstaller::CLI::Execution::
         if (context.ShouldExecuteWorkflowTask(task))
 #endif
         {
+            task.Log();
             task(context);
         }
     }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -265,7 +265,8 @@ namespace AppInstaller::CLI::Workflow
     {
         if (m_isFunc)
         {
-            AICLI_LOG(Workflow, Info, << "Running task: 0x" << m_func << "[ln WindowsPackageManager!" << (reinterpret_cast<char*>(m_func) - reinterpret_cast<char*>(&__ImageBase)) << "]");
+            // Using `00000001`80000000` as base address default when loading dll into windbg as dump file.
+            AICLI_LOG(Workflow, Info, << "Running task: 0x" << m_func << " [ln 00000001`80000000+" << std::hex << (reinterpret_cast<char*>(m_func) - reinterpret_cast<char*>(&__ImageBase)) << "]");
         }
         else
         {
@@ -1382,10 +1383,10 @@ namespace AppInstaller::CLI::Workflow
 
     void GetInstalledPackageVersion(Execution::Context& context)
     {
-        std::shared_ptr<IPackage> installed = context.Get<Execution::Data::Package>()->GetInstalled();
-
         if (ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::SideBySide))
         {
+            std::shared_ptr<IPackage> installed = context.Get<Execution::Data::Package>()->GetInstalled();
+
             if (installed)
             {
                 // TODO: This may need to be expanded dramatically to enable targeting across a variety of dimensions (architecture, etc.)

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1410,6 +1410,10 @@ namespace AppInstaller::CLI::Workflow
                     context.Add<Execution::Data::InstalledPackageVersion>(installed->GetLatestVersion());
                 }
             }
+            else
+            {
+                context.Add<Execution::Data::InstalledPackageVersion>(nullptr);
+            }
         }
         else
         {

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -69,6 +69,7 @@ namespace AppInstaller::CLI::Workflow
         bool IsFunction() const { return m_isFunc; }
         Func Function() const { return m_func; }
         bool ExecuteAlways() const { return m_executeAlways; }
+        void Log() const;
 
     private:
         bool m_isFunc = false;

--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -10,7 +10,7 @@ namespace AppInstaller::Repository
 {
     using namespace std::string_view_literals;
 
-    namespace
+    namespace anon
     {
         Utility::VersionAndChannel GetVACFromVersion(IPackageVersion* packageVersion)
         {
@@ -1364,6 +1364,8 @@ namespace AppInstaller::Repository
             return {};
         }
     }
+
+    using namespace anon;
 
     CompositeSource::CompositeSource(std::string identifier)
     {

--- a/src/AppInstallerSharedLib/AppInstallerLogging.cpp
+++ b/src/AppInstallerSharedLib/AppInstallerLogging.cpp
@@ -20,6 +20,7 @@ namespace AppInstaller::Logging
         case Channel::Core:   return "CORE";
         case Channel::Test:   return "TEST";
         case Channel::Config: return "CONF";
+        case Channel::Workflow: return "WORK";
         default:              return "NONE";
         }
     }
@@ -59,6 +60,10 @@ namespace AppInstaller::Logging
         else if (lowerChannel == "conf" || lowerChannel == "config")
         {
             return Channel::Config;
+        }
+        else if (lowerChannel == "workflow")
+        {
+            return Channel::Workflow;
         }
         else if (lowerChannel == "default" || lowerChannel == "defaults")
         {

--- a/src/AppInstallerSharedLib/Public/AppInstallerLanguageUtilities.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerLanguageUtilities.h
@@ -89,8 +89,12 @@ namespace AppInstaller
         static constexpr inline size_t Index(Enum e) { return static_cast<size_t>(e) + 1; }
     };
 
+    // A callback function that can be used for logging map actions.
+    template <typename Enum>
+    using EnumBasedVariantMapActionCallback = void (*)(Enum value, bool isAdd);
+
     // Provides a map of the Enum to the mapped types.
-    template <typename Enum, template<Enum> typename Mapping>
+    template <typename Enum, template<Enum> typename Mapping, EnumBasedVariantMapActionCallback<Enum> Callback = nullptr>
     struct EnumBasedVariantMap
     {
         using Variant = EnumBasedVariant<Enum, Mapping>;
@@ -103,12 +107,20 @@ namespace AppInstaller
         template <Enum E>
         void Add(mapping_t<E>&& v)
         {
+            if constexpr (Callback)
+            {
+                Callback(E, true);
+            }
             m_data[E].emplace<Variant::Index(E)>(std::move(std::forward<mapping_t<E>>(v)));
         }
 
         template <Enum E>
         void Add(const mapping_t<E>& v)
         {
+            if constexpr (Callback)
+            {
+                Callback(E, true);
+            }
             m_data[E].emplace<Variant::Index(E)>(v);
         }
 
@@ -119,12 +131,20 @@ namespace AppInstaller
         template <Enum E>
         mapping_t<E>& Get()
         {
+            if constexpr (Callback)
+            {
+                Callback(E, false);
+            }
             return std::get<Variant::Index(E)>(GetVariant(E));
         }
 
         template <Enum E>
         const mapping_t<E>& Get() const
         {
+            if constexpr (Callback)
+            {
+                Callback(E, false);
+            }
             return std::get<Variant::Index(E)>(GetVariant(E));
         }
 

--- a/src/AppInstallerSharedLib/Public/AppInstallerLogging.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerLogging.h
@@ -56,9 +56,10 @@ namespace AppInstaller::Logging
         Core = 0x20,
         Test = 0x40,
         Config = 0x80,
+        Workflow = 0x100,
         None = 0,
         All = 0xFFFFFFFF,
-        Defaults = All & ~SQL,
+        Defaults = All & ~(SQL | Workflow),
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(Channel);


### PR DESCRIPTION
Fixes #4425 

## Change
This adds a `Workflow` channel (disabled by default) that has the entry to tasks and the `Get`/`Add`/`Contains` calls logged to it.  This enables a view into a flow that can be collected by a third party.

It also fixes a behavior change with the side-by-side code path for selecting the installed version that would lead to no data item being inserted, when the previous behavior was that a `nullptr` would be inserted when no version is installed.

## Validation
Manual validation of the workflow output, including using the windbg command to see the function name (for function pointer tasks).
Manual validation of at least one case of the `GetVariant(14)` issue being fixed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4432)