### PR TITLE
Add pwsh support for trust level and explicit

### DIFF
--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -2874,7 +2874,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="SettingsSetCommandShortDescription" xml:space="preserve">
     <value>Sets the value of an admin setting.</value>
   </data>
-  <data name="SourceRequireExplicitArgumentDescription" xml:space="preserve">
+  <data name="SourceExplicitArgumentDescription" xml:space="preserve">
     <value>Excludes a source from discovery unless specified</value>
   </data>
   <data name="SourceListExplicit" xml:space="preserve">

--- a/src/Microsoft.Management.Deployment/PackageCatalogInfo.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogInfo.cpp
@@ -59,4 +59,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             return PackageCatalogTrustLevel::None;
         }
     }
+    bool PackageCatalogInfo::Explicit()
+    {
+        return m_sourceDetails.Explicit;
+    }
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalogInfo.h
+++ b/src/Microsoft.Management.Deployment/PackageCatalogInfo.h
@@ -22,6 +22,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Windows::Foundation::DateTime LastUpdateTime();
         winrt::Microsoft::Management::Deployment::PackageCatalogOrigin Origin();
         winrt::Microsoft::Management::Deployment::PackageCatalogTrustLevel TrustLevel();
+        bool Explicit();
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Management.Deployment
 {
-    [contractversion(10)]
+    [contractversion(11)] // For version 1.9
     apicontract WindowsPackageManagerContract{};
 
     /// State of the install
@@ -263,7 +263,7 @@ namespace Microsoft.Management.Deployment
         /// The trust level of the package catalog
         PackageCatalogTrustLevel TrustLevel { get; };
 
-        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 10)]
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 11)]
         {
             /// Excludes a source from discovery unless specified.
             Boolean Explicit{ get; };

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -262,6 +262,12 @@ namespace Microsoft.Management.Deployment
         PackageCatalogOrigin Origin { get; };
         /// The trust level of the package catalog
         PackageCatalogTrustLevel TrustLevel { get; };
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 10)]
+        {
+            /// Excludes a source from discovery unless specified.
+            Boolean Explicit{ get; };
+        }
     }
 
     /// A metadata item of a package version.

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Add-WinGetSource.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Add-WinGetSource.md
@@ -15,7 +15,7 @@ Adds a new source.
 ## SYNTAX
 
 ```
-Add-WinGetSource -Name <String> -Argument <String> [-Type <String>] [<CommonParameters>]
+Add-WinGetSource -Name <String> -Argument <String> [-Type <String>] [-TrustLevel {Default | None | Trusted}] [-Explicit] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -65,6 +65,42 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Explicit
+
+Excludes a source from discovery unless specified.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -TrustLevel
+
+Specify the trust level of the WinGet source. The parameter accepts the following values:
+
+- `None`
+- `Trusted`
+
+```yaml
+Type: Microsoft.WinGet.Client.PSObjects.PSSourceTrustLevel
+Parameter Sets: (All)
+Aliases:
+Accepted values: ENone, Trusted
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Add-WinGetSource.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Add-WinGetSource.md
@@ -95,7 +95,7 @@ Specify the trust level of the WinGet source. The parameter accepts the followin
 Type: Microsoft.WinGet.Client.PSObjects.PSSourceTrustLevel
 Parameter Sets: (All)
 Aliases:
-Accepted values: ENone, Trusted
+Accepted values: None, Trusted
 
 Required: False
 Position: Named

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
@@ -46,7 +46,7 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         /// <summary>
         /// Gets or sets the trust level of the source to add.
         /// </summary>
-        [Parameter(ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ValueFromPipelineByPropertyName = true)]
         public PSSourceTrustLevel TrustLevel { get; set; } = PSSourceTrustLevel.Default;
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
@@ -65,20 +65,10 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             command.AddSource(this.Name, this.Argument, this.Type, this.ConvertPSSourceTrustLevelToString(this.TrustLevel), this.Explicit.ToBool());
         }
 
