### PR TITLE
Store configuration status and enable remote watch events

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -330,7 +330,7 @@ Testrun
 testsettingname
 TEXTFORMAT
 TEXTINCLUDE
-Threadpool
+threadpool
 tpl
 TRACELOGGING
 triaged

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -194,6 +194,7 @@ norestart
 normalizednameandpublisher
 normalizedpackagenameandpublisher
 notcontains
+NTAPI
 NTSTATUS
 nullsoft
 nunit

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -219,6 +219,8 @@ namespace AppInstaller::CLI
             return { type, "history"_liv, 'h', ArgTypeCategory::ConfigurationSetChoice, ArgTypeExclusiveSet::ConfigurationSetChoice };
         case Execution::Args::Type::ConfigurationHistoryRemove:
             return { type, "remove"_liv };
+        case Execution::Args::Type::ConfigurationStatusWatch:
+            return { type, "live"_liv };
 
         // Download command
         case Execution::Args::Type::DownloadDirectory:

--- a/src/AppInstallerCLICore/Commands/ConfigureListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureListCommand.cpp
@@ -15,6 +15,7 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::ConfigurationHistoryItem, Resource::String::ConfigurationHistoryItemArgumentDescription, ArgumentType::Standard },
             Argument{ Execution::Args::Type::OutputFile, Resource::String::OutputFileArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationHistoryRemove, Resource::String::ConfigurationHistoryRemoveArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },
+            Argument{ Execution::Args::Type::ConfigurationStatusWatch, Resource::String::ConfigurationStatusWatchArgumentDescription, ArgumentType::Flag, Argument::Visibility::Hidden },
         };
     }
 
@@ -57,6 +58,10 @@ namespace AppInstaller::CLI
             {
                 context << ShowSingleConfigurationSetHistory;
             }
+        }
+        else if (context.Args.Contains(Execution::Args::Type::ConfigurationStatusWatch))
+        {
+            context << MonitorConfigurationStatus;
         }
         else
         {

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -132,6 +132,7 @@ namespace AppInstaller::CLI::Execution
             ConfigurationExportResource,
             ConfigurationHistoryItem,
             ConfigurationHistoryRemove,
+            ConfigurationStatusWatch,
 
             // Common arguments
             NoVT, // Disable VirtualTerminal outputs

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -99,7 +99,12 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationNoTestRun);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationNotInDesiredState);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationReadingConfigFile);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSetStateCompleted);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSetStateInProgress);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSetStatePending);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSetStateUnknown);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSettings);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationStatusWatchArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSuccessfullyApplied);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnexpectedTestResult);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitAssertHadNegativeResult);
@@ -131,6 +136,11 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitReturnedInvalidResult);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitSettingConfigRoot);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitSkipped);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitStateCompleted);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitStateInProgress);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitStatePending);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitStateSkipped);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitStateUnknown);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationValidationFoundNoIssues);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationWaitingOnAnother);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationWarning);
@@ -148,6 +158,8 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureExportResource);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureExportUnitDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureExportUnitInstallDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListApplyBegun);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListApplyEnded);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListFirstApplied);
@@ -155,6 +167,10 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListName);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListOrigin);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListPath);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListResult);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListResultDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListState);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigureListUnit);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureShowCommandLongDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureShowCommandShortDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigureTestCommandLongDescription);

--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
@@ -2058,7 +2058,7 @@ namespace AppInstaller::CLI::Workflow
             {
                 UnitSiblings unitChildren;
                 unitChildren.Depth = currentSiblings.Depth + 1;
-                auto units = set.Units();
+                auto units = currentUnit.Units();
                 unitChildren.Siblings.resize(units.Size());
                 units.GetMany(0, unitChildren.Siblings);
                 stack.emplace_back(std::move(unitChildren));

--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.h
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.h
@@ -150,4 +150,10 @@ namespace AppInstaller::CLI::Workflow
     // Inputs: None
     // Outputs: None
     void CompleteConfigurationHistoryItem(Execution::Context& context);
+
+    // Monitors configuration status.
+    // Required Args: None
+    // Inputs: None
+    // Outputs: None
+    void MonitorConfigurationStatus(Execution::Context& context);
 }

--- a/src/AppInstallerCLIE2ETests/ConfigureShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureShowCommand.cs
@@ -93,7 +93,7 @@ namespace AppInstallerCLIE2ETests
             TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
             WinGetSettingsHelper.ConfigureFeature("configuration03", true);
 
-            var result = TestCommon.RunAICLICommand("configure show", TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo_0_3.yml"));
+            var result = TestCommon.RunAICLICommand("configure show", $"{TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo_0_3.yml")} --verbose");
             Assert.AreEqual(0, result.ExitCode);
             Assert.True(result.StdOut.Contains(Constants.TestRepoName));
         }

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -237,9 +237,12 @@ namespace AppInstallerCLIE2ETests.Helpers
         private static void SetWingetSettings(JObject settingsJson)
         {
             var forcedExperimentalFeatures = ForcedExperimentalFeatures;
-            foreach (var feature in forcedExperimentalFeatures)
+            if (forcedExperimentalFeatures != null)
             {
-                ConfigureFeature(settingsJson, feature, true);
+                foreach (var feature in forcedExperimentalFeatures)
+                {
+                    ConfigureFeature(settingsJson, feature, true);
+                }
             }
 
             SetWingetSettings(settingsJson.ToString());

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3045,4 +3045,62 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="WINGET_CONFIG_ERROR_HISTORY_ITEM_NOT_FOUND" xml:space="preserve">
     <value>The specified configuration could not be found.</value>
   </data>
+  <data name="ConfigurationSetStateCompleted" xml:space="preserve">
+    <value>Completed</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationSetStateInProgress" xml:space="preserve">
+    <value>In progress</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationSetStatePending" xml:space="preserve">
+    <value>Pending</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationSetStateUnknown" xml:space="preserve">
+    <value>Unknown</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationStatusWatchArgumentDescription" xml:space="preserve">
+    <value>Monitor configuration status.</value>
+  </data>
+  <data name="ConfigurationUnitStateCompleted" xml:space="preserve">
+    <value>Completed</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationUnitStateInProgress" xml:space="preserve">
+    <value>In progress</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationUnitStatePending" xml:space="preserve">
+    <value>Pending</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationUnitStateSkipped" xml:space="preserve">
+    <value>Skipped</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigurationUnitStateUnknown" xml:space="preserve">
+    <value>Unknown</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigureListApplyBegun" xml:space="preserve">
+    <value>Apply Begun</value>
+  </data>
+  <data name="ConfigureListApplyEnded" xml:space="preserve">
+    <value>Apply Ended</value>
+  </data>
+  <data name="ConfigureListResult" xml:space="preserve">
+    <value>Result</value>
+  </data>
+  <data name="ConfigureListResultDescription" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="ConfigureListState" xml:space="preserve">
+    <value>State</value>
+    <comment>The state of processing an item.</comment>
+  </data>
+  <data name="ConfigureListUnit" xml:space="preserve">
+    <value>Unit</value>
+  </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3063,6 +3063,7 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="ConfigurationStatusWatchArgumentDescription" xml:space="preserve">
     <value>Monitor configuration status.</value>
+    <comment>As in "to monitor the status of a configuration being applied".</comment>
   </data>
   <data name="ConfigurationUnitStateCompleted" xml:space="preserve">
     <value>Completed</value>
@@ -3085,10 +3086,12 @@ Please specify one of them using the --source option to proceed.</value>
     <comment>The state of processing an item.</comment>
   </data>
   <data name="ConfigureListApplyBegun" xml:space="preserve">
-    <value>Apply Begun</value>
+    <value>Apply Started</value>
+    <comment>When the configuration application started.</comment>
   </data>
   <data name="ConfigureListApplyEnded" xml:space="preserve">
     <value>Apply Ended</value>
+    <comment>When the configuration application ended.</comment>
   </data>
   <data name="ConfigureListResult" xml:space="preserve">
     <value>Result</value>

--- a/src/AppInstallerCLITests/SQLiteDynamicStorage.cpp
+++ b/src/AppInstallerCLITests/SQLiteDynamicStorage.cpp
@@ -20,7 +20,7 @@ TEST_CASE("SQLiteDynamicStorage_UpgradeDetection", "[sqlite_dynamic]")
     SQLiteDynamicStorage storage{ tempFile.GetPath(), Version{ 1, 0 } };
 
     {
-        auto transactionLock = storage.TryBeginTransaction("test");
+        auto transactionLock = storage.TryBeginTransaction("test", false);
         REQUIRE(transactionLock);
     }
 
@@ -33,11 +33,11 @@ TEST_CASE("SQLiteDynamicStorage_UpgradeDetection", "[sqlite_dynamic]")
 
     REQUIRE(storage.GetVersion() == Version{ 1, 0 });
 
-    auto transactionLock = storage.TryBeginTransaction("test");
+    auto transactionLock = storage.TryBeginTransaction("test", false);
     REQUIRE(!transactionLock);
 
     REQUIRE(storage.GetVersion() == Version{ 2, 0 });
 
-    transactionLock = storage.TryBeginTransaction("test");
+    transactionLock = storage.TryBeginTransaction("test", false);
     REQUIRE(transactionLock);
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_0/ManifestTable.cpp
@@ -213,7 +213,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_0
             }
             else
             {
-                builder.LiteralColumn("");
+                builder.Value(std::string_view{});
             }
 
             builder.As(valueAlias).From(s_ManifestTable_Table_Name);

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/2_0/SystemReferenceStringTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/2_0/SystemReferenceStringTable.cpp
@@ -227,7 +227,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V2_0
             //      where table.value = <value1> and paired.pairedValue = <value2>
             builder.Select().
                 Column(QCol(tableName, s_SystemReferenceStringTable_PrimaryName)).As(primaryAlias).
-                LiteralColumn("").As(valueAlias).
+                Value(std::string_view{}).As(valueAlias).
                 From(tableName).
                 Join(pairedTableName).On(QCol(tableName, s_SystemReferenceStringTable_PrimaryName), QCol(pairedTableName, s_SystemReferenceStringTable_PrimaryName)).
                 Where(QCol(tableName, valueName));

--- a/src/AppInstallerSharedLib/DateTime.cpp
+++ b/src/AppInstallerSharedLib/DateTime.cpp
@@ -37,6 +37,13 @@ namespace AppInstaller::Utility
         }
     }
 
+    std::string TimePointToString(const std::chrono::system_clock::time_point& time, bool useRFC3339)
+    {
+        std::ostringstream stream;
+        OutputTimePoint(stream, time, useRFC3339);
+        return std::move(stream).str();
+    }
+
     std::string GetCurrentTimeForFilename()
     {
         std::stringstream stream;

--- a/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
@@ -12,6 +12,9 @@ namespace AppInstaller::Utility
     // Time is also assumed to be after the epoch.
     void OutputTimePoint(std::ostream& stream, const std::chrono::system_clock::time_point& time, bool useRFC3339 = false);
 
+    // Converts the time point to a string using OutputTimePoint.
+    std::string TimePointToString(const std::chrono::system_clock::time_point& time, bool useRFC3339 = false);
+
     // Gets the current time as a string. Can be used as a file name.
     std::string GetCurrentTimeForFilename();
 

--- a/src/AppInstallerSharedLib/Public/winget/SQLiteDynamicStorage.h
+++ b/src/AppInstallerSharedLib/Public/winget/SQLiteDynamicStorage.h
@@ -34,7 +34,7 @@ namespace AppInstaller::SQLite
             TransactionLock(std::mutex& mutex);
 
             _Acquires_lock_(mutex)
-            TransactionLock(std::mutex& mutex, Connection& connection, std::string_view name);
+            TransactionLock(std::mutex& mutex, Connection& connection, std::string_view name, bool immediateWrite);
 
             // Abandons the transaction and any changes; releases the connection lock.
             void Rollback(bool throwOnError = true);
@@ -44,12 +44,12 @@ namespace AppInstaller::SQLite
 
         private:
             std::lock_guard<std::mutex> m_lock;
-            Savepoint m_transaction;
+            Transaction m_transaction;
         };
 
         // Acquires the connection lock and begins a transaction on the database.
         // If the returned result is empty, the schema version has changed and the caller must handle this.
-        std::unique_ptr<TransactionLock> TryBeginTransaction(std::string_view name);
+        std::unique_ptr<TransactionLock> TryBeginTransaction(std::string_view name, bool immediateWrite);
 
         // Locks the connection for use during the schema upgrade.
         std::unique_ptr<TransactionLock> LockConnection();

--- a/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
+++ b/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
@@ -286,6 +286,7 @@ namespace AppInstaller::SQLite::Builder
         StatementBuilder& Equals(details::unbound_t, std::optional<size_t> index = {});
         StatementBuilder& Equals(std::nullptr_t);
         StatementBuilder& Equals();
+        StatementBuilder& Equals(const QualifiedColumn& column);
 
         template <typename ValueType>
         StatementBuilder& IsGreaterThan(const ValueType& value)
@@ -305,8 +306,6 @@ namespace AppInstaller::SQLite::Builder
 
         StatementBuilder& LikeWithEscape(std::string_view value);
         StatementBuilder& Like(details::unbound_t);
-
-        StatementBuilder& LiteralColumn(std::string_view value);
 
         StatementBuilder& Escape(std::string_view escapeChar);
 

--- a/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
+++ b/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
@@ -242,6 +242,10 @@ namespace AppInstaller::SQLite::Builder
         StatementBuilder& Select(std::initializer_list<QualifiedColumn> columns);
         StatementBuilder& Select(details::rowcount_t);
 
+        // The maximum value aggregate function.
+        StatementBuilder& Max(std::string_view column);
+        StatementBuilder& Max(const QualifiedColumn& column);
+
         // Indicate the table that the statement will be operating on.
         // The initializer_list form enables the table name to be constructed from multiple parts.
         StatementBuilder& From();
@@ -379,6 +383,17 @@ namespace AppInstaller::SQLite::Builder
         StatementBuilder& Column(Aggregate aggOp, const QualifiedColumn& column);
         StatementBuilder& Column(const details::SubBuilder& column);
         StatementBuilder& EndColumns();
+
+        // Set the columns null constraint.
+        StatementBuilder& NotNull(bool isTrue = true);
+
+        // Set the column's default value.
+        template <typename ValueType>
+        StatementBuilder& Default(const ValueType& value)
+        {
+            m_stream << " DEFAULT (" << value << ")";
+            return *this;
+        }
 
         // Add the values clause for an insert statement.
         template <typename... ValueTypes>

--- a/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
+++ b/src/AppInstallerSharedLib/Public/winget/SQLiteStatementBuilder.h
@@ -242,10 +242,6 @@ namespace AppInstaller::SQLite::Builder
         StatementBuilder& Select(std::initializer_list<QualifiedColumn> columns);
         StatementBuilder& Select(details::rowcount_t);
 
-        // The maximum value aggregate function.
-        StatementBuilder& Max(std::string_view column);
-        StatementBuilder& Max(const QualifiedColumn& column);
-
         // Indicate the table that the statement will be operating on.
         // The initializer_list form enables the table name to be constructed from multiple parts.
         StatementBuilder& From();

--- a/src/AppInstallerSharedLib/Public/winget/SQLiteWrapper.h
+++ b/src/AppInstallerSharedLib/Public/winget/SQLiteWrapper.h
@@ -377,6 +377,39 @@ namespace AppInstaller::SQLite
         State m_state = State::Prepared;
     };
 
+    // A SQLite transaction.
+    // Use as the beginning of a transaction stack, specifically when the transaction will write
+    // and the database is in WAL mode.
+    struct Transaction
+    {
+        // Creates a transaction, beginning it.
+        static Transaction Create(Connection& connection, std::string name, bool immediateWrite);
+
+        Transaction();
+
+        Transaction(const Transaction&) = delete;
+        Transaction& operator=(const Transaction&) = delete;
+
+        Transaction(Transaction&&) = default;
+        Transaction& operator=(Transaction&&) = default;
+
+        ~Transaction();
+
+        // Rolls back the Transaction.
+        void Rollback(bool throwOnError = true);
+
+        // Commits the Transaction.
+        void Commit();
+
+    private:
+        Transaction(Connection& connection, std::string&& name, bool immediateWrite);
+
+        std::string m_name;
+        DestructionToken m_inProgress = true;
+        Statement m_rollback;
+        Statement m_commit;
+    };
+
     // A SQLite savepoint.
     struct Savepoint
     {

--- a/src/AppInstallerSharedLib/SQLiteDynamicStorage.cpp
+++ b/src/AppInstallerSharedLib/SQLiteDynamicStorage.cpp
@@ -54,10 +54,10 @@ namespace AppInstaller::SQLite
     }
 
     _Acquires_lock_(mutex)
-    SQLiteDynamicStorage::TransactionLock::TransactionLock(std::mutex& mutex, Connection& connection, std::string_view name) :
+    SQLiteDynamicStorage::TransactionLock::TransactionLock(std::mutex& mutex, Connection& connection, std::string_view name, bool immediateWrite) :
         m_lock(mutex)
     {
-        m_transaction = Savepoint::Create(connection, std::string{ name });
+        m_transaction = Transaction::Create(connection, std::string{ name }, immediateWrite);
     }
 
     void SQLiteDynamicStorage::TransactionLock::Rollback(bool throwOnError)
@@ -70,9 +70,9 @@ namespace AppInstaller::SQLite
         m_transaction.Commit();
     }
 
-    std::unique_ptr<SQLiteDynamicStorage::TransactionLock> SQLiteDynamicStorage::TryBeginTransaction(std::string_view name)
+    std::unique_ptr<SQLiteDynamicStorage::TransactionLock> SQLiteDynamicStorage::TryBeginTransaction(std::string_view name, bool immediateWrite)
     {
-        auto result = std::make_unique<TransactionLock>(*m_interfaceLock, m_dbconn, name);
+        auto result = std::make_unique<TransactionLock>(*m_interfaceLock, m_dbconn, name, immediateWrite);
 
         Version currentVersion = Version::GetSchemaVersion(m_dbconn);
         if (currentVersion != m_version)

--- a/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
@@ -288,6 +288,20 @@ namespace AppInstaller::SQLite::Builder
         return *this;
     }
 
