### PR TITLE
Make v2 index EF enabled by default

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,13 +245,6 @@ jobs:
 
   - template: templates/e2e-test.template.yml
     parameters:
-      title: "E2E Tests Packaged (Index V2)"
-      isPackaged: true
-      filter: "TestCategory!=InProcess&TestCategory!=OutOfProcess"
-      experimentalFeatures: indexV2
-
-  - template: templates/e2e-test.template.yml
-    parameters:
       title: "Microsoft.Management.Deployment E2E Tests (In-process)"
       isPackaged: false
       filter: "TestCategory=InProcess"

--- a/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
+++ b/src/AppInstallerCLIE2ETests/FeaturesCommand.cs
@@ -41,14 +41,6 @@ namespace AppInstallerCLIE2ETests
             var result = TestCommon.RunAICLICommand("features", string.Empty);
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
             Assert.True(result.StdOut.Contains("Direct MSI Installation"));
-            if (WinGetSettingsHelper.ForcedExperimentalFeatures.Length > 0 && WinGetSettingsHelper.ForcedExperimentalFeatures[0] != "none")
-            {
-                Assert.True(result.StdOut.Contains("Enabled"));
-            }
-            else
-            {
-                Assert.False(result.StdOut.Contains("Enabled"));
-            }
         }
 
         /// <summary>

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -159,7 +159,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFSideBySide, bool, bool, false, ".experimentalFeatures.sideBySide"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFConfigureSelfElevation, bool, bool, false, ".experimentalFeatures.configureSelfElevate"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFStoreDownload, bool, bool, false, ".experimentalFeatures.storeDownload"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::EFIndexV2, bool, bool, false, ".experimentalFeatures.indexV2"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::EFIndexV2, bool, bool, true, ".experimentalFeatures.indexV2"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFConfigureExport, bool, bool, false, ".experimentalFeatures.configureExport"sv);
         // Telemetry
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);


### PR DESCRIPTION
## Change
Enable the v2 index experimental feature by default as it seems to be functioning properly and this will increase coverage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4553)