### PR TITLE
Skip uninstall attempt when installed package version is not present

### DIFF
--- a/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
@@ -206,6 +206,13 @@ namespace AppInstaller::CLI::Workflow
     void GetUninstallInfo(Execution::Context& context)
     {
         auto installedPackageVersion = context.Get<Execution::Data::InstalledPackageVersion>();
+
+        if (!installedPackageVersion)
+        {
+            AICLI_LOG(CLI, Verbose, << "No installed package version; cannot get uninstall information.");
+            return;
+        }
+
         const std::string installedTypeString = installedPackageVersion->GetMetadata()[PackageVersionMetadata::InstalledType];
         switch (ConvertToInstallerTypeEnum(installedTypeString))
         {
@@ -290,7 +297,15 @@ namespace AppInstaller::CLI::Workflow
 
     void ExecuteUninstaller(Execution::Context& context)
     {
-        const std::string installedTypeString = context.Get<Execution::Data::InstalledPackageVersion>()->GetMetadata()[PackageVersionMetadata::InstalledType];
+        auto installedPackageVersion = context.Get<Execution::Data::InstalledPackageVersion>();
+
+        if (!installedPackageVersion)
+        {
+            AICLI_LOG(CLI, Verbose, << "No installed package version; cannot uninstall.");
+            return;
+        }
+
+        const std::string installedTypeString = installedPackageVersion->GetMetadata()[PackageVersionMetadata::InstalledType];
         InstallerTypeEnum installerType = ConvertToInstallerTypeEnum(installedTypeString);
 
         Synchronization::CrossProcessInstallLock lock;

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -52,6 +52,9 @@
   <ItemGroup>
     <None Remove="TestData\Configuration\ShowDetails_TestRepo_0_3.yml" />
     <None Remove="TestData\Configuration\WithParameters_0_3.yml" />
+    <None Remove="TestData\Manifests\TestUpgradeAddsDependency.1.0.yaml" />
+    <None Remove="TestData\Manifests\TestUpgradeAddsDependency.2.0.yaml" />
+    <None Remove="TestData\Manifests\TestUpgradeAddsDependencyDependent.1.0.yaml" />
     <Content Include="..\..\doc\admx\DesktopAppInstaller.admx" Link="TestData\DesktopAppInstaller.admx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
+PackageVersion: 1.0
+PackageName: TestUpgradeAddsDependency
+PackageLocale: en-US
+Publisher: Microsoft
+License: Test
+ShortDescription: E2E test for adding a new package dependency during an upgrade.
+Installers:
+  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: <EXEHASH>
+    ProductCode: '{fda6c0e2-0977-482f-bda1-9bd025457b81}'
+    InstallerSwitches:
+      Custom: '/ProductID {fda6c0e2-0977-482f-bda1-9bd025457b81}'
+      InstallLocation: /InstallDir <INSTALLPATH>
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
@@ -1,7 +1,6 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
 PackageVersion: 1.0
 PackageName: TestUpgradeAddsDependency
-PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.1.0.yaml
@@ -1,11 +1,13 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
 PackageVersion: 1.0
 PackageName: TestUpgradeAddsDependency
+PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.
 Installers:
-  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+  - Architecture: x86
+    InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
     InstallerType: exe
     InstallerSha256: <EXEHASH>
     ProductCode: '{fda6c0e2-0977-482f-bda1-9bd025457b81}'

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
@@ -1,0 +1,20 @@
+PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
+PackageVersion: 2.0
+PackageName: TestUpgradeAddsDependency
+PackageLocale: en-US
+Publisher: Microsoft
+License: Test
+ShortDescription: E2E test for adding a new package dependency during an upgrade.
+Installers:
+  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: <EXEHASH>
+    ProductCode: '{fda6c0e2-0977-482f-bda1-9bd025457b81}'
+    InstallerSwitches:
+      Custom: '/ProductID {fda6c0e2-0977-482f-bda1-9bd025457b81}'
+      InstallLocation: /InstallDir <INSTALLPATH>
+    Dependencies:
+      PackageDependencies:
+      - PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependencyDependent
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
@@ -1,7 +1,6 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
 PackageVersion: 2.0
 PackageName: TestUpgradeAddsDependency
-PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependency.2.0.yaml
@@ -1,11 +1,13 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependency
 PackageVersion: 2.0
 PackageName: TestUpgradeAddsDependency
+PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.
 Installers:
-  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+  - Architecture: x86
+    InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
     InstallerType: exe
     InstallerSha256: <EXEHASH>
     ProductCode: '{fda6c0e2-0977-482f-bda1-9bd025457b81}'

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
@@ -1,0 +1,17 @@
+PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependencyDependent
+PackageVersion: 1.0
+PackageName: TestUpgradeAddsDependencyDependent
+PackageLocale: en-US
+Publisher: Microsoft
+License: Test
+ShortDescription: E2E test for adding a new package dependency during an upgrade.
+Installers:
+  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: <EXEHASH>
+    ProductCode: '{648274a3-17aa-4731-8bf1-5854ca61e475}'
+    InstallerSwitches:
+      Custom: '/ProductID {648274a3-17aa-4731-8bf1-5854ca61e475}'
+      InstallLocation: /InstallDir <INSTALLPATH>
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
@@ -1,7 +1,6 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependencyDependent
 PackageVersion: 1.0
 PackageName: TestUpgradeAddsDependencyDependent
-PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
@@ -9,6 +9,7 @@ Installers:
   - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
     InstallerType: exe
     InstallerSha256: <EXEHASH>
+    UpgradeBehavior: uninstallPrevious
     ProductCode: '{648274a3-17aa-4731-8bf1-5854ca61e475}'
     InstallerSwitches:
       Custom: '/ProductID {648274a3-17aa-4731-8bf1-5854ca61e475}'

--- a/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
+++ b/src/AppInstallerCLIE2ETests/TestData/Manifests/TestUpgradeAddsDependencyDependent.1.0.yaml
@@ -1,11 +1,13 @@
 PackageIdentifier: AppInstallerTest.TestUpgradeAddsDependencyDependent
 PackageVersion: 1.0
 PackageName: TestUpgradeAddsDependencyDependent
+PackageLocale: en-US
 Publisher: Microsoft
 License: Test
 ShortDescription: E2E test for adding a new package dependency during an upgrade.
 Installers:
-  - InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
+  - Architecture: x86
+    InstallerUrl: https://localhost:5001/TestKit/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.exe
     InstallerType: exe
     InstallerSha256: <EXEHASH>
     UpgradeBehavior: uninstallPrevious

--- a/src/AppInstallerCLIE2ETests/UpgradeCommand.cs
+++ b/src/AppInstallerCLIE2ETests/UpgradeCommand.cs
@@ -194,7 +194,7 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void UpgradeAddsDependency()
         {
-            var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestUpgradeAddsDependency -v 1.0");
+            var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestUpgradeAddsDependency -v 1.0 --verbose");
             Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
 
             result = TestCommon.RunAICLICommand("upgrade", $"AppInstallerTest.TestUpgradeAddsDependency");

--- a/src/AppInstallerCLIE2ETests/UpgradeCommand.cs
+++ b/src/AppInstallerCLIE2ETests/UpgradeCommand.cs
@@ -187,5 +187,18 @@ namespace AppInstallerCLIE2ETests
             Assert.True(result2.StdOut.Contains("Successfully installed"));
             TestCommon.VerifyPortablePackage(Path.Combine(installDir, packageDirName), commandAlias, fileName, productCode, true, TestCommon.Scope.User);
         }
+
+        /// <summary>
+        /// Test upgrade when a new dependency is added that is not installed.
+        /// </summary>
+        [Test]
+        public void UpgradeAddsDependency()
+        {
+            var result = TestCommon.RunAICLICommand("install", $"AppInstallerTest.TestUpgradeAddsDependency -v 1.0");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+
+            result = TestCommon.RunAICLICommand("upgrade", $"AppInstallerTest.TestUpgradeAddsDependency");
+            Assert.AreEqual(Constants.ErrorCode.S_OK, result.ExitCode);
+        }
     }
 }


### PR DESCRIPTION
## Issue
We are seeing crashes from the installed package version being null, but only during upgrades with a dependency when attempting to uninstall said dependency (either due to user request or manifest).

## Change
Simply exit the two workflow tasks involved with the uninstall if the installed package version is not present.

## Validation
Added a new test to exercise an upgrade that adds a dependency that is not installed and that dependency has `UpgradeBehavior: uninstallPrevious`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4685)