### PR TITLE
Use digest verification APIs for MSIX when available

### DIFF
--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -65,6 +65,7 @@ namespace AppInstaller::CLI::Execution
         DownloadDirectory,
         ModifyPath,
         RepairString,
+        MsixDigests,
         Max
     };
 
@@ -276,11 +277,17 @@ namespace AppInstaller::CLI::Execution
             using value_t = std::string;
         };
 
-
         template<>
         struct DataMapping<Data::RepairString>
         {
             using value_t = std::string;
+        };
+
+        template<>
+        struct DataMapping<Data::MsixDigests>
+        {
+            // The pair is { URL, Digest }
+            using value_t = std::vector<std::pair<std::string, std::wstring>>;
         };
     }
 }

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -189,6 +189,7 @@ namespace AppInstaller::CLI::Workflow
         void MsixInstall(Execution::Context& context)
         {
             std::string uri;
+            Deployment::Options deploymentOptions;
             if (context.Contains(Execution::Data::InstallerPath))
             {
                 uri = context.Get<Execution::Data::InstallerPath>().u8string();
@@ -196,7 +197,10 @@ namespace AppInstaller::CLI::Workflow
             else
             {
                 uri = context.Get<Execution::Data::Installer>()->Url;
+                deploymentOptions.ExpectedDigests = context.Get<Execution::Data::MsixDigests>();
             }
+
+            deploymentOptions.SkipReputationCheck = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerTrusted);
 
             bool isMachineScope = Manifest::ConvertToScopeEnum(context.Args.GetArg(Execution::Args::Type::InstallScope)) == Manifest::ScopeEnum::Machine;
 
@@ -220,11 +224,11 @@ namespace AppInstaller::CLI::Workflow
                     {
                         if (isMachineScope)
                         {
-                            return Deployment::AddPackageMachineScope(uri, callback);
+                            return Deployment::AddPackageMachineScope(uri, deploymentOptions, callback);
                         }
                         else
                         {
-                            return Deployment::AddPackageWithDeferredFallback(uri, WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerTrusted), callback);
+                            return Deployment::AddPackageWithDeferredFallback(uri, deploymentOptions, callback);
                         }
                     });
             }

--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{5890d6ed-7c3b-40f3-b436-b54f640d9e65}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerLoggingCore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>

--- a/src/AppInstallerCommonCore/Deployment.cpp
+++ b/src/AppInstallerCommonCore/Deployment.cpp
@@ -338,4 +338,10 @@ namespace AppInstaller::Deployment
 
         WaitForDeployment(deployOperation, id, callback);
     }
+
+    bool IsExpectedDigestsSupported()
+    {
+        static bool s_IsExpectedDigestsSupported = Metadata::ApiInformation::IsPropertyPresent(winrt::name_of<AddPackageOptions>(), L"ExpectedDigests");
+        return s_IsExpectedDigestsSupported;
+    }
 }

--- a/src/AppInstallerCommonCore/MsixInfo.cpp
+++ b/src/AppInstallerCommonCore/MsixInfo.cpp
@@ -625,6 +625,24 @@ namespace AppInstaller::Msix
         return Utility::SHA256::ComputeHash(signature.data(), static_cast<uint32_t>(signature.size()));
     }
 
