### PR TITLE
External HR error message support

### DIFF
--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3106,4 +3106,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="ConfigureListUnit" xml:space="preserve">
     <value>Unit</value>
   </data>
+  <data name="StoreInstall_PackageNotAvailableForCurrentSystem" xml:space="preserve">
+    <value>The package is not compatible with the current Windows version or platform.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #3982 

## Change
Add support for externally defined HRESULTs to have a custom message.  Use this to provide a message for the errors associated with a Microsoft Store package being unavailable for the current system.

## Validation
Manually confirmed that `GetUserPresentableMessageForHR` will get the intended message.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4746)