### PR TITLE
Add Argument for Upgrading only minor versions

### DIFF
--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -172,9 +172,9 @@ namespace AppInstaller::CLI
         case Execution::Args::Type::UninstallPrevious:
             return { type, "uninstall-previous"_liv, ArgTypeCategory::InstallerBehavior | ArgTypeCategory::CopyFlagToSubContext };
         case Execution::Args::Type::MinorVersionOnly:
-            return { type, "minor-version-only"_liv, NoAlias, "minor"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
+            return { type, "minor-version-only"_liv, NoAlias, "minor"_liv, ArgTypeCategory::MultiplePackages | ArgTypeCategory::CopyFlagToSubContext, ArgTypeExclusiveSet::VersionSelection };
         case Execution::Args::Type::PatchVersionOnly:
-            return { type, "patch-version-only"_liv, NoAlias, "patch"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
+            return { type, "patch-version-only"_liv, NoAlias, "patch"_liv, ArgTypeCategory::MultiplePackages | ArgTypeCategory::CopyFlagToSubContext, ArgTypeExclusiveSet::VersionSelection };
 
         // Show command
         case Execution::Args::Type::ListVersions:

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -54,7 +54,7 @@ namespace AppInstaller::CLI
 
         // Manifest selection behavior after an app is found
         case Execution::Args::Type::Version:
-            return { type, "version"_liv, 'v', ArgTypeCategory::PackageQuery | ArgTypeCategory::SinglePackageQuery };
+            return { type, "version"_liv, 'v', ArgTypeCategory::PackageQuery | ArgTypeCategory::SinglePackageQuery, ArgTypeExclusiveSet::VersionSelection};
         case Execution::Args::Type::Channel:
             return { type, "channel"_liv, 'c', ArgTypeCategory::PackageQuery };
 
@@ -171,6 +171,10 @@ namespace AppInstaller::CLI
             return { type, "include-pinned"_liv, "pinned"_liv, ArgTypeCategory::CopyFlagToSubContext };
         case Execution::Args::Type::UninstallPrevious:
             return { type, "uninstall-previous"_liv, ArgTypeCategory::InstallerBehavior | ArgTypeCategory::CopyFlagToSubContext };
+        case Execution::Args::Type::MinorVersionOnly:
+            return { type, "minor-version-only"_liv, NoAlias, "minor-only"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
+        case Execution::Args::Type::PatchVersionOnly:
+            return { type, "patch-version-only"_liv, NoAlias, "patch-only"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
 
         // Show command
         case Execution::Args::Type::ListVersions:
@@ -402,6 +406,10 @@ namespace AppInstaller::CLI
             return Argument{ type, Resource::String::OpenLogsArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
         case Args::Type::UninstallPrevious:
             return Argument{ type, Resource::String::UninstallPreviousArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
+        case Args::Type::MinorVersionOnly:
+            return Argument{ type, Resource::String::MinorVersionOnlyArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
+        case Args::Type::PatchVersionOnly:
+            return Argument{ type, Resource::String::PatchVersionOnlyArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
         case Args::Type::Force:
             return Argument{ type, Resource::String::ForceArgumentDescription, ArgumentType::Flag, false };
         case Args::Type::DownloadDirectory:

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -172,9 +172,9 @@ namespace AppInstaller::CLI
         case Execution::Args::Type::UninstallPrevious:
             return { type, "uninstall-previous"_liv, ArgTypeCategory::InstallerBehavior | ArgTypeCategory::CopyFlagToSubContext };
         case Execution::Args::Type::MinorVersionOnly:
-            return { type, "minor-version-only"_liv, NoAlias, "minor-only"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
+            return { type, "minor-version-only"_liv, NoAlias, "minor"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
         case Execution::Args::Type::PatchVersionOnly:
-            return { type, "patch-version-only"_liv, NoAlias, "patch-only"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
+            return { type, "patch-version-only"_liv, NoAlias, "patch"_liv, ArgTypeCategory::MultiplePackages, ArgTypeExclusiveSet::VersionSelection };
 
         // Show command
         case Execution::Args::Type::ListVersions:

--- a/src/AppInstallerCLICore/Argument.h
+++ b/src/AppInstallerCLICore/Argument.h
@@ -90,6 +90,7 @@ namespace AppInstaller::CLI
         Proxy = 0x20,
         AllAndTargetVersion = 0x40,
         ConfigurationSetChoice = 0x80,
+        VersionSelection = 0x100,
 
         // This must always be at the end
         Max

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -31,6 +31,8 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::Upgrade, Resource::String::UpgradeArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::IncludeUnknown, Resource::String::IncludeUnknownInListArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::IncludePinned, Resource::String::IncludePinnedInListArgumentDescription, ArgumentType::Flag},
+            Argument::ForType(Execution::Args::Type::MinorVersionOnly),
+            Argument::ForType(Execution::Args::Type::PatchVersionOnly),
         };
     }
 
@@ -79,6 +81,8 @@ namespace AppInstaller::CLI
     {
         Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludeUnknown, Execution::Args::Type::Upgrade);
         Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludePinned, Execution::Args::Type::Upgrade);
+        Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::MinorVersionOnly, Execution::Args::Type::Upgrade);
+        Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::PatchVersionOnly, Execution::Args::Type::Upgrade);
     }
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -71,6 +71,8 @@ namespace AppInstaller::CLI
             Argument{ Args::Type::All, Resource::String::UpdateAllArgumentDescription, ArgumentType::Flag },
             Argument{ Args::Type::IncludeUnknown, Resource::String::IncludeUnknownArgumentDescription, ArgumentType::Flag },
             Argument{ Args::Type::IncludePinned, Resource::String::IncludePinnedArgumentDescription, ArgumentType::Flag},
+            Argument::ForType(Args::Type::MinorVersionOnly),
+            Argument::ForType(Args::Type::PatchVersionOnly),
             Argument::ForType(Args::Type::UninstallPrevious),
             Argument::ForType(Args::Type::Force),
         };

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -150,6 +150,7 @@ namespace AppInstaller::CLI
     void UpgradeCommand::ExecuteInternal(Execution::Context& context) const
     {
         context.SetFlags(Execution::ContextFlag::InstallerExecutionUseUpdate);
+        context << SetUpdateType;
 
         // Only allow for source failures when doing a list of available upgrades.
         // We have to set it now to allow for source open failures to also just warn.

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -102,6 +102,8 @@ namespace AppInstaller::CLI::Execution
             IncludeUnknown, // Used in Upgrade command to allow upgrades of packages with unknown versions
             IncludePinned, // Used in Upgrade command to allow upgrades to pinned packages (only for pinning type of pins)
             UninstallPrevious, // Used in Upgrade command to override the default manifest behavior to UninstallPrevious
+            MinorVersionOnly, // Used in Upgrade command to only upgrade packages which have not changed major version. Requires >=2 versions parts
+            PatchVersionOnly, // Used in Upgrade command to only upgrade packages which have not changed major or minor version. Requires >=3 version parts
 
             // Show command
             ListVersions, // Used in Show command to list all available versions of an app

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -323,10 +323,6 @@ namespace AppInstaller::CLI::Execution
             clone->EnableSignalTerminationHandler();
         }
         CopyArgsToSubContext(clone.get());
-
-        // Copy specific execution data to the subcontext
-        clone->Add<Data::UpdateType>(this->Get<Data::UpdateType>());
-
         return clone;
     }
 
@@ -392,21 +388,6 @@ namespace AppInstaller::CLI::Execution
         else
         {
             Reporter.SetStyle(User().Get<Setting::ProgressBarVisualStyle>());
-        }
-
-        // Set version filtering for listing and installing upgrades
-        // This is set as data in the context as listing and installing use different workflows
-        if (Args.Contains(Args::Type::MinorVersionOnly))
-        {
-            this->Add<Data::UpdateType>(Utility::UpdateType::Minor);
-        }
-        else if (Args.Contains(Args::Type::PatchVersionOnly))
-        {
-            this->Add<Data::UpdateType>(Utility::UpdateType::Patch);
-        }
-        else
-        {
-            this->Add<Data::UpdateType>(Utility::UpdateType::Any);
         }
     }
 

--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -323,6 +323,10 @@ namespace AppInstaller::CLI::Execution
             clone->EnableSignalTerminationHandler();
         }
         CopyArgsToSubContext(clone.get());
