### PR TITLE
Add extended error codes to results without them

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -85,6 +85,10 @@ namespace AppInstaller::CLI::Workflow
     Authentication::AuthenticationArguments GetAuthenticationArguments(const Execution::Context& context);
 
     // Helper to report exceptions and return the HRESULT.
+    // If context is null, no output will be attempted.
+    HRESULT HandleException(Execution::Context* context, std::exception_ptr exception);
+
+    // Helper to report exceptions and return the HRESULT.
     HRESULT HandleException(Execution::Context& context, std::exception_ptr exception);
 
     // Creates the source object.

--- a/src/Microsoft.Management.Deployment/ConnectResult.cpp
+++ b/src/Microsoft.Management.Deployment/ConnectResult.cpp
@@ -6,10 +6,11 @@
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
-    void ConnectResult::Initialize(winrt::Microsoft::Management::Deployment::ConnectResultStatus status, winrt::Microsoft::Management::Deployment::PackageCatalog packageCatalog)
+    void ConnectResult::Initialize(winrt::Microsoft::Management::Deployment::ConnectResultStatus status, winrt::Microsoft::Management::Deployment::PackageCatalog packageCatalog, winrt::hresult extendedErrorCode)
     {
         m_status = status;
         m_packageCatalog = packageCatalog;
+        m_extendedErrorCode = extendedErrorCode;
     }
     winrt::Microsoft::Management::Deployment::ConnectResultStatus ConnectResult::Status()
     {
@@ -18,5 +19,10 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     winrt::Microsoft::Management::Deployment::PackageCatalog ConnectResult::PackageCatalog()
     {
         return m_packageCatalog;
+    }
+
+    winrt::hresult ConnectResult::ExtendedErrorCode()
+    {
+        return m_extendedErrorCode;
     }
 }

--- a/src/Microsoft.Management.Deployment/ConnectResult.h
+++ b/src/Microsoft.Management.Deployment/ConnectResult.h
@@ -10,16 +10,18 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         ConnectResult() = default;
         
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
-        void Initialize(winrt::Microsoft::Management::Deployment::ConnectResultStatus status, winrt::Microsoft::Management::Deployment::PackageCatalog packageCatalog);
+        void Initialize(winrt::Microsoft::Management::Deployment::ConnectResultStatus status, winrt::Microsoft::Management::Deployment::PackageCatalog packageCatalog, winrt::hresult extendedErrorCode);
 #endif
 
         winrt::Microsoft::Management::Deployment::ConnectResultStatus Status();
         winrt::Microsoft::Management::Deployment::PackageCatalog PackageCatalog();
+        winrt::hresult ExtendedErrorCode();
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         winrt::Microsoft::Management::Deployment::ConnectResultStatus m_status = winrt::Microsoft::Management::Deployment::ConnectResultStatus::Ok;
         winrt::Microsoft::Management::Deployment::PackageCatalog m_packageCatalog{ nullptr };
+        winrt::hresult m_extendedErrorCode = S_OK;
 #endif
     };
 }

--- a/src/Microsoft.Management.Deployment/FindPackagesResult.cpp
+++ b/src/Microsoft.Management.Deployment/FindPackagesResult.cpp
@@ -10,11 +10,13 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     void FindPackagesResult::Initialize(
         winrt::Microsoft::Management::Deployment::FindPackagesResultStatus status,
         bool wasLimitExceeded, 
-        Windows::Foundation::Collections::IVector<Microsoft::Management::Deployment::MatchResult> matches)
+        Windows::Foundation::Collections::IVector<Microsoft::Management::Deployment::MatchResult> matches,
+        winrt::hresult extendedErrorCode)
     {
         m_status = status;
         m_matches = matches;
         m_wasLimitExceeded = wasLimitExceeded;
+        m_extendedErrorCode = extendedErrorCode;
     }
     winrt::Microsoft::Management::Deployment::FindPackagesResultStatus FindPackagesResult::Status()
     {
@@ -27,5 +29,10 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     bool FindPackagesResult::WasLimitExceeded()
     {
         return m_wasLimitExceeded;
+    }
+
+    winrt::hresult FindPackagesResult::ExtendedErrorCode()
+    {
+        return m_extendedErrorCode;
     }
 }

