### PR TITLE
Binskim error EnableCriticalCompilerWarnings

### DIFF
--- a/src/VcpkgCustomTriplets/arm-release-static.cmake
+++ b/src/VcpkgCustomTriplets/arm-release-static.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE arm)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/arm-release.cmake
+++ b/src/VcpkgCustomTriplets/arm-release.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE arm)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/arm64-release-static.cmake
+++ b/src/VcpkgCustomTriplets/arm64-release-static.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/arm64-release.cmake
+++ b/src/VcpkgCustomTriplets/arm64-release.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x64-release-static.cmake
+++ b/src/VcpkgCustomTriplets/x64-release-static.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x64-release.cmake
+++ b/src/VcpkgCustomTriplets/x64-release.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x86-release-static.cmake
+++ b/src/VcpkgCustomTriplets/x86-release-static.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x86-release.cmake
+++ b/src/VcpkgCustomTriplets/x86-release.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre")
-set(VCPKG_CXX_FLAGS "/Qspectre")
+set(VCPKG_C_FLAGS "/Qspectre /W3")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3")
 set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
Fixes a binskim error where sfsclient dependencies (curl -> ares)  were not getting compiled with a warning level > 3 compiler flag. Added `/W3` to only the release triplets

Verified that of WindowsPackageManager.dll no longer shows an error when running with binskim.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4764)