### PR TITLE
Initialize logging of global logger for inproc invocations

### DIFF
--- a/src/AppInstallerCLICore/COMContext.cpp
+++ b/src/AppInstallerCLICore/COMContext.cpp
@@ -75,10 +75,10 @@ namespace AppInstaller::CLI::Execution
         return m_correlationData;
     }
 
-    void COMContext::SetLoggers()
+    void COMContext::SetLoggers(std::optional<AppInstaller::Logging::Channel> channel, std::optional<AppInstaller::Logging::Level> level)
     {
-        Logging::Log().EnableChannel(Settings::User().Get<Settings::Setting::LoggingChannelPreference>());
-        Logging::Log().SetLevel(Settings::User().Get<Settings::Setting::LoggingLevelPreference>());
+        Logging::Log().EnableChannel(channel.has_value() ? channel.value() : Settings::User().Get<Settings::Setting::LoggingChannelPreference>());
+        Logging::Log().SetLevel(level.has_value() ? level.value() : Settings::User().Get<Settings::Setting::LoggingLevelPreference>());
 
         // TODO: Log to file for COM API calls only when debugging in visual studio
         Logging::FileLogger::Add(s_comLogFileNamePrefix);

--- a/src/AppInstallerCLICore/COMContext.h
+++ b/src/AppInstallerCLICore/COMContext.h
@@ -66,7 +66,7 @@ namespace AppInstaller::CLI::Execution
 
         // Set Diagnostic and Telemetry loggers, Wil failure callback
         // This should be called only once per COM Server instance
-        static void SetLoggers();
+        static void SetLoggers(std::optional<AppInstaller::Logging::Channel> channel = std::nullopt, std::optional<AppInstaller::Logging::Level> level = std::nullopt);
 
         // Set COM call context for diagnostic and telemetry loggers
         // This should be called for every COMContext object instance

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -191,6 +191,6 @@ namespace AppInstaller::CLI
 #endif
 
         // Explicitly set default channel and level before user settings from PackageManagerSettings
-        AppInstaller::CLI::Execution::COMContext::SetLoggers(AppInstaller::Logging::Channel::Defaults, AppInstaller::Logging::Level::Verbose);
+        AppInstaller::CLI::Execution::COMContext::SetLoggers(AppInstaller::Logging::Channel::Defaults, AppInstaller::Logging::Level::Info);
     }
 }

--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -180,4 +180,17 @@ namespace AppInstaller::CLI
 
         AppInstaller::CLI::Execution::COMContext::SetLoggers();
     }
+
+    void InProcInitialize()
+    {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (Settings::User().Get<Settings::Setting::EnableSelfInitiatedMinidump>())
+        {
+            Debugging::EnableSelfInitiatedMinidump();
+        }
+#endif
+
+        // Explicitly set default channel and level before user settings from PackageManagerSettings
+        AppInstaller::CLI::Execution::COMContext::SetLoggers(AppInstaller::Logging::Channel::Defaults, AppInstaller::Logging::Level::Verbose);
+    }
 }

--- a/src/AppInstallerCLICore/Public/AppInstallerCLICore.h
+++ b/src/AppInstallerCLICore/Public/AppInstallerCLICore.h
@@ -9,4 +9,7 @@ namespace AppInstaller::CLI
 
     // Initializes the Windows Package Manager COM server.
     void ServerInitialize();
+
+    // Initializations for InProc invocation.
+    void InProcInitialize();
 }

--- a/src/Microsoft.Management.Deployment/PackageManagerSettings.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManagerSettings.cpp
@@ -48,6 +48,11 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             [&]()
             {
                 success = AppInstaller::Settings::TryInitializeCustomUserSettings(AppInstaller::Utility::ConvertToUTF8(settingsContent));
+                if (success)
+                {
+                    AppInstaller::Logging::Log().EnableChannel(AppInstaller::Settings::User().Get<AppInstaller::Settings::Setting::LoggingChannelPreference>());
+                    AppInstaller::Logging::Log().SetLevel(AppInstaller::Settings::User().Get<AppInstaller::Settings::Setting::LoggingLevelPreference>());
+                }
             });
         return success;
     }

--- a/src/WindowsPackageManager/main.cpp
+++ b/src/WindowsPackageManager/main.cpp
@@ -86,6 +86,7 @@ extern "C"
     WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerInProcModuleInitialize() try
     {
         ::Microsoft::WRL::Module<::Microsoft::WRL::ModuleType::InProc>::Create();
+        AppInstaller::CLI::InProcInitialize();
         return S_OK;
     }
     CATCH_RETURN();


### PR DESCRIPTION
With Inproc invocation, logging was only enabled at context level (during an actual package operation). This change initializes the global logger for inproc invocations so package catalog, package search and package correlation can be logged too.

Manually validated logs exist after the change.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4490)