### PR TITLE
update curl vcpkg version to 8.8.0

### DIFF
--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "curl",
-      "version": "8.4.0"
+      "version": "8.8.0"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
Fixes a component issue with 8.4.0 by updating to latest version available

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4655)