### PR TITLE
Run Unpackaged Unit Tests with winget-installed PsExec

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -348,13 +348,23 @@ jobs:
       packageFeedSelector: 'nugetOrg'
 
   - pwsh: |
+      Add-AppxPackage "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail\x64\Microsoft.VCLibs.x64.14.00.Desktop.appx"
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
       Repair-WingetPackageManager -AllUsers
-      winget install --id Microsoft.Sysinternals.PsTools -s winget
+      Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+    displayName: Install Sysinternals PsTools Using Winget
+    condition: succeededOrFailed()
+
+  - pwsh: |
       $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
+      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
     displayName: Run Unit Tests Unpackaged Under System Context
     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+    condition: succeededOrFailed()
+
+  - pwsh: |
+      Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+    displayName: Clean up Sysinternals PsTools
     condition: succeededOrFailed()
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,19 +69,6 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
-  - powershell: |
-      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers
-      Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
-    displayName: Install Sysinternals PsTools Using Winget
-    condition: succeededOrFailed()
-
-  - powershell: |
-      Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
-    displayName: Clean up Sysinternals PsTools
-    condition: succeededOrFailed()
-
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,15 +69,6 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
-  - pwsh: |
-      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers
-      winget install --id Microsoft.Sysinternals.PsTools -s winget
-      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
-    displayName: Install WinGet and PsExec
-    condition: succeededOrFailed()
-
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -362,16 +353,8 @@ jobs:
       winget install --id Microsoft.Sysinternals.PsTools -s winget
       $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
       PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
-    displayName: Install WinGet and PsExec
-    workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
-    condition: succeededOrFailed()
-
-  - task: CmdLine@2
     displayName: Run Unit Tests Unpackaged Under System Context
-    inputs:
-      script: |
-        PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
-      workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+    workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
     condition: succeededOrFailed()
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,19 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
+  - powershell: |
+      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+      Repair-WingetPackageManager -AllUsers
+      Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+    displayName: Install Sysinternals PsTools Using Winget
+    condition: succeededOrFailed()
+
+  - powershell: |
+      Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+    displayName: Clean up Sysinternals PsTools
+    condition: succeededOrFailed()
+
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -347,22 +360,22 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  - pwsh: |
-      Add-AppxPackage "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail\x64\Microsoft.VCLibs.x64.14.00.Desktop.appx"
+  - powershell: |
+      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
       Repair-WingetPackageManager -AllUsers
       Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()
 
-  - pwsh: |
+  - powershell: |
       $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
       PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
     displayName: Run Unit Tests Unpackaged Under System Context
     workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
     condition: succeededOrFailed()
 
-  - pwsh: |
+  - powershell: |
       Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Clean up Sysinternals PsTools
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,24 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
+  - powershell: |
+      iwr https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller.msixbundle
+      Add-AppxPackage Microsoft.DesktopAppInstaller.msixbundle
+      winget install --id Microsoft.Sysinternals.PsTools --source winget
+    displayName: Install Sysinternals PsTools Using Winget
+    condition: succeededOrFailed()
+
+  - powershell: |
+      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
+    displayName: Run Unit Tests Unpackaged Under System Context
+    condition: succeededOrFailed()
+
+  - powershell: |
+      winget uninstall --id Microsoft.Sysinternals.PsTools --source winget
+    displayName: Clean up Sysinternals PsTools
+    condition: succeededOrFailed()
+
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -347,11 +365,11 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
+  # TODO: Replace with Repair-WinGetPackageManager once x86 is supported.
   - powershell: |
-      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers
-      Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+      iwr https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller.msixbundle
+      Add-AppxPackage Microsoft.DesktopAppInstaller.msixbundle
+      winget install --id Microsoft.Sysinternals.PsTools --source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()
 
@@ -363,7 +381,7 @@ jobs:
     condition: succeededOrFailed()
 
   - powershell: |
-      Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
+      winget uninstall --id Microsoft.Sysinternals.PsTools --source winget
     displayName: Clean up Sysinternals PsTools
     condition: succeededOrFailed()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -356,7 +356,7 @@ jobs:
       }
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers
+      Repair-WingetPackageManager -AllUsers -Latest
       Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -350,8 +350,10 @@ jobs:
   # TODO: Repair-WinGetPackageManager will fail because it tries to install x64 for an x86 build machine.
   # Remove manual installation of VCLibs (x64) once this is fixed.
   - powershell: |
-      iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.appx
-      Add-AppxPackage Microsoft.VCLibs.x64.appx
+      if ("$(buildPlatform)" -eq "x86") {
+        iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.appx
+        Add-AppxPackage Microsoft.VCLibs.x64.appx
+      }
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
       Repair-WingetPackageManager -AllUsers

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,17 +347,23 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  - task: DownloadSecureFile@1
-    name: PsExec
-    displayName: 'Download PsExec.exe'
+  - task: PowerShell@2
+    displayName: Install WinGet and PsExec
     inputs:
