### PR TITLE
Attempt to update dependencies when not registered

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetPackageManagerCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -138,7 +138,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                             this.RepairEnvPath();
                             break;
                         case IntegrityCategory.AppInstallerNotRegistered:
-                            this.Register();
+                            this.Register(expectedVersion);
                             break;
                         case IntegrityCategory.AppInstallerNotInstalled:
                         case IntegrityCategory.AppInstallerNotSupported:
@@ -197,10 +197,10 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             await appxModule.InstallFromGitHubReleaseAsync(toInstallVersion, allUsers, false, force);
         }
 
-        private void Register()
+        private void Register(string toRegisterVersion)
         {
             var appxModule = new AppxModuleHelper(this);
-            appxModule.RegisterAppInstaller();
+            appxModule.RegisterAppInstaller(toRegisterVersion);
         }
 
         private void RepairEnvPath()

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AppxModuleHelper.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -127,8 +127,15 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// <summary>
         /// Calls Add-AppxPackage to register with AppInstaller's AppxManifest.xml.
         /// </summary>
-        public void RegisterAppInstaller()
+        /// <param name="releaseTag">Release tag of GitHub release.</param>
+        public void RegisterAppInstaller(string releaseTag)
         {
+            // Ensure that all dependencies are present when attempting to register.
+            // If dependencies are missing, a provisioned package can appear to only need registration,
+            // but will fail to register. `InstallDependenciesAsync` checks for the packages before
+            // acting, so it should be mostly a no-op if they are already available.
+            this.InstallDependenciesAsync(releaseTag).Wait();
+
             string? packageFullName = this.GetAppInstallerPropertyValue(PackageFullName);
 
             if (packageFullName == null)


### PR DESCRIPTION
Fixes #4337 

## Change
Before registering the package for repair, ensure that the dependencies are present and in good standing.  Fortunately, the existing function to install the dependencies does this, so we just call it.

## Validation
Successfully repaired a machine in the state described in #4337 (provisioned, "registered" for the user, but Xaml 2.8 missing).
[Was not 100% successful since I forgot to build the production version and it wanted to find `wingetdev.exe`, but verified manually that the repair succeeded.]
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4606)