### PR TITLE
Pull in latest SFS client

### DIFF
--- a/src/SfsClient/readme.md
+++ b/src/SfsClient/readme.md
@@ -1,9 +1,9 @@
 ## SfsClient
 
-Do not change code under the sfs-client directory; it contains sfs-client source code from commit [6ab78af](https://github.com/microsoft/sfs-client/commits/6ab78af).  
+Do not change code under the sfs-client directory; it contains sfs-client source code from commit [be733af](https://github.com/microsoft/sfs-client/commits/be733af).  
 It is created using git subtree command:
 ```
-    git subtree add --prefix=src/SfsClient/sfs-client https://github.com/microsoft/sfs-client.git 6ab78af61bc859461ea8298786d87f24b49e3ec2 --squash
+    git subtree add --prefix=src/SfsClient/sfs-client https://github.com/microsoft/sfs-client.git be733af9e5c8e9227f2018ff618800bf08a31180 --squash
 ```
 
 ### Update

--- a/src/SfsClient/sfs-client/cgmanifest.json
+++ b/src/SfsClient/sfs-client/cgmanifest.json
@@ -37,7 +37,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/curl/curl",
-          "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+          "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
         }
       },
       "developmentDependency": false
@@ -56,7 +56,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+            "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
           }
         }
       ]
@@ -75,7 +75,7 @@
           "type": "git",
           "git": {
             "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
+            "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
           }
         }
       ]

--- a/src/SfsClient/sfs-client/vcpkg.json
+++ b/src/SfsClient/sfs-client/vcpkg.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "curl",
-      "version": "8.8.0"
+      "version": "8.9.1"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
Pulls in the latest commit from SFS client: be733af

Change includes an update to the curl vcpkg package from 8.8.0 to 8.9.1 to address a component governance issue.

https://github.com/advisories/GHSA-97c4-2w4v-c7r8

cURL / libcURL contains an out-of-bounds read flaw in the GTime2str() function in lib/vtls/x509asn1.c that is triggered when parsing a syntactically incorrect ASN.1 Generalized Time field. This may allow a context-dependent attacker to crash a process linked against the library or potentially disclose memory contents.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4725)