+
+        // Copy specific execution data to the subcontext
+        clone->Add<Data::UpdateType>(this->Get<Data::UpdateType>());
+
         return clone;
     }
 
@@ -388,6 +392,21 @@ namespace AppInstaller::CLI::Execution
         else
         {
             Reporter.SetStyle(User().Get<Setting::ProgressBarVisualStyle>());
+        }
+
+        // Set version filtering for listing and installing upgrades
+        // This is set as data in the context as listing and installing use different workflows
+        if (Args.Contains(Args::Type::MinorVersionOnly))
+        {
+            this->Add<Data::UpdateType>(Utility::UpdateType::Minor);
+        }
+        else if (Args.Contains(Args::Type::PatchVersionOnly))
+        {
+            this->Add<Data::UpdateType>(Utility::UpdateType::Patch);
+        }
+        else
+        {
+            this->Add<Data::UpdateType>(Utility::UpdateType::Any);
         }
     }
 

--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -66,6 +66,7 @@ namespace AppInstaller::CLI::Execution
         ModifyPath,
         RepairString,
         MsixDigests,
+        UpdateType,
         Max
     };
 
@@ -288,6 +289,12 @@ namespace AppInstaller::CLI::Execution
         {
             // The pair is { URL, Digest }
             using value_t = std::vector<std::pair<std::string, std::wstring>>;
+        };
+
+        template<>
+        struct DataMapping<Data::UpdateType>
+        {
+            using value_t = Utility::UpdateType;
         };
     }
 }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -342,6 +342,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ManifestValidationSuccess);
         WINGET_DEFINE_RESOURCE_STRINGID(ManifestValidationWarning);
         WINGET_DEFINE_RESOURCE_STRINGID(MissingArgumentError);
