### PR TITLE
Trim Version When Parsing

### DIFF
--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::Utility
 
     Version::Version(std::string&& version, std::string_view splitChars)
     {
-        Assign(std::move(Utility::Trim(version)), splitChars);
+        Assign(std::move(version), splitChars);
     }
 
     Version::Version(Version baseVersion, ApproximateComparator approximateComparator) : Version(std::move(baseVersion))
@@ -438,12 +438,12 @@ namespace AppInstaller::Utility
 
     UInt64Version::UInt64Version(std::string&& version, std::string_view splitChars)
     {
-        Assign(std::move(Utility::Trim(version)), splitChars);
+        Assign(std::move(version), splitChars);
     }
 
     void UInt64Version::Assign(std::string version, std::string_view splitChars)
     {
-        Version::Assign(std::move(Utility::Trim(version)), splitChars);
+        Version::Assign(std::move(version), splitChars);
 
         // After trimming trailing parts (0 or empty),
         // at most 4 parts must be present
@@ -460,7 +460,7 @@ namespace AppInstaller::Utility
 
     SemanticVersion::SemanticVersion(std::string&& version)
     {
-        Assign(std::move(Utility::Trim(version)), DefaultSplitChars);
+        Assign(std::move(version), DefaultSplitChars);
     }
 
     void SemanticVersion::Assign(std::string version, std::string_view splitChars)

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::Utility
 
     Version::Version(std::string&& version, std::string_view splitChars)
     {
-        Assign(std::move(version), splitChars);
+        Assign(std::move(Utility::Trim(version)), splitChars);
     }
 
     Version::Version(Version baseVersion, ApproximateComparator approximateComparator) : Version(std::move(baseVersion))
@@ -41,7 +41,7 @@ namespace AppInstaller::Utility
 
     void Version::Assign(std::string version, std::string_view splitChars)
     {
-        m_version = std::move(version);
+        m_version = std::move(Utility::Trim(version));
 
         // Process approximate comparator if applicable
         std::string baseVersion = m_version;
@@ -281,7 +281,8 @@ namespace AppInstaller::Utility
 
     Version::Part::Part(const std::string& part)
     {
-        const char* begin = part.c_str();
+        std::string interimPart = Utility::Trim(part.c_str());
+        const char* begin = interimPart.c_str();
         char* end = nullptr;
         errno = 0;
         Integer = strtoull(begin, &end, 10);
@@ -289,9 +290,9 @@ namespace AppInstaller::Utility
         if (errno == ERANGE)
         {
             Integer = 0;
-            Other = part;
+            Other = interimPart;
         }
-        else if (static_cast<size_t>(end - begin) != part.length())
+        else if (static_cast<size_t>(end - begin) != interimPart.length())
         {
             Other = end;
         }
@@ -300,7 +301,7 @@ namespace AppInstaller::Utility
     }
 
     Version::Part::Part(uint64_t integer, std::string other) :
-        Integer(integer), Other(std::move(other))
+        Integer(integer), Other(std::move(Utility::Trim(other)))
     {
         m_foldedOther = Utility::FoldCase(static_cast<std::string_view>(Other));
     }
@@ -437,12 +438,12 @@ namespace AppInstaller::Utility
 
     UInt64Version::UInt64Version(std::string&& version, std::string_view splitChars)
     {
-        Assign(std::move(version), splitChars);
+        Assign(std::move(Utility::Trim(version)), splitChars);
     }
 
     void UInt64Version::Assign(std::string version, std::string_view splitChars)
     {
-        Version::Assign(std::move(version), splitChars);
+        Version::Assign(std::move(Utility::Trim(version)), splitChars);
 
         // After trimming trailing parts (0 or empty),
         // at most 4 parts must be present
@@ -459,7 +460,7 @@ namespace AppInstaller::Utility
 
     SemanticVersion::SemanticVersion(std::string&& version)
     {
-        Assign(std::move(version), DefaultSplitChars);
+        Assign(std::move(Utility::Trim(version)), DefaultSplitChars);
     }
 
     void SemanticVersion::Assign(std::string version, std::string_view splitChars)
@@ -468,7 +469,7 @@ namespace AppInstaller::Utility
         THROW_HR_IF(E_INVALIDARG, splitChars != DefaultSplitChars);
 
         // First split off any trailing build metadata
-        std::string interimVersion = version;
+        std::string interimVersion = Utility::Trim(version);
         size_t buildMetadataPos = interimVersion.find('+', 0);
 
         if (buildMetadataPos != std::string::npos)


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

When parsing a version, it may be possible that a publisher included one or more whitespace characters at the end of the DisplayVersion key. Since a folder name cannot end with a whitespace character, this means that any PackageVersion in the community repository cannot have a trailing whitespace character.

Due to the way versions are parsed, the trailing whitespace gets considered as an "other" of the version part during the version comparison. This means that `5.8 ` is considered a lower version than `5.8` when parsed. 

This PR makes it so that when a version is assigned, as is the case when parsing the installed versions, both the final version and the version parts are trimmed of whitespace. This means that `5.0.13` is now considered equal to `5.0 .13`, `5.0.13 `, or even ` 5 .   0   .13 `
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4554)