### PR TITLE
Remove PAT token for ADO fuzzing task

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,7 @@
 abcd
 ABORTIFHUNG
 accepteula
+ACCESSTOKEN
 adjacents
 adml
 admx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -604,6 +604,4 @@ jobs:
       onefuzzOSes: 'Windows'
     env:
       onefuzzDropDirectory: '$(buildOutDir)\WinGetYamlFuzzing'
-      onefuzzDropPAT: $(onefuzzDropPAT)
-      onefuzzFilingBugPAT: $(onefuzzBugFilingPAT)
-      onefuzzCodeCoveragePAT: $(onefuzzCodeCoveragePAT)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/src/WinGetYamlFuzzing/OneFuzzConfig.json
+++ b/src/WinGetYamlFuzzing/OneFuzzConfig.json
@@ -21,10 +21,10 @@
         "clang_rt.asan_dynamic*.dll"
       ],
       "AdoTemplate": {
-        "Org": "ms",
-        "Project": "winget-cli",
+        "Org": "microsoft",
+        "Project": "OS",
         "AssignedTo": "ryfu@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\InstaDev",
+        "AreaPath": "Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\InstaDev",
         "IterationPath": "OS"
       },
       "codeCoverage": {

--- a/src/WinGetYamlFuzzing/OneFuzzConfig.json
+++ b/src/WinGetYamlFuzzing/OneFuzzConfig.json
@@ -24,7 +24,7 @@
         "Org": "microsoft",
         "Project": "OS",
         "AssignedTo": "ryfu@microsoft.com",
-        "AreaPath": "Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\InstaDev",
+        "AreaPath": "OS\\Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\InstaDev",
         "IterationPath": "OS"
       },
       "codeCoverage": {


### PR DESCRIPTION
Removed usage of PAT tokens for submitting fuzzing artifacts. Verified manually by running the CI pipeline and checking that the artifacts were successfully submitted.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4478)