### PR TITLE
Fix for attempted use of capability API before it was introduced

### DIFF
--- a/src/AppInstallerSharedLib/Public/winget/Security.h
+++ b/src/AppInstallerSharedLib/Public/winget/Security.h
@@ -27,6 +27,12 @@ namespace AppInstaller::Security
     // and is at least equal integrity level (higher will also be allowed).
     bool IsCOMCallerSameUserAndIntegrityLevel();
 
+    // Determines if the current COM caller is at least the minimum integrity level provided.
+    bool IsCOMCallerIntegrityLevelAtLeast(IntegrityLevel minimumLevel);
+
+    // Determines if the current integrity level is at least the minimum integrity level provided.
+    bool IsCurrentIntegrityLevelAtLeast(IntegrityLevel minimumLevel);
+
     // Gets the string representation of the given SID.
     std::string ToString(PSID sid);
 }

--- a/src/AppInstallerSharedLib/Security.cpp
+++ b/src/AppInstallerSharedLib/Security.cpp
@@ -112,6 +112,25 @@ namespace AppInstaller::Security
         return true;
     }
 
+    bool IsCOMCallerIntegrityLevelAtLeast(IntegrityLevel minimumLevel)
+    {
+        auto impersonation = ImpersonateCOMorRPCCaller::BeginImpersonation();
+        return IsCurrentIntegrityLevelAtLeast(minimumLevel);
+    }
+
+    bool IsCurrentIntegrityLevelAtLeast(IntegrityLevel minimumLevel)
+    {
+        IntegrityLevel callingIntegrityLevel = GetEffectiveIntegrityLevel();
+
+        if (ToIntegral(callingIntegrityLevel) < ToIntegral(minimumLevel))
+        {
+            AICLI_LOG(Core, Crit, << "Attempt to access by a lower integrity process than required: " << callingIntegrityLevel << " < " << minimumLevel);
+            return false;
+        }
+
+        return true;
+    }
+
     std::string ToString(PSID sid)
     {
         wil::unique_hlocal_ansistring result;

--- a/src/Microsoft.Management.Deployment/pch.h
+++ b/src/Microsoft.Management.Deployment/pch.h
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
 #include <unknwn.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Web.Http.h>
 
 #include <ostream>


### PR DESCRIPTION
## Change
Check for the existence of
`Windows::Security::Authorization::AppCapabilityAccess::AppCapability`, and if it is not present, simply force the caller to be at least medium integrity level.

Cherry-pick of #4620 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4623)