### PR TITLE
PS Gallery tests are unreliable

### DIFF
--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -40,6 +40,7 @@ namespace AppInstallerCLIE2ETests
         /// Intentionally has no settings to force a failure, but only after acquiring the module.
         /// </summary>
         [Test]
+        [Ignore("PS Gallery tests are unreliable.")]
         public void ConfigureFromGallery()
         {
             TestCommon.EnsureModuleState(Constants.GalleryTestModuleName, present: false);

--- a/src/AppInstallerCLIE2ETests/ConfigureShowCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureShowCommand.cs
@@ -29,6 +29,7 @@ namespace AppInstallerCLIE2ETests
         /// Simple test to confirm that a resource without a module specified can be discovered in the PSGallery.
         /// </summary>
         [Test]
+        [Ignore("PS Gallery tests are unreliable.")]
         public void ShowDetailsFromGallery()
         {
             TestCommon.EnsureModuleState(Constants.GalleryTestModuleName, present: false);

--- a/src/PowerShell/tests/Microsoft.WinGet.Configuration.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Configuration.Tests.ps1
@@ -351,7 +351,8 @@ Describe 'Invoke-WinGetConfiguration' {
     BeforeEach {
         DeleteConfigTxtFiles
     }
-
+    
+<# PS Gallery tests are unreliable.
     It 'From Gallery' {
         EnsureModuleState "XmlContentDsc" $false
 
@@ -366,6 +367,7 @@ Describe 'Invoke-WinGetConfiguration' {
         $result.UnitResults[0].State | Should -Be "Completed"
         $result.UnitResults[0].ResultCode | Should -Be -1978285819
     }
+#>
 
     It 'From TestRepo' {
         EnsureModuleState $e2eTestModule $false
@@ -530,7 +532,8 @@ Describe 'Start|Complete-WinGetConfiguration' {
     BeforeEach {
         DeleteConfigTxtFiles
     }
-
+    
+<# PS Gallery tests are unreliable.
     It 'From Gallery' {
         EnsureModuleState "XmlContentDsc" $false
 
@@ -548,6 +551,7 @@ Describe 'Start|Complete-WinGetConfiguration' {
         $result.UnitResults[0].State | Should -Be "Completed"
         $result.UnitResults[0].ResultCode | Should -Be -1978285819
     }
+#>
 
     It 'From TestRepo' {
         $testFile = GetConfigTestDataFile "Configure_TestRepo.yml"


### PR DESCRIPTION
## Change
These tests that rely on the PowerShell Gallery are unreliable.  Disable them.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4791)