+    StatementBuilder& StatementBuilder::Max(std::string_view column)
+    {
+        OutputColumns(m_stream, "MAX(", column);
+        m_stream << ")";
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::Max(const QualifiedColumn& column)
+    {
+        OutputColumns(m_stream, "MAX(", column);
+        m_stream << ")";
+        return *this;
+    }
+
     StatementBuilder& StatementBuilder::From()
     {
         m_stream << " FROM ";
@@ -676,6 +690,15 @@ namespace AppInstaller::SQLite::Builder
     {
         m_stream << ')';
         m_needsComma = false;
+        return *this;
+    }
+
+    StatementBuilder& StatementBuilder::NotNull(bool isTrue)
+    {
+        if (isTrue)
+        {
+            m_stream << " NOT NULL";
+        }
         return *this;
     }
 

--- a/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
@@ -372,6 +372,12 @@ namespace AppInstaller::SQLite::Builder
         return *this;
     }
 
+    StatementBuilder& StatementBuilder::Equals(const QualifiedColumn& column)
+    {
+        OutputColumns(m_stream, " = ", column);
+        return *this;
+    }
+
     StatementBuilder& StatementBuilder::IsGreaterThan(details::unbound_t, std::optional<size_t> index)
     {
         AppendOpAndBinder(Op::GreaterThan, index);
@@ -393,17 +399,6 @@ namespace AppInstaller::SQLite::Builder
     StatementBuilder& StatementBuilder::Like(details::unbound_t)
     {
         AppendOpAndBinder(Op::Like);
-        return *this;
-    }
-
-    StatementBuilder& StatementBuilder::LiteralColumn(std::string_view value)
-    {
-        if (m_needsComma)
-        {
-            m_stream << ", ";
-        }
-        AddBindFunctor(AppendOpAndBinder(Op::Literal), value);
-        m_needsComma = true;
         return *this;
     }
 

--- a/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
+++ b/src/AppInstallerSharedLib/SQLiteStatementBuilder.cpp
@@ -288,20 +288,6 @@ namespace AppInstaller::SQLite::Builder
         return *this;
     }
 
-    StatementBuilder& StatementBuilder::Max(std::string_view column)
-    {
-        OutputColumns(m_stream, "MAX(", column);
-        m_stream << ")";
-        return *this;
-    }
-
-    StatementBuilder& StatementBuilder::Max(const QualifiedColumn& column)
-    {
-        OutputColumns(m_stream, "MAX(", column);
-        m_stream << ")";
-        return *this;
-    }
-
     StatementBuilder& StatementBuilder::From()
     {
         m_stream << " FROM ";

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         {
             // To run the tests OOP, you need to replace Microsoft.Management.Configuration.dll with Microsoft.Management.Configuration.OutOfProc.dll (renamed to remove the OutOfProc).
             // You will also need to copy over Microsoft.Management.Configuration.winmd as it is needed by COM.
+            //
+            // You can use the script to do this:
+            //  <GITROOT>\src\Microsoft.Management.Configuration.OutOfProc\Prepare-ConfigurationOOPTests.ps1 -BuildOutputPath <GITROOT>\src\x64\Debug
+            //
             // It can be easier to run the tests on the command line because any changes needing a recompile will overwrite the DLL update above.
             // The test runner is located somewhere like this:
             //  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
             // You will also need to copy over Microsoft.Management.Configuration.winmd as it is needed by COM.
             //
             // You can use the script to do this:
-            //  <GITROOT>\src\Microsoft.Management.Configuration.OutOfProc\Prepare-ConfigurationOOPTests.ps1 -BuildOutputPath <GITROOT>\src\x64\Debug
+            //  <git root>\src\Microsoft.Management.Configuration.OutOfProc\Prepare-ConfigurationOOPTests.ps1 -BuildOutputPath <git root>\src\x64\Debug
             //
             // It can be easier to run the tests on the command line because any changes needing a recompile will overwrite the DLL update above.
             // The test runner is located somewhere like this:

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcDiscoverer.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcDiscoverer.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="OutOfProcDiscoverer.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationSetProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -42,6 +42,11 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
             new Dictionary<ConfigurationUnit, Exception>();
 
         /// <summary>
+        /// Gets or sets a value indicating whether the default unit processors for groups will enable group processing.
+        /// </summary>
+        internal bool EnableDefaultGroupProcessorCreation { get; set; } = false;
+
+        /// <summary>
         /// Gets the ConfigurationSet that this processor targets.
         /// </summary>
         protected ConfigurationSet? Set { get; private set; }
@@ -60,7 +65,14 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
 
             if (!this.Processors.ContainsKey(unit))
             {
-                this.Processors.Add(unit, new TestConfigurationUnitProcessor(unit));
+                if (this.EnableDefaultGroupProcessorCreation && unit.IsGroup)
+                {
+                    this.Processors.Add(unit, new TestConfigurationUnitGroupProcessor(unit));
+                }
+                else
+                {
+                    this.Processors.Add(unit, new TestConfigurationUnitProcessor(unit));
+                }
             }
 
             return this.Processors[unit];

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationHistoryTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationHistoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
     /// Unit tests for configuration history.
     /// </summary>
     [Collection("UnitTestCollection")]
-    [OutOfProc]
+    [InProc]
     public class ConfigurationHistoryTests : ConfigurationProcessorTestBase
     {
         /// <summary>
@@ -38,6 +38,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         /// Checks that the history matches the applied set.
         /// </summary>
         [Fact]
+        [OutOfProc]
         public void ApplySet_HistoryMatches_0_1()
         {
             this.RunApplyHistoryMatchTest(
@@ -79,6 +80,7 @@ properties:
         /// Checks that the history matches the applied set.
         /// </summary>
         [Fact]
+        [OutOfProc]
         public void ApplySet_HistoryMatches_0_2()
         {
             this.RunApplyHistoryMatchTest(
@@ -168,13 +170,14 @@ resources:
             i: '7'
             j: 8
             q: 42
-", new string[] { "AssertIdentifier2" });
+");
         }
 
         /// <summary>
         /// Applies a set, reads the history, changes the read set and reapplies it.
         /// </summary>
         [Fact]
+        [OutOfProc]
         public void ApplySet_ChangeHistory()
         {
             string disabledIdentifier = "AssertIdentifier2";
@@ -241,6 +244,7 @@ properties:
         /// Applies a set, reads the history and removes it.
         /// </summary>
         [Fact]
+        [OutOfProc]
         public void ApplySet_RemoveHistory()
         {
             ConfigurationSet returnedSet = this.RunApplyHistoryMatchTest(

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorApplyTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorApplyTests.cs
@@ -418,6 +418,12 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
                 new ExpectedConfigurationChangeData() { Change = ConfigurationSetChangeEventType.SetStateChanged, SetState = ConfigurationSetState.Completed },
             };
 
+            // Drop the pending event if it happens to be present
+            if (progressEvents.Count > 0 && progressEvents[0].Change == ConfigurationSetChangeEventType.SetStateChanged && progressEvents[0].SetState == ConfigurationSetState.Pending)
+            {
+                progressEvents.RemoveAt(0);
+            }
+
             Assert.Equal(expectedProgress.Count(), progressEvents.Count);
 
             for (int i = 0; i < progressEvents.Count; ++i)
@@ -531,6 +537,8 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
             waitingUnitApply.Set();
             WaitOn(waitingProgress);
             Assert.Equal(ConfigurationSetState.Completed, progressState);
+
+            waitingSetOperation.AsTask().Wait();
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Configuration/ConfigurationChangeData.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationChangeData.h
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         ConfigurationChangeEventType m_change{};
-        guid m_instanceIdentifier;
+        guid m_instanceIdentifier{};
         ConfigurationSetState m_state{};
 #endif
     };

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
@@ -184,7 +184,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         std::ignore = m_threadGlobals.GetTelemetryLogger().EnableRuntime(value);
     }
 
-    event_token ConfigurationProcessor::ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, ConfigurationChangeData>& handler)
+    event_token ConfigurationProcessor::ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>& handler)
     {
         if (!m_configurationChange)
         {
@@ -205,10 +205,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         }
     }
 
-    void ConfigurationProcessor::ConfigurationChange(ConfigurationSet& set, ConfigurationChangeData& data)
+    void ConfigurationProcessor::ConfigurationChange(ConfigurationSet& set, Configuration::ConfigurationChangeData& data) try
     {
         m_configurationChange(set, data);
     }
+    CATCH_LOG();
 
     Windows::Foundation::Collections::IVector<Configuration::ConfigurationSet> ConfigurationProcessor::GetConfigurationHistory()
     {
@@ -571,7 +572,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                     }
 
                     // Create progress object
-                    auto applyResult = make_self<wil::details::module_count_wrapper<implementation::ConfigurationSetChangeData>>();
+                    auto applyResult = make_self<implementation::ConfigurationSetChangeData>();
                     applyResult->Initialize(unitResult);
                     progress.Progress(*applyResult);
                 });

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
@@ -206,7 +206,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         }
     }
 
-    void ConfigurationProcessor::ConfigurationChange(Configuration::ConfigurationSet& set, Configuration::ConfigurationChangeData& data) try
+    void ConfigurationProcessor::ConfigurationChange(const Configuration::ConfigurationSet& set, const Configuration::ConfigurationChangeData& data) try
     {
         m_configurationChange(set, data);
     }

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp
@@ -20,6 +20,7 @@
 #include "GetConfigurationSetDetailsResult.h"
 #include "DefaultSetGroupProcessor.h"
 #include "ConfigurationSequencer.h"
+#include "ConfigurationStatus.h"
 
 #include <AppInstallerErrors.h>
 #include <AppInstallerStrings.h>
@@ -184,7 +185,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         std::ignore = m_threadGlobals.GetTelemetryLogger().EnableRuntime(value);
     }
 
-    event_token ConfigurationProcessor::ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>& handler)
+    event_token ConfigurationProcessor::ConfigurationChange(const Windows::Foundation::TypedEventHandler<Configuration::ConfigurationSet, Configuration::ConfigurationChangeData>& handler)
     {
         if (!m_configurationChange)
         {
@@ -205,7 +206,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         }
     }
 
-    void ConfigurationProcessor::ConfigurationChange(ConfigurationSet& set, Configuration::ConfigurationChangeData& data) try
+    void ConfigurationProcessor::ConfigurationChange(Configuration::ConfigurationSet& set, Configuration::ConfigurationChangeData& data) try
     {
         m_configurationChange(set, data);
     }
@@ -328,7 +329,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     Windows::Foundation::Collections::IVector<ConfigurationConflict> ConfigurationProcessor::CheckForConflicts(
-        const Windows::Foundation::Collections::IVectorView<ConfigurationSet>& configurationSets,
+        const Windows::Foundation::Collections::IVectorView<Configuration::ConfigurationSet>& configurationSets,
         bool includeConfigurationHistory)
     {
         UNREFERENCED_PARAMETER(configurationSets);
@@ -337,24 +338,26 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     Windows::Foundation::IAsyncOperation<Windows::Foundation::Collections::IVector<ConfigurationConflict>> ConfigurationProcessor::CheckForConflictsAsync(
-        const Windows::Foundation::Collections::IVectorView<ConfigurationSet>& configurationSets,
+        const Windows::Foundation::Collections::IVectorView<Configuration::ConfigurationSet>& configurationSets,
         bool includeConfigurationHistory)
     {
         co_return CheckForConflicts(configurationSets, includeConfigurationHistory);
     }
 
-    Configuration::GetConfigurationSetDetailsResult ConfigurationProcessor::GetSetDetails(const ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags)
+    Configuration::GetConfigurationSetDetailsResult ConfigurationProcessor::GetSetDetails(const Configuration::ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
         return GetSetDetailsImpl(configurationSet, detailFlags);
     }
 
-    Windows::Foundation::IAsyncOperationWithProgress<Configuration::GetConfigurationSetDetailsResult, Configuration::GetConfigurationUnitDetailsResult> ConfigurationProcessor::GetSetDetailsAsync(const ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags)
+    Windows::Foundation::IAsyncOperationWithProgress<Configuration::GetConfigurationSetDetailsResult, Configuration::GetConfigurationUnitDetailsResult> ConfigurationProcessor::GetSetDetailsAsync(
+        const Configuration::ConfigurationSet& configurationSet,
+        ConfigurationUnitDetailFlags detailFlags)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
 
         auto strong_this{ get_strong() };
-        ConfigurationSet localSet = configurationSet;
+        Configuration::ConfigurationSet localSet = configurationSet;
 
         co_await winrt::resume_background();
 
@@ -368,7 +371,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         m_database.EnsureOpened(false);
         cancellation.ThrowIfCancelled();
 
-        std::vector<ConfigurationSet> result;
+        std::vector<Configuration::ConfigurationSet> result;
         for (const auto& set : m_database.GetSetHistory())
         {
             PropagateLifetimeWatcher(*set);
@@ -379,7 +382,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     Configuration::GetConfigurationSetDetailsResult ConfigurationProcessor::GetSetDetailsImpl(
-        const ConfigurationSet& configurationSet,
+        const Configuration::ConfigurationSet& configurationSet,
         ConfigurationUnitDetailFlags detailFlags,
         AppInstaller::WinRT::AsyncProgress<GetConfigurationSetDetailsResult, GetConfigurationUnitDetailsResult> progress)
     {
@@ -460,18 +463,20 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         return *unitResult;
     }
 
-    Configuration::ApplyConfigurationSetResult ConfigurationProcessor::ApplySet(const ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags)
+    Configuration::ApplyConfigurationSetResult ConfigurationProcessor::ApplySet(const Configuration::ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
         return ApplySetImpl(configurationSet, flags);
     }
 
-    Windows::Foundation::IAsyncOperationWithProgress<Configuration::ApplyConfigurationSetResult, Configuration::ConfigurationSetChangeData> ConfigurationProcessor::ApplySetAsync(const ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags)
+    Windows::Foundation::IAsyncOperationWithProgress<Configuration::ApplyConfigurationSetResult, Configuration::ConfigurationSetChangeData> ConfigurationProcessor::ApplySetAsync(
+        const Configuration::ConfigurationSet& configurationSet,
+        ApplyConfigurationSetFlags flags)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
 
         auto strong_this{ get_strong() };
-        ConfigurationSet localSet = configurationSet;
+        Configuration::ConfigurationSet localSet = configurationSet;
 
         co_await winrt::resume_background();
 
@@ -479,13 +484,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     Configuration::ApplyConfigurationSetResult ConfigurationProcessor::ApplySetImpl(
-        const ConfigurationSet& configurationSet,
+        const Configuration::ConfigurationSet& configurationSet,
         ApplyConfigurationSetFlags flags,
         AppInstaller::WinRT::AsyncProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> progress)
     {
         auto threadGlobals = m_threadGlobals.SetForCurrentThread();
 
         IConfigurationGroupProcessor groupProcessor;
+        bool recordHistoryAndStatus = false;
 
         if (WI_IsFlagSet(flags, ApplyConfigurationSetFlags::PerformConsistencyCheckOnly))
         {
@@ -500,6 +506,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
             // Write this set to the database history
             // This is a somewhat arbitrary time to write it, but it should not be done if PerformConsistencyCheckOnly is passed, so this is convenient.
+            recordHistoryAndStatus = true;
             m_database.EnsureOpened();
             progress.ThrowIfCancelled();
             m_database.WriteSetHistory(configurationSet, WI_IsFlagSet(flags, ApplyConfigurationSetFlags::DoNotOverwriteMatchingOriginSet));
@@ -539,28 +546,34 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         try
         {
             ConfigurationSequencer sequencer{ m_database };
+            auto status = ConfigurationStatus::Instance();
+            guid setInstanceIdentifier = configurationSet.InstanceIdentifier();
+            auto updateState = [&](ConfigurationSetState state)
+                {
+                    try
+                    {
+                        progress.Progress(implementation::ConfigurationSetChangeData::Create(state));
+                    }
+                    CATCH_LOG();
+
+                    if (recordHistoryAndStatus)
+                    {
+                        status->UpdateSetState(setInstanceIdentifier, state);
+                    }
+                };
 
             if (!WI_IsFlagSet(flags, ApplyConfigurationSetFlags::PerformConsistencyCheckOnly))
             {
                 if (sequencer.Enqueue(configurationSet))
                 {
-                    try
-                    {
-                        progress.Progress(implementation::ConfigurationSetChangeData::Create(ConfigurationSetState::Pending));
-                    }
-                    CATCH_LOG();
-
+                    updateState(ConfigurationSetState::Pending);
                     sequencer.Wait(progress);
                 }
             }
 
             progress.ThrowIfCancelled();
 
-            try
-            {
-                progress.Progress(implementation::ConfigurationSetChangeData::Create(ConfigurationSetState::InProgress));
-            }
-            CATCH_LOG();
+            updateState(ConfigurationSetState::InProgress);
 
             // Forward unit result progress to caller
             auto applyOperation = groupProcessor.ApplyGroupSettingsAsync([&](const auto&, const IApplyGroupMemberSettingsResult& unitResult)
@@ -575,6 +588,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                     auto applyResult = make_self<implementation::ConfigurationSetChangeData>();
                     applyResult->Initialize(unitResult);
                     progress.Progress(*applyResult);
+
+                    if (recordHistoryAndStatus)
+                    {
+                        status->UpdateUnitState(setInstanceIdentifier, applyResult);
+                    }
                 });
 
             // Cancel the inner operation if we are cancelled
@@ -607,11 +625,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                     itr->second->ResultInformation());
             }
 
-            try
-            {
-                progress.Progress(implementation::ConfigurationSetChangeData::Create(ConfigurationSetState::Completed));
-            }
-            CATCH_LOG();
+            updateState(ConfigurationSetState::Completed);
 
             m_threadGlobals.GetTelemetryLogger().LogConfigProcessingSummaryForApply(*winrt::get_self<implementation::ConfigurationSet>(configurationSet), *result);
             return *result;
@@ -626,18 +640,18 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         }
     }
 
-    Configuration::TestConfigurationSetResult ConfigurationProcessor::TestSet(const ConfigurationSet& configurationSet)
+    Configuration::TestConfigurationSetResult ConfigurationProcessor::TestSet(const Configuration::ConfigurationSet& configurationSet)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
         return TestSetImpl(configurationSet);
     }
 
-    Windows::Foundation::IAsyncOperationWithProgress<Configuration::TestConfigurationSetResult, Configuration::TestConfigurationUnitResult> ConfigurationProcessor::TestSetAsync(const ConfigurationSet& configurationSet)
+    Windows::Foundation::IAsyncOperationWithProgress<Configuration::TestConfigurationSetResult, Configuration::TestConfigurationUnitResult> ConfigurationProcessor::TestSetAsync(const Configuration::ConfigurationSet& configurationSet)
     {
         THROW_HR_IF(E_NOT_VALID_STATE, !m_factory);
 
         auto strong_this{ get_strong() };
-        ConfigurationSet localSet = configurationSet;
+        Configuration::ConfigurationSet localSet = configurationSet;
 
         co_await winrt::resume_background();
 
@@ -645,7 +659,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     Configuration::TestConfigurationSetResult ConfigurationProcessor::TestSetImpl(
-        const ConfigurationSet& configurationSet,
+        const Configuration::ConfigurationSet& configurationSet,
         AppInstaller::WinRT::AsyncProgress<TestConfigurationSetResult, TestConfigurationUnitResult> progress)
     {
         auto threadGlobals = m_threadGlobals.SetForCurrentThread();
@@ -834,7 +848,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         return *result;
     }
 
-    IConfigurationGroupProcessor ConfigurationProcessor::GetSetGroupProcessor(const ConfigurationSet& configurationSet)
+    IConfigurationGroupProcessor ConfigurationProcessor::GetSetGroupProcessor(const Configuration::ConfigurationSet& configurationSet)
     {
         IConfigurationSetProcessor setProcessor = m_factory.CreateSetProcessor(configurationSet);
 

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -99,7 +99,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void SetSupportsSchema03(bool value);
 
         // Indicate a configuration change occurred.
-        void ConfigurationChange(Configuration::ConfigurationSet& set, Configuration::ConfigurationChangeData& data);
+        void ConfigurationChange(const Configuration::ConfigurationSet& set, const Configuration::ConfigurationChangeData& data);
 
     private:
         Windows::Foundation::Collections::IVector<Configuration::ConfigurationSet> GetConfigurationHistoryImpl(AppInstaller::WinRT::AsyncCancellation cancellation = {});

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -6,6 +6,7 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include "ConfigThreadGlobals.h"
+#include "ConfigurationStatus.h"
 #include "Database/ConfigurationDatabase.h"
 #include <winget/AsyncTokens.h>
 #include <winget/ILifetimeWatcher.h>
@@ -98,8 +99,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         // Temporary entry point to enable experimental schema support.
         void SetSupportsSchema03(bool value);
 
-        // Removes the history for the given set.
-        void RemoveHistory(const ConfigurationSet& configurationSet);
+        // Indicate a configuration change occurred.
+        void ConfigurationChange(ConfigurationSet& set, ConfigurationChangeData& data);
 
     private:
         Windows::Foundation::Collections::IVector<ConfigurationSet> GetConfigurationHistoryImpl(AppInstaller::WinRT::AsyncCancellation cancellation = {});
@@ -139,6 +140,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         bool m_isHandlingDiagnostics = false;
         // Temporary value to enable experimental schema support.
         bool m_supportSchema03 = true;
+        std::shared_ptr<ConfigurationStatus::ChangeRegistration> m_changeRegistration;
 #endif
     };
 }

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -51,7 +51,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         bool GenerateTelemetryEvents();
         void GenerateTelemetryEvents(bool value);
 
