### PR TITLE
Allow for smaller configuration outputs

### DIFF
--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -204,7 +204,7 @@ namespace AppInstaller::CLI
         case Execution::Args::Type::ConfigurationAcceptWarning:
             return { type, "accept-configuration-agreements"_liv };
         case Execution::Args::Type::ConfigurationSuppressPrologue:
-            return { type, "suppress-prologue"_liv };
+            return { type, "suppress-initial-details"_liv };
         case Execution::Args::Type::ConfigurationEnable:
             return { type, "enable"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::StubType };
         case Execution::Args::Type::ConfigurationDisable:

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -203,6 +203,8 @@ namespace AppInstaller::CLI
             return { type, "file"_liv, 'f', ArgTypeCategory::ConfigurationSetChoice, ArgTypeExclusiveSet::ConfigurationSetChoice };
         case Execution::Args::Type::ConfigurationAcceptWarning:
             return { type, "accept-configuration-agreements"_liv };
+        case Execution::Args::Type::ConfigurationSuppressPrologue:
+            return { type, "suppress-prologue"_liv };
         case Execution::Args::Type::ConfigurationEnable:
             return { type, "enable"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::StubType };
         case Execution::Args::Type::ConfigurationDisable:

--- a/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
@@ -39,6 +39,7 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath, ArgumentType::Positional },
             Argument{ Execution::Args::Type::ConfigurationHistoryItem, Resource::String::ConfigurationHistoryItemArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationAcceptWarning, Resource::String::ConfigurationAcceptWarningArgumentDescription, ArgumentType::Flag },
+            Argument{ Execution::Args::Type::ConfigurationSuppressPrologue, Resource::String::ConfigurationSuppressPrologueArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationEnable, Resource::String::ConfigurationEnableMessage, ArgumentType::Flag, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationDisable, Resource::String::ConfigurationDisableMessage, ArgumentType::Flag, Argument::Visibility::Help },
         };

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -124,6 +124,7 @@ namespace AppInstaller::CLI::Execution
             // Configuration
             ConfigurationFile,
             ConfigurationAcceptWarning,
+            ConfigurationSuppressPrologue,
             ConfigurationEnable,
             ConfigurationDisable,
             ConfigurationModulePath,

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -106,6 +106,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSettings);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationStatusWatchArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSuccessfullyApplied);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationSuppressPrologueArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnexpectedTestResult);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitAssertHadNegativeResult);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationUnitFailed);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3110,6 +3110,6 @@ Please specify one of them using the --source option to proceed.</value>
     <value>The package is not compatible with the current Windows version or platform.</value>
   </data>
   <data name="ConfigurationSuppressPrologueArgumentDescription" xml:space="preserve">
-    <value>Suppress the configuration prologue when possible</value>
+    <value>Suppress showing initial configuration details when possible</value>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3109,4 +3109,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="StoreInstall_PackageNotAvailableForCurrentSystem" xml:space="preserve">
     <value>The package is not compatible with the current Windows version or platform.</value>
   </data>
+  <data name="ConfigurationSuppressPrologueArgumentDescription" xml:space="preserve">
+    <value>Suppress the configuration prologue when possible</value>
+  </data>
 </root>

--- a/src/ConfigurationRemotingServer/Program.cs
+++ b/src/ConfigurationRemotingServer/Program.cs
@@ -70,6 +70,9 @@ namespace ConfigurationRemotingServer
 
         static int Main(string[] args)
         {
+            // Remove any attached console to prevent modules (or their actions) from writing to our console.
+            FreeConsole();
+
             // Help find WindowsPackageManager.dll
             AssemblyLoadContext.Default.ResolvingUnmanagedDll += NativeAssemblyLoadContext.ResolvingUnmanagedHandler;
 
@@ -196,5 +199,9 @@ namespace ConfigurationRemotingServer
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         private static extern IntPtr GetCommandLineW();
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FreeConsole();
     }
 }


### PR DESCRIPTION
## Change
To prevent anything from outputting to our console, call `FreeConsole` in the configuration server.

To allow for output of primarily results, when `--accept-configuration-agreements` is passed, one can now also pass `--suppress-prologue` to prevent the initial details from being presented.  The only output (beyond the temporary progress spinner+text) will then be the disclaimer warning and the individual results.

## Validation
Confirmed that both changes work manually.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4754)