### PR TITLE
Generate Microsoft.WinGet.Client help docs in cmdlet output

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,6 +215,15 @@ jobs:
       TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Configuration\SharedDependencies\$(BuildPlatform)
       flattenFolders: true
 
+  - task: PowerShell@2
+    displayName: Generate Microsoft.WinGet.Client Help Documentation
+    pwsh: true
+    inputs:
+      targetType: 'inline'
+      script: |
+        Install-Module -Name PlatyPS -Force
+        New-ExternalHelp -Path '$(Build.SourcesDirectory)\src\PowerShell\Help\Microsoft.WinGet.Client' -OutputPath '$(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Client'
+
   - task: CopyFiles@2
     displayName: 'Copy PowerShell AnyCPU Module Files'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,9 +217,9 @@ jobs:
 
   - task: PowerShell@2
     displayName: Generate Microsoft.WinGet.Client Help Documentation
-    pwsh: true
     inputs:
-      targetType: 'inline'
+      pwsh: true
+      targetType: inline
       script: |
         Install-Module -Name platyPS -Force
         Import-Module platyPS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,16 +215,6 @@ jobs:
       TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Configuration\SharedDependencies\$(BuildPlatform)
       flattenFolders: true
 
-  - task: PowerShell@2
-    displayName: Generate Microsoft.WinGet.Client Help Documentation
-    inputs:
-      pwsh: true
-      targetType: inline
-      script: |
-        Install-Module -Name platyPS -Force
-        Import-Module platyPS
-        New-ExternalHelp -Path '$(Build.SourcesDirectory)\src\PowerShell\Help\Microsoft.WinGet.Client' -OutputPath '$(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Client'
-
   - task: CopyFiles@2
     displayName: 'Copy PowerShell AnyCPU Module Files'
     inputs:
@@ -552,6 +542,16 @@ jobs:
       SourceFolder: '$(Pipeline.Workspace)\Build.x86release\PowerShell'
       Contents: '**\*'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PowerShell@2
+    displayName: Generate Microsoft.WinGet.Client Help Documentation
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        Install-Module -Name platyPS -Force
+        Import-Module platyPS
+        New-ExternalHelp -Path '$(Build.SourcesDirectory)\src\PowerShell\Help\Microsoft.WinGet.Client' -OutputPath '$(Build.ArtifactStagingDirectory)\Microsoft.WinGet.Client'
 
   - task: CopyFiles@2
     displayName: 'Copy Microsoft.WinGet.DSC module to staging directory'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,7 +221,8 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        Install-Module -Name PlatyPS -Force
+        Install-Module -Name platyPS -Force
+        Import-Module platyPS
         New-ExternalHelp -Path '$(Build.SourcesDirectory)\src\PowerShell\Help\Microsoft.WinGet.Client' -OutputPath '$(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Client'
 
   - task: CopyFiles@2

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Disable-WinGetSetting.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Disable-WinGetSetting.md
@@ -30,7 +30,6 @@ This command support the following administrative settings:
 - InstallerHashOverride
 - LocalArchiveMalwareScanOverride
 - ProxyCommandLineOptions
-- DefaultProxy
 
 Administrative settings are disabled by default. Administrative settings can also be managed using
 Group Policy objects.


### PR DESCRIPTION
Builds the help doc xml and includes it in the Microsoft.WinGet.Client powershell module. 

`New-ExternalHelp` cmdlet does verify if the docs are formatted correctly so this is more of a sanity check. Will update AppInstaller pipeline to do the same before publishing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4731)