-        event_token ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, ConfigurationChangeData>& handler);
+        event_token ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>& handler);
         void ConfigurationChange(const event_token& token) noexcept;
 
         Windows::Foundation::Collections::IVector<ConfigurationSet> GetConfigurationHistory();
@@ -100,7 +100,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void SetSupportsSchema03(bool value);
 
         // Indicate a configuration change occurred.
-        void ConfigurationChange(ConfigurationSet& set, ConfigurationChangeData& data);
+        void ConfigurationChange(ConfigurationSet& set, Configuration::ConfigurationChangeData& data) const;
 
     private:
         Windows::Foundation::Collections::IVector<ConfigurationSet> GetConfigurationHistoryImpl(AppInstaller::WinRT::AsyncCancellation cancellation = {});
@@ -131,7 +131,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         IConfigurationSetProcessorFactory m_factory = nullptr;
         event<Windows::Foundation::EventHandler<IDiagnosticInformation>> m_diagnostics;
-        event<Windows::Foundation::TypedEventHandler<ConfigurationSet, ConfigurationChangeData>> m_configurationChange;
+        event<Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>> m_configurationChange;
         ConfigThreadGlobals m_threadGlobals;
         IConfigurationSetProcessorFactory::Diagnostics_revoker m_factoryDiagnosticsEventRevoker;
         DiagnosticLevel m_minimumLevel = DiagnosticLevel::Informational;

--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -19,7 +19,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 {
     struct ConfigurationProcessor : ConfigurationProcessorT<ConfigurationProcessor, winrt::cloaked<AppInstaller::WinRT::ILifetimeWatcher>>, AppInstaller::WinRT::LifetimeWatcherBase
     {
-        using ConfigurationSet = Configuration::ConfigurationSet;
         using ConfigurationSetChangeData = Configuration::ConfigurationSetChangeData;
         using ConfigurationUnit = Configuration::ConfigurationUnit;
         using ApplyConfigurationSetResult = Configuration::ApplyConfigurationSetResult;
@@ -51,33 +50,33 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         bool GenerateTelemetryEvents();
         void GenerateTelemetryEvents(bool value);
 
-        event_token ConfigurationChange(const Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>& handler);
+        event_token ConfigurationChange(const Windows::Foundation::TypedEventHandler<Configuration::ConfigurationSet, Configuration::ConfigurationChangeData>& handler);
         void ConfigurationChange(const event_token& token) noexcept;
 
-        Windows::Foundation::Collections::IVector<ConfigurationSet> GetConfigurationHistory();
-        Windows::Foundation::IAsyncOperation<Windows::Foundation::Collections::IVector<ConfigurationSet>> GetConfigurationHistoryAsync();
+        Windows::Foundation::Collections::IVector<Configuration::ConfigurationSet> GetConfigurationHistory();
+        Windows::Foundation::IAsyncOperation<Windows::Foundation::Collections::IVector<Configuration::ConfigurationSet>> GetConfigurationHistoryAsync();
 
         Configuration::OpenConfigurationSetResult OpenConfigurationSet(const Windows::Storage::Streams::IInputStream& stream);
         Windows::Foundation::IAsyncOperation<Configuration::OpenConfigurationSetResult> OpenConfigurationSetAsync(const Windows::Storage::Streams::IInputStream& stream);
 
         Windows::Foundation::Collections::IVector<ConfigurationConflict> CheckForConflicts(
-            const Windows::Foundation::Collections::IVectorView<ConfigurationSet>& configurationSets,
+            const Windows::Foundation::Collections::IVectorView<Configuration::ConfigurationSet>& configurationSets,
             bool includeConfigurationHistory);
         Windows::Foundation::IAsyncOperation<Windows::Foundation::Collections::IVector<ConfigurationConflict>> CheckForConflictsAsync(
-            const Windows::Foundation::Collections::IVectorView<ConfigurationSet>& configurationSets,
+            const Windows::Foundation::Collections::IVectorView<Configuration::ConfigurationSet>& configurationSets,
             bool includeConfigurationHistory);
 
-        GetConfigurationSetDetailsResult GetSetDetails(const ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags);
-        Windows::Foundation::IAsyncOperationWithProgress<GetConfigurationSetDetailsResult, GetConfigurationUnitDetailsResult> GetSetDetailsAsync(const ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags);
+        GetConfigurationSetDetailsResult GetSetDetails(const Configuration::ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags);
+        Windows::Foundation::IAsyncOperationWithProgress<GetConfigurationSetDetailsResult, GetConfigurationUnitDetailsResult> GetSetDetailsAsync(const Configuration::ConfigurationSet& configurationSet, ConfigurationUnitDetailFlags detailFlags);
 
         GetConfigurationUnitDetailsResult GetUnitDetails(const ConfigurationUnit& unit, ConfigurationUnitDetailFlags detailFlags);
         Windows::Foundation::IAsyncOperation<GetConfigurationUnitDetailsResult> GetUnitDetailsAsync(const ConfigurationUnit& unit, ConfigurationUnitDetailFlags detailFlags);
 
-        ApplyConfigurationSetResult ApplySet(const ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags);
-        Windows::Foundation::IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> ApplySetAsync(const ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags);
+        ApplyConfigurationSetResult ApplySet(const Configuration::ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags);
+        Windows::Foundation::IAsyncOperationWithProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> ApplySetAsync(const Configuration::ConfigurationSet& configurationSet, ApplyConfigurationSetFlags flags);
 
-        TestConfigurationSetResult TestSet(const ConfigurationSet& configurationSet);
-        Windows::Foundation::IAsyncOperationWithProgress<TestConfigurationSetResult, TestConfigurationUnitResult> TestSetAsync(const ConfigurationSet& configurationSet);
+        TestConfigurationSetResult TestSet(const Configuration::ConfigurationSet& configurationSet);
+        Windows::Foundation::IAsyncOperationWithProgress<TestConfigurationSetResult, TestConfigurationUnitResult> TestSetAsync(const Configuration::ConfigurationSet& configurationSet);
 
         GetConfigurationUnitSettingsResult GetUnitSettings(const ConfigurationUnit& unit);
         Windows::Foundation::IAsyncOperation<GetConfigurationUnitSettingsResult> GetUnitSettingsAsync(const ConfigurationUnit& unit);
@@ -100,38 +99,38 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void SetSupportsSchema03(bool value);
 
         // Indicate a configuration change occurred.
-        void ConfigurationChange(ConfigurationSet& set, Configuration::ConfigurationChangeData& data) const;
+        void ConfigurationChange(Configuration::ConfigurationSet& set, Configuration::ConfigurationChangeData& data);
 
     private:
-        Windows::Foundation::Collections::IVector<ConfigurationSet> GetConfigurationHistoryImpl(AppInstaller::WinRT::AsyncCancellation cancellation = {});
+        Windows::Foundation::Collections::IVector<Configuration::ConfigurationSet> GetConfigurationHistoryImpl(AppInstaller::WinRT::AsyncCancellation cancellation = {});
 
         GetConfigurationSetDetailsResult GetSetDetailsImpl(
-            const ConfigurationSet& configurationSet,
+            const Configuration::ConfigurationSet& configurationSet,
             ConfigurationUnitDetailFlags detailFlags,
             AppInstaller::WinRT::AsyncProgress<GetConfigurationSetDetailsResult, GetConfigurationUnitDetailsResult> progress = {});
 
         GetConfigurationUnitDetailsResult GetUnitDetailsImpl(const ConfigurationUnit& unit, ConfigurationUnitDetailFlags detailFlags);
 
         ApplyConfigurationSetResult ApplySetImpl(
-            const ConfigurationSet& configurationSet,
+            const Configuration::ConfigurationSet& configurationSet,
             ApplyConfigurationSetFlags flags,
             AppInstaller::WinRT::AsyncProgress<ApplyConfigurationSetResult, ConfigurationSetChangeData> progress = {});
 
         TestConfigurationSetResult TestSetImpl(
-            const ConfigurationSet& configurationSet,
+            const Configuration::ConfigurationSet& configurationSet,
             AppInstaller::WinRT::AsyncProgress<TestConfigurationSetResult, TestConfigurationUnitResult> progress = {});
 
         GetConfigurationUnitSettingsResult GetUnitSettingsImpl(const ConfigurationUnit& unit, AppInstaller::WinRT::AsyncCancellation cancellation = {});
         
         GetAllConfigurationUnitSettingsResult GetAllUnitSettingsImpl(const ConfigurationUnit& unit, AppInstaller::WinRT::AsyncCancellation cancellation = {});
 
-        IConfigurationGroupProcessor GetSetGroupProcessor(const ConfigurationSet& configurationSet);
+        IConfigurationGroupProcessor GetSetGroupProcessor(const Configuration::ConfigurationSet& configurationSet);
 
         void SendDiagnosticsImpl(const IDiagnosticInformation& information);
 
         IConfigurationSetProcessorFactory m_factory = nullptr;
         event<Windows::Foundation::EventHandler<IDiagnosticInformation>> m_diagnostics;
-        event<Windows::Foundation::TypedEventHandler<ConfigurationSet, Configuration::ConfigurationChangeData>> m_configurationChange;
+        event<Windows::Foundation::TypedEventHandler<Configuration::ConfigurationSet, Configuration::ConfigurationChangeData>> m_configurationChange;
         ConfigThreadGlobals m_threadGlobals;
         IConfigurationSetProcessorFactory::Diagnostics_revoker m_factoryDiagnosticsEventRevoker;
         DiagnosticLevel m_minimumLevel = DiagnosticLevel::Informational;

--- a/src/Microsoft.Management.Configuration/ConfigurationSequencer.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSequencer.h
@@ -39,6 +39,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         using QueueObjectType = wil::unique_event;
 
         ConfigurationDatabase& m_database;
+        guid m_setInstanceIdentifier;
         std::string m_queueItemObjectName;
         QueueObjectType m_queueItemObject;
         wil::unique_mutex m_applyMutex;

--- a/src/Microsoft.Management.Configuration/ConfigurationSequencer.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSequencer.h
@@ -39,7 +39,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         using QueueObjectType = wil::unique_event;
 
         ConfigurationDatabase& m_database;
-        guid m_setInstanceIdentifier;
+        guid m_setInstanceIdentifier{};
         std::string m_queueItemObjectName;
         QueueObjectType m_queueItemObject;
         wil::unique_mutex m_applyMutex;

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.cpp
@@ -18,7 +18,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     }
 
     ConfigurationSet::ConfigurationSet(const guid& instanceIdentifier) :
-        m_instanceIdentifier(instanceIdentifier), m_inHistory(true)
+        m_instanceIdentifier(instanceIdentifier)
     {
     }
 

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "ConfigurationSet.g.h"
+#include "ConfigurationSetChangeData.h"
 #include "ConfigurationStatus.h"
 #include <winget/ILifetimeWatcher.h>
 #include <winget/ModuleCountBase.h>
@@ -23,7 +24,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         ConfigurationSet(const guid& instanceIdentifier);
         void Units(std::vector<Configuration::ConfigurationUnit>&& units);
         void Parameters(std::vector<Configuration::ConfigurationParameter>&& value);
-        void ConfigurationSetChange(ConfigurationSetChangeData& data);
+        void ConfigurationSetChange(com_ptr<ConfigurationSetChangeData>& data, const std::optional<guid>& unitInstanceIdentifier);
 #endif
 
         hstring Name();
@@ -47,7 +48,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         hstring SchemaVersion();
         void SchemaVersion(const hstring& value);
 
-        event_token ConfigurationSetChange(const Windows::Foundation::TypedEventHandler<WinRT_Self, ConfigurationSetChangeData>& handler);
+        event_token ConfigurationSetChange(const Windows::Foundation::TypedEventHandler<WinRT_Self, Configuration::ConfigurationSetChangeData>& handler);
         void ConfigurationSetChange(const event_token& token) noexcept;
 
         void Serialize(const Windows::Storage::Streams::IOutputStream& stream);
@@ -80,7 +81,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         clock::time_point m_firstApply{};
         Windows::Foundation::Collections::IVector<ConfigurationUnit> m_units{ winrt::multi_threaded_vector<ConfigurationUnit>() };
         hstring m_schemaVersion;
-        winrt::event<Windows::Foundation::TypedEventHandler<WinRT_Self, ConfigurationSetChangeData>> m_configurationSetChange;
+        winrt::event<Windows::Foundation::TypedEventHandler<WinRT_Self, Configuration::ConfigurationSetChangeData>> m_configurationSetChange;
         Windows::Foundation::Collections::ValueSet m_metadata;
         Windows::Foundation::Collections::IVector<ConfigurationParameter> m_parameters{ winrt::multi_threaded_vector<ConfigurationParameter>() };
         Windows::Foundation::Collections::ValueSet m_variables;

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.h
@@ -87,7 +87,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         Windows::Foundation::Collections::ValueSet m_variables;
         Windows::Foundation::Uri m_schemaUri = nullptr;
         std::string m_inputHash;
-        bool m_inHistory = false;
         std::shared_ptr<ConfigurationStatus::SetChangeRegistration> m_setChangeRegistration;
 #endif
     };

--- a/src/Microsoft.Management.Configuration/ConfigurationSet.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSet.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "ConfigurationSet.g.h"
+#include "ConfigurationStatus.h"
 #include <winget/ILifetimeWatcher.h>
 #include <winget/ModuleCountBase.h>
 #include <winrt/Windows.Foundation.h>
@@ -20,11 +21,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
         ConfigurationSet(const guid& instanceIdentifier);
-        void FirstApply(clock::time_point value);
         void Units(std::vector<Configuration::ConfigurationUnit>&& units);
         void Parameters(std::vector<Configuration::ConfigurationParameter>&& value);
-
-        bool IsFromHistory() const;
+        void ConfigurationSetChange(ConfigurationSetChangeData& data);
 #endif
 
         hstring Name();
@@ -87,7 +86,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         Windows::Foundation::Collections::ValueSet m_variables;
         Windows::Foundation::Uri m_schemaUri = nullptr;
         std::string m_inputHash;
-        bool m_fromHistory = false;
+        bool m_inHistory = false;
+        std::shared_ptr<ConfigurationStatus::SetChangeRegistration> m_setChangeRegistration;
 #endif
     };
 }

--- a/src/Microsoft.Management.Configuration/ConfigurationSetChangeData.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationSetChangeData.cpp
@@ -8,14 +8,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 {
     Configuration::ConfigurationSetChangeData ConfigurationSetChangeData::Create(ConfigurationSetState state)
     {
-        auto result = make_self<wil::details::module_count_wrapper<implementation::ConfigurationSetChangeData>>();
+        auto result = make_self<implementation::ConfigurationSetChangeData>();
         result->Initialize(state);
         return *result;
     }
 
     Configuration::ConfigurationSetChangeData ConfigurationSetChangeData::Create(ConfigurationUnitState state, IConfigurationUnitResultInformation resultInformation, ConfigurationUnit unit)
     {
-        auto result = make_self<wil::details::module_count_wrapper<implementation::ConfigurationSetChangeData>>();
+        auto result = make_self<implementation::ConfigurationSetChangeData>();
         result->Initialize(state, resultInformation, unit);
         return *result;
     }
@@ -67,5 +67,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     ConfigurationUnit ConfigurationSetChangeData::Unit()
     {
         return m_unit;
+    }
+
+    void ConfigurationSetChangeData::Unit(const ConfigurationUnit& unit)
+    {
+        m_unit = unit;
     }
 }

--- a/src/Microsoft.Management.Configuration/ConfigurationSetChangeData.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationSetChangeData.h
@@ -3,10 +3,11 @@
 #pragma once
 #include "ConfigurationSetChangeData.g.h"
 #include "ConfigurationUnitResultInformation.h"
