### PR TITLE
Check for an empty installer locale

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
+++ b/src/AppInstallerCLICore/Workflows/ManifestComparator.cpp
@@ -645,6 +645,12 @@ namespace AppInstaller::CLI::Workflow
 
             InapplicabilityFlags IsApplicable(const Manifest::ManifestInstaller& installer) override
             {
+                // We have to assume an unknown installer locale will match our installed locale, or the entire catalog would stop working for upgrade.
+                if (installer.Locale.empty())
+                {
+                    return InapplicabilityFlags::None;
+                }
+
                 InapplicabilityFlags inapplicableFlag = m_isInstalledLocale ? InapplicabilityFlags::InstalledLocale : InapplicabilityFlags::Locale;
 
                 if (!m_requirement.empty())
@@ -665,9 +671,7 @@ namespace AppInstaller::CLI::Workflow
                     // For installed locale preference, check at least compatible match for preference
                     for (auto const& preferredLocale : m_preference)
                     {
-                        // We have to assume an unknown installer locale will match our installed locale, or the entire catalog would stop working for upgrade.
-                        if (installer.Locale.empty() ||
-                            Locale::GetDistanceOfLanguage(preferredLocale, installer.Locale) >= Locale::MinimumDistanceScoreAsCompatibleMatch)
+                        if (Locale::GetDistanceOfLanguage(preferredLocale, installer.Locale) >= Locale::MinimumDistanceScoreAsCompatibleMatch)
                         {
                             return InapplicabilityFlags::None;
                         }


### PR DESCRIPTION
It is possible that a package manifest does not supply a `InstallerLocale`.  In such case, if `--locale` is supplied by user, currently required locale list will not ever match, as the list compared against an empty installer locale string.

This moves the existing check so that applies for both locale preference and locale requirement.

Fixes #2305

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.

-----
