### PR TITLE
Send unit telemetry on success

### DIFF
--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTelemetryTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationProcessorTelemetryTests.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
 
             GetConfigurationUnitSettingsResult result = testObjects.Processor.GetUnitSettings(testObjects.Unit);
 
-            Assert.Empty(this.EventSink.Events);
+            Assert.Single(this.EventSink.Events);
+            Assert.Equal(TelemetryEvent.ConfigUnitRunName, this.EventSink.Events[0].Name);
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
+++ b/src/Microsoft.Management.Configuration/Telemetry/Telemetry.cpp
@@ -263,12 +263,12 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         std::string_view action,
         const IConfigurationUnitResultInformation& resultInformation) const noexcept try
     {
-        // We only want to send telemetry for failures of publicly available units.
-        if (!IsTelemetryEnabled() || SUCCEEDED(static_cast<int32_t>(resultInformation.ResultCode())))
+        if (!IsTelemetryEnabled())
         {
             return;
         }
 
+        // We only want to send telemetry for publicly available units.
         IConfigurationUnitProcessorDetails details = unit.Details();
         if (!details || !details.IsPublic())
         {


### PR DESCRIPTION
## Change
Write the `ConfigUnitRun` event on success as well, which helps us better understand the configuration units in use.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4720)