+#include <winget/ModuleCountBase.h>
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
-    struct ConfigurationSetChangeData : ConfigurationSetChangeDataT<ConfigurationSetChangeData>
+    struct ConfigurationSetChangeData : ConfigurationSetChangeDataT<ConfigurationSetChangeData>, AppInstaller::WinRT::ModuleCountBase
     {
         using ConfigurationUnit = Configuration::ConfigurationUnit;
 
@@ -19,6 +20,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void Initialize(ConfigurationSetState state);
         void Initialize(ConfigurationUnitState state, IConfigurationUnitResultInformation resultInformation, ConfigurationUnit unit);
         void Initialize(const IApplyGroupMemberSettingsResult& unitResult);
+
+        void Unit(const ConfigurationUnit& unit);
 #endif
 
         ConfigurationSetChangeEventType Change();

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
@@ -74,11 +74,16 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                             // A unit status change
                             ConfigurationUnitState state = AppInstaller::ToEnum<ConfigurationUnitState>(change.State);
 
-                            auto resultInformation = make_self<wil::details::module_count_wrapper<implementation::ConfigurationUnitResultInformation>>();
-                            resultInformation->ResultCode(change.ResultCode);
-                            resultInformation->Description(hstring{ AppInstaller::Utility::ConvertToUTF16(change.ResultDescription) });
-                            resultInformation->Details(hstring{ AppInstaller::Utility::ConvertToUTF16(change.ResultDetails) });
-                            resultInformation->ResultSource(change.ResultSource);
+                            decltype(make_self<wil::details::module_count_wrapper<implementation::ConfigurationUnitResultInformation>>()) resultInformation;
+
+                            if (change.ResultCode)
+                            {
+                                resultInformation = make_self<wil::details::module_count_wrapper<implementation::ConfigurationUnitResultInformation>>();
+                                resultInformation->ResultCode(change.ResultCode.value());
+                                resultInformation->Description(hstring{ AppInstaller::Utility::ConvertToUTF16(change.ResultDescription) });
+                                resultInformation->Details(hstring{ AppInstaller::Utility::ConvertToUTF16(change.ResultDetails) });
+                                resultInformation->ResultSource(change.ResultSource);
+                            }
 
                             auto changeData = make_self<implementation::ConfigurationSetChangeData>();
                             changeData->Initialize(state, *resultInformation, nullptr);

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "ConfigurationStatus.h"
+#include "ConfigurationProcessor.h"
+#include "ConfigurationSet.h"
+
+
+namespace winrt::Microsoft::Management::Configuration::implementation
+{
+    namespace details
+    {
+#define WINGET_CHANGE_SYNC_EVENT_NAME_1 L"WinGetChangeSyncEvent1"
+#define WINGET_CHANGE_SYNC_EVENT_NAME_2 L"WinGetChangeSyncEvent2"
+
+        struct ChangeSynchronizationBase
+        {
+            ChangeSynchronizationBase()
+            {
+                m_events[0].create(wil::EventOptions::ManualReset, WINGET_CHANGE_SYNC_EVENT_NAME_1);
+                m_events[1].create(wil::EventOptions::ManualReset, WINGET_CHANGE_SYNC_EVENT_NAME_2);
+            }
+
+            wil::unique_event& CurrentEvent()
+            {
+                return m_events[m_currentEvent];
+            }
+
+            wil::unique_event& NextEvent()
+            {
+                m_currentEvent = (m_currentEvent + 1) % m_events.size();
+                return CurrentEvent();
+            }
+
+        private:
+            size_t m_currentEvent = 0;
+            std::array<wil::unique_event, 2> m_events;
+        };
+
+        // Implements the consuming side of the status signaling.
+        struct ChangeListener : protected ChangeSynchronizationBase
+        {
+            ChangeListener(ConfigurationStatus& status, int64_t changeIdentifier) : m_status(status), m_changeIdentifier(changeIdentifier)
+            {
+                m_threadPoolWait.reset(CreateThreadpoolWait(StaticWaitCallback, this, nullptr));
+                THROW_LAST_ERROR_IF(!m_threadPoolWait);
+
+                SetThreadpoolWait(m_threadPoolWait.get(), CurrentEvent().get(), NULL);
+            }
+
+        private:
+            static void StaticWaitCallback(PTP_CALLBACK_INSTANCE, void* context, TP_WAIT*, TP_WAIT_RESULT)
+            {
+                reinterpret_cast<ChangeListener*>(context)->WaitCallback();
+            }
+
+            void WaitCallback()
+            {
+                SetThreadpoolWait(m_threadPoolWait.get(), NextEvent().get(), NULL);
+
+                if (ShouldBecomeUpdateThread())
+                {
+                    do
+                    {
+
+                    } while (ShouldContinueUpdateThread());
+                }
+            }
+
+            bool ShouldBecomeUpdateThread()
+            {
+                size_t state =  m_workState.load();
+                while (state < 2)
+                {
+                    size_t newState = state + 1;
+                    m_workState.compare_exchange_strong(state, newState);
+                }
+
+                return state == 0;
+            }
+
+            bool ShouldContinueUpdateThread()
+            {
+                return m_workState.fetch_sub(1) != 1;
+            }
+
+            ConfigurationStatus& m_status;
+            int64_t m_changeIdentifier;
+            wil::unique_threadpool_wait m_threadPoolWait;
+            std::atomic_size_t m_workState;
+        };
+
+        // Implements the producing side of the status signaling
+        struct ChangeSignaler : protected ChangeSynchronizationBase
+        {
+            ChangeSignaler() = default;
+
+            void PrepareForChange()
+            {
+                CurrentEvent().ResetEvent();
+            }
+
+            void SignalChange()
+            {
+                NextEvent().SetEvent();
+            }
+        };
+    }
+
+    ConfigurationStatus::ConfigurationStatus() = default;
+
+    ConfigurationStatus::~ConfigurationStatus() = default;
+
+    std::shared_ptr<ConfigurationStatus> ConfigurationStatus::Instance()
+    {
+        static std::shared_ptr<ConfigurationStatus> s_instance;
+
+        std::shared_ptr<ConfigurationStatus> result = std::atomic_load(&s_instance);
+        if (!result)
+        {
+            result = std::make_shared<ConfigurationStatus>();
+            std::shared_ptr<ConfigurationStatus> empty;
+
+            if (!std::atomic_compare_exchange_strong(&s_instance, &empty, result))
+            {
+                result = empty;
+            }
+        }
+
+        return result;
+    }
+
+    ConfigurationSetState ConfigurationStatus::GetSetState(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetSetState(instanceIdentifier);
+    }
+
+    clock::time_point ConfigurationStatus::GetSetFirstApply(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetSetFirstApply(instanceIdentifier);
+    }
+
+    clock::time_point ConfigurationStatus::GetSetApplyBegun(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetSetApplyBegun(instanceIdentifier);
+    }
+
+    clock::time_point ConfigurationStatus::GetSetApplyEnded(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetSetApplyEnded(instanceIdentifier);
+    }
+
+    ConfigurationUnitState ConfigurationStatus::GetUnitState(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetUnitState(instanceIdentifier);
+    }
+
+    IConfigurationUnitResultInformation ConfigurationStatus::GetUnitResultInformation(const winrt::guid& instanceIdentifier)
+    {
+        m_database.EnsureOpened(false);
+        return m_database.GetUnitResultInformation(instanceIdentifier);
+    }
+
+    ConfigurationStatus::SetChangeRegistration::SetChangeRegistration(const winrt::guid& instanceIdentifier) :
+        m_status(Instance()), m_instanceIdentifier(instanceIdentifier) {}
+
+    ConfigurationStatus::SetChangeRegistration::~SetChangeRegistration()
+    {
+        m_status->RemoveSetChangeRegistration(m_instanceIdentifier);
+    }
+
+    std::shared_ptr<ConfigurationStatus::SetChangeRegistration> ConfigurationStatus::RegisterForSetChange(const ConfigurationSet& set)
+    {
+        m_database.EnsureOpened();
+
+        winrt::guid instanceIdentifier = set.InstanceIdentifier();
+
+        {
+            std::lock_guard<std::mutex> lock{ m_changeRegistrationsMutex };
+            m_setChangeRegistrations.emplace(instanceIdentifier, &set);
+            EnableChangeListeningIfNeeded();
+        }
+
+        return std::make_shared<SetChangeRegistration>(instanceIdentifier);
+    }
+
+    void ConfigurationStatus::RemoveSetChangeRegistration(const winrt::guid& instanceIdentifier) noexcept
+    {
+        std::lock_guard<std::mutex> lock{ m_changeRegistrationsMutex };
+
+        m_setChangeRegistrations.erase(instanceIdentifier);
+        DisableChangeListeningIfNeeded();
+    }
+
+    ConfigurationStatus::ChangeRegistration::ChangeRegistration(const winrt::guid& instanceIdentifier) :
+        m_status(Instance()), m_instanceIdentifier(instanceIdentifier) {}
+
+    ConfigurationStatus::ChangeRegistration::~ChangeRegistration()
+    {
+        m_status->RemoveChangeRegistration(m_instanceIdentifier);
+    }
+
+    std::shared_ptr<ConfigurationStatus::ChangeRegistration> ConfigurationStatus::RegisterForChange(const ConfigurationProcessor& processor)
+    {
+        m_database.EnsureOpened();
+
+        GUID instanceIdentifier;
+        std::ignore = CoCreateGuid(&instanceIdentifier);
+
+        {
+            std::lock_guard<std::mutex> lock{ m_changeRegistrationsMutex };
+            m_changeRegistrations.emplace_back(instanceIdentifier, &processor);
+            EnableChangeListeningIfNeeded();
+        }
+
+        return std::make_shared<ChangeRegistration>(instanceIdentifier);
+    }
+
+    void ConfigurationStatus::RemoveChangeRegistration(const winrt::guid& instanceIdentifier) noexcept
+    {
+        std::lock_guard<std::mutex> lock{ m_changeRegistrationsMutex };
+
+        for (auto itr = m_changeRegistrations.begin(); itr != m_changeRegistrations.end(); ++itr)
+        {
+            if (itr->first == instanceIdentifier)
+            {
+                m_changeRegistrations.erase(itr);
+                DisableChangeListeningIfNeeded();
+                return;
+            }
+        }
+    }
+
+    void ConfigurationStatus::EnableChangeListeningIfNeeded()
+    {
+        if (!m_changeListener)
+        {
+            m_changeListener = std::make_unique<details::ChangeListener>(*this, m_database.GetLatestChangeIdentifier());
+        }
+    }
+
+    void ConfigurationStatus::DisableChangeListeningIfNeeded()
+    {
+        if (m_changeListener && m_setChangeRegistrations.empty() && m_changeRegistrations.empty())
+        {
+            m_changeListener.reset();
+        }
+    }
+
+    int64_t ConfigurationStatus::ChangeDetected(int64_t previousChangeIdentifier)
+    {
+
+    }
+
+    std::shared_ptr<details::ChangeSignaler> ConfigurationStatus::GetChangeSignaler()
+    {
+        std::shared_ptr<details::ChangeSignaler> result = std::atomic_load(&m_changeSignaler);
+        if (!result)
+        {
+            result = std::make_shared<details::ChangeSignaler>();
+            std::shared_ptr<details::ChangeSignaler> empty;
+
+            if (!std::atomic_compare_exchange_strong(&m_changeSignaler, &empty, result))
+            {
+                result = empty;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.cpp
@@ -55,7 +55,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             }
 
         private:
-            static void StaticWaitCallback(PTP_CALLBACK_INSTANCE, void* context, TP_WAIT*, TP_WAIT_RESULT)
+            static void NTAPI StaticWaitCallback(PTP_CALLBACK_INSTANCE, void* context, TP_WAIT*, TP_WAIT_RESULT)
             {
                 reinterpret_cast<ChangeListener*>(context)->WaitCallback();
             }

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.h
@@ -113,7 +113,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         bool HasChangeRegistrations();
 
         void SetChangeDetected(const guid& setInstanceIdentifier, com_ptr<ConfigurationSetChangeData>& data, const std::optional<GUID>& unitInstanceIdentifier);
-        void ChangeDetected(Configuration::ConfigurationSet& set, Configuration::ConfigurationChangeData data);
+        void ChangeDetected(const Configuration::ConfigurationSet& set, const Configuration::ConfigurationChangeData& data);
 
         ConfigurationDatabase m_database;
 

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.h
@@ -26,7 +26,13 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     // Provides access to overall configuration status information.
     struct ConfigurationStatus
     {
+    private:
+        struct private_construction {};
+
+    public:
         friend details::ChangeListener;
+
+        ConfigurationStatus(private_construction);
 
         ConfigurationStatus(const ConfigurationStatus&) = delete;
         ConfigurationStatus& operator=(const ConfigurationStatus&) = delete;
@@ -96,8 +102,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void RemoveChangeRegistration(const guid& instanceIdentifier) noexcept;
 
     private:
-        ConfigurationStatus();
-
         void EnableChangeListeningIfNeeded();
         void DisableChangeListeningIfNeeded();
 

--- a/src/Microsoft.Management.Configuration/ConfigurationStatus.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationStatus.h
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Database/ConfigurationDatabase.h"
+#include <winrt/Microsoft.Management.Configuration.h>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+
+namespace winrt::Microsoft::Management::Configuration::implementation
+{
+    // Forward declarations
+    struct ConfigurationProcessor;
+    struct ConfigurationSet;
+
+    namespace details
+    {
+        struct ChangeListener;
+        struct ChangeSignaler;
+    }
+
+    // Provides access to overall configuration status information.
+    struct ConfigurationStatus
+    {
+        friend details::ChangeListener;
+
+        ConfigurationStatus(const ConfigurationStatus&) = delete;
+        ConfigurationStatus& operator=(const ConfigurationStatus&) = delete;
+
+        ConfigurationStatus(ConfigurationStatus&&) = delete;
+        ConfigurationStatus& operator=(ConfigurationStatus&&) = delete;
+
+        ~ConfigurationStatus();
+
+        // Gets the singleton instance.
+        static std::shared_ptr<ConfigurationStatus> Instance();
+
+        // Get various set state information
+        ConfigurationSetState GetSetState(const winrt::guid& instanceIdentifier);
+        clock::time_point GetSetFirstApply(const winrt::guid& instanceIdentifier);
+        clock::time_point GetSetApplyBegun(const winrt::guid& instanceIdentifier);
+        clock::time_point GetSetApplyEnded(const winrt::guid& instanceIdentifier);
+        ConfigurationUnitState GetUnitState(const winrt::guid& instanceIdentifier);
+        IConfigurationUnitResultInformation GetUnitResultInformation(const winrt::guid& instanceIdentifier);
+
+        // Keeps data for a set change listener.
+        struct SetChangeRegistration
+        {
+            SetChangeRegistration(const winrt::guid& instanceIdentifier);
+
+            SetChangeRegistration(const SetChangeRegistration&) = delete;
+            SetChangeRegistration& operator=(const SetChangeRegistration&) = delete;
+
+            SetChangeRegistration(SetChangeRegistration&&) = delete;
+            SetChangeRegistration& operator=(SetChangeRegistration&&) = delete;
+
+            ~SetChangeRegistration();
+
+        private:
+            std::shared_ptr<ConfigurationStatus> m_status;
+            winrt::guid m_instanceIdentifier;
+        };
+
+        std::shared_ptr<SetChangeRegistration> RegisterForSetChange(const ConfigurationSet& set);
+        void RemoveSetChangeRegistration(const winrt::guid& instanceIdentifier) noexcept;
+
+        // Keeps data for a change listener.
+        struct ChangeRegistration
+        {
+            ChangeRegistration(const winrt::guid& instanceIdentifier);
+
+            ChangeRegistration(const ChangeRegistration&) = delete;
+            ChangeRegistration& operator=(const ChangeRegistration&) = delete;
+
+            ChangeRegistration(ChangeRegistration&&) = delete;
+            ChangeRegistration& operator=(ChangeRegistration&&) = delete;
+
+            ~ChangeRegistration();
+
+        private:
+            std::shared_ptr<ConfigurationStatus> m_status;
+            winrt::guid m_instanceIdentifier;
+        };
+
+        std::shared_ptr<ChangeRegistration> RegisterForChange(const ConfigurationProcessor& processor);
+        void RemoveChangeRegistration(const winrt::guid& instanceIdentifier) noexcept;
+
+    private:
+        ConfigurationStatus();
+
+        void EnableChangeListeningIfNeeded();
+        void DisableChangeListeningIfNeeded();
+
+        // Indicate that a change occurred, receiving the previous change identifier value.
+        // Returns the latest change identifier.
+        int64_t ChangeDetected(int64_t previousChangeIdentifier);
+
+        std::shared_ptr<details::ChangeSignaler> GetChangeSignaler();
+
+        ConfigurationDatabase m_database;
+
+        std::mutex m_changeRegistrationsMutex;
+        std::map<winrt::guid, ConfigurationSet*> m_setChangeRegistrations;
+        std::vector<std::pair<winrt::guid, ConfigurationProcessor*>> m_changeRegistrations;
+        std::unique_ptr<details::ChangeListener> m_changeListener;
+
+        std::shared_ptr<details::ChangeSignaler> m_changeSignaler;
+    };
+}

--- a/src/Microsoft.Management.Configuration/ConfigurationUnit.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationUnit.cpp
@@ -4,6 +4,7 @@
 #include "ConfigurationUnit.h"
 #include "ConfigurationUnit.g.cpp"
 #include "ConfigurationSetParser.h"
+#include "ConfigurationStatus.h"
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
@@ -137,12 +138,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
     ConfigurationUnitState ConfigurationUnit::State()
     {
-        return ConfigurationUnitState::Unknown;
+        auto status = ConfigurationStatus::Instance();
+        return status->GetUnitState(m_instanceIdentifier);
     }
 
     IConfigurationUnitResultInformation ConfigurationUnit::ResultInformation()
     {
-        return nullptr;
+        auto status = ConfigurationStatus::Instance();
+        return status->GetUnitResultInformation(m_instanceIdentifier);
     }
 
     bool ConfigurationUnit::IsActive()

--- a/src/Microsoft.Management.Configuration/ConfigurationUnitResultInformation.cpp
+++ b/src/Microsoft.Management.Configuration/ConfigurationUnitResultInformation.cpp
@@ -58,6 +58,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         m_resultSource = resultSource;
     }
 
+    void ConfigurationUnitResultInformation::Initialize(hresult resultCode, std::wstring_view description, std::wstring_view details, ConfigurationUnitResultSource resultSource)
+    {
+        m_resultCode = resultCode;
+        m_description = description;
+        m_details = details;
+        m_resultSource = resultSource;
+    }
+
     hresult ConfigurationUnitResultInformation::ResultCode() const
     {
         return m_resultCode;

--- a/src/Microsoft.Management.Configuration/ConfigurationUnitResultInformation.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationUnitResultInformation.h
@@ -14,6 +14,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void Initialize(hresult resultCode, std::wstring_view description);
         void Initialize(hresult resultCode, hstring description);
         void Initialize(hresult resultCode, ConfigurationUnitResultSource resultSource);
+        void Initialize(hresult resultCode, std::wstring_view description, std::wstring_view details, ConfigurationUnitResultSource resultSource);
 #endif
 
         hresult ResultCode() const;

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
@@ -680,11 +680,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             auto transaction = BeginTransaction("GetUnitResultInformation", database);
             auto resultInformation = database->GetUnitResultInformation(instanceIdentifier);
 
-            // CppWinRT does not support S_FALSE, so we will use it as a sentinel value to indicate that there is no value available.
-            if (std::get<0>(resultInformation) != S_FALSE)
+            if (resultInformation)
             {
                 result = make_self<wil::details::module_count_wrapper<implementation::ConfigurationUnitResultInformation>>();
-                result->Initialize(std::get<0>(resultInformation), ConvertToUTF16(std::get<1>(resultInformation)), ConvertToUTF16(std::get<2>(resultInformation)), std::get<3>(resultInformation));
+                result->Initialize(
+                    std::get<0>(resultInformation.value()),
+                    ConvertToUTF16(std::get<1>(resultInformation.value())),
+                    ConvertToUTF16(std::get<2>(resultInformation.value())),
+                    std::get<3>(resultInformation.value()));
             }
         }
 

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
@@ -110,6 +110,30 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 #endif
     }
 
+    ConfigurationDatabase::ConfigurationSetPtr ConfigurationDatabase::GetSet(const GUID& instanceIdentifier) const
+    {
+#ifdef AICLI_DISABLE_TEST_HOOKS
+        // While under development, treat errors escaping this function as a test hook.
+        try
+        {
+#endif
+        auto database = std::atomic_load(&m_database);
+
+        if (!database)
+        {
+            return {};
+        }
+
+        auto transaction = BeginTransaction("GetSet", database);
+        return database->GetSet(instanceIdentifier);
+#ifdef AICLI_DISABLE_TEST_HOOKS
+        }
+        CATCH_LOG();
+
+        return {};
+#endif
+    }
+
     void ConfigurationDatabase::WriteSetHistory(const Configuration::ConfigurationSet& configurationSet, bool preferNewHistory)
     {
 #ifdef AICLI_DISABLE_TEST_HOOKS

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
@@ -691,7 +691,13 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             }
         }
 
-        return *result;
+        IConfigurationUnitResultInformation actualResult;
+        if (result)
+        {
+            actualResult = *result;
+        }
+
+        return actualResult;
 #ifdef AICLI_DISABLE_TEST_HOOKS
         }
         CATCH_LOG();

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.cpp
@@ -127,7 +127,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             return {};
         }
 
-        auto transaction = BeginTransaction("GetSetHistory", database);
+        auto transaction = BeginTransaction("GetSetHistory", false, database);
         return database->GetSets();
 #ifdef AICLI_DISABLE_TEST_HOOKS
         }
@@ -151,7 +151,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             return {};
         }
 
-        auto transaction = BeginTransaction("GetSet", database);
+        auto transaction = BeginTransaction("GetSet", false, database);
         return database->GetSet(instanceIdentifier);
 #ifdef AICLI_DISABLE_TEST_HOOKS
         }
@@ -173,7 +173,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         THROW_HR_IF_NULL(E_POINTER, configurationSet);
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("WriteSetHistory", database);
+        auto transaction = BeginTransaction("WriteSetHistory", true, database);
 
         std::optional<rowid_t> setRowId = database->GetSetRowId(configurationSet.InstanceIdentifier());
 
