### PR TITLE
Documentation - added `Microsoft.Rest` as a supported source type

### DIFF
--- a/doc/windows/package-manager/winget/source.md
+++ b/doc/windows/package-manager/winget/source.md
@@ -71,6 +71,7 @@ The **add** sub-command also supports the optional **type** parameter. The **typ
 | Type  | Description |
 |--------------|-------------|
 | **Microsoft.PreIndexed.Package** | The type of source \<default>. |
+| **Microsoft.Rest** | A Microsoft REST API source. |
 
 ## list
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [X] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

On the winget source documentation page, there is a missing supported source type, namely `Microsoft.Rest`. 

E.g. see the Winget [troubleshooting page](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting#:~:text=%3E%20winget%20source%20add%20%2Dn%20mysource%20%2Dt%20Microsoft.REST%20%2Da%20https%3A//www.contoso.org%20%2D%2Dverbose) which shows examples of `Microsoft.Rest` usage.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4873)