### PR TITLE
Make dependency lookup case insensitive

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/1_4/DependenciesTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/1_4/DependenciesTable.cpp
@@ -70,7 +70,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V1_4
             {
                 installer.Dependencies.ApplyToType(dependencyType, [&](Manifest::Dependency dependency)
                 {
-                    auto packageRowId = IdTable::SelectIdByValue(connection, dependency.Id());
+                    auto packageRowId = IdTable::SelectIdByValue(connection, dependency.Id(), true);
                     std::optional<Utility::NormalizedString> version;
 
                     if (!packageRowId.has_value())


### PR DESCRIPTION
Fixes #3679 

## Change
Makes the dependency lookup case insensitive.

## Validation
Adds a new test that exercises adding a package with a dependency that does not match the case of the original package identifier.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4866)