--- a/src/Microsoft.Management.Deployment/FindPackagesResult.h
+++ b/src/Microsoft.Management.Deployment/FindPackagesResult.h
@@ -14,12 +14,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         void Initialize(
             winrt::Microsoft::Management::Deployment::FindPackagesResultStatus status,
             bool wasLimitExceeded, 
-            Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Deployment::MatchResult> matches);
+            Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Deployment::MatchResult> matches,
+            winrt::hresult extendedErrorCode);
 #endif
 
         winrt::Microsoft::Management::Deployment::FindPackagesResultStatus Status();
         winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Management::Deployment::MatchResult> Matches();
         bool WasLimitExceeded();
+        winrt::hresult ExtendedErrorCode();
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
@@ -27,6 +29,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Deployment::MatchResult> m_matches{ 
             winrt::single_threaded_vector<winrt::Microsoft::Management::Deployment::MatchResult>() };
         bool m_wasLimitExceeded = false;
+        winrt::hresult m_extendedErrorCode = S_OK;
 #endif
     };
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalog.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalog.cpp
@@ -115,7 +115,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             winrt::Microsoft::Management::Deployment::implementation::FindPackagesResult>>();
         // TODO: Add search timeout and error code.
         winrt::Microsoft::Management::Deployment::FindPackagesResultStatus status = FindPackagesResultStatus(hr);
-        findPackagesResult->Initialize(status, isTruncated, matches);
+        findPackagesResult->Initialize(status, isTruncated, matches, hr);
         return *findPackagesResult;
     }
 

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Management.Deployment
 {
-    [contractversion(11)] // For version 1.9
+    [contractversion(12)] // For version 1.10
     apicontract WindowsPackageManagerContract{};
 
     /// State of the install
@@ -663,6 +663,12 @@ namespace Microsoft.Management.Deployment
         /// USAGE NOTE: Windows Package Manager does not support result pagination, there is no way to continue 
         /// getting more results.
         Boolean WasLimitExceeded { get; };
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 12)]
+        {
+            /// The error code of the operation.
+            HRESULT ExtendedErrorCode{ get; };
+        }
     }
 
     /// Options for FindPackages
@@ -782,6 +788,12 @@ namespace Microsoft.Management.Deployment
         ConnectResultStatus Status { get; };
 
         PackageCatalog PackageCatalog { get; };
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 12)]
+        {
+            /// The error code of the operation.
+            HRESULT ExtendedErrorCode{ get; };
+        }
     }
 
     /// A reference to a catalog that callers can try to Connect.

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Management.Deployment
 {
-    [contractversion(12)] // For version 1.10
+    [contractversion(11)] // For version 1.9
     apicontract WindowsPackageManagerContract{};
 
     /// State of the install
@@ -664,7 +664,7 @@ namespace Microsoft.Management.Deployment
         /// getting more results.
         Boolean WasLimitExceeded { get; };
 
-        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 12)]
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 11)]
         {
             /// The error code of the operation.
             HRESULT ExtendedErrorCode{ get; };
@@ -789,7 +789,7 @@ namespace Microsoft.Management.Deployment
 
         PackageCatalog PackageCatalog { get; };
 
-        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 12)]
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 11)]
         {
             /// The error code of the operation.
             HRESULT ExtendedErrorCode{ get; };


### PR DESCRIPTION
## Change
Adds `HRESULT ExtendedErrorCode{ get; };` to the `FindPackagesResult` and `ConnectResult` classes that did not have them.  They work just like the other cases, exposing the raw `HRESULT` value from their respective operations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4858)