@@ -216,7 +216,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             return;
         }
 
-        auto transaction = BeginTransaction("RemoveSetHistory", database);
+        auto transaction = BeginTransaction("RemoveSetHistory", true, database);
 
         std::optional<rowid_t> setRowId = database->GetSetRowId(configurationSet.InstanceIdentifier());
 
@@ -251,7 +251,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         THROW_HR_IF_NULL(E_POINTER, configurationSet);
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("AddQueueItem", database);
+        auto transaction = BeginTransaction("AddQueueItem", true, database);
 
         database->AddQueueItem(configurationSet.InstanceIdentifier(), objectName);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -274,7 +274,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("SetActiveQueueItem", database);
+        auto transaction = BeginTransaction("SetActiveQueueItem", true, database);
 
         database->SetActiveQueueItem(objectName);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -297,7 +297,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("GetQueueItems", database);
+        auto transaction = BeginTransaction("GetQueueItems", false, database);
 
         std::vector<ConfigurationDatabase::QueueItem> result;
         auto queueItems = database->GetQueueItems();
@@ -330,7 +330,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("RemoveQueueItem", database);
+        auto transaction = BeginTransaction("RemoveQueueItem", true, database);
 
         database->RemoveQueueItem(objectName);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -354,7 +354,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetStatusSince", database);
+            auto transaction = BeginTransaction("GetStatusSince", false, database);
             result = ConvertStatusItems(database->GetStatusSince(changeIdentifier));
         }
 
@@ -379,7 +379,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetStatusBaseline", database);
+            auto transaction = BeginTransaction("GetStatusBaseline", false, database);
             auto [changeIdentifier, setStatus] = database->GetStatusBaseline();
             result.ChangeIdentifier = changeIdentifier;
             result.SetStatus = ConvertStatusItems(setStatus);
@@ -405,7 +405,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("AddListener", database);
+        auto transaction = BeginTransaction("AddListener", true, database);
 
         database->AddListener(objectName);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -428,7 +428,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("RemoveListener", database);
+        auto transaction = BeginTransaction("RemoveListener", true, database);
 
         database->RemoveListener(objectName);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -452,7 +452,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetChangeListeners", database);
+            auto transaction = BeginTransaction("GetChangeListeners", false, database);
 
             for (const auto& item : database->GetChangeListeners())
             {
@@ -482,7 +482,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("UpdateSetState", database);
+        auto transaction = BeginTransaction("UpdateSetState", true, database);
 
         database->UpdateSetState(setInstanceIdentifier, state);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -505,7 +505,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("UpdateSetInQueue", database);
+        auto transaction = BeginTransaction("UpdateSetInQueue", true, database);
 
         database->UpdateSetInQueue(setInstanceIdentifier, inQueue);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -528,7 +528,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, database);
 
-        auto transaction = BeginTransaction("UpdateUnitState", database);
+        auto transaction = BeginTransaction("UpdateUnitState", true, database);
 
         database->UpdateUnitState(setInstanceIdentifier, changeData);
         std::atomic_load(&m_connection)->SetLastWriteTime();
@@ -552,7 +552,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetSetState", database);
+            auto transaction = BeginTransaction("GetSetState", false, database);
             result = database->GetSetState(instanceIdentifier);
         }
 
@@ -577,7 +577,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetSetFirstApply", database);
+            auto transaction = BeginTransaction("GetSetFirstApply", false, database);
             result = database->GetSetFirstApply(instanceIdentifier);
         }
 
@@ -602,7 +602,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetSetApplyBegun", database);
+            auto transaction = BeginTransaction("GetSetApplyBegun", false, database);
             result = database->GetSetApplyBegun(instanceIdentifier);
         }
 
@@ -627,7 +627,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetSetApplyEnded", database);
+            auto transaction = BeginTransaction("GetSetApplyEnded", false, database);
             result = database->GetSetApplyEnded(instanceIdentifier);
         }
 
@@ -652,7 +652,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetUnitState", database);
+            auto transaction = BeginTransaction("GetUnitState", false, database);
             result = database->GetUnitState(instanceIdentifier);
         }
 
@@ -677,7 +677,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         if (database)
         {
-            auto transaction = BeginTransaction("GetUnitResultInformation", database);
+            auto transaction = BeginTransaction("GetUnitResultInformation", false, database);
             auto resultInformation = database->GetUnitResultInformation(instanceIdentifier);
 
             if (resultInformation)
@@ -706,12 +706,12 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 #endif
     }
 
-    ConfigurationDatabase::TransactionLock ConfigurationDatabase::BeginTransaction(std::string_view name, std::shared_ptr<IConfigurationDatabase>& database) const
+    ConfigurationDatabase::TransactionLock ConfigurationDatabase::BeginTransaction(std::string_view name, bool forWrite, std::shared_ptr<IConfigurationDatabase>& database) const
     {
         auto connection = std::atomic_load(&m_connection);
         THROW_HR_IF_NULL(E_NOT_VALID_STATE, connection);
 
-        TransactionLock result = connection->TryBeginTransaction(name);
+        TransactionLock result = connection->TryBeginTransaction(name, forWrite);
 
         while (!result)
         {
@@ -724,7 +724,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                 }
             }
 
-            result = connection->TryBeginTransaction(name);
+            result = connection->TryBeginTransaction(name, forWrite);
         }
 
         return result;

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
+#include "ConfigurationSetChangeData.h"
 #include <winget/SQLiteWrapper.h>
 #include <winget/SQLiteDynamicStorage.h>
 #include <winrt/Microsoft.Management.Configuration.h>
@@ -58,7 +59,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             GUID SetInstanceIdentifier{};
             std::string ObjectName;
             std::chrono::system_clock::time_point QueuedAt;
-            DWORD ProcessId;
+            DWORD ProcessId{};
             bool Active = false;
         };
 
@@ -72,7 +73,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         struct StatusItem
         {
             int64_t ChangeIdentifier;
-            int64_t ChangeTime;
+            std::chrono::system_clock::time_point ChangeTime;
             GUID SetInstanceIdentifier;
             bool InQueue;
             std::optional<GUID> UnitInstanceIdentifier;
@@ -89,7 +90,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         // The status baseline data.
         struct StatusBaseline
         {
-            int64_t ChangeIdentifier;
+            int64_t ChangeIdentifier = 0;
             std::vector<StatusItem> SetStatus;
         };
 
@@ -101,7 +102,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         {
             std::string ObjectName;
             std::chrono::system_clock::time_point Started;
-            DWORD ProcessId;
+            DWORD ProcessId{};
         };
 
         // Adds a listener to the database.
@@ -124,9 +125,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         // Read various status values.
         ConfigurationSetState GetSetState(const guid& instanceIdentifier);
-        clock::time_point GetSetFirstApply(const guid& instanceIdentifier);
-        clock::time_point GetSetApplyBegun(const guid& instanceIdentifier);
-        clock::time_point GetSetApplyEnded(const guid& instanceIdentifier);
+        std::chrono::system_clock::time_point GetSetFirstApply(const guid& instanceIdentifier);
+        std::chrono::system_clock::time_point GetSetApplyBegun(const guid& instanceIdentifier);
+        std::chrono::system_clock::time_point GetSetApplyEnded(const guid& instanceIdentifier);
         ConfigurationUnitState GetUnitState(const guid& instanceIdentifier);
         IConfigurationUnitResultInformation GetUnitResultInformation(const guid& instanceIdentifier);
 

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -5,6 +5,7 @@
 #include <winget/SQLiteDynamicStorage.h>
 #include <winrt/Microsoft.Management.Configuration.h>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace winrt::Microsoft::Management::Configuration::implementation
@@ -62,6 +63,26 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         // Removes the queue item with the given object name.
         void RemoveQueueItem(const std::string& objectName);
+
+        // A status line item.
+        struct StatusItem
+        {
+            int64_t ChangeIdentifier;
+            GUID SetInstanceIdentifier;
+            bool InQueue;
+            std::optional<GUID> UnitInstanceIdentifier;
+            int32_t State;
+            HRESULT ResultCode;
+            std::string ResultDescription;
+            std::string ResultDetails;
+            ConfigurationUnitResultSource ResultSource;
+        };
+
+        struct StatusBaseline
+        {
+            int64_t ChangeIdentifier;
+            std::vector<StatusItem> SetStatus;
+        };
 
     private:
         std::shared_ptr<AppInstaller::SQLite::SQLiteDynamicStorage> m_connection;

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #pragma once
-#include "ConfigurationSet.h"
 #include <winget/SQLiteWrapper.h>
 #include <winget/SQLiteDynamicStorage.h>
+#include <winrt/Microsoft.Management.Configuration.h>
 #include <memory>
 #include <vector>
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
-    // Forward declaration of internal interface.
+    // Forward declarations
+    struct ConfigurationSet;
     struct IConfigurationDatabase;
 
     // Allows access to the configuration database.

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             bool InQueue;
             std::optional<GUID> UnitInstanceIdentifier;
             int32_t State;
-            HRESULT ResultCode;
+            std::optional<HRESULT> ResultCode;
             std::string ResultDescription;
             std::string ResultDetails;
             ConfigurationUnitResultSource ResultSource;

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -64,11 +64,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
     private:
         std::shared_ptr<AppInstaller::SQLite::SQLiteDynamicStorage> m_connection;
-        mutable std::unique_ptr<IConfigurationDatabase> m_database;
+        mutable std::shared_ptr<IConfigurationDatabase> m_database;
 
         using TransactionLock = decltype(m_connection->TryBeginTransaction({}));
 
         // Begins a transaction, which may require upgrading to a newer schema version.
-        TransactionLock BeginTransaction(std::string_view name) const;
+        TransactionLock BeginTransaction(std::string_view name, std::shared_ptr<IConfigurationDatabase>& database) const;
     };
 }

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -135,9 +135,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         std::shared_ptr<AppInstaller::SQLite::SQLiteDynamicStorage> m_connection;
         mutable std::shared_ptr<IConfigurationDatabase> m_database;
 
-        using TransactionLock = decltype(m_connection->TryBeginTransaction({}));
+        using TransactionLock = decltype(m_connection->TryBeginTransaction({}, true));
 
         // Begins a transaction, which may require upgrading to a newer schema version.
-        TransactionLock BeginTransaction(std::string_view name, std::shared_ptr<IConfigurationDatabase>& database) const;
+        TransactionLock BeginTransaction(std::string_view name, bool forWrite, std::shared_ptr<IConfigurationDatabase>& database) const;
     };
 }

--- a/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/ConfigurationDatabase.h
@@ -139,5 +139,13 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         // Begins a transaction, which may require upgrading to a newer schema version.
         TransactionLock BeginTransaction(std::string_view name, bool forWrite, std::shared_ptr<IConfigurationDatabase>& database) const;
+
+        // Performs the boilerplate setup for a read, then executes the given operation.
+        template <typename OperationT>
+        auto ExecuteReadOperation(std::string_view operationName, OperationT&& operation, bool requireDatabase = false) const;
+
+        // Performs the boilerplate setup for a write, then executes the given operation.
+        template <typename OperationT>
+        void ExecuteWriteOperation(std::string_view operationName, OperationT&& operation, bool silentlyIgnoreNoDatabase = false);
     };
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/Interface.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/Interface.h
@@ -22,6 +22,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         // Version 0.2
         bool MigrateFrom(IConfigurationDatabase* current) override;
 
+        // Version 0.3
+        ConfigurationSetPtr GetSet(const GUID& instanceIdentifier) override;
+
     protected:
         std::shared_ptr<AppInstaller::SQLite::SQLiteDynamicStorage> m_storage;
     };

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/Interface_0_1.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/Interface_0_1.cpp
@@ -83,4 +83,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
     {
         return current->GetSchemaVersion() == s_InterfaceVersion;
     }
+
+    Interface::ConfigurationSetPtr Interface::GetSet(const GUID& instanceIdentifier)
+    {
+        SetInfoTable setInfoTable(*m_storage);
+        return setInfoTable.GetSet(instanceIdentifier);
+    }
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
@@ -175,7 +175,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
             configurationSet->Name(hstring{ ConvertToUTF16(getAllSets.GetColumn<std::string>(2)) });
             configurationSet->Origin(hstring{ ConvertToUTF16(getAllSets.GetColumn<std::string>(3)) });
             configurationSet->Path(hstring{ ConvertToUTF16(getAllSets.GetColumn<std::string>(4)) });
-            configurationSet->FirstApply(clock::from_sys(ConvertUnixEpochToSystemClock(getAllSets.GetColumn<int64_t>(5))));
 
             std::string schemaVersion = getAllSets.GetColumn<std::string>(6);
             configurationSet->SchemaVersion(hstring{ ConvertToUTF16(schemaVersion) });

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
@@ -74,6 +74,16 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
 
     SetInfoTable::SetInfoTable(Connection& connection) : m_connection(connection) {}
 
+    std::string_view SetInfoTable::TableName()
+    {
+        return s_SetInfoTable_Table;
+    }
+
+    std::string_view SetInfoTable::InstanceIdentifierColumn()
+    {
+        return s_SetInfoTable_Column_InstanceIdentifier;
+    }
+
     void SetInfoTable::Create()
     {
         Savepoint savepoint = Savepoint::Create(m_connection, "SetInfoTable_Create_0_1");

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
@@ -37,11 +37,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
                 s_SetInfoTable_Column_Name,                 // 2
                 s_SetInfoTable_Column_Origin,               // 3
                 s_SetInfoTable_Column_Path,                 // 4
-                s_SetInfoTable_Column_FirstApply,           // 5
-                s_SetInfoTable_Column_SchemaVersion,        // 6
-                s_SetInfoTable_Column_Metadata,             // 7
-                s_SetInfoTable_Column_Parameters,           // 8
-                s_SetInfoTable_Column_Variables,            // 9
+                s_SetInfoTable_Column_SchemaVersion,        // 5
+                s_SetInfoTable_Column_Metadata,             // 6
+                s_SetInfoTable_Column_Parameters,           // 7
+                s_SetInfoTable_Column_Variables,            // 8
             }).From(s_SetInfoTable_Table);
         }
 
@@ -53,13 +52,13 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
             configurationSet->Origin(hstring{ ConvertToUTF16(statement.GetColumn<std::string>(3)) });
             configurationSet->Path(hstring{ ConvertToUTF16(statement.GetColumn<std::string>(4)) });
 
-            std::string schemaVersion = statement.GetColumn<std::string>(6);
+            std::string schemaVersion = statement.GetColumn<std::string>(5);
             configurationSet->SchemaVersion(hstring{ ConvertToUTF16(schemaVersion) });
 
             auto parser = ConfigurationSetParser::CreateForSchemaVersion(schemaVersion);
-            configurationSet->Metadata(parser->ParseValueSet(statement.GetColumn<std::string>(7)));
-            THROW_HR_IF(E_NOTIMPL, !statement.GetColumn<std::string>(8).empty());
-            configurationSet->Variables(parser->ParseValueSet(statement.GetColumn<std::string>(9)));
+            configurationSet->Metadata(parser->ParseValueSet(statement.GetColumn<std::string>(6)));
+            THROW_HR_IF(E_NOTIMPL, !statement.GetColumn<std::string>(7).empty());
+            configurationSet->Variables(parser->ParseValueSet(statement.GetColumn<std::string>(8)));
 
             std::vector<Configuration::ConfigurationUnit> winrtUnits;
             for (const auto& unit : unitInfoTable.GetAllUnitsForSet(statement.GetColumn<rowid_t>(0), schemaVersion))

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.cpp
@@ -250,4 +250,14 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
 
         return result;
     }
+
+    std::chrono::system_clock::time_point SetInfoTable::GetSetFirstApply(const GUID& instanceIdentifier)
+    {
+        StatementBuilder builder;
+        builder.Select(s_SetInfoTable_Column_FirstApply).From(s_SetInfoTable_Table).Where(s_SetInfoTable_Column_InstanceIdentifier).Equals(instanceIdentifier);
+
+        Statement statement = builder.Prepare(m_connection);
+
+        return (statement.Step() ? ConvertUnixEpochToSystemClock(statement.GetColumn<int64_t>(0)) : std::chrono::system_clock::time_point{});
+    }
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
@@ -38,6 +38,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         // Gets the set with the given instance identifier.
         IConfigurationDatabase::ConfigurationSetPtr GetSet(const GUID& instanceIdentifier);
 
+        // Gets a set's first apply time.
+        std::chrono::system_clock::time_point GetSetFirstApply(const GUID& instanceIdentifier);
+
     private:
         AppInstaller::SQLite::Connection& m_connection;
     };

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
@@ -13,6 +13,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
     {
         SetInfoTable(AppInstaller::SQLite::Connection& connection);
 
+        static std::string_view TableName();
+        static std::string_view InstanceIdentifierColumn();
+
         // Creates the set info table.
         void Create();
 

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_1/SetInfoTable.h
@@ -32,6 +32,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         // Gets the row id of the set with the given instance identifier.
         std::optional<AppInstaller::SQLite::rowid_t> GetSetRowId(const GUID& instanceIdentifier);
 
+        // Gets the set with the given instance identifier.
+        IConfigurationDatabase::ConfigurationSetPtr GetSet(const GUID& instanceIdentifier);
+
     private:
         AppInstaller::SQLite::Connection& m_connection;
     };

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface.h
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         bool MigrateFrom(IConfigurationDatabase* current) override;
         void AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName) override;
         void SetActiveQueueItem(const std::string& objectName) override;
-        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, bool>> GetQueueItems() override;
+        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> GetQueueItems() override;
         void RemoveQueueItem(const std::string& objectName) override;
 
     private:

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface_0_2.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface_0_2.cpp
@@ -60,10 +60,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         queueTable.SetActiveQueueItem(objectName);
     }
 
-    std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, bool>> Interface::GetQueueItems()
+    std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> Interface::GetQueueItems()
     {
         QueueTable queueTable(*m_storage);
-        return queueTable.GetQueueItems();
+        return queueTable.GetQueueItemsWithoutProcess();
     }
 
     void Interface::RemoveQueueItem(const std::string& objectName)

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface_0_2.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_2/Interface_0_2.cpp
@@ -20,7 +20,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
     void Interface::InitializeDatabase()
     {
         V0_1::Interface::InitializeDatabase();
+
+        Savepoint savepoint = Savepoint::Create(*m_storage, "InitializeDatabase_0_2");
         MigrateFrom0_1();
+        savepoint.Commit();
     }
 
     bool Interface::MigrateFrom(IConfigurationDatabase* current)
@@ -51,7 +54,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
     void Interface::AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName)
     {
         QueueTable queueTable(*m_storage);
-        queueTable.AddQueueItem(instanceIdentifier, objectName);
+        queueTable.AddQueueItemWithoutProcess(instanceIdentifier, objectName);
     }
 
     void Interface::SetActiveQueueItem(const std::string& objectName)

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_2/QueueTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_2/QueueTable.h
@@ -18,7 +18,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         void AddProcessColumn();
 
         // Adds a new queue item for the given configuration set and object name.
-        void AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName);
+        void AddQueueItemWithoutProcess(const GUID& instanceIdentifier, const std::string& objectName);
+
+        // Adds a new queue item for the given configuration set and object name.
+        void AddQueueItemWithProcess(const GUID& instanceIdentifier, const std::string& objectName);
 
         // Sets the queue item with the given object name as active.
         void SetActiveQueueItem(const std::string& objectName);

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_2/QueueTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_2/QueueTable.h
@@ -14,6 +14,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         // Creates the queue table.
         void Create();
 
