### PR TITLE
Update build status badge

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -368,6 +368,7 @@ oop
 opensource
 OPTOUT
 osfhandle
+oss
 outfile
 OUTOFMEMORY
 Outptr

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can also [build the client yourself](#building-the-client). While the client
 
 ## Build Status
 
-[![Build Status](https://dev.azure.com/shine-oss/winget-cli/_apis/build/status%2Fwinget-cli%20Build_Test?branchName=master)](https://dev.azure.com/shine-oss/winget-cli/_build/latest?definitionId=10&branchName=master)
+[![Build Status](https://dev.azure.com/shine-oss/winget-cli/_apis/build/status/winget-cli%20Build_Test?branchName=master&label=Main%20Branch%20(Including%20PRs))](https://dev.azure.com/shine-oss/winget-cli/_build/latest?definitionId=10&branchName=master)
 
 ## Windows Package Manager Release Roadmap
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can also [build the client yourself](#building-the-client). While the client
 
 ## Build Status
 
-[![Build Status](https://dev.azure.com/ms/winget-cli/_apis/build/status/microsoft.winget-cli?branchName=master)](https://dev.azure.com/ms/winget-cli/_build/latest?definitionId=344&branchName=master)
+[![Build Status](https://dev.azure.com/shine-oss/winget-cli/_apis/build/status%2Fwinget-cli%20Build_Test?branchName=master)](https://dev.azure.com/shine-oss/winget-cli/_build/latest?definitionId=10&branchName=master)
 
 ## Windows Package Manager Release Roadmap
 


### PR DESCRIPTION
## Change
We moved our pipelines to a new ADO organization; this moves the status badge to point to it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4758)