### PR TITLE
Fix Reset-WinGetSource behavior

### DIFF
--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Assert-WinGetPackageManager.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Assert-WinGetPackageManager.md
@@ -23,7 +23,7 @@ Assert-WinGetPackageManager [-Version <String>] [<CommonParameters>]
 ### IntegrityLatestSet
 
 ```
-Assert-WinGetPackageManager [-Latest] [-IncludePreRelease] [<CommonParameters>]
+Assert-WinGetPackageManager [-Latest] [-IncludePrerelease] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
@@ -17,13 +17,13 @@ Resets WinGet sources.
 ### DefaultSet (Default)
 
 ```
-Reset-WinGetSource [-Name <String>] [<CommonParameters>]
+Reset-WinGetSource -Name <String> [<CommonParameters>]
 ```
 
 ### OptionalSet
 
 ```
-Reset-WinGetSource [-All] [<CommonParameters>]
+Reset-WinGetSource -All [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
@@ -10,30 +10,30 @@ title: Reset-WinGetSource
 # Reset-WinGetSource
 
 ## SYNOPSIS
-Resets default WinGet sources.
+Resets WinGet sources.
 
 ## SYNTAX
+
+### DefaultSet (Default)
 
 ```
 Reset-WinGetSource [-Name <String>] [<CommonParameters>]
 ```
 
+### OptionalSet
+
+```
+Reset-WinGetSource [-All] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
-Resets the current WinGet sources to the default source configurations. If a source name is specified, that named source is removed. This command must be
-executed with administrator permissions.
+Resets a named WinGet source by removing the source configuration. You can reset all configured sources and add the default source configurations using the **All** switch parameter.
+This command must be executed with administrator permissions.
 
 ## EXAMPLES
 
-### Example 1: Reset to default sources
-
-```powershell
-Reset-WinGetSource
-```
-
-This example removes all sources and adds the default sources.
-
-### Example 2: Reset the msstore source
+### Example 1: Reset the msstore source
 
 ```powershell
 Reset-WinGetSource -Name msstore
@@ -41,7 +41,31 @@ Reset-WinGetSource -Name msstore
 
 This example resets the configured source named 'msstore' by removing it.
 
+### Example 2: Reset all sources
+
+```powershell
+Reset-WinGetSource -All
+```
+
+This example resets all configured sources and adds the default sources.
+
 ## PARAMETERS
+
+### -All
+
+Reset all sources and add the default sources.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (OptionalSet)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
 
 ### -Name
 
@@ -49,10 +73,10 @@ The name of the source.
 
 ```yaml
 Type: System.String
-Parameter Sets: (All)
+Parameter Sets: (DefaultSet)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Reset-WinGetSource.md
@@ -15,17 +15,25 @@ Resets default WinGet sources.
 ## SYNTAX
 
 ```
-Reset-WinGetSource -Name <String> [<CommonParameters>]
+Reset-WinGetSource [-Name <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Resets the current WinGet sources to the default source configurations. This command must be
+Resets the current WinGet sources to the default source configurations. If a source name is specified, that named source is removed. This command must be
 executed with administrator permissions.
 
 ## EXAMPLES
 
-### Example 1: Reset the msstore source
+### Example 1: Reset to default sources
+
+```powershell
+Reset-WinGetSource
+```
+
+This example removes all sources and adds the default sources.
+
+### Example 2: Reset the msstore source
 
 ```powershell
 Reset-WinGetSource -Name msstore
@@ -44,7 +52,7 @@ Type: System.String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AssertWinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AssertWinGetPackageManagerCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AssertWinGetPackageManagerCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -29,7 +29,7 @@ namespace Microsoft.WinGet.Client.Commands
             var command = new WinGetPackageManagerCommand(this);
             if (this.ParameterSetName == Constants.IntegrityLatestSet)
             {
-                command.AssertUsingLatest(this.IncludePreRelease.ToBool());
+                command.AssertUsingLatest(this.IncludePrerelease.ToBool());
             }
             else
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/WinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/WinGetPackageManagerCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetPackageManagerCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -36,6 +36,6 @@ namespace Microsoft.WinGet.Client.Commands.Common
         [Parameter(
             ParameterSetName = Constants.IntegrityLatestSet,
             ValueFromPipelineByPropertyName = true)]
-        public SwitchParameter IncludePreRelease { get; set; }
+        public SwitchParameter IncludePrerelease { get; set; }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RemoveSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RemoveSourceCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="RemoveSourceCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -20,6 +20,7 @@ namespace Microsoft.WinGet.Client.Cmdlets
         /// Gets or sets the name of the source to remove.
         /// </summary>
         [Parameter(
+            Position = 0,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RepairWinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RepairWinGetPackageManagerCmdlet.cs
@@ -44,7 +44,7 @@ namespace Microsoft.WinGet.Client.Commands
             this.command = new WinGetPackageManagerCommand(this);
             if (this.ParameterSetName == Constants.IntegrityLatestSet)
             {
-                this.command.RepairUsingLatest(this.IncludePreRelease.ToBool(), this.AllUsers.ToBool(), this.Force.ToBool());
+                this.command.RepairUsingLatest(this.IncludePrerelease.ToBool(), this.AllUsers.ToBool(), this.Force.ToBool());
             }
             else
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
@@ -20,6 +20,7 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         /// Gets or sets the name of the source to reset.
         /// </summary>
         [Parameter(
+            Position = 0,
             Mandatory = true,
             ParameterSetName = Constants.DefaultSet,
             ValueFromPipeline = true,

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
@@ -13,17 +13,24 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
     /// <summary>
     /// Resets a source. Requires admin.
     /// </summary>
-    [Cmdlet(VerbsCommon.Reset, Constants.WinGetNouns.Source)]
+    [Cmdlet(VerbsCommon.Reset, Constants.WinGetNouns.Source, DefaultParameterSetName = Constants.DefaultSet)]
     public sealed class ResetSourceCmdlet : PSCmdlet
     {
         /// <summary>
         /// Gets or sets the name of the source to reset.
         /// </summary>
         [Parameter(
-            Mandatory = false,
+            Mandatory = true,
+            ParameterSetName = Constants.DefaultSet,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to reset all sources.
+        /// </summary>
+        [Parameter(ParameterSetName = Constants.OptionalSet, ValueFromPipelineByPropertyName = true)]
+        public SwitchParameter All { get; set; }
 
         /// <summary>
         /// Resets source.
@@ -36,9 +43,9 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             {
                 command.ResetSourceByName(this.Name);
             }
-            else
+            else if (this.All)
             {
-                command.ResetSources();
+                command.ResetAllSources();
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ResetSourceCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -20,7 +20,7 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         /// Gets or sets the name of the source to reset.
         /// </summary>
         [Parameter(
-            Mandatory = true,
+            Mandatory = false,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         public string Name { get; set; }
@@ -31,7 +31,15 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         protected override void ProcessRecord()
         {
             var command = new CliCommand(this);
-            command.ResetSource(this.Name);
+
+            if (!string.IsNullOrEmpty(this.Name))
+            {
+                command.ResetSourceByName(this.Name);
+            }
+            else
+            {
+                command.ResetSources();
+            }
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Common/Constants.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="Constants.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -31,6 +31,16 @@ namespace Microsoft.WinGet.Client.Common
         /// needs to be found by searching a package source.
         /// </summary>
         public const string FoundSet = "FoundSet";
+
+        /// <summary>
+        /// This parameter set indicates the default parameters associated with a cmdlet.
+        /// </summary>
+        public const string DefaultSet = "DefaultSet";
+
+        /// <summary>
+        ///  This parameter set indicates the optional parameters associated with a cmdlet.
+        /// </summary>
+        public const string OptionalSet = "OptionalSet";
 
         /// <summary>
         /// Parameter set for an specific version parameter.

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- If these target frameworks are updated, make sure to also update the .psd1 and .nuspec files.-->

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
@@ -106,7 +106,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <summary>
         /// Resets all sources and adds the defaults.
         /// </summary>
-        public void ResetSources()
+        public void ResetAllSources()
         {
             Utilities.VerifyAdmin();
             _ = this.Run("source", $"reset --force");

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="CliCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -94,13 +94,22 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         }
 
         /// <summary>
-        /// Resets source.
+        /// Resets a source.
         /// </summary>
         /// <param name="name">Name of source.</param>
-        public void ResetSource(string name)
+        public void ResetSourceByName(string name)
         {
             Utilities.VerifyAdmin();
             _ = this.Run("source", $"reset --name {name} --force");
+        }
+
+        /// <summary>
+        /// Resets all sources and adds the defaults.
+        /// </summary>
+        public void ResetSources()
+        {
+            Utilities.VerifyAdmin();
+            _ = this.Run("source", $"reset --force");
         }
 
         private WinGetCLICommandResult Run(string command, string parameters, int timeOut = 60000)

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/GitHubClient.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/GitHubClient.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="GitHubClient.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -43,24 +43,24 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// <summary>
         /// Gets the latest released and waits.
         /// </summary>
-        /// <param name="includePreRelease">Include prerelease.</param>
+        /// <param name="includePrerelease">Include prerelease.</param>
         /// <returns>Latest version.</returns>
-        public async Task<string> GetLatestReleaseTagNameAsync(bool includePreRelease)
+        public async Task<string> GetLatestReleaseTagNameAsync(bool includePrerelease)
         {
-            return (await this.GetLatestReleaseAsync(includePreRelease)).TagName;
+            return (await this.GetLatestReleaseAsync(includePrerelease)).TagName;
         }
 
         /// <summary>
         /// Gets the latest released version.
         /// </summary>
-        /// <param name="includePreRelease">Include prerelease.</param>
+        /// <param name="includePrerelease">Include prerelease.</param>
         /// <returns>Latest version.</returns>
-        public async Task<Release> GetLatestReleaseAsync(bool includePreRelease)
+        public async Task<Release> GetLatestReleaseAsync(bool includePrerelease)
         {
             Release release;
 
             // GetLatest doesn't respect prerelease or gives an option to get it.
-            if (includePreRelease)
+            if (includePrerelease)
             {
                 // GetAll orders by newest and includes pre releases.
                 release = (await this.gitHubClient.Repository.Release.GetAll(this.owner, this.repo))[0];

--- a/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psm1
+++ b/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psm1
@@ -366,7 +366,7 @@ class WinGetPackageManager
             } elseif ($this.UseLatestPreRelease)
             {
                 $hashArgs.Add("Latest", $true)
-                $hashArgs.Add("IncludePreRelease", $true)
+                $hashArgs.Add("IncludePrerelease", $true)
             } elseif (-not [string]::IsNullOrWhiteSpace($this.Version))
             {
                 $hashArgs.Add("Version", $this.Version)
@@ -398,7 +398,7 @@ class WinGetPackageManager
             } elseif ($this.UseLatestPreRelease)
             {
                 $hashArgs.Add("Latest", $true)
-                $hashArgs.Add("IncludePreRelease", $true)
+                $hashArgs.Add("IncludePrerelease", $true)
             } elseif (-not [string]::IsNullOrWhiteSpace($this.Version))
             {
                 $hashArgs.Add("Version", $this.Version)

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -136,6 +136,21 @@ Describe 'Get-WinGetVersion' {
     }
 }
 
+Describe 'Reset-WinGetSource' {
+    BeforeAll {
+        AddTestSource
+    }
+
+    # Requires admin
+    It 'Resets all sources' {
+        Reset-WinGetSource
+    }
+
+    It 'Test source should be removed' {
+        { Get-WinGetSource -Name 'TestSource' } | Should -Throw
+    }
+}
+
 Describe 'Get|Add|Reset-WinGetSource' {
 
     BeforeAll {

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -143,7 +143,7 @@ Describe 'Reset-WinGetSource' {
 
     # Requires admin
     It 'Resets all sources' {
-        Reset-WinGetSource
+        Reset-WinGetSource -All
     }
 
     It 'Test source should be removed' {


### PR DESCRIPTION
Issue:

Reset-WinGetSource required a name which does not match the current behavior of `winget source reset`. 

Changes:
- Added '-All' parameter so that Reset-WinGetsource will reset all sources. I also created two separate parameter sets so that they can only be used separately.
- Made the '-Name' parameter also positional=0 for Reset-WinGetsource and Remove-WinGetsource (recommended by PowerShell docs team)
- Fixed the naming of PreRelease -> Prerelease as recommended by PowerShell docs team
- 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4732)