### PR TITLE
Revert PowerShell modules to alpha

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Microsoft.WinGet.Client.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Microsoft.WinGet.Client.psd1
@@ -160,7 +160,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        # Prerelease = 'alpha'
+        Prerelease = 'alpha'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Configuration/ModuleFiles/Microsoft.WinGet.Configuration.psd1
@@ -33,6 +33,7 @@
             )
             ProjectUri = 'https://github.com/microsoft/winget-cli'
             IconUri = 'https://aka.ms/winget-icon'
+            Prerelease = 'alpha'
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psd1
+++ b/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psd1
@@ -118,7 +118,7 @@
             # ReleaseNotes = ''
     
             # Prerelease string of this module
-            # Prerelease = 'alpha'
+            Prerelease = 'alpha'
     
             # Flag to indicate whether the module requires explicit user acceptance for install/update/save
             # RequireLicenseAcceptance = $false


### PR DESCRIPTION
## Change
We want to be able to publish both prerelease and release version of the PowerShell modules.  For ease of use, we will consistently have the modules marked as prerelease here and only mark them as release as needed in our official builds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4823)