-      secureFile: 'PsExec.exe'
+      pwsh: true
+      targetType: 'inline'
+      script: |
+        Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+        Repair-WingetPackageManager
+        winget install --id Microsoft.Sysinternals.PsTools --accept-source-agreements
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+    condition: succeededOrFailed()
 
   - task: CmdLine@2
     displayName: Run Unit Tests Unpackaged Under System Context
     inputs:
       script: |
-        $(PsExec.secureFilePath) -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
+        PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
       workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
     condition: succeededOrFailed()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,15 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
+  - pwsh: |
+      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+      Repair-WingetPackageManager -AllUsers
+      winget install --id Microsoft.Sysinternals.PsTools -s winget
+      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
+    displayName: Install WinGet and PsExec
+    condition: succeededOrFailed()
+
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -108,16 +117,6 @@ jobs:
       filePath: 'src\binver\Update-BinVer.ps1'
       arguments: '-TargetFile binver\binver\version.h -BuildVersion $(BuildVer)'
       workingDirectory: 'src'
-      
-  - pwsh: |
-      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers
-      winget install --id Microsoft.Sysinternals.PsTools -s winget
-      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
-    displayName: Install WinGet and PsExec
-    workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
-    condition: succeededOrFailed()
 
   # Build all solutions in the root directory.
   - task: VSBuild@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,16 +347,12 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  - task: PowerShell@2
+  - pwsh: |
+      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+      Repair-WingetPackageManager -AllUsers
+      winget install --id Microsoft.Sysinternals.PsTools -s winget
+      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
     displayName: Install WinGet and PsExec
-    inputs:
-      pwsh: true
-      targetType: 'inline'
-      script: |
-        Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-        Repair-WingetPackageManager
-        winget install --id Microsoft.Sysinternals.PsTools --accept-source-agreements
-        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
     condition: succeededOrFailed()
 
   - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,16 @@ jobs:
       filePath: 'src\binver\Update-BinVer.ps1'
       arguments: '-TargetFile binver\binver\version.h -BuildVersion $(BuildVer)'
       workingDirectory: 'src'
+      
+  - pwsh: |
+      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+      Repair-WingetPackageManager -AllUsers
+      winget install --id Microsoft.Sysinternals.PsTools -s winget
+      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
+    displayName: Install WinGet and PsExec
+    workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
+    condition: succeededOrFailed()
 
   # Build all solutions in the root directory.
   - task: VSBuild@1
@@ -352,7 +362,9 @@ jobs:
       Repair-WingetPackageManager -AllUsers
       winget install --id Microsoft.Sysinternals.PsTools -s winget
       $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml      
     displayName: Install WinGet and PsExec
+    workingDirectory: '$(buildOutDir)\AppInstallerCLITests'
     condition: succeededOrFailed()
 
   - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,24 +69,6 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
-  - powershell: |
-      iwr https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller.msixbundle
-      Add-AppxPackage Microsoft.DesktopAppInstaller.msixbundle
-      winget install --id Microsoft.Sysinternals.PsTools --source winget
-    displayName: Install Sysinternals PsTools Using Winget
-    condition: succeededOrFailed()
-
-  - powershell: |
-      $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-      PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
-    displayName: Run Unit Tests Unpackaged Under System Context
-    condition: succeededOrFailed()
-
-  - powershell: |
-      winget uninstall --id Microsoft.Sysinternals.PsTools --source winget
-    displayName: Clean up Sysinternals PsTools
-    condition: succeededOrFailed()
-
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -365,11 +347,15 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  # TODO: Replace with Repair-WinGetPackageManager once x86 is supported.
+  # TODO: Repair-WinGetPackageManager will fail because it tries to install x64 for an x86 build machine.
+  # Remove manual installation of VCLibs (x64) once this is fixed.
   - powershell: |
-      iwr https://aka.ms/getwinget -OutFile Microsoft.DesktopAppInstaller.msixbundle
-      Add-AppxPackage Microsoft.DesktopAppInstaller.msixbundle
-      winget install --id Microsoft.Sysinternals.PsTools --source winget
+      iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.appx
+      Add-AppxPackage Microsoft.VCLibs.x64.appx
+      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+      Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
+      Repair-WingetPackageManager -AllUsers
+      Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()
 
@@ -381,7 +367,7 @@ jobs:
     condition: succeededOrFailed()
 
   - powershell: |
-      winget uninstall --id Microsoft.Sysinternals.PsTools --source winget
+      Uninstall-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Clean up Sysinternals PsTools
     condition: succeededOrFailed()
 


### PR DESCRIPTION
Currently forked builds do not have the permission to access secure files. 

To workaround using PsExec from a secure file, we will use a stable release of winget to install the latest PsTools and try invoking unit tests from the PsExec executable that is installed as part of the zip package.