-        private string ConvertPSSourceTrustLevelToString(PSSourceTrustLevel trustLevel)
+        private string ConvertPSSourceTrustLevelToString(PSSourceTrustLevel trustLevel) => trustLevel switch
         {
-            string trustLevelString = string.Empty;
-            switch (trustLevel)
-            {
-                case PSSourceTrustLevel.None:
-                    trustLevelString = "None";
-                    break;
-                case PSSourceTrustLevel.Trusted:
-                    trustLevelString = "Trusted";
-                    break;
-            }
-
-            return trustLevelString;
-        }
+            PSSourceTrustLevel.Default => string.Empty,
+            _ => trustLevel.ToString(),
+        };
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="AddSourceCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -7,6 +7,7 @@
 namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
 {
     using System.Management.Automation;
+    using Microsoft.WinGet.Client.Cmdlets.PSObjects;
     using Microsoft.WinGet.Client.Common;
     using Microsoft.WinGet.Client.Engine.Commands;
 
@@ -43,12 +44,41 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or sets the trust level of the source to add.
+        /// </summary>
+        [Parameter(ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        public PSSourceTrustLevel TrustLevel { get; set; } = PSSourceTrustLevel.Default;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the source to add is explicit.
+        /// </summary>
+        ///
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public SwitchParameter Explicit { get; set; }
+
+        /// <summary>
         /// Adds source.
         /// </summary>
         protected override void ProcessRecord()
         {
             var command = new CliCommand(this);
-            command.AddSource(this.Name, this.Argument, this.Type);
+            command.AddSource(this.Name, this.Argument, this.Type, this.ConvertPSSourceTrustLevelToString(this.TrustLevel), this.Explicit.ToBool());
+        }
+
+        private string ConvertPSSourceTrustLevelToString(PSSourceTrustLevel trustLevel)
+        {
+            string trustLevelString = string.Empty;
+            switch (trustLevel)
+            {
+                case PSSourceTrustLevel.None:
+                    trustLevelString = "None";
+                    break;
+                case PSSourceTrustLevel.Trusted:
+                    trustLevelString = "Trusted";
+                    break;
+            }
+
+            return trustLevelString;
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/PSObjects/PSSourceTrustLevel.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/PSObjects/PSSourceTrustLevel.cs
@@ -1,0 +1,29 @@
+// -----------------------------------------------------------------------------
+// <copyright file="PSSourceTrustLevel.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGet.Client.Cmdlets.PSObjects
+{
+    /// <summary>
+    /// This is the powershell argument equivalent of AppInstaller::Repository::SourceTrustLevel.
+    /// </summary>
+    public enum PSSourceTrustLevel
+    {
+        /// <summary>
+        /// Let winget decide.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// None.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Trusted.
+        /// </summary>
+        Trusted,
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public void EnableSetting(string name)
         {
             Utilities.VerifyAdmin();
-            _ = this.Run("settings", $"--enable {name}");
+            _ = this.Run("settings", $"--enable \"{name}\"");
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public void DisableSetting(string name)
         {
             Utilities.VerifyAdmin();
-            _ = this.Run("settings", $"--disable {name}");
+            _ = this.Run("settings", $"--disable \"{name}\"");
         }
 
         /// <summary>
@@ -75,20 +75,16 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public void AddSource(string name, string arg, string type, string trustLevel, bool isExplicit)
         {
             Utilities.VerifyAdmin();
-            string parameters = string.Empty;
+            string parameters = $"add --name \"{name}\" --arg \"{arg}\"";
 
-            if (string.IsNullOrEmpty(type))
+            if (!string.IsNullOrEmpty(type))
             {
-                parameters = $"add --name {name} --arg {arg}";
-            }
-            else
-            {
-                parameters = $"add --name {name} --arg {arg} --type {type}";
+                parameters += $" --type \"{type}\"";
             }
 
             if (!string.IsNullOrEmpty(trustLevel))
             {
-                parameters += $" --trust-level {trustLevel}";
+                parameters += $" --trust-level \"{trustLevel}\"";
             }
 
             if (isExplicit)
@@ -106,7 +102,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public void RemoveSource(string name)
         {
             Utilities.VerifyAdmin();
-            _ = this.Run("source", $"remove --name {name}");
+            _ = this.Run("source", $"remove --name \"{name}\"");
         }
 
         /// <summary>
@@ -116,7 +112,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         public void ResetSourceByName(string name)
         {
             Utilities.VerifyAdmin();
-            _ = this.Run("source", $"reset --name {name} --force");
+            _ = this.Run("source", $"reset --name \"{name}\" --force");
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
@@ -70,17 +70,33 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="name">Name of source.</param>
         /// <param name="arg">Arg of source.</param>
         /// <param name="type">Type of source.</param>
-        public void AddSource(string name, string arg, string type)
+        /// <param name="trustLevel">Trust level of source.</param>
+        /// <param name="isExplicit">Make source explicit.</param>
+        public void AddSource(string name, string arg, string type, string trustLevel, bool isExplicit)
         {
             Utilities.VerifyAdmin();
+            string parameters = string.Empty;
+
             if (string.IsNullOrEmpty(type))
             {
-                _ = this.Run("source", $"add --name {name} --arg {arg}", 300000);
+                parameters = $"add --name {name} --arg {arg}";
             }
             else
             {
-                _ = this.Run("source", $"add --name {name} --arg {arg} --type {type}", 300000);
+                parameters = $"add --name {name} --arg {arg} --type {type}";
             }
+
+            if (!string.IsNullOrEmpty(trustLevel))
+            {
+                parameters += $" --trust-level {trustLevel}";
+            }
+
+            if (isExplicit)
+            {
+                parameters += " --explicit";
+            }
+
+            _ = this.Run("source", parameters, 300000);
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSSourceResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSSourceResult.cs
@@ -41,7 +41,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         public string Type { get; private set; }
 
         /// <summary>
-        /// Gets the 
+        /// Gets the trust level of the source.
         /// </summary>
         public string TrustLevel { get; private set; }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSSourceResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSSourceResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="PSSourceResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -6,8 +6,6 @@
 
 namespace Microsoft.WinGet.Client.Engine.PSObjects
 {
-    using System.Management.Automation;
-
     /// <summary>
     /// SourceResult wrapper object for displaying to PowerShell.
     /// </summary>
@@ -23,6 +21,8 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
             this.Name = info.Name;
             this.Argument = info.Argument;
             this.Type = info.Type;
+            this.TrustLevel = info.TrustLevel.ToString();
+            this.Explicit = info.Explicit;
         }
 
         /// <summary>
@@ -39,5 +39,15 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         /// Gets the type of the source.
         /// </summary>
         public string Type { get; private set; }
+
+        /// <summary>
+        /// Gets the 
+        /// </summary>
+        public string TrustLevel { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the source must be explicitly specified for discovery.
+        /// </summary>
+        public bool Explicit { get; private set; }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
+++ b/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Format.ps1xml
@@ -283,6 +283,12 @@
           <TableColumnHeader>
             <Label>Type</Label>
           </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>TrustLevel</Label>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Explicit</Label>
+          </TableColumnHeader>          
         </TableHeaders>
         <TableRowEntries>
           <TableRowEntry>
@@ -295,6 +301,12 @@
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>$_.Type</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.TrustLevel</ScriptBlock>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>$_.Explicit</ScriptBlock>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -42,10 +42,7 @@ BeforeAll {
             Get-WinGetSource -Name 'TestSource'
         }
         catch {
-            # TODO: Add-WinGetSource does not support setting trust level yet.
-            # Add-WinGetSource -Name 'TestSource' -Arg 'https://localhost:5001/TestKit/'
-            $sourceAddCommand = "${wingetExeName} source add TestSource https://localhost:5001/TestKit/ --trust-level trusted"
-            Invoke-Expression -Command $sourceAddCommand
+            Add-WinGetSource -Name 'TestSource' -Arg 'https://localhost:5001/TestKit/' -TrustLevel 'Trusted'
         }
     }
 
@@ -154,7 +151,7 @@ Describe 'Reset-WinGetSource' {
 Describe 'Get|Add|Reset-WinGetSource' {
 
     BeforeAll {
-        AddTestSource
+        Add-WinGetSource -Name 'TestSource' -Arg 'https://localhost:5001/TestKit/' -TrustLevel 'Trusted' -Explicit
     }
 
     It 'Get Test source' {
@@ -164,6 +161,8 @@ Describe 'Get|Add|Reset-WinGetSource' {
         $source.Name | Should -Be 'TestSource'
         $source.Argument | Should -Be 'https://localhost:5001/TestKit/'
         $source.Type | Should -Be 'Microsoft.PreIndexed.Package'
+        $source.TrustLevel | Should -Be 'Trusted'
+        $source.Explicit | Should -Be $true
     }
 
     It 'Get fake source' {


### PR DESCRIPTION
Adds support for `-TrustLevel` and `-Explicit`. 

The pwsh tests can now use the Add-winGetsource cmdlet to modify the trust level. 

Updated Get-WinGetsource to report the TrustLevel and Explicit flag.

Updated tests and docs to reflect these changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4750)