### PR TITLE
WinGetDownload E_ACCESSDENIED

### DIFF
--- a/src/AppInstallerCommonCore/NetworkSettings.cpp
+++ b/src/AppInstallerCommonCore/NetworkSettings.cpp
@@ -43,7 +43,11 @@ namespace AppInstaller::Settings
     NetworkSettings::NetworkSettings()
     {
         // Get the default proxy
-        m_proxyUri = GetAdminSetting(StringAdminSetting::DefaultProxy);
+        try
+        {
+            m_proxyUri = GetAdminSetting(StringAdminSetting::DefaultProxy);
+        }
+        CATCH_LOG()
         AICLI_LOG(Core, Info, << "Default proxy is " << (m_proxyUri ? m_proxyUri.value() : "not set"));
     }
 


### PR DESCRIPTION
Fix issue when calling WinGetDownload from Az Functions.

It is most likely caused by an attempt to create the directory while reading the admin settings. Instead of failing, catch the exception and use the default settings.

If we ever read more settings from WinGetUtil a more robust solution is required.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4518)