### PR TITLE
Use ContinueWith rather than finally for coroutine result types

### DIFF
--- a/src/PowerShell/CommonFiles/PowerShellCmdlet.cs
+++ b/src/PowerShell/CommonFiles/PowerShellCmdlet.cs
@@ -97,11 +97,14 @@ namespace Microsoft.WinGet.Common.Command
                 this.Write(StreamType.Verbose, "Already running on MTA");
                 try
                 {
-                    return func();
+                    Task result = func();
+                    result.ContinueWith((task) => this.Complete(), TaskContinuationOptions.ExecuteSynchronously);
+                    return result;
                 }
-                finally
+                catch
                 {
                     this.Complete();
+                    throw;
                 }
             }
 
@@ -150,11 +153,14 @@ namespace Microsoft.WinGet.Common.Command
                 this.Write(StreamType.Verbose, "Already running on MTA");
                 try
                 {
-                    return func();
+                    Task<TResult> result = func();
+                    result.ContinueWith((task) => this.Complete(), TaskContinuationOptions.ExecuteSynchronously);
+                    return result;
                 }
-                finally
+                catch
                 {
                     this.Complete();
+                    throw;
                 }
             }
 


### PR DESCRIPTION
## Issue
When run in PowerShell with MTA (multi-threaded apartment) enabled, the `RunOnMTA` methods have an optimization to run directly rather than spinning up a new thread.  This optimization used a `finally` to call `Complete`, but a `Task` will be returned (and the finally executed) before the task is completed.  This resulted in a completed collection and errors when attempting to add more messages to it.

```
Invoke-WinGetConfiguration: The collection has been marked as complete with regards to additions.
```

## Change
Use `ContinueWith` and `ExecuteSynchronously` to effectively make a `finally` for the `Task` result object.  Convert the existing `finally` to only call `Complete` on exception.

## Validation
Manually confirmed the -MTA case with `Invoke` and `Start`/`Complete` command use cases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4669)