+        // Adds the process column to the table.
+        void AddProcessColumn();
+
         // Adds a new queue item for the given configuration set and object name.
         void AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName);
 
@@ -21,7 +24,10 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         void SetActiveQueueItem(const std::string& objectName);
 
         // Gets all queue items in queue order (item at index 0 is active/next).
-        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, bool>> GetQueueItems();
+        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> GetQueueItemsWithoutProcess();
+
+        // Gets all queue items in queue order (item at index 0 is active/next).
+        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> GetQueueItemsWithProcess();
 
         // Removes the queue item with the given object name.
         void RemoveQueueItem(const std::string& objectName);

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/ChangeListenerTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/ChangeListenerTable.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "ChangeListenerTable.h"
+#include <AppInstallerDateTime.h>
+#include <winget/SQLiteStatementBuilder.h>
+
+using namespace AppInstaller::SQLite;
+using namespace AppInstaller::SQLite::Builder;
+using namespace AppInstaller::Utility;
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    namespace
+    {
+        constexpr std::string_view s_ChangeListenerTable_Table = "change_listeners"sv;
+
+        constexpr std::string_view s_ChangeListenerTable_Column_ObjectName = "object_name"sv;
+        constexpr std::string_view s_ChangeListenerTable_Column_StartedAt = "started_at"sv;
+        constexpr std::string_view s_ChangeListenerTable_Column_Process = "process"sv;
+    }
+
+    ChangeListenerTable::ChangeListenerTable(Connection& connection) : m_connection(connection) {}
+
+    void ChangeListenerTable::Create()
+    {
+        Savepoint savepoint = Savepoint::Create(m_connection, "ChangeListenerTable_Create_0_3");
+
+        StatementBuilder tableBuilder;
+        tableBuilder.CreateTable(s_ChangeListenerTable_Table).Columns({
+            IntegerPrimaryKey(),
+            ColumnBuilder(s_ChangeListenerTable_Column_ObjectName, Type::Text).Unique().NotNull(),
+            ColumnBuilder(s_ChangeListenerTable_Column_StartedAt, Type::Int64).NotNull(),
+            ColumnBuilder(s_ChangeListenerTable_Column_Process, Type::Int64).NotNull(),
+        });
+
+        tableBuilder.Execute(m_connection);
+
+        savepoint.Commit();
+    }
+
+    void ChangeListenerTable::AddChangeListener(const std::string& objectName)
+    {
+        StatementBuilder builder;
+        builder.InsertInto(s_ChangeListenerTable_Table).Columns({
+            s_ChangeListenerTable_Column_ObjectName,
+            s_ChangeListenerTable_Column_StartedAt,
+            s_ChangeListenerTable_Column_Process
+            }).Values(
+                objectName,
+                GetCurrentUnixEpoch(),
+                static_cast<int64_t>(GetCurrentProcessId())
+            );
+
+        builder.Execute(m_connection);
+    }
+
+    void ChangeListenerTable::RemoveChangeListener(const std::string& objectName)
+    {
+        StatementBuilder builder;
+        builder.DeleteFrom(s_ChangeListenerTable_Table).Where(s_ChangeListenerTable_Column_ObjectName).Equals(objectName);
+
+        builder.Execute(m_connection);
+    }
+
+    std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> ChangeListenerTable::GetChangeListeners()
+    {
+        StatementBuilder builder;
+        builder.Select({
+            s_ChangeListenerTable_Column_ObjectName,
+            s_ChangeListenerTable_Column_StartedAt,
+            s_ChangeListenerTable_Column_Process
+        }).From(s_ChangeListenerTable_Table);
+
+        Statement statement = builder.Prepare(m_connection);
+
+        std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> result;
+
+        while (statement.Step())
+        {
+            result.emplace_back(std::make_tuple(statement.GetColumn<std::string>(0), ConvertUnixEpochToSystemClock(statement.GetColumn<int64_t>(1)), static_cast<DWORD>(statement.GetColumn<int64_t>(2))));
+        }
+
+        return result;
+    }
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/ChangeListenerTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/ChangeListenerTable.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include <winget/SQLiteWrapper.h>
+#include <vector>
+#include <tuple>
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    struct ChangeListenerTable
+    {
+        ChangeListenerTable(AppInstaller::SQLite::Connection& connection);
+
+        // Creates the table.
+        void Create();
+
+        // Adds a new change listener to the table.
+        void AddChangeListener(const std::string& objectName);
+
+        // Removes the change listener with the given name from the table.
+        void RemoveChangeListener(const std::string& objectName);
+
+        // Gets all change listeners.
+        std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> GetChangeListeners();
+
+    private:
+        AppInstaller::SQLite::Connection& m_connection;
+    };
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Database/Schema/IConfigurationDatabase.h"
+#include "Database/Schema/0_2/Interface.h"
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    struct Interface : public V0_2::Interface
+    {
+        using V0_2::Interface::Interface;
+
+        const AppInstaller::SQLite::Version& GetSchemaVersion() override;
+
+        // Version 0.1
+        void InitializeDatabase() override;
+        void RemoveSet(AppInstaller::SQLite::rowid_t target) override;
+
+        // Version 0.2
+        bool MigrateFrom(IConfigurationDatabase* current) override;
+        void AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName) override;
+        std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> GetQueueItems() override;
+
+        // Version 0.3
+        std::vector<StatusItemTuple> GetStatusSince(int64_t changeIdentifier) override;
+        std::tuple<int64_t, std::vector<StatusItemTuple>> GetStatusBaseline() override;
+        void AddListener(const std::string& objectName) override;
+        void RemoveListener(const std::string& objectName) override;
+        std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> GetChangeListeners() override;
+        void UpdateSetState(const guid& setInstanceIdentifier, ConfigurationSetState state) override;
+        void UpdateSetInQueue(const guid& setInstanceIdentifier, bool inQueue) override;
+        void UpdateUnitState(const guid& setInstanceIdentifier, const ConfigurationSetChangeDataPtr& changeData) override;
+        ConfigurationSetState GetSetState(const guid& instanceIdentifier) override;
+        std::chrono::system_clock::time_point GetSetFirstApply(const guid& instanceIdentifier) override;
+        std::chrono::system_clock::time_point GetSetApplyBegun(const guid& instanceIdentifier) override;
+        std::chrono::system_clock::time_point GetSetApplyEnded(const guid& instanceIdentifier) override;
+        ConfigurationUnitState GetUnitState(const guid& instanceIdentifier) override;
+        std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> GetUnitResultInformation(const guid& instanceIdentifier) override;
+
+    private:
+        // Unconditionally attempts to migrate from the 0.2 base.
+        void MigrateFrom0_2();
+    };
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface_0_3.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface_0_3.cpp
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Interface.h"
+#include "Database/Schema/0_2/QueueTable.h"
+#include "StatusItemTable.h"
+#include "ChangeListenerTable.h"
+#include <winget/SQLiteMetadataTable.h>
+
+using namespace AppInstaller::SQLite;
+using namespace AppInstaller::Utility;
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    static constexpr AppInstaller::SQLite::Version s_InterfaceVersion{ 0, 3 };
+
+    const AppInstaller::SQLite::Version& Interface::GetSchemaVersion()
+    {
+        return s_InterfaceVersion;
+    }
+
+    void Interface::InitializeDatabase()
+    {
+        V0_2::Interface::InitializeDatabase();
+
+        Savepoint savepoint = Savepoint::Create(*m_storage, "InitializeDatabase_0_3");
+        MigrateFrom0_2();
+        savepoint.Commit();
+    }
+
+    void Interface::RemoveSet(AppInstaller::SQLite::rowid_t target)
+    {
+        Savepoint savepoint = Savepoint::Create(*m_storage, "RemoveSet_0_3");
+
+        V0_2::Interface::RemoveSet(target);
+
+        StatusItemTable statusItemTable(*m_storage);
+        statusItemTable.RemoveForSet(target);
+
+        savepoint.Commit();
+    }
+
+    bool Interface::MigrateFrom(IConfigurationDatabase* current)
+    {
+        auto currentSchemaVersion = current->GetSchemaVersion();
+        if (currentSchemaVersion < s_InterfaceVersion)
+        {
+            if (V0_2::Interface::MigrateFrom(current))
+            {
+                Savepoint savepoint = Savepoint::Create(*m_storage, "MigrateFrom0_2");
+
+                MigrateFrom0_2();
+                s_InterfaceVersion.SetSchemaVersion(*m_storage);
+
+                savepoint.Commit();
+
+                return true;
+            }
+        }
+        else if (currentSchemaVersion == s_InterfaceVersion)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    void Interface::AddQueueItem(const GUID& instanceIdentifier, const std::string& objectName)
+    {
+        V0_2::QueueTable queueTable(*m_storage);
+        queueTable.AddQueueItemWithProcess(instanceIdentifier, objectName);
+    }
+
+    std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> Interface::GetQueueItems()
+    {
+        V0_2::QueueTable queueTable(*m_storage);
+        return queueTable.GetQueueItemsWithProcess();
+    }
+
+    void Interface::MigrateFrom0_2()
+    {
+        V0_2::QueueTable queueTable(*m_storage);
+        queueTable.AddProcessColumn();
+
+        ChangeListenerTable changeListenerTable(*m_storage);
+        changeListenerTable.Create();
+
+        StatusItemTable statusItemTable(*m_storage);
+        statusItemTable.Create();
+    }
+
+    std::vector<IConfigurationDatabase::StatusItemTuple> Interface::GetStatusSince(int64_t changeIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetStatusSince(changeIdentifier);
+    }
+
+    std::tuple<int64_t, std::vector<IConfigurationDatabase::StatusItemTuple>> Interface::GetStatusBaseline()
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetStatusBaseline();
+    }
+
+    void Interface::AddListener(const std::string& objectName)
+    {
+        ChangeListenerTable changeListenerTable(*m_storage);
+        changeListenerTable.AddChangeListener(objectName);
+    }
+
+    void Interface::RemoveListener(const std::string& objectName)
+    {
+        ChangeListenerTable changeListenerTable(*m_storage);
+        changeListenerTable.RemoveChangeListener(objectName);
+    }
+
+    std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> Interface::GetChangeListeners()
+    {
+        ChangeListenerTable changeListenerTable(*m_storage);
+        return changeListenerTable.GetChangeListeners();
+    }
+
+    void Interface::UpdateSetState(const guid& setInstanceIdentifier, ConfigurationSetState state)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        statusItemTable.UpdateSetState(setInstanceIdentifier, state);
+    }
+
+    void Interface::UpdateSetInQueue(const guid& setInstanceIdentifier, bool inQueue)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        statusItemTable.UpdateSetInQueue(setInstanceIdentifier, inQueue);
+    }
+
+    void Interface::UpdateUnitState(const guid& setInstanceIdentifier, const ConfigurationSetChangeDataPtr& changeData)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        statusItemTable.UpdateUnitState(setInstanceIdentifier, changeData);
+    }
+
+    ConfigurationSetState Interface::GetSetState(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetSetState(instanceIdentifier);
+    }
+
+    std::chrono::system_clock::time_point Interface::GetSetFirstApply(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetSetFirstApply(instanceIdentifier);
+    }
+
+    std::chrono::system_clock::time_point Interface::GetSetApplyBegun(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetSetApplyBegun(instanceIdentifier);
+    }
+
+    std::chrono::system_clock::time_point Interface::GetSetApplyEnded(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetSetApplyEnded(instanceIdentifier);
+    }
+
+    ConfigurationUnitState Interface::GetUnitState(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetUnitState(instanceIdentifier);
+    }
+
+    std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> Interface::GetUnitResultInformation(const guid& instanceIdentifier)
+    {
+        StatusItemTable statusItemTable(*m_storage);
+        return statusItemTable.GetUnitResultInformation(instanceIdentifier);
+    }
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface_0_3.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/Interface_0_3.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "Interface.h"
+#include "Database/Schema/0_1/SetInfoTable.h"
 #include "Database/Schema/0_2/QueueTable.h"
 #include "StatusItemTable.h"
 #include "ChangeListenerTable.h"