+        WINGET_DEFINE_RESOURCE_STRINGID(MinorVersionOnlyArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ModifiedPathRequiresShellRestart);
         WINGET_DEFINE_RESOURCE_STRINGID(MonikerArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(MsixArgumentDescription);
@@ -407,6 +408,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(PackageDependencies);
         WINGET_DEFINE_RESOURCE_STRINGID(PackageIsPinned);
         WINGET_DEFINE_RESOURCE_STRINGID(PackageRequiresDependencies);
+        WINGET_DEFINE_RESOURCE_STRINGID(PatchVersionOnlyArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PendingWorkError);
         WINGET_DEFINE_RESOURCE_STRINGID(PinAddBlockingArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(PinAddCommandLongDescription);

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -17,11 +17,6 @@ namespace AppInstaller::CLI::Workflow
 {
     namespace
     {
-        bool IsUpdateVersionAvailable(const Utility::Version& installedVersion, const Utility::Version& updateVersion)
-        {
-            return installedVersion < updateVersion;
-        }
-
         void AddToPackageSubContextsIfNotPresent(std::vector<std::unique_ptr<Execution::Context>>& packageSubContexts, std::unique_ptr<Execution::Context> packageContext)
         {
             for (auto const& existing : packageSubContexts)
@@ -82,7 +77,7 @@ namespace AppInstaller::CLI::Workflow
         for (const auto& key : versionKeys)
         {
             // Check Applicable Version
-            if (!isUpgrade || IsUpdateVersionAvailable(installedVersion, Utility::Version(key.Version)))
+            if (!isUpgrade || installedVersion.IsUpdatedBy(Utility::Version(key.Version), context.Get<Execution::Data::UpdateType>()))
             {
                 // The only way to enter this portion of the statement with isUpgrade is if the version is available
                 if (isUpgrade)
@@ -197,7 +192,7 @@ namespace AppInstaller::CLI::Workflow
         Utility::Version installedVersion = Utility::Version(installedPackage->GetProperty(PackageVersionProperty::Version));
         Utility::Version updateVersion(context.Get<Execution::Data::Manifest>().Version);
 
-        if (!IsUpdateVersionAvailable(installedVersion, updateVersion))
+        if (!installedVersion.IsUpdatedBy(updateVersion, context.Get<Execution::Data::UpdateType>()))
         {
             context.Reporter.Info() << Resource::String::UpdateNoPackagesFound << std::endl
                 << Resource::String::UpdateNoPackagesFoundReason << std::endl;

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.cpp
@@ -200,6 +200,24 @@ namespace AppInstaller::CLI::Workflow
         }
     }
 
+    void SetUpdateType(Execution::Context& context)
+    {
+        // Set version filtering for listing and installing upgrades
+        // This is set as data in the context as listing and installing use different workflows
+        if (context.Args.Contains(Execution::Args::Type::MinorVersionOnly))
+        {
+            context.Add<Execution::Data::UpdateType>(Utility::UpdateType::Minor);
+        }
+        else if (context.Args.Contains(Execution::Args::Type::PatchVersionOnly))
+        {
+            context.Add<Execution::Data::UpdateType>(Utility::UpdateType::Patch);
+        }
+        else
+        {
+            context.Add<Execution::Data::UpdateType>(Utility::UpdateType::Any);
+        }
+    }
+
     void UpdateAllApplicable(Execution::Context& context)
     {
         const auto& matches = context.Get<Execution::Data::SearchResult>().Matches;
@@ -229,6 +247,7 @@ namespace AppInstaller::CLI::Workflow
             }
 
             updateContext <<
+                SetUpdateType <<
                 Workflow::GetInstalledPackageVersion <<
                 Workflow::ReportExecutionStage(ExecutionStage::Discovery) <<
                 SelectLatestApplicableVersion(false);

--- a/src/AppInstallerCLICore/Workflows/UpdateFlow.h
+++ b/src/AppInstallerCLICore/Workflows/UpdateFlow.h
@@ -27,6 +27,12 @@ namespace AppInstaller::CLI::Workflow
     // Outputs: None
     void EnsureUpdateVersionApplicable(Execution::Context& context);
 
+    // Sets the UpdateType for version comparison
+    // Required Args: None
+    // Inputs: None
+    // Outputs: None
+    void SetUpdateType(Execution::Context& context);
+
     // Update all packages from SearchResult to latest if applicable
     // Required Args: None
     // Inputs: SearchResult

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -20,7 +20,6 @@ using namespace AppInstaller::Utility::literals;
 using namespace AppInstaller::Pinning;
 using namespace AppInstaller::Repository;
 using namespace AppInstaller::Settings;
-using namespace AppInstaller::Utility;
 using namespace winrt::Windows::Foundation;
 
 namespace AppInstaller::CLI::Workflow
@@ -825,14 +824,7 @@ namespace AppInstaller::CLI::Workflow
             // We only want to evaluate update availability for the latest version.
             bool isFirstInstalledVersion = true;
 
-            UpdateType updateType =
-                // If the user specified minor version only, set UpdateType to minor
-                context.Args.Contains(Execution::Args::Type::MinorVersionOnly) ? UpdateType::Minor :
-                // If the user specified patch version only, set UpdateType to patch
-                context.Args.Contains(Execution::Args::Type::PatchVersionOnly) ? UpdateType::Patch :
-                // Otherwise, allow all update types
-                Utility::UpdateType::Any;
-            AICLI_LOG(CLI, Verbose, << "Filtering updates to type " << updateType);
+            const auto& updateType = context.Get<Execution::Data::UpdateType>();
 
             for (const auto& installedVersionKey : installedPackage->GetVersionKeys())
             {

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -829,10 +829,10 @@ namespace AppInstaller::CLI::Workflow
                 // If the user specified minor version only, set UpdateType to minor
                 context.Args.Contains(Execution::Args::Type::MinorVersionOnly) ? UpdateType::Minor :
                 // If the user specified patch version only, set UpdateType to patch
-                (context.Args.Contains(Execution::Args::Type::PatchVersionOnly) ? UpdateType::Patch :
+                context.Args.Contains(Execution::Args::Type::PatchVersionOnly) ? UpdateType::Patch :
                 // Otherwise, allow all update types
-                Utility::UpdateType::Any);
-            AICLI_LOG(CLI, Verbose, << "Update Type " << updateType);
+                Utility::UpdateType::Any;
+            AICLI_LOG(CLI, Verbose, << "Filtering updates to type " << updateType);
 
             for (const auto& installedVersionKey : installedPackage->GetVersionKeys())
             {

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -373,6 +373,9 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Argument value required, but none found: '{0}'</value>
     <comment>{Locked="{0}"} Error message displayed when the user does not provide a required command line argument value. {0} is a placeholder replaced by the argument name.</comment>
   </data>
+  <data name="MinorVersionOnlyArgumentDescription" xml:space="preserve">
+    <value>Upgrade only the packages which have not changed Major version according to semantic version parsing</value>
+  </data>
   <data name="MonikerArgumentDescription" xml:space="preserve">
     <value>Filter results by moniker</value>
   </data>
@@ -433,6 +436,9 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="Package" xml:space="preserve">
     <value>Package: {0}</value>
     <comment>{Locked="{0}"} Label displayed for a software package. {0} is a placeholder replaced by the software package name.</comment>
+  </data>
+  <data name="PatchVersionOnlyArgumentDescription" xml:space="preserve">
+    <value>Upgrade only the packages which have not changed Major or Minor version according to semantic version parsing</value>
   </data>
   <data name="PendingWorkError" xml:space="preserve">
     <value>Oops, we forgot to do this...</value>

--- a/src/AppInstallerRepositoryCore/PinningData.cpp
+++ b/src/AppInstallerRepositoryCore/PinningData.cpp
@@ -167,13 +167,14 @@ namespace AppInstaller::Pinning
         return {};
     }
 
-    bool PinningData::PinStateEvaluator::IsUpdate(const std::shared_ptr<IPackageVersion>& availableVersion)
+    bool PinningData::PinStateEvaluator::IsUpdate(const std::shared_ptr<IPackageVersion>& availableVersion, Utility::UpdateType updateType)
     {
         if (m_installedVersion && availableVersion)
         {
             Utility::VersionAndChannel availableVersionAndChannel{
                 Utility::Version{ availableVersion->GetProperty(PackageVersionProperty::Version) },
-                Utility::Channel{ availableVersion->GetProperty(PackageVersionProperty::Channel) }
+                Utility::Channel{ availableVersion->GetProperty(PackageVersionProperty::Channel) },
+                updateType,
             };
 
             return m_installedVersion->IsUpdatedBy(availableVersionAndChannel);

--- a/src/AppInstallerRepositoryCore/PinningData.cpp
+++ b/src/AppInstallerRepositoryCore/PinningData.cpp
@@ -174,10 +174,9 @@ namespace AppInstaller::Pinning
             Utility::VersionAndChannel availableVersionAndChannel{
                 Utility::Version{ availableVersion->GetProperty(PackageVersionProperty::Version) },
                 Utility::Channel{ availableVersion->GetProperty(PackageVersionProperty::Channel) },
-                updateType,
             };
 
-            return m_installedVersion->IsUpdatedBy(availableVersionAndChannel);
+            return m_installedVersion->IsUpdatedBy(availableVersionAndChannel, updateType);
         }
 
         return false;

--- a/src/AppInstallerRepositoryCore/PinningData.cpp
+++ b/src/AppInstallerRepositoryCore/PinningData.cpp
@@ -173,7 +173,7 @@ namespace AppInstaller::Pinning
         {
             Utility::VersionAndChannel availableVersionAndChannel{
                 Utility::Version{ availableVersion->GetProperty(PackageVersionProperty::Version) },
-                Utility::Channel{ availableVersion->GetProperty(PackageVersionProperty::Channel) },
+                Utility::Channel{ availableVersion->GetProperty(PackageVersionProperty::Channel) }
             };
 
             return m_installedVersion->IsUpdatedBy(availableVersionAndChannel, updateType);

--- a/src/AppInstallerRepositoryCore/Public/winget/PinningData.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PinningData.h
@@ -83,7 +83,7 @@ namespace AppInstaller::Pinning
 
             // Determines if the given version is an update to the installed version that this object was created with.
             // This should be a version associated with the installed version for which this evaluator was created.
-            bool IsUpdate(const std::shared_ptr<AppInstaller::Repository::IPackageVersion>& availableVersion);
+            bool IsUpdate(const std::shared_ptr<AppInstaller::Repository::IPackageVersion>& availableVersion, Utility::UpdateType);
 
             // Determines the pin type to apply to the given version.
             PinType EvaluatePinType(const std::shared_ptr<AppInstaller::Repository::IPackageVersion>& packageVersion);

--- a/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
@@ -7,6 +7,16 @@
 
 namespace AppInstaller::Utility
 {
+    enum class UpdateType : uint32_t
+    {
+        // Ordered smallest to largest
+        Build = 0x1,
+        Patch = 0x2,
+        Minor = 0x4,
+        Major = 0x8,
+        Any = Major | Minor | Patch | Build,
+    };
+
     using namespace std::string_view_literals;
 
     // Creates a comparable version object from a string.
@@ -262,7 +272,9 @@ namespace AppInstaller::Utility
     struct VersionAndChannel
     {
         VersionAndChannel() = default;
-        VersionAndChannel(Version&& version, Channel&& channel);
+        VersionAndChannel(Version&& version, Channel&& channel) :
+            VersionAndChannel(std::move(version), std::move(channel), UpdateType::Any) {}
+        VersionAndChannel(Version&& version, Channel&& channel, Utility::UpdateType updateType);
 
         const Version& GetVersion() const { return m_version; }
         const Channel& GetChannel() const { return m_channel; }
@@ -277,6 +289,7 @@ namespace AppInstaller::Utility
     private:
         Version m_version;
         Channel m_channel;
+        UpdateType m_updateType = UpdateType::Any;
     };
 
     // Checks if there are overlaps within the list of version ranges

--- a/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
@@ -272,9 +272,7 @@ namespace AppInstaller::Utility
     struct VersionAndChannel
     {
         VersionAndChannel() = default;
-        VersionAndChannel(Version&& version, Channel&& channel) :
-            VersionAndChannel(std::move(version), std::move(channel), UpdateType::Any) {}
-        VersionAndChannel(Version&& version, Channel&& channel, Utility::UpdateType updateType);
+        VersionAndChannel(Version&& version, Channel&& channel);
 
         const Version& GetVersion() const { return m_version; }
         const Channel& GetChannel() const { return m_channel; }
@@ -284,12 +282,11 @@ namespace AppInstaller::Utility
         bool operator<(const VersionAndChannel& other) const;
 
         // A convenience function to make more semantic sense at call sites over the somewhat awkward less than ordering.
-        bool IsUpdatedBy(const VersionAndChannel& other) const;
+        bool IsUpdatedBy(const VersionAndChannel& other, Utility::UpdateType = Utility::UpdateType::Any) const;
 
     private:
         Version m_version;
         Channel m_channel;
-        UpdateType m_updateType = UpdateType::Any;
     };
 
     // Checks if there are overlaps within the list of version ranges

--- a/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
@@ -92,7 +92,7 @@ namespace AppInstaller::Utility
         bool IsEmpty() const { return m_version.empty(); }
 
         // A convenience function to make more semantic sense
-        // Returns whether or not the other version is newer
+        // Returns whether or not the other version is an applicable update given the type of update requested
         bool IsUpdatedBy(const Version& other, UpdateType type) const;
 
         // An individual version part in between split characters.

--- a/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerVersions.h
@@ -10,6 +10,8 @@ namespace AppInstaller::Utility
     enum class UpdateType : uint32_t
     {
         // Ordered smallest to largest
+        // These are are not currently implemented as flags in the context; however, values have been assigned to make this easy in the future
+        // This would allow accommodation of a user setting to allow only specific update types with less refactoring
         Build = 0x1,
         Patch = 0x2,
         Minor = 0x4,
@@ -88,6 +90,10 @@ namespace AppInstaller::Utility
         // Does not indicate that Parts is empty; for instance when "0.0" is given,
         // this will be false while GetParts().empty() would be true.
         bool IsEmpty() const { return m_version.empty(); }
+
+        // A convenience function to make more semantic sense
+        // Returns whether or not the other version is newer
+        bool IsUpdatedBy(const Version& other, UpdateType type) const;
 
         // An individual version part in between split characters.
         struct Part
@@ -282,7 +288,7 @@ namespace AppInstaller::Utility
         bool operator<(const VersionAndChannel& other) const;
 
         // A convenience function to make more semantic sense at call sites over the somewhat awkward less than ordering.
-        bool IsUpdatedBy(const VersionAndChannel& other, Utility::UpdateType = Utility::UpdateType::Any) const;
+        bool IsUpdatedBy(const VersionAndChannel& other, Utility::UpdateType) const;
 
     private:
         Version m_version;

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -273,7 +273,7 @@ namespace AppInstaller::Utility
                     this->PartAt(2) < other.PartAt(2);
                 break;
             case UpdateType::Build:
-                // An update is a build version update iff the major, minor, and build version have not changed but the patch version has
+                // An update is a build version update iff the major, minor, and patch version have not changed but the build version has
                 return this->PartAt(0) == other.PartAt(0) &&
                     this->PartAt(1) == other.PartAt(1) &&
                     this->PartAt(2) == other.PartAt(2) &&

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -366,8 +366,8 @@ namespace AppInstaller::Utility
         return m_channel < other.m_channel;
     }
 
-    VersionAndChannel::VersionAndChannel(Version&& version, Channel&& channel, UpdateType updateType) : 
-        m_version(std::move(version)), m_channel(std::move(channel)), m_updateType(updateType) {}
+    VersionAndChannel::VersionAndChannel(Version&& version, Channel&& channel) : 
+        m_version(std::move(version)), m_channel(std::move(channel)) {}
 
     std::string VersionAndChannel::ToString() const
     {
@@ -402,7 +402,7 @@ namespace AppInstaller::Utility
         return false;
     }
 
-    bool VersionAndChannel::IsUpdatedBy(const VersionAndChannel& other) const
+    bool VersionAndChannel::IsUpdatedBy(const VersionAndChannel& other, Utility::UpdateType updateType) const
     {
         // Channel crossing should not happen here.
         if (!Utility::ICUCaseInsensitiveEquals(m_channel.ToString(), other.m_channel.ToString()))
@@ -410,7 +410,7 @@ namespace AppInstaller::Utility
             return false;
         }
 
-        switch (other.m_updateType)
+        switch (updateType)
         {
         case UpdateType::Any:
             return m_version < other.m_version;

--- a/src/Microsoft.Management.Deployment/CatalogPackage.cpp
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.cpp
@@ -79,7 +79,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                     evaluator.GetLatestAvailableVersionForPins(::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package));
                 if (latestVersion)
                 {
-                    m_updateAvailable = evaluator.IsUpdate(latestVersion);
+                    m_updateAvailable = evaluator.IsUpdate(latestVersion, AppInstaller::Utility::UpdateType::Any);
 
                     // DefaultInstallVersion hasn't been created yet, create and populate it.
                     // DefaultInstallVersion is the LatestAvailableVersion of the internal package object.

--- a/src/Microsoft.Management.Deployment/CatalogPackage.cpp
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.cpp
@@ -79,6 +79,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                     evaluator.GetLatestAvailableVersionForPins(::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package));
                 if (latestVersion)
                 {
+                    // Because this is the default install verion, all update types should be checked
                     m_updateAvailable = evaluator.IsUpdate(latestVersion, AppInstaller::Utility::UpdateType::Any);
 
                     // DefaultInstallVersion hasn't been created yet, create and populate it.

--- a/src/Microsoft.Management.Deployment/CatalogPackage.cpp
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.cpp
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 std::shared_ptr<::AppInstaller::Repository::IPackageVersion> latestVersion =
                     evaluator.GetLatestAvailableVersionForPins(::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package));
                 if (latestVersion)
-                
+                {
                     m_updateAvailable = evaluator.IsUpdate(latestVersion, AppInstaller::Utility::UpdateType::Any);
 
                     // DefaultInstallVersion hasn't been created yet, create and populate it.

--- a/src/Microsoft.Management.Deployment/CatalogPackage.cpp
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.cpp
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 std::shared_ptr<::AppInstaller::Repository::IPackageVersion> latestVersion =
                     evaluator.GetLatestAvailableVersionForPins(::AppInstaller::Repository::GetAvailableVersionsForInstalledVersion(m_package));
                 if (latestVersion)
-                {
+                
                     m_updateAvailable = evaluator.IsUpdate(latestVersion, AppInstaller::Utility::UpdateType::Any);
 
                     // DefaultInstallVersion hasn't been created yet, create and populate it.

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -653,7 +653,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                     THROW_HR(APPINSTALLER_CLI_ERROR_UPGRADE_VERSION_UNKNOWN);
                 }
             }
-            else if (!installedVersion.IsUpdatedBy(upgradeVersion))
+            else if (!installedVersion.IsUpdatedBy(upgradeVersion, comContext->Get<Execution::Data::UpdateType>()))
             {
                 THROW_HR(APPINSTALLER_CLI_ERROR_UPGRADE_VERSION_NOT_NEWER);
             }


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - #1914
-----

This PR adds support for `--minor-version-only` and `--patch-version-only` in `winget upgrade`.  
`winget upgrade --minor` lists packages available for upgrade, where only a minor version upgrade is available.
`winget upgrade --all --minor` installs packages where only a minor version upgrade is available.

It may be possible for there to be both a newer major version and a newer minor version available in the source. In this case, the upgrade will be skipped entirely. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4602)