### PR TITLE
Fix issue with unicode characters in symlink target path

### DIFF
--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -72,7 +72,7 @@ namespace AppInstaller::CLI::Portable
         }
         else if (fileType == PortableFileType::Symlink)
         {
-            std::filesystem::path symlinkTargetPath = AppInstaller::Utility::ConvertToUTF16(entry.SymlinkTarget);
+            std::filesystem::path symlinkTargetPath{ AppInstaller::Utility::ConvertToUTF16(entry.SymlinkTarget) };
             if (Filesystem::SymlinkExists(filePath) && !Filesystem::VerifySymlink(filePath, symlinkTargetPath))
             {
                 AICLI_LOG(CLI, Warning, << "Symlink target does not match ARP Entry. Expected: " << symlinkTargetPath << " Actual: " << std::filesystem::read_symlink(filePath));
@@ -151,7 +151,7 @@ namespace AppInstaller::CLI::Portable
                     m_stream << Resource::String::OverwritingExistingFileAtMessage(Utility::LocIndView{ filePath.u8string() }) << std::endl;
                 }
 
-                std::filesystem::path symlinkTargetPath = Utility::ConvertToUTF16(entry.SymlinkTarget);
+                std::filesystem::path symlinkTargetPath{ Utility::ConvertToUTF16(entry.SymlinkTarget) };
                 if (Filesystem::CreateSymlink(symlinkTargetPath, filePath))
                 {
                     AICLI_LOG(Core, Info, << "Symlink created at: " << filePath << " with target path: " << symlinkTargetPath);

--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -72,9 +72,10 @@ namespace AppInstaller::CLI::Portable
         }
         else if (fileType == PortableFileType::Symlink)
         {
-            if (Filesystem::SymlinkExists(filePath) && !Filesystem::VerifySymlink(filePath, entry.SymlinkTarget))
+            std::filesystem::path symlinkTargetPath = AppInstaller::Utility::ConvertToUTF16(entry.SymlinkTarget);
+            if (Filesystem::SymlinkExists(filePath) && !Filesystem::VerifySymlink(filePath, symlinkTargetPath))
             {
-                AICLI_LOG(CLI, Warning, << "Symlink target does not match ARP Entry. Expected: " << entry.SymlinkTarget << " Actual: " << std::filesystem::read_symlink(filePath));
+                AICLI_LOG(CLI, Warning, << "Symlink target does not match ARP Entry. Expected: " << symlinkTargetPath << " Actual: " << std::filesystem::read_symlink(filePath));
                 return false;
             }
         }
@@ -150,9 +151,10 @@ namespace AppInstaller::CLI::Portable
                     m_stream << Resource::String::OverwritingExistingFileAtMessage(Utility::LocIndView{ filePath.u8string() }) << std::endl;
                 }
 
-                if (Filesystem::CreateSymlink(entry.SymlinkTarget, filePath))
+                std::filesystem::path symlinkTargetPath = Utility::ConvertToUTF16(entry.SymlinkTarget);
+                if (Filesystem::CreateSymlink(symlinkTargetPath, filePath))
                 {
-                    AICLI_LOG(Core, Info, << "Symlink created at: " << filePath);
+                    AICLI_LOG(Core, Info, << "Symlink created at: " << filePath << " with target path: " << symlinkTargetPath);
                 }
                 else
                 {


### PR DESCRIPTION
Resolves #3312

Fixes an issue when creating a symlink with a target path that includes unicode characters by converting the symlink target path to a UTF16 string prior to creation. 

Added a test that includes unicode characters in the symlink target path and verified that install and uninstall are both supported.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4834)