### PR TITLE
Update curl to 8.9.1

### DIFF
--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "curl",
-      "version": "8.8.0"
+      "version": "8.9.1"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
Forgot to update our own vcpkg.json with the updated curl package 8.9.1

Related to: #4725 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4745)