### PR TITLE
Use atomic functions to ensure single initialization of tracking catalog

### DIFF
--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -344,6 +344,6 @@ namespace AppInstaller::Repository
         bool m_isComposite = false;
         std::optional<TimeSpan> m_backgroundUpdateInterval;
         bool m_installedPackageInformationOnly = false;
-        mutable PackageTrackingCatalog m_trackingCatalog;
+        mutable std::shared_ptr<PackageTrackingCatalog> m_trackingCatalog;
     };
 }


### PR DESCRIPTION
Fixes #4587 

## Change
Hold the tracking catalog object in a `shared_ptr` and use the atomic functions to ensure that only one thread can initialize it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4592)