### PR TITLE
Run test tasks if succeededOrFailed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ pr:
   paths:
     include:
     - azure-pipelines.yml
+    - templates/*
     - src/*
     - schemas/JSON/manifests/*
 

--- a/templates/e2e-setup.yml
+++ b/templates/e2e-setup.yml
@@ -31,6 +31,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=TestSigningCert.CerPath;]$certCerPath"
       Write-Host "##vso[task.setvariable variable=TestSigningCert.Password;]$certPassword"
     displayName: Create test codesigning cert
+    condition: succeededOrFailed()
 
   - pwsh: |
       $httpsCertPath = Join-Path $(Agent.TempDirectory) HttpsCert.pfx
@@ -43,12 +44,15 @@ steps:
       Write-Host "##vso[task.setvariable variable=HttpsCert.Path;]$httpsCertPath"
       Write-Host "##vso[task.setvariable variable=HttpsCert.Password;]$httpsCertPassword"
     displayName: Create and install localhost HTTPS cert
+    condition: succeededOrFailed()
 
   - pwsh: ${{ parameters.sourceDir }}\src\LocalhostWebServer\Run-LocalhostWebServer.ps1 -CertPath $(HttpsCert.Path) -CertPassword $(HttpsCert.Password) -OutCertFile $(Agent.TempDirectory)\servercert.cer ${{ parameters.localhostWebServerArgs }}
     displayName: Launch LocalhostWebServer
+    condition: succeededOrFailed()
 
   - task: PowerShell@2
     displayName: Setup Local PS Repository
+    condition: succeededOrFailed()
     inputs:
       filePath: '${{ parameters.sourceDir }}\src\AppInstallerCLIE2ETests\TestData\Configuration\Init-TestRepository.ps1'
       arguments: '-Force'

--- a/templates/e2e-test.template.yml
+++ b/templates/e2e-test.template.yml
@@ -18,6 +18,7 @@ steps:
 
   - task: VSTest@2
     displayName: Run ${{ parameters.title }}
+    condition: succeededOrFailed()
     inputs:
       testRunTitle: ${{ parameters.title }}
       testSelector: 'testAssemblies'


### PR DESCRIPTION
## Change
Add `condition: succeededOrFailed()` to the tasks run in the e2e templates that were missing them.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4759)