### PR TITLE
Fix limit mode metadata blocking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -345,7 +345,7 @@ jobs:
       testSelector: 'testAssemblies'
       testAssemblyVer2: '**\Microsoft.Management.Configuration.UnitTests.dll'
       searchFolder: '$(buildOutDir)\Microsoft.Management.Configuration.UnitTests'
-      codeCoverageEnabled: true
+      codeCoverageEnabled: false
       platform: '$(buildPlatform)'
       configuration: '$(BuildConfiguration)'
       diagnosticsEnabled: true

--- a/src/Microsoft.Management.Configuration/ConfigurationSetSerializer.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSetSerializer.h
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 #pragma once
 #include "ConfigurationSetSerializer.h"
+#include "ConfigurationSetUtilities.h"
 #include "ConfigurationSet.h"
 
 #include <winget/Yaml.h>
+#include <initializer_list>
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
@@ -26,7 +28,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         ConfigurationSetSerializer() = default;
 
         void WriteYamlConfigurationUnits(AppInstaller::YAML::Emitter& emitter, const std::vector<ConfigurationUnit>& units);
-        void WriteYamlValueSet(AppInstaller::YAML::Emitter& emitter, const Windows::Foundation::Collections::ValueSet& valueSet);
+        void WriteYamlValueSet(AppInstaller::YAML::Emitter& emitter, const Windows::Foundation::Collections::ValueSet& valueSet, std::initializer_list<ConfigurationField> exclusions = {});
         void WriteYamlValue(AppInstaller::YAML::Emitter& emitter, const winrt::Windows::Foundation::IInspectable& value);
         void WriteYamlValueSetAsArray(AppInstaller::YAML::Emitter& emitter, const Windows::Foundation::Collections::ValueSet& valueSetArray);
         winrt::hstring GetSchemaVersionComment(winrt::hstring version);

--- a/src/Microsoft.Management.Configuration/ConfigurationSetSerializer_0_2.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationSetSerializer_0_2.cpp
@@ -73,15 +73,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
     void ConfigurationSetSerializer_0_2::WriteResourceDirectives(AppInstaller::YAML::Emitter& emitter, const ConfigurationUnit& unit)
     {
-        auto metadata = unit.Metadata();
-
-        const auto moduleKey = GetConfigurationFieldNameHString(ConfigurationField::ModuleDirective);
-        if (metadata.HasKey(moduleKey))
-        {
-            metadata.Remove(moduleKey);
-        }
-
         emitter << Key << GetConfigurationFieldName(ConfigurationField::Directives);
-        WriteYamlValueSet(emitter, metadata);
+        WriteYamlValueSet(emitter, unit.Metadata(), { ConfigurationField::ModuleDirective });
     }
 }


### PR DESCRIPTION
## Change
The serialization code should not be modifying the object that it is operating on.  Move it to instead skip the output of some values rather than removing them.

When the remoting server is operating in limited mode, the metadata must match between the initial limitation set and the incoming unit.  This removal was also breaking that, as the entry was now missing.

## Validation
Manual confirmation that the limit mode works after the change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4489)