+    std::wstring MsixInfo::GetDigest()
+    {
+        ComPtr<IAppxDigestProvider> digestProvider;
+        if (m_isBundle)
+        {
+            THROW_IF_FAILED(m_bundleReader.As(&digestProvider));
+        }
+        else
+        {
+            THROW_IF_FAILED(m_packageReader.As(&digestProvider));
+        }
+
+        wil::unique_cotaskmem_string result;
+        THROW_IF_FAILED(digestProvider->GetDigest(&result));
+
+        return result.get();
+    }
+
     std::wstring MsixInfo::GetPackageFullNameWide()
     {
         ComPtr<IAppxManifestPackageId> packageId;

--- a/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
@@ -7,12 +7,24 @@
 
 namespace AppInstaller::Deployment
 {
+    // A set of optional values useful across many of the deployment functions.
+    struct Options
+    {
+        Options() = default;
+        explicit Options(bool skipReputationCheck) : SkipReputationCheck(skipReputationCheck) {}
+
+        // Avoid using APIs that make a reputation check.
+        bool SkipReputationCheck = false;
+
+        // The pairs of URI+Digest to enforce.
+        std::vector<std::pair<std::string, std::wstring>> ExpectedDigests;
+    };
+
     // Calls winrt::Windows::Management::Deployment::PackageManager::AddPackageAsync if skipSmartScreen is true,
     // Otherwise, calls winrt::Windows::Management::Deployment::PackageManager::RequestAddPackageAsync
     void AddPackage(
         const winrt::Windows::Foundation::Uri& uri,
-        winrt::Windows::Management::Deployment::DeploymentOptions options,
-        bool skipSmartScreen,
+        const Options& options,
         IProgressCallback& callback);
 
     // Calls winrt::Windows::Management::Deployment::PackageManager::AddPackageAsync if skipSmartScreen is true,
@@ -22,7 +34,7 @@ namespace AppInstaller::Deployment
     // Returns true if the registration was deferred; false if not.
     bool AddPackageWithDeferredFallback(
         std::string_view uri,
-        bool skipSmartScreen,
+        const Options& options,
         IProgressCallback& callback);
 
     // Calls winrt::Windows::Management::Deployment::PackageManager::RemovePackageAsync
@@ -36,6 +48,7 @@ namespace AppInstaller::Deployment
     //       winrt::Windows::Management::Deployment::PackageManager::RegisterPackageByFullNameAsync if not running as system
     bool AddPackageMachineScope(
         std::string_view uri,
+        const Options& options,
         IProgressCallback& callback);
 
     // Calls winrt::Windows::Management::Deployment::PackageManager::DeprovisionPackageForAllUsersAsync

--- a/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDeployment.h
@@ -52,4 +52,7 @@ namespace AppInstaller::Deployment
     void RegisterPackage(
         std::string_view packageFamilyName,
         IProgressCallback& callback);
+
+    // Determines if the ExpectedDigests property (and thus feture) is supported on the current version of Windows.
+    bool IsExpectedDigestsSupported();
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerMsixInfo.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerMsixInfo.h
@@ -73,8 +73,11 @@ namespace AppInstaller::Msix
         // If skipP7xFileId is true, returns content of converted .p7s
         std::vector<byte> GetSignature(bool skipP7xFileId = false);
 
-        // Get the signature sha256 hash.
+        // Gets the signature sha256 hash.
         Utility::SHA256::HashBuffer GetSignatureHash();
+
+        // Gets the digest of the package.
+        std::wstring GetDigest();
 
         // Gets the package full name.
         std::wstring GetPackageFullNameWide();

--- a/src/AppInstallerCommonCore/pch.h
+++ b/src/AppInstallerCommonCore/pch.h
@@ -86,6 +86,7 @@
 #include <winrt/Windows.ApplicationModel.AppExtensions.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Management.Deployment.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Services.Store.h>

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -527,8 +527,7 @@ namespace AppInstaller::Repository::Microsoft
                 winrt::Windows::Foundation::Uri uri = winrt::Windows::Foundation::Uri(localFile.c_str());
                 Deployment::AddPackage(
                     uri,
-                    winrt::Windows::Management::Deployment::DeploymentOptions::None,
-                    WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::Trusted),
+                    Deployment::Options{ WI_IsFlagSet(details.TrustLevel, SourceTrustLevel::Trusted) },
                     progress);
 
                 if (download)


### PR DESCRIPTION
## Change
When available (10.0.23504.0 according to MSDN), use the MSIX digest APIs to verify the package during streaming installation.  When not available, download instead.

## Validation
Manual installation successful, with logs indicating usage of digest.  Manual installation with debugger memory change to invalidate the digest results in an error (although not the best error experience, it should also be extremely rare).

Existing regression tests should get some coverage as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4564)