### PR TITLE
Set WindowsSdkPackageVersion to older value

### DIFF
--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -8,6 +8,12 @@
     <OutputType>Library</OutputType>
     <DocumentationFile>$(OutDir)\AppInstallerCLIE2ETests.xml</DocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -9,11 +9,10 @@
     <DocumentationFile>$(OutDir)\AppInstallerCLIE2ETests.xml</DocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -31,7 +30,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -11,11 +11,10 @@
     <SelfContained>true</SelfContained>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm;win10-arm64</RuntimeIdentifiers>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'x64' ">
@@ -35,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -10,6 +10,12 @@
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm;win10-arm64</RuntimeIdentifiers>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'x64' ">

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Helpers/DiagnosticInformation.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Helpers/DiagnosticInformation.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="DiagnosticInformation.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
     /// <summary>
     /// Implements IDiagnosticInformation.
     /// </summary>
-    internal sealed class DiagnosticInformation : IDiagnosticInformation
+    internal sealed partial class DiagnosticInformation : IDiagnosticInformation
     {
         /// <inheritdoc/>
         public DiagnosticLevel Level { get; internal set; }

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -19,11 +19,10 @@
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <CsWinRTEnableLogging>true</CsWinRTEnableLogging>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -44,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.8" GeneratePathProperty="true">
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -18,6 +18,12 @@
     <NoWarn>1591,8785</NoWarn>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <CsWinRTEnableLogging>true</CsWinRTEnableLogging>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Set/ConfigurationSetProcessor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Management.Configuration.Processor.Set
     /// <summary>
     /// Configuration set processor.
     /// </summary>
-    internal sealed class ConfigurationSetProcessor : IConfigurationSetProcessor
+    internal sealed partial class ConfigurationSetProcessor : IConfigurationSetProcessor
     {
         private readonly ConfigurationSet? configurationSet;
         private List<ConfigurationUnit> limitUnitList = new List<ConfigurationUnit>();

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ApplySettingsResult.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ApplySettingsResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ApplySettingsResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Implements IApplySettingsResult.
     /// </summary>
-    internal sealed class ApplySettingsResult : IApplySettingsResult
+    internal sealed partial class ApplySettingsResult : IApplySettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplySettingsResult"/> class.

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Provides access to a specific configuration unit within the runtime.
     /// </summary>
-    internal sealed class ConfigurationUnitProcessor : IConfigurationUnitProcessor
+    internal sealed partial class ConfigurationUnitProcessor : IConfigurationUnitProcessor
     {
         private readonly IProcessorEnvironment processorEnvironment;
         private readonly ConfigurationUnitAndResource unitResource;

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessorDetails.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitProcessorDetails.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationUnitProcessorDetails.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -18,7 +18,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Provides information for a specific configuration unit within the runtime.
     /// </summary>
-    internal sealed class ConfigurationUnitProcessorDetails : IConfigurationUnitProcessorDetails
+    internal sealed partial class ConfigurationUnitProcessorDetails : IConfigurationUnitProcessorDetails
     {
         private static readonly IEnumerable<string> PublicRepositories = new string[]
         {

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitResultInformation.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitResultInformation.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationUnitResultInformation.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Implements IConfigurationUnitResultInformation.
     /// </summary>
-    internal sealed class ConfigurationUnitResultInformation : IConfigurationUnitResultInformation
+    internal sealed partial class ConfigurationUnitResultInformation : IConfigurationUnitResultInformation
     {
         /// <inheritdoc/>
         public string? Description { get; internal set; }

--- a/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitSettingDetails.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/ConfigurationUnitSettingDetails.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ConfigurationUnitSettingDetails.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -13,7 +13,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Provides information for a specific configuration unit setting.
     /// </summary>
-    internal sealed class ConfigurationUnitSettingDetails : IConfigurationUnitSettingDetails
+    internal sealed partial class ConfigurationUnitSettingDetails : IConfigurationUnitSettingDetails
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurationUnitSettingDetails"/> class.

--- a/src/Microsoft.Management.Configuration.Processor/Unit/GetAllSettingsResult.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/GetAllSettingsResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="GetAllSettingsResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -13,7 +13,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Implements IGetAllSettingsResult.
     /// </summary>
-    internal class GetAllSettingsResult : IGetAllSettingsResult
+    internal partial class GetAllSettingsResult : IGetAllSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAllSettingsResult"/> class.

--- a/src/Microsoft.Management.Configuration.Processor/Unit/GetSettingsResult.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/GetSettingsResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="GetSettingsResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Implements IGetSettingsResult.
     /// </summary>
-    internal sealed class GetSettingsResult : IGetSettingsResult
+    internal sealed partial class GetSettingsResult : IGetSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GetSettingsResult"/> class.

--- a/src/Microsoft.Management.Configuration.Processor/Unit/TestSettingsResult.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Unit/TestSettingsResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestSettingsResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.Processor.Unit
     /// <summary>
     /// Implements ITestSettingsResult.
     /// </summary>
-    internal sealed class TestSettingsResult : ITestSettingsResult
+    internal sealed partial class TestSettingsResult : ITestSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestSettingsResult"/> class.

--- a/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
+++ b/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
@@ -8,11 +8,10 @@
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
+++ b/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
+++ b/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
@@ -7,6 +7,12 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplyGroupMemberSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplyGroupMemberSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ApplyGroupMemberSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -9,7 +9,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements IApplyGroupMemberSettingsResult.
     /// </summary>
-    internal sealed class ApplyGroupMemberSettingsResultInstance : IApplyGroupMemberSettingsResult
+    internal sealed partial class ApplyGroupMemberSettingsResultInstance : IApplyGroupMemberSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplyGroupMemberSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplyGroupSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplyGroupSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ApplyGroupSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements IApplyGroupSettingsResult.
     /// </summary>
-    internal sealed class ApplyGroupSettingsResultInstance : IApplyGroupSettingsResult
+    internal sealed partial class ApplyGroupSettingsResultInstance : IApplyGroupSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplyGroupSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplySettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/ApplySettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ApplySettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements IApplySettingsResult.
     /// </summary>
-    internal sealed class ApplySettingsResultInstance : IApplySettingsResult
+    internal sealed partial class ApplySettingsResultInstance : IApplySettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplySettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/GetAllSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/GetAllSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="GetAllSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -13,7 +13,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements IGetAllSettingsResult.
     /// </summary>
-    internal sealed class GetAllSettingsResultInstance : IGetAllSettingsResult
+    internal sealed partial class GetAllSettingsResultInstance : IGetAllSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAllSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/GetSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/GetSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="GetSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements IGetSettingsResult.
     /// </summary>
-    internal sealed class GetSettingsResultInstance : IGetSettingsResult
+    internal sealed partial class GetSettingsResultInstance : IGetSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GetSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationProcessorFactory.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationProcessorFactory.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationProcessorFactory.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationSetProcessorFactory.
     /// </summary>
-    internal class TestConfigurationProcessorFactory : IConfigurationSetProcessorFactory
+    internal partial class TestConfigurationProcessorFactory : IConfigurationSetProcessorFactory
     {
         /// <summary>
         /// Delegate type for CreateSetProcessor.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetGroupProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetGroupProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationSetGroupProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -18,7 +18,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationGroupProcessor.
     /// </summary>
-    internal class TestConfigurationSetGroupProcessor : TestConfigurationSetProcessor, IConfigurationGroupProcessor
+    internal partial class TestConfigurationSetGroupProcessor : TestConfigurationSetProcessor, IConfigurationGroupProcessor
     {
         /// <summary>
         /// The event that is waited on before actually processing the async operations.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationSetProcessor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationSetProcessor.
     /// </summary>
-    internal class TestConfigurationSetProcessor : IConfigurationSetProcessor
+    internal partial class TestConfigurationSetProcessor : IConfigurationSetProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestConfigurationSetProcessor"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitGroupProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitGroupProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationUnitGroupProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -18,7 +18,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationGroupProcessor.
     /// </summary>
-    internal class TestConfigurationUnitGroupProcessor : TestConfigurationUnitProcessor, IConfigurationGroupProcessor
+    internal partial class TestConfigurationUnitGroupProcessor : TestConfigurationUnitProcessor, IConfigurationGroupProcessor
     {
         /// <summary>
         /// The Setting key that will be used to set the TestResult of the unit.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationUnitProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationProcessorFactory.
     /// </summary>
-    internal class TestConfigurationUnitProcessor : IConfigurationUnitProcessor
+    internal partial class TestConfigurationUnitProcessor : IConfigurationUnitProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestConfigurationUnitProcessor"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessorDetails.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitProcessorDetails.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationUnitProcessorDetails.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -13,7 +13,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationProcessorFactory.
     /// </summary>
-    internal class TestConfigurationUnitProcessorDetails : IConfigurationUnitProcessorDetails
+    internal partial class TestConfigurationUnitProcessorDetails : IConfigurationUnitProcessorDetails
     {
         private ConfigurationUnit unit;
         private ConfigurationUnitDetailFlags detailFlags;

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitResultInformation.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestConfigurationUnitResultInformation.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestConfigurationUnitResultInformation.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationSetProcessorFactory.
     /// </summary>
-    internal class TestConfigurationUnitResultInformation : IConfigurationUnitResultInformation
+    internal partial class TestConfigurationUnitResultInformation : IConfigurationUnitResultInformation
     {
         /// <summary>
         /// Gets or sets the description.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestGetAllSettingsConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestGetAllSettingsConfigurationUnitProcessor.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestGetAllSettingsConfigurationUnitProcessor.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -9,7 +9,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// A test implementation of IConfigurationProcessorFactory.
     /// </summary>
-    internal class TestGetAllSettingsConfigurationUnitProcessor : TestConfigurationUnitProcessor, IGetAllSettingsConfigurationUnitProcessor
+    internal partial class TestGetAllSettingsConfigurationUnitProcessor : TestConfigurationUnitProcessor, IGetAllSettingsConfigurationUnitProcessor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestGetAllSettingsConfigurationUnitProcessor"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestGroupSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestGroupSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestGroupSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements ITestGroupSettingsResult.
     /// </summary>
-    internal class TestGroupSettingsResultInstance : ITestGroupSettingsResult
+    internal partial class TestGroupSettingsResultInstance : ITestGroupSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestGroupSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestSettingsResultInstance.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/TestSettingsResultInstance.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="TestSettingsResultInstance.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
     /// <summary>
     /// Implements ITestSettingsResult.
     /// </summary>
-    internal sealed class TestSettingsResultInstance : ITestSettingsResult
+    internal sealed partial class TestSettingsResultInstance : ITestSettingsResult
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestSettingsResultInstance"/> class.

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -8,11 +8,10 @@
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm;win10-arm64</RuntimeIdentifiers>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -25,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -7,6 +7,12 @@
     <Platforms>x64;x86;arm64</Platforms>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <RuntimeIdentifiers>win10-x64;win10-x86;win10-arm;win10-arm64</RuntimeIdentifiers>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -7,6 +7,12 @@
     <Platforms>x64;x86;arm64</Platforms>
     <OutputType>Library</OutputType>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -8,15 +8,14 @@
     <OutputType>Library</OutputType>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <!-- CsWinRT properties -->

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <!-- CsWinRT properties -->

--- a/src/Microsoft.Management.Deployment.Projection/Utils/ComUtils.cs
+++ b/src/Microsoft.Management.Deployment.Projection/Utils/ComUtils.cs
@@ -1,14 +1,16 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Management.Deployment.Projection
 {
     using System;
     using System.Runtime.InteropServices;
-    using WinRT;
 
     internal static class ComUtils
     {
+        [DllImport("api-ms-win-core-com-l1-1-0.dll")]
+        private static extern unsafe int CoCreateInstance(ref Guid clsid, IntPtr outer, uint clsContext, ref Guid iid, IntPtr* instance);
+
         /// <summary>
         /// CLSCTX enumeration
         /// https://docs.microsoft.com/en-us/windows/win32/api/wtypesbase/ne-wtypesbase-clsctx
@@ -31,7 +33,7 @@ namespace Microsoft.Management.Deployment.Projection
         private static unsafe IntPtr CoCreateInstance(Guid clsid, CLSCTX clsContext, Guid iid)
         {
             IntPtr instanceIntPtr;
-            int hr = Platform.CoCreateInstance(ref clsid, IntPtr.Zero, (uint)clsContext, ref iid, &instanceIntPtr);
+            int hr = CoCreateInstance(ref clsid, IntPtr.Zero, (uint)clsContext, ref iid, &instanceIntPtr);
             Marshal.ThrowExceptionForHR(hr);
             return instanceIntPtr;
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -8,11 +8,10 @@
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -58,7 +57,7 @@
 
   <!-- This project doesn't reference it directly, but if I don't add it here it will fail with NETSDK1130 *.winmd cannot be referenced. -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -7,6 +7,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -52,7 +52,7 @@
 
   <!-- This project doesn't reference it directly, but if I don't add it here it will fail with NETSDK1130 *.winmd cannot be referenced. -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -8,6 +8,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- If these target frameworks are updated, make sure to also update the .psd1 and .nuspec files.-->
@@ -49,7 +49,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22000.196" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
   </ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -9,11 +9,10 @@
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,7 +54,7 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22000.196" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
   </ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -11,6 +11,12 @@
     <BuildOutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</BuildOutputDirectory>
     <RootNamespace>Microsoft.WinGet.Configuration</RootNamespace>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -12,11 +12,10 @@
     <RootNamespace>Microsoft.WinGet.Configuration</RootNamespace>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -49,7 +48,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -10,6 +10,12 @@
     <DocumentationFile>$(OutputPath)\$(MSBuildProjectName).xml</DocumentationFile>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
+    <!--
+    Forcing this version as the minimum based on the CsWinRT release.
+    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
+    -->
+    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -11,11 +11,10 @@
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
     <!--
-    Forcing this version as the minimum based on the CsWinRT release.
-    https://github.com/microsoft/CsWinRT/releases/tag/2.1.5.241003.1
+    Forcing this version to continue using an older CsWinRT release while issues are resolved.
     !!! Remove this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.46</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.34</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -49,7 +48,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.5" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Change
Set the `WindowsSdkPackageVersion` to an older, working for us version.  This fixes an issue that was occurring with the latest SDK.

Also:
- defines our own `CoCreateInstance` PInvoke in Microsoft.Management.Deployment.Projection rather than relying on the on provided by CsWinRT (which was no longer compiling after the update).
- Adds `partial` to a number of classes that will need it when we eventually do move to a newer CsWinRT

Future maintainer note: Set `CsWinRTCcwLookupTableGeneratorEnabled` to false to prevent needing to pull in WinRT.Runtime before we have our assembly resolver set up yet.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4860)