@@ -145,8 +146,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
 
     std::chrono::system_clock::time_point Interface::GetSetFirstApply(const guid& instanceIdentifier)
     {
-        StatusItemTable statusItemTable(*m_storage);
-        return statusItemTable.GetSetFirstApply(instanceIdentifier);
+        V0_1::SetInfoTable setInfoTable(*m_storage);
+        return setInfoTable.GetSetFirstApply(instanceIdentifier);
     }
 
     std::chrono::system_clock::time_point Interface::GetSetApplyBegun(const guid& instanceIdentifier)

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "StatusItemTable.h"
+#include "Database/Schema/0_1/SetInfoTable.h"
+#include <AppInstallerDateTime.h>
+#include <winget/SQLiteStatementBuilder.h>
+
+using namespace AppInstaller::SQLite;
+using namespace AppInstaller::SQLite::Builder;
+using namespace AppInstaller::Utility;
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    namespace
+    {
+        constexpr std::string_view s_StatusItemTable_Table = "status_items"sv;
+        constexpr std::string_view s_StatusItemTable_ChangeIdentifierIndex = "status_items_change_idx"sv;
+        constexpr std::string_view s_StatusItemTable_SetRowIdIndex = "status_items_set_idx"sv;
+        constexpr std::string_view s_StatusItemTable_UnitInstanceIndex = "status_items_unit_idx"sv;
+
+        constexpr std::string_view s_StatusItemTable_Column_ChangeIdentifier = "change_identifier"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ChangeTime = "change_time"sv;
+        constexpr std::string_view s_StatusItemTable_Column_SetRowId = "set_rowid"sv;
+        constexpr std::string_view s_StatusItemTable_Column_InQueue = "in_queue"sv;
+        constexpr std::string_view s_StatusItemTable_Column_UnitInstanceIdentifier = "unit_instance_identifier"sv;
+        constexpr std::string_view s_StatusItemTable_Column_State = "state"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ResultCode = "result_code"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ResultDescription = "result_description"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ResultDetails = "result_details"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ResultSource = "result_source"sv;
+
+        void BuildBaseStatusSelectStatement(StatementBuilder& builder)
+        {
+            builder.Select({
+                s_StatusItemTable_Column_ChangeIdentifier,          // 0
+                s_StatusItemTable_Column_ChangeTime,                // 1
+                V0_1::SetInfoTable::InstanceIdentifierColumn(),     // 2
+                s_StatusItemTable_Column_InQueue,                   // 3
+                s_StatusItemTable_Column_UnitInstanceIdentifier,    // 4
+                s_StatusItemTable_Column_State,                     // 5
+                s_StatusItemTable_Column_ResultCode,                // 6
+                s_StatusItemTable_Column_ResultDescription,         // 7
+                s_StatusItemTable_Column_ResultDetails,             // 8
+                s_StatusItemTable_Column_ResultSource,              // 9
+            }).From(s_StatusItemTable_Table).LeftOuterJoin(V0_1::SetInfoTable::TableName()).On(QualifiedColumn{ s_StatusItemTable_Table, s_StatusItemTable_Column_SetRowId }, QualifiedColumn{ V0_1::SetInfoTable::TableName(), RowIDName });
+        }
+
+        IConfigurationDatabase::StatusItemTuple GetTupleFromStatement(Statement& statement)
+        {
+            return std::make_tuple(
+                statement.GetColumn<int64_t>(0),
+                ConvertUnixEpochToSystemClock(statement.GetColumn<int64_t>(1)),
+                statement.GetColumn<GUID>(2),
+                statement.GetColumn<bool>(3),
+                statement.GetColumnIsNull(4) ? std::nullopt : std::make_optional<GUID>(statement.GetColumn<GUID>(4)),
+                statement.GetColumn<int32_t>(5),
+                statement.GetColumnIsNull(6) ? std::nullopt : std::make_optional<HRESULT>(statement.GetColumn<int32_t>(6)),
+                statement.GetColumnIsNull(7) ? std::string{} : statement.GetColumn<std::string>(7),
+                statement.GetColumnIsNull(8) ? std::string{} : statement.GetColumn<std::string>(8),
+                statement.GetColumnIsNull(9) ? ConfigurationUnitResultSource::None : statement.GetColumn<ConfigurationUnitResultSource>(9)
+            );
+        }
+    }
+
+    StatusItemTable::StatusItemTable(Connection& connection) : m_connection(connection) {}
+
+    void StatusItemTable::Create()
+    {
+        Savepoint savepoint = Savepoint::Create(m_connection, "StatusItemTable_Create_0_3");
+
+        StatementBuilder tableBuilder;
+        tableBuilder.CreateTable(s_StatusItemTable_Table).Columns({
+            IntegerPrimaryKey(),
+            ColumnBuilder(s_StatusItemTable_Column_ChangeIdentifier, Type::Int64).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_ChangeTime, Type::Int64).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_SetRowId, Type::RowId).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_InQueue, Type::Bool).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_UnitInstanceIdentifier, Type::Blob),
+            ColumnBuilder(s_StatusItemTable_Column_State, Type::Int).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_ResultCode, Type::Int),
+            ColumnBuilder(s_StatusItemTable_Column_ResultDescription, Type::Text),
+            ColumnBuilder(s_StatusItemTable_Column_ResultDetails, Type::Text),
+            ColumnBuilder(s_StatusItemTable_Column_ResultSource, Type::Int),
+        });
+
+        tableBuilder.Execute(m_connection);
+
+        {
+            StatementBuilder indexBuilder;
+            indexBuilder.CreateIndex(s_StatusItemTable_ChangeIdentifierIndex).On(s_StatusItemTable_Table).Columns(s_StatusItemTable_Column_ChangeIdentifier);
+            indexBuilder.Execute(m_connection);
+        }
+
+        {
+            StatementBuilder indexBuilder;
+            indexBuilder.CreateIndex(s_StatusItemTable_SetRowIdIndex).On(s_StatusItemTable_Table).Columns(s_StatusItemTable_Column_SetRowId);
+            indexBuilder.Execute(m_connection);
+        }
+
+        {
+            StatementBuilder indexBuilder;
+            indexBuilder.CreateUniqueIndex(s_StatusItemTable_UnitInstanceIndex).On(s_StatusItemTable_Table).Columns(s_StatusItemTable_Column_UnitInstanceIdentifier);
+            indexBuilder.Execute(m_connection);
+        }
+
+        savepoint.Commit();
+    }
+
+    void StatusItemTable::RemoveForSet(AppInstaller::SQLite::rowid_t target)
+    {
+        StatementBuilder builder;
+        builder.DeleteFrom(s_StatusItemTable_Table).Where(s_StatusItemTable_Column_SetRowId).Equals(target);
+        builder.Execute(m_connection);
+    }
+
+    std::vector<IConfigurationDatabase::StatusItemTuple> StatusItemTable::GetStatusSince(int64_t changeIdentifier)
+    {
+        StatementBuilder builder;
+        BuildBaseStatusSelectStatement(builder);
+        builder.Where(s_StatusItemTable_Column_ChangeIdentifier).IsGreaterThan(changeIdentifier).OrderBy(s_StatusItemTable_Column_ChangeIdentifier);
+
+        Statement statement = builder.Prepare(m_connection);
+
+        std::vector<IConfigurationDatabase::StatusItemTuple> result;
+
+        while (statement.Step())
+        {
+            result.emplace_back(GetTupleFromStatement(statement));
+        }
+
+        return result;
+    }
+
+    std::tuple<int64_t, std::vector<IConfigurationDatabase::StatusItemTuple>> StatusItemTable::GetStatusBaseline()
+    {
+        int64_t latestChange = 0;
+        std::vector<IConfigurationDatabase::StatusItemTuple> setStatus;
+
+        StatementBuilder getLatestChangeBuilder;
+        getLatestChangeBuilder.Select().Max(s_StatusItemTable_Column_ChangeIdentifier).From(s_StatusItemTable_Table);
+
+        Statement getLatestChange = getLatestChangeBuilder.Prepare(m_connection);
+
+        if (getLatestChange.Step())
+        {
+            latestChange = getLatestChange.GetColumn<int64_t>(0);
+        }
+
+        StatementBuilder builder;
+        BuildBaseStatusSelectStatement(builder);
+        builder.Where(s_StatusItemTable_Column_UnitInstanceIdentifier).IsNull();
+
+        Statement statement = builder.Prepare(m_connection);
+
+        while (statement.Step())
+        {
+            setStatus.emplace_back(GetTupleFromStatement(statement));
+        }
+
+        return std::make_tuple(latestChange, std::move(setStatus));
+    }
+
+    void StatusItemTable::UpdateSetState(const guid& setInstanceIdentifier, ConfigurationSetState state)
+    {
+        UNREFERENCED_PARAMETER(setInstanceIdentifier);
+        UNREFERENCED_PARAMETER(state);
+        // update status_items set state = 1 from (select rowid from set_info where instance_identifier = "foo") as sub where status_items.set_rowid = sub.rowid
+        // check change count, if 0 then insert
+        //StatementBuilder builder;
+        //builder.Update(s_StatusItemTable_Table).Set().Column(s_StatusItemTable_Column_State).Equals(state).From(s_StatusItemTable_Table);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    void StatusItemTable::UpdateSetInQueue(const guid& setInstanceIdentifier, bool inQueue)
+    {
+        UNREFERENCED_PARAMETER(setInstanceIdentifier);
+        UNREFERENCED_PARAMETER(inQueue);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    void StatusItemTable::UpdateUnitState(const guid& setInstanceIdentifier, const IConfigurationDatabase::ConfigurationSetChangeDataPtr& changeData)
+    {
+        UNREFERENCED_PARAMETER(setInstanceIdentifier);
+        UNREFERENCED_PARAMETER(changeData);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    ConfigurationSetState StatusItemTable::GetSetState(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    std::chrono::system_clock::time_point StatusItemTable::GetSetFirstApply(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyBegun(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyEnded(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    ConfigurationUnitState StatusItemTable::GetUnitState(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+
+    std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> StatusItemTable::GetUnitResultInformation(const guid& instanceIdentifier)
+    {
+        UNREFERENCED_PARAMETER(instanceIdentifier);
+        THROW_HR(E_NOTIMPL);
+    }
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
@@ -313,7 +313,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
             resultSource = resultInformation.ResultSource();
         }
 
-        UpdateStatus(m_connection, setInstanceIdentifier, std::nullopt, std::nullopt, changeData->Unit().InstanceIdentifier(), resultCode, resultDescription, resultDetails, resultSource);
+        UpdateStatus(m_connection, setInstanceIdentifier, AppInstaller::ToIntegral(changeData->UnitState()), std::nullopt, changeData->Unit().InstanceIdentifier(), resultCode, resultDescription, resultDetails, resultSource);
     }
 
     ConfigurationSetState StatusItemTable::GetSetState(const guid& instanceIdentifier)

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
@@ -4,6 +4,8 @@
 #include "StatusItemTable.h"
 #include "Database/Schema/0_1/SetInfoTable.h"
 #include <AppInstallerDateTime.h>
+#include <AppInstallerLanguageUtilities.h>
+#include <AppInstallerStrings.h>
 #include <winget/SQLiteStatementBuilder.h>
 
 using namespace AppInstaller::SQLite;
@@ -20,7 +22,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         constexpr std::string_view s_StatusItemTable_UnitInstanceIndex = "status_items_unit_idx"sv;
 
         constexpr std::string_view s_StatusItemTable_Column_ChangeIdentifier = "change_identifier"sv;
-        constexpr std::string_view s_StatusItemTable_Column_ChangeTime = "change_time"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ChangeTimeInitial = "change_time_initial"sv;
+        constexpr std::string_view s_StatusItemTable_Column_ChangeTimeLatest = "change_time_latest"sv;
         constexpr std::string_view s_StatusItemTable_Column_SetRowId = "set_rowid"sv;
         constexpr std::string_view s_StatusItemTable_Column_InQueue = "in_queue"sv;
         constexpr std::string_view s_StatusItemTable_Column_UnitInstanceIdentifier = "unit_instance_identifier"sv;
@@ -34,7 +37,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         {
             builder.Select({
                 s_StatusItemTable_Column_ChangeIdentifier,          // 0
-                s_StatusItemTable_Column_ChangeTime,                // 1
+                s_StatusItemTable_Column_ChangeTimeLatest,          // 1
                 V0_1::SetInfoTable::InstanceIdentifierColumn(),     // 2
                 s_StatusItemTable_Column_InQueue,                   // 3
                 s_StatusItemTable_Column_UnitInstanceIdentifier,    // 4
@@ -61,6 +64,137 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
                 statement.GetColumnIsNull(9) ? ConfigurationUnitResultSource::None : statement.GetColumn<ConfigurationUnitResultSource>(9)
             );
         }
+
+        int64_t GetLatestChangeIdentifier(Connection& connection)
+        {
+            StatementBuilder getLatestChangeBuilder;
+            getLatestChangeBuilder.Select().Max(s_StatusItemTable_Column_ChangeIdentifier).From(s_StatusItemTable_Table);
+
+            Statement getLatestChange = getLatestChangeBuilder.Prepare(connection);
+
+            return (getLatestChange.Step() ? getLatestChange.GetColumn<int64_t>(0) : 0);
+        }
+
+        int64_t GetNextChangeIdentifier(Connection& connection)
+        {
+            return GetLatestChangeIdentifier(connection) + 1;
+        }
+
+        void UpdateStatus(
+            Connection& connection,
+            const GUID& setInstanceIdentifier,
+            const std::optional<int32_t>& state,
+            const std::optional<bool>& inQueue,
+            const std::optional<GUID>& unitInstanceIdentifier = std::nullopt,
+            const std::optional<int32_t>& resultCode = std::nullopt,
+            const std::optional<std::string>& resultDescription = std::nullopt,
+            const std::optional<std::string>& resultDetails = std::nullopt,
+            const std::optional<ConfigurationUnitResultSource>& resultSource = std::nullopt)
+        {
+            static constexpr std::string_view s_alias = "sub_expression";
+
+            int64_t changeIdentifier = GetNextChangeIdentifier(connection);
+            int64_t changeTime = GetCurrentUnixEpoch();
+
+            // Statement like:
+            // Update status_items set state = 1 from (Select rowid from set_info where instance_identifier = "foo") as sub where status_items.set_rowid = sub.rowid
+            StatementBuilder updateBuilder;
+            updateBuilder.Update(s_StatusItemTable_Table).Set();
+
+            if (state)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_State).Equals(state.value());
+            }
+
+            if (inQueue)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_InQueue).Equals(inQueue.value());
+            }
+
+            if (resultCode)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_ResultCode).Equals(resultCode.value());
+            }
+
+            if (resultDescription)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_ResultDescription).Equals(resultDescription.value());
+            }
+
+            if (resultDetails)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_ResultDetails).Equals(resultDetails.value());
+            }
+
+            if (resultSource)
+            {
+                updateBuilder.Column(s_StatusItemTable_Column_ResultSource).Equals(resultSource.value());
+            }
+
+            updateBuilder.
+                Column(s_StatusItemTable_Column_ChangeIdentifier).Equals(changeIdentifier).
+                Column(s_StatusItemTable_Column_ChangeTimeLatest).Equals(changeTime).
+            From().BeginParenthetical().
+                Select(RowIDName).From(V0_1::SetInfoTable::TableName()).Where(V0_1::SetInfoTable::InstanceIdentifierColumn()).Equals(setInstanceIdentifier).
+            EndParenthetical().As(s_alias).Where(QualifiedColumn{ s_StatusItemTable_Table, s_StatusItemTable_Column_SetRowId }).Equals(QualifiedColumn{ s_alias, RowIDName }).
+                And(QualifiedColumn{ s_StatusItemTable_Table, s_StatusItemTable_Column_UnitInstanceIdentifier }).Equals(unitInstanceIdentifier);
+
+            updateBuilder.Execute(connection);
+
+            if (connection.GetChanges() == 0)
+            {
+                // No change; we need to insert the status row
+                StatementBuilder insertBuilder;
+                insertBuilder.InsertInto(s_StatusItemTable_Table).Columns({
+                    s_StatusItemTable_Column_ChangeIdentifier,
+                    s_StatusItemTable_Column_ChangeTimeInitial,
+                    s_StatusItemTable_Column_ChangeTimeLatest,
+                    s_StatusItemTable_Column_SetRowId,
+                    s_StatusItemTable_Column_InQueue,
+                    s_StatusItemTable_Column_UnitInstanceIdentifier,
+                    s_StatusItemTable_Column_State,
+                    s_StatusItemTable_Column_ResultCode,
+                    s_StatusItemTable_Column_ResultDescription,
+                    s_StatusItemTable_Column_ResultDetails,
+                    s_StatusItemTable_Column_ResultSource,
+                }).Select().
+                    Value(changeIdentifier).
+                    Value(changeTime).
+                    Value(changeTime).
+                    Column(QualifiedColumn{ V0_1::SetInfoTable::TableName(), RowIDName }).
+                    Value(inQueue.value_or(false)).
+                    Value(unitInstanceIdentifier).
+                    Value(state.value_or(0)).
+                    Value(resultCode).
+                    Value(resultDescription).
+                    Value(resultDetails).
+                    Value(resultSource).
+                From(V0_1::SetInfoTable::TableName()).Where(QualifiedColumn{ V0_1::SetInfoTable::TableName(), V0_1::SetInfoTable::InstanceIdentifierColumn() }).Equals(setInstanceIdentifier);
+
+                insertBuilder.Execute(connection);
+            }
+        }
+
+        Statement PrepareSelectStatusValues(Connection& connection, const std::optional<GUID>& setInstanceIdentifier, const std::optional<GUID>& unitInstanceIdentifier, std::initializer_list<std::string_view> columns)
+        {
+            THROW_HR_IF(E_INVALIDARG, (setInstanceIdentifier && unitInstanceIdentifier) || (!setInstanceIdentifier && !unitInstanceIdentifier));
+
+            StatementBuilder builder;
+            builder.Select(columns).From(s_StatusItemTable_Table);
+
+            if (setInstanceIdentifier)
+            {
+                builder.Join(V0_1::SetInfoTable::TableName()).On(QualifiedColumn{ s_StatusItemTable_Table, s_StatusItemTable_Column_SetRowId }, QualifiedColumn{ V0_1::SetInfoTable::TableName(), RowIDName }).
+                    Where(QualifiedColumn{ V0_1::SetInfoTable::TableName(), V0_1::SetInfoTable::InstanceIdentifierColumn() }).Equals(setInstanceIdentifier).
+                    And(s_StatusItemTable_Column_UnitInstanceIdentifier).IsNull();
+            }
+            else
+            {
+                builder.Where(s_StatusItemTable_Column_UnitInstanceIdentifier).Equals(unitInstanceIdentifier.value());
+            }
+
+            return builder.Prepare(connection);
+        }
     }
 
     StatusItemTable::StatusItemTable(Connection& connection) : m_connection(connection) {}
@@ -73,7 +207,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         tableBuilder.CreateTable(s_StatusItemTable_Table).Columns({
             IntegerPrimaryKey(),
             ColumnBuilder(s_StatusItemTable_Column_ChangeIdentifier, Type::Int64).NotNull(),
-            ColumnBuilder(s_StatusItemTable_Column_ChangeTime, Type::Int64).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_ChangeTimeInitial, Type::Int64).NotNull(),
+            ColumnBuilder(s_StatusItemTable_Column_ChangeTimeLatest, Type::Int64).NotNull(),
             ColumnBuilder(s_StatusItemTable_Column_SetRowId, Type::RowId).NotNull(),
             ColumnBuilder(s_StatusItemTable_Column_InQueue, Type::Bool).NotNull(),
             ColumnBuilder(s_StatusItemTable_Column_UnitInstanceIdentifier, Type::Blob),
@@ -134,18 +269,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
 
     std::tuple<int64_t, std::vector<IConfigurationDatabase::StatusItemTuple>> StatusItemTable::GetStatusBaseline()
     {
-        int64_t latestChange = 0;
+        int64_t latestChange = GetLatestChangeIdentifier(m_connection);
         std::vector<IConfigurationDatabase::StatusItemTuple> setStatus;
-
-        StatementBuilder getLatestChangeBuilder;
-        getLatestChangeBuilder.Select().Max(s_StatusItemTable_Column_ChangeIdentifier).From(s_StatusItemTable_Table);
-
-        Statement getLatestChange = getLatestChangeBuilder.Prepare(m_connection);
-
-        if (getLatestChange.Step())
-        {
-            latestChange = getLatestChange.GetColumn<int64_t>(0);
-        }
 
         StatementBuilder builder;
         BuildBaseStatusSelectStatement(builder);
@@ -163,62 +288,78 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
 
     void StatusItemTable::UpdateSetState(const guid& setInstanceIdentifier, ConfigurationSetState state)
     {
-        UNREFERENCED_PARAMETER(setInstanceIdentifier);
-        UNREFERENCED_PARAMETER(state);
-        // update status_items set state = 1 from (select rowid from set_info where instance_identifier = "foo") as sub where status_items.set_rowid = sub.rowid
-        // check change count, if 0 then insert
-        //StatementBuilder builder;
-        //builder.Update(s_StatusItemTable_Table).Set().Column(s_StatusItemTable_Column_State).Equals(state).From(s_StatusItemTable_Table);
-        THROW_HR(E_NOTIMPL);
+        UpdateStatus(m_connection, setInstanceIdentifier, AppInstaller::ToIntegral(state), std::nullopt);
     }
 
     void StatusItemTable::UpdateSetInQueue(const guid& setInstanceIdentifier, bool inQueue)
     {
-        UNREFERENCED_PARAMETER(setInstanceIdentifier);
-        UNREFERENCED_PARAMETER(inQueue);
-        THROW_HR(E_NOTIMPL);
+        UpdateStatus(m_connection, setInstanceIdentifier, std::nullopt, inQueue);
     }
 
     void StatusItemTable::UpdateUnitState(const guid& setInstanceIdentifier, const IConfigurationDatabase::ConfigurationSetChangeDataPtr& changeData)
     {
-        UNREFERENCED_PARAMETER(setInstanceIdentifier);
-        UNREFERENCED_PARAMETER(changeData);
-        THROW_HR(E_NOTIMPL);
+        const auto& resultInformation = changeData->ResultInformation();
+
+        std::optional<HRESULT> resultCode;
+        std::optional<std::string> resultDescription;
+        std::optional<std::string> resultDetails;
+        std::optional<ConfigurationUnitResultSource> resultSource;
+
+        if (resultInformation)
+        {
+            resultCode = resultInformation.ResultCode();
+            resultDescription = ConvertToUTF8(resultInformation.Description());
+            resultDetails = ConvertToUTF8(resultInformation.Details());
+            resultSource = resultInformation.ResultSource();
+        }
+
+        UpdateStatus(m_connection, setInstanceIdentifier, std::nullopt, std::nullopt, changeData->Unit().InstanceIdentifier(), resultCode, resultDescription, resultDetails, resultSource);
     }
 
     ConfigurationSetState StatusItemTable::GetSetState(const guid& instanceIdentifier)
     {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
+        Statement statement = PrepareSelectStatusValues(m_connection, instanceIdentifier, std::nullopt, { s_StatusItemTable_Column_State });
+
+        return (statement.Step() ? statement.GetColumn<ConfigurationSetState>(0) : ConfigurationSetState::Unknown);
     }
 
-    std::chrono::system_clock::time_point StatusItemTable::GetSetFirstApply(const guid& instanceIdentifier)
+    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyBegun(const GUID& instanceIdentifier)
     {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
+        Statement statement = PrepareSelectStatusValues(m_connection, instanceIdentifier, std::nullopt, { s_StatusItemTable_Column_ChangeTimeInitial });
+
+        return (statement.Step() ? ConvertUnixEpochToSystemClock(statement.GetColumn<int64_t>(0)) : std::chrono::system_clock::time_point{});
     }
 
-    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyBegun(const guid& instanceIdentifier)
+    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyEnded(const GUID& instanceIdentifier)
     {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
-    }
+        Statement statement = PrepareSelectStatusValues(m_connection, instanceIdentifier, std::nullopt, { s_StatusItemTable_Column_ChangeTimeLatest, s_StatusItemTable_Column_InQueue });
 
-    std::chrono::system_clock::time_point StatusItemTable::GetSetApplyEnded(const guid& instanceIdentifier)
-    {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
+        // Only return the end time if no longer in the queue
+        if (statement.Step() && !statement.GetColumn<bool>(1))
+        {
+            return ConvertUnixEpochToSystemClock(statement.GetColumn<int64_t>(0));
+        }
+
+        return std::chrono::system_clock::time_point{};
     }
 
     ConfigurationUnitState StatusItemTable::GetUnitState(const guid& instanceIdentifier)
     {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
+        Statement statement = PrepareSelectStatusValues(m_connection, std::nullopt, instanceIdentifier, { s_StatusItemTable_Column_State });
+
+        return (statement.Step() ? statement.GetColumn<ConfigurationUnitState>(0) : ConfigurationUnitState::Unknown);
     }
 
     std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> StatusItemTable::GetUnitResultInformation(const guid& instanceIdentifier)
     {
-        UNREFERENCED_PARAMETER(instanceIdentifier);
-        THROW_HR(E_NOTIMPL);
+        Statement statement = PrepareSelectStatusValues(m_connection, std::nullopt, instanceIdentifier,
+            { s_StatusItemTable_Column_ResultCode, s_StatusItemTable_Column_ResultDescription, s_StatusItemTable_Column_ResultDetails, s_StatusItemTable_Column_ResultSource });
+
+        if (statement.Step() && !statement.GetColumnIsNull(0))
+        {
+            return statement.GetRow<int32_t, std::string, std::string, ConfigurationUnitResultSource>();
+        }
+
+        return std::nullopt;
     }
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.cpp
@@ -68,7 +68,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         int64_t GetLatestChangeIdentifier(Connection& connection)
         {
             StatementBuilder getLatestChangeBuilder;
-            getLatestChangeBuilder.Select().Max(s_StatusItemTable_Column_ChangeIdentifier).From(s_StatusItemTable_Table);
+            getLatestChangeBuilder.Select().Column(Aggregate::Max, s_StatusItemTable_Column_ChangeIdentifier).From(s_StatusItemTable_Table);
 
             Statement getLatestChange = getLatestChangeBuilder.Prepare(connection);
 

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.h
@@ -36,14 +36,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation::Database:
         // Gets a set's state.
         ConfigurationSetState GetSetState(const guid& instanceIdentifier);
 
-        // Gets a set's first apply time.
-        std::chrono::system_clock::time_point GetSetFirstApply(const guid& instanceIdentifier);
-
         // Gets a set's latest apply begin time.
-        std::chrono::system_clock::time_point GetSetApplyBegun(const guid& instanceIdentifier);
+        std::chrono::system_clock::time_point GetSetApplyBegun(const GUID& instanceIdentifier);
 
         // Gets a set's latest apply end time.
-        std::chrono::system_clock::time_point GetSetApplyEnded(const guid& instanceIdentifier);
+        std::chrono::system_clock::time_point GetSetApplyEnded(const GUID& instanceIdentifier);
 
         // Gets a unit's state.
         ConfigurationUnitState GetUnitState(const guid& instanceIdentifier);

--- a/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/0_3/StatusItemTable.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Database/Schema/IConfigurationDatabase.h"
+#include <winget/SQLiteWrapper.h>
+#include <vector>
+#include <tuple>
+
+namespace winrt::Microsoft::Management::Configuration::implementation::Database::Schema::V0_3
+{
+    struct StatusItemTable
+    {
+        StatusItemTable(AppInstaller::SQLite::Connection& connection);
+
+        // Creates the table.
+        void Create();
+
+        // Removes the status for the target set.
+        void RemoveForSet(AppInstaller::SQLite::rowid_t target);
+
+        // Gets all status items that have changed since the given change identifier, in order of changes (last item is the new latest change to pass next).
+        std::vector<IConfigurationDatabase::StatusItemTuple> GetStatusSince(int64_t changeIdentifier);
+
+        // Gets the latest change identifier and the set status items.
+        std::tuple<int64_t, std::vector<IConfigurationDatabase::StatusItemTuple>> GetStatusBaseline();
+
+        // Updates a set's state.
+        void UpdateSetState(const guid& setInstanceIdentifier, ConfigurationSetState state);
+
+        // Updates whether a set is in the queue or not.
+        void UpdateSetInQueue(const guid& setInstanceIdentifier, bool inQueue);
+
+        // Updates a unit's state.
+        void UpdateUnitState(const guid& setInstanceIdentifier, const IConfigurationDatabase::ConfigurationSetChangeDataPtr& changeData);
+
+        // Gets a set's state.
+        ConfigurationSetState GetSetState(const guid& instanceIdentifier);
+
+        // Gets a set's first apply time.
+        std::chrono::system_clock::time_point GetSetFirstApply(const guid& instanceIdentifier);
+
+        // Gets a set's latest apply begin time.
+        std::chrono::system_clock::time_point GetSetApplyBegun(const guid& instanceIdentifier);
+
+        // Gets a set's latest apply end time.
+        std::chrono::system_clock::time_point GetSetApplyEnded(const guid& instanceIdentifier);
+
+        // Gets a unit's state.
+        ConfigurationUnitState GetUnitState(const guid& instanceIdentifier);
+
+        // Gets a unit's latest result information.
+        std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> GetUnitResultInformation(const guid& instanceIdentifier);
+
+    private:
+        AppInstaller::SQLite::Connection& m_connection;
+    };
+}

--- a/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.cpp
@@ -66,12 +66,77 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     {
     }
 
-    std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, bool>> IConfigurationDatabase::GetQueueItems()
+    std::vector<std::tuple<GUID, std::string, std::chrono::system_clock::time_point, DWORD, bool>> IConfigurationDatabase::GetQueueItems()
     {
         return {};
     }
 
     void IConfigurationDatabase::RemoveQueueItem(const std::string&)
     {
+    }
+
+    std::vector<IConfigurationDatabase::StatusItemTuple> IConfigurationDatabase::GetStatusSince(int64_t)
+    {
+        return {};
+    }
+
+    std::tuple<int64_t, std::vector<IConfigurationDatabase::StatusItemTuple>> IConfigurationDatabase::GetStatusBaseline()
+    {
+        return { 0, {} };
+    }
+
+    void IConfigurationDatabase::AddListener(const std::string&)
+    {
+    }
+
+    void IConfigurationDatabase::RemoveListener(const std::string&)
+    {
+    }
+
+    std::vector<std::tuple<std::string, std::chrono::system_clock::time_point, DWORD>> IConfigurationDatabase::GetChangeListeners()
+    {
+        return {};
+    }
+
+    void IConfigurationDatabase::UpdateSetState(const guid&, ConfigurationSetState)
+    {
+    }
+
+    void IConfigurationDatabase::UpdateSetInQueue(const guid&, bool)
+    {
+    }
+
+    void IConfigurationDatabase::UpdateUnitState(const guid&, const ConfigurationSetChangeDataPtr&)
+    {
+    }
+
+    ConfigurationSetState IConfigurationDatabase::GetSetState(const guid&)
+    {
+        return ConfigurationSetState::Unknown;
+    }
+
+    std::chrono::system_clock::time_point IConfigurationDatabase::GetSetFirstApply(const guid&)
+    {
+        return {};
+    }
+
+    std::chrono::system_clock::time_point IConfigurationDatabase::GetSetApplyBegun(const guid&)
+    {
+        return {};
+    }
+
+    std::chrono::system_clock::time_point IConfigurationDatabase::GetSetApplyEnded(const guid&)
+    {
+        return {};
+    }
+
+    ConfigurationUnitState IConfigurationDatabase::GetUnitState(const guid&)
+    {
+        return ConfigurationUnitState::Unknown;
+    }
+
+    std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource> IConfigurationDatabase::GetUnitResultInformation(const guid&)
+    {
+        return { S_FALSE, {}, {}, ConfigurationUnitResultSource::None };
     }
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.cpp
+++ b/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.cpp
@@ -5,6 +5,7 @@
 
 #include "Database/Schema/0_1/Interface.h"
 #include "Database/Schema/0_2/Interface.h"
+#include "Database/Schema/0_3/Interface.h"
 
 namespace winrt::Microsoft::Management::Configuration::implementation
 {
@@ -16,10 +17,11 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
             if (version.MajorVersion == 0)
             {
-                constexpr std::array<std::unique_ptr<IConfigurationDatabase>(*)(const StorageT& s), 2> versionCreatorMap =
+                constexpr std::array<std::unique_ptr<IConfigurationDatabase>(*)(const StorageT& s), 3> versionCreatorMap =
                 {
                     [](const StorageT& s) { return std::unique_ptr<IConfigurationDatabase>(std::make_unique<Database::Schema::V0_1::Interface>(s)); },
                     [](const StorageT& s) { return std::unique_ptr<IConfigurationDatabase>(std::make_unique<Database::Schema::V0_2::Interface>(s)); },
+                    [](const StorageT& s) { return std::unique_ptr<IConfigurationDatabase>(std::make_unique<Database::Schema::V0_3::Interface>(s)); },
                 };
 
                 size_t minorVersion = static_cast<size_t>(version.MinorVersion);
@@ -36,7 +38,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
     AppInstaller::SQLite::Version IConfigurationDatabase::GetLatestVersion()
     {
-        return { 0, 2 };
+        return { 0, 3 };
     }
 
     std::unique_ptr<IConfigurationDatabase> IConfigurationDatabase::CreateFor(const std::shared_ptr<AppInstaller::SQLite::SQLiteDynamicStorage>& storage, bool allowMigration)
@@ -135,8 +137,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         return ConfigurationUnitState::Unknown;
     }
 
-    std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource> IConfigurationDatabase::GetUnitResultInformation(const guid&)
+    std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> IConfigurationDatabase::GetUnitResultInformation(const guid&)
     {
-        return { S_FALSE, {}, {}, ConfigurationUnitResultSource::None };
+        return std::nullopt;
     }
 }

--- a/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.h
+++ b/src/Microsoft.Management.Configuration/Database/Schema/IConfigurationDatabase.h
@@ -83,7 +83,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
             bool,
             std::optional<GUID>,
             int32_t,
-            HRESULT,
+            std::optional<HRESULT>,
             std::string,
             std::string,
             ConfigurationUnitResultSource>;
@@ -128,6 +128,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         virtual ConfigurationUnitState GetUnitState(const guid& instanceIdentifier);
 
         // Gets a unit's latest result information.
-        virtual std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource> GetUnitResultInformation(const guid& instanceIdentifier);
+        virtual std::optional<std::tuple<HRESULT, std::string, std::string, ConfigurationUnitResultSource>> GetUnitResultInformation(const guid& instanceIdentifier);
     };
 }

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -278,7 +278,7 @@ namespace Microsoft.Management.Configuration
 
         // The state of the configuration set for this event (the ConfigurationSet can be used to get the current state, which may be different).
         ConfigurationSetState SetState{ get; };
-            
+
         // The state of the configuration unit for this event (the ConfigurationUnit can be used to get the current state, which may be different).
         ConfigurationUnitState UnitState{ get; };
 
@@ -368,7 +368,7 @@ namespace Microsoft.Management.Configuration
         String SchemaVersion;
 
         // Only changes for this set are sent to this event.
-        // This includes things like: start/stop of the entire set for application or test, start/stop of a unit for application or test.
+        // This includes things like: start/stop of the entire set for application, start/stop of a unit for application.
         event Windows.Foundation.TypedEventHandler<ConfigurationSet, ConfigurationSetChangeData> ConfigurationSetChange;
 
         // Writes the configuration set to the given stream.
@@ -858,7 +858,7 @@ namespace Microsoft.Management.Configuration
         Boolean GenerateTelemetryEvents;
 
         // Only top level configuration changes are sent to this event.
-        // This includes things like: creation of a new set for intent to run, start/stop of a set for application or test, deletion of a not started set.
+        // This includes things like: creation of a new set for intent to run, start/stop of a set for application, deletion of a not started set.
         event Windows.Foundation.TypedEventHandler<ConfigurationSet, ConfigurationChangeData> ConfigurationChange;
 
         // Gets the configuration sets that have already been applied or with the intent to be applied (this may include in progress sets or those that are waiting on others).

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
@@ -220,6 +220,7 @@
     <ClInclude Include="ConfigurationSetSerializer_0_2.h" />
     <ClInclude Include="ConfigurationSetUtilities.h" />
     <ClInclude Include="ConfigurationStaticFunctions.h" />
+    <ClInclude Include="ConfigurationStatus.h" />
     <ClInclude Include="ConfigurationUnit.h" />
     <ClInclude Include="ConfigurationUnitResultInformation.h" />
     <ClInclude Include="Database\ConfigurationDatabase.h" />
@@ -270,6 +271,7 @@
     <ClCompile Include="ConfigurationSetSerializer_0_2.cpp" />
     <ClCompile Include="ConfigurationSetUtilities.cpp" />
     <ClCompile Include="ConfigurationStaticFunctions.cpp" />
+    <ClCompile Include="ConfigurationStatus.cpp" />
     <ClCompile Include="ConfigurationUnit.cpp" />
     <ClCompile Include="ConfigurationUnitResultInformation.cpp" />
     <ClCompile Include="Database\ConfigurationDatabase.cpp" />

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
@@ -229,6 +229,9 @@
     <ClInclude Include="Database\Schema\0_1\UnitInfoTable.h" />
     <ClInclude Include="Database\Schema\0_2\Interface.h" />
     <ClInclude Include="Database\Schema\0_2\QueueTable.h" />
+    <ClInclude Include="Database\Schema\0_3\ChangeListenerTable.h" />
+    <ClInclude Include="Database\Schema\0_3\Interface.h" />
+    <ClInclude Include="Database\Schema\0_3\StatusItemTable.h" />
     <ClInclude Include="Database\Schema\IConfigurationDatabase.h" />
     <ClInclude Include="DefaultSetGroupProcessor.h" />
     <ClInclude Include="DiagnosticInformationInstance.h" />
@@ -280,6 +283,9 @@
     <ClCompile Include="Database\Schema\0_1\UnitInfoTable.cpp" />
     <ClCompile Include="Database\Schema\0_2\Interface_0_2.cpp" />
     <ClCompile Include="Database\Schema\0_2\QueueTable.cpp" />
+    <ClCompile Include="Database\Schema\0_3\ChangeListenerTable.cpp" />
+    <ClCompile Include="Database\Schema\0_3\Interface_0_3.cpp" />
+    <ClCompile Include="Database\Schema\0_3\StatusItemTable.cpp" />
     <ClCompile Include="Database\Schema\IConfigurationDatabase.cpp" />
     <ClCompile Include="DefaultSetGroupProcessor.cpp" />
     <ClCompile Include="DiagnosticInformationInstance.cpp" />

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj.filters
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="Database\Schema\0_2\QueueTable.cpp">
       <Filter>Database\Schema\0_2</Filter>
     </ClCompile>
+    <ClCompile Include="ConfigurationStatus.cpp">
+      <Filter>Internals</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -284,6 +287,9 @@
     </ClInclude>
     <ClInclude Include="Database\Schema\0_2\QueueTable.h">
       <Filter>Database\Schema\0_2</Filter>
+    </ClInclude>
+    <ClInclude Include="ConfigurationStatus.h">
+      <Filter>Internals</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj.filters
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj.filters
@@ -141,6 +141,15 @@
     <ClCompile Include="ConfigurationStatus.cpp">
       <Filter>Internals</Filter>
     </ClCompile>
+    <ClCompile Include="Database\Schema\0_3\Interface_0_3.cpp">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClCompile>
+    <ClCompile Include="Database\Schema\0_3\ChangeListenerTable.cpp">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClCompile>
+    <ClCompile Include="Database\Schema\0_3\StatusItemTable.cpp">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -291,6 +300,15 @@
     <ClInclude Include="ConfigurationStatus.h">
       <Filter>Internals</Filter>
     </ClInclude>
+    <ClInclude Include="Database\Schema\0_3\Interface.h">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClInclude>
+    <ClInclude Include="Database\Schema\0_3\ChangeListenerTable.h">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClInclude>
+    <ClInclude Include="Database\Schema\0_3\StatusItemTable.h">
+      <Filter>Database\Schema\0_3</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="Microsoft.Management.Configuration.idl" />
@@ -327,6 +345,9 @@
     </Filter>
     <Filter Include="Database\Schema\0_2">
       <UniqueIdentifier>{f214d0f3-3e9c-469b-91ae-213315d39a69}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Database\Schema\0_3">
+      <UniqueIdentifier>{d059436d-cd54-4cf2-96bc-4db53c617537}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
+++ b/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
@@ -296,7 +296,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
     void TelemetryTraceLogger::LogConfigProcessingSummary(
         const guid& setIdentifier,
         std::string_view inputHash,
-        bool fromHistory,
         ConfigurationUnitIntent runIntent,
         hresult result,
         ConfigurationUnitResultSource failurePoint,
@@ -310,7 +309,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                 "ConfigProcessingSummary",
                 TraceLoggingGuid(setIdentifier, "SetID"),
                 AICLI_TraceLoggingStringView(inputHash, "InputHash"),
-                TraceLoggingBool(fromHistory, "FromHistory"),
+                TraceLoggingBool(false, "FromHistory"), // deprecated
                 TraceLoggingInt32(static_cast<int32_t>(runIntent), "RunIntent"),
                 TraceLoggingHResult(result, "Result"),
                 TraceLoggingInt32(static_cast<int32_t>(failurePoint), "FailurePoint"),
@@ -325,7 +324,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
                 "ConfigProcessingSummary",
                 WinGet_EventItem(setIdentifier, "SetID"),
                 WinGet_EventItem(inputHash, "InputHash"),
-                WinGet_EventItem(fromHistory, "FromHistory"),
+                WinGet_EventItem(false, "FromHistory"), // deprecated
                 WinGet_EventItem(static_cast<int32_t>(runIntent), "RunIntent"),
                 WinGet_EventItem(result, "Result"),
                 WinGet_EventItem(static_cast<int32_t>(failurePoint), "FailurePoint"),
@@ -347,7 +346,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         ConfigRunSummaryData summaryData = ProcessRunResult(result.UnitResults());
 
-        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), configurationSet.IsFromHistory(), ConfigurationUnitIntent::Assert,
+        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), ConfigurationUnitIntent::Assert,
             summaryData.Result, summaryData.FailurePoint, summaryData.AssertSummary, summaryData.InformSummary, summaryData.ApplySummary);
     }
     CATCH_LOG();
@@ -364,7 +363,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         ConfigRunSummaryData summaryData = ProcessRunResult(result.UnitResults());
 
-        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), configurationSet.IsFromHistory(), ConfigurationUnitIntent::Assert,
+        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), ConfigurationUnitIntent::Assert,
             error, ConfigurationUnitResultSource::Internal, summaryData.AssertSummary, summaryData.InformSummary, summaryData.ApplySummary);
     }
     CATCH_LOG();
@@ -380,7 +379,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         ConfigRunSummaryData summaryData = ProcessRunResult(result.UnitResults());
 
-        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), configurationSet.IsFromHistory(), ConfigurationUnitIntent::Apply,
+        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), ConfigurationUnitIntent::Apply,
             result.ResultCode(), summaryData.FailurePoint, summaryData.AssertSummary, summaryData.InformSummary, summaryData.ApplySummary);
     }
     CATCH_LOG();
@@ -397,7 +396,7 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         ConfigRunSummaryData summaryData = ProcessRunResult(result.UnitResults());
 
-        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), configurationSet.IsFromHistory(), ConfigurationUnitIntent::Apply,
+        LogConfigProcessingSummary(configurationSet.InstanceIdentifier(), configurationSet.GetInputHash(), ConfigurationUnitIntent::Apply,
             error, ConfigurationUnitResultSource::Internal, summaryData.AssertSummary, summaryData.InformSummary, summaryData.ApplySummary);
     }
     CATCH_LOG();

--- a/src/Microsoft.Management.Configuration/Telemetry/Telemetry.h
+++ b/src/Microsoft.Management.Configuration/Telemetry/Telemetry.h
@@ -86,7 +86,6 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         void LogConfigProcessingSummary(
             const guid& setIdentifier,
             std::string_view inputHash,
-            bool fromHistory,
             ConfigurationUnitIntent runIntent,
             hresult result,
             ConfigurationUnitResultSource failurePoint,


### PR DESCRIPTION
## Change
This change stores ongoing status information during configuration application in the database.  This data is then retrievable via the existing API surface from a set retrieved from `GetConfigurationHistory`.  The data includes: configuration set state, configuration set apply start/stop times, configuration unit state, and configuration unit results.

In addition, the existing events on the `ConfigurationProcessor` and `ConfigurationSet` are implemented to send data when appropriate.  This works across processes, using named events to indicate changes and the database to carry the actual data.

`winget configure list` is updated to expose this information, for example:

```
PS > wingetdev configure list
Identifier                             Name      State     Origin
--------------------------------------------------------------------
{7D5CF50E-F3C6-4333-BFE6-5A806F9EBA4E} Test Name Completed Test Path
{51837FDE-C290-408B-A847-B176DB184B89} Test Name Completed Test Path
{E7367B3D-07A2-4875-A190-C369B79E6F5B} Test Name Completed Test Path
{B186F2D0-3245-4AD1-A712-260906033E57} Test Name Completed Test Path
{2AA76541-A0DF-45EE-91F4-401F93FA88CD} Test Name Completed Test Path
PS > wingetdev configure list --history 7D5CF50E
Field         Value
----------------------------------------------------
Identifier    {7D5CF50E-F3C6-4333-BFE6-5A806F9EBA4E}
Name          Test Name
Origin        Test Origin
Path          Test Path
State         Completed
First Applied 2024-07-16 21:15:13.000
Apply Begun   2024-07-16 21:15:13.000
Apply Ended   2024-07-16 21:15:13.000

Unit                         State     Result
-------------------------------------------------
Module/Resource [Name]       Completed 0x00000000
Module/Resource2 [Name2]     Completed 0x00000000
Module2/Resource [Group]     Completed 0x00000000
|-Module3/Resource [Child1]  Completed 0x00000000
|-Module4/Resource2 [Child2] Completed 0x00000000
```
 
## Validation
Updated tests to check for status data.  Manually verified eventing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4647)