### PR TITLE
Bring back WinGetUtil nuspec for dev development

### DIFF
--- a/src/WinGetUtilInterop/scripts/CreateLocalNuget.ps1
+++ b/src/WinGetUtilInterop/scripts/CreateLocalNuget.ps1
@@ -66,12 +66,12 @@ CopyFile "$BuildRoot\x86\$Configuration\WinGetUtil\WinGetUtil.pdb" "$x86NugetPat
 CopyFile "$repoPath\src\WinGetUtilInterop\bin\$Configuration\netstandard2.1\WinGetUtilInterop.dll" "$interopNugetPath\WinGetUtilInterop.dll"
 CopyFile "$repoPath\src\WinGetUtilInterop\bin\$Configuration\netstandard2.1\WinGetUtilInterop.pdb" "$interopNugetPath\WinGetUtilInterop.pdb"
 CopyFile "$repoPath\src\WinGetUtilInterop\build\Microsoft.WindowsPackageManager.Utils.targets" "$targetsNugetPath\Microsoft.WindowsPackageManager.Utils.targets"
-CopyFile "$repoPath\WinGetUtil.nuspec" "$nugetWorkingDir\WinGetUtil.nuspec"
+CopyFile "$PSScriptRoot\WinGetUtilDev.nuspec" "$nugetWorkingDir\WinGetUtilDev.nuspec"
 Copy-Item "$repoPath\schemas\JSON\manifests" $manifestsNugetPath -Recurse
 
 # Create nuget
 Write-Host "Creating nuget package"
-$local:result = nuget pack .\NugetFiles\WinGetUtil.nuspec -Version $NugetVersion -OutputDirectory NugetOut
+$local:result = nuget pack .\NugetFiles\WinGetUtilDev.nuspec -Version $NugetVersion -OutputDirectory NugetOut
 $local:outFile = $result -match "nupkg"
 $outFile = $outFile[0]
 $outFile = $outFile.Substring($outFile.IndexOf("'") + 1, $outFile.LastIndexOf("'") - $outFile.IndexOf("'") - 1)

--- a/src/WinGetUtilInterop/scripts/WinGetUtilDev.nuspec
+++ b/src/WinGetUtilInterop/scripts/WinGetUtilDev.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.WindowsPackageManager.Utils</id>
+    <version>$version$</version>
+    <title></title>
+    <authors>Microsoft</authors>
+    <owners></owners>
+    <projectUrl>https://github.com/microsoft/winget-cli</projectUrl>
+    <license type="expression">MIT</license>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>The utility binary for use with the WinGet CLI.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>winget</tags>
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="YamlDotNet" version="8.1.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Build.x64release\src\x64\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x64\native\WinGetUtil.dll"/>
+    <file src="Build.x64release\src\x64\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x64\native\WinGetUtil.pdb"/>
+    <file src="Build.x86release\src\x86\Release\WinGetUtil\WinGetUtil.dll" target="runtimes\win-x86\native\WinGetUtil.dll"/>
+    <file src="Build.x86release\src\x86\Release\WinGetUtil\WinGetUtil.pdb" target="runtimes\win-x86\native\WinGetUtil.pdb"/>
+    <file src="Build.x64release\schemas\JSON\manifests\**" target="content\schemas\JSON\manifests" />
+    <file src="Build.x64release\src\WinGetUtilInterop\bin\Release\netstandard2.1\WinGetUtilInterop.dll" target="lib/netstandard2.1/WinGetUtilInterop.dll" />
+    <file src="Build.x64release\src\WinGetUtilInterop\bin\Release\netstandard2.1\WinGetUtilInterop.pdb" target="lib/netstandard2.1/WinGetUtilInterop.pdb" />
+    <file src="Build.x64release\src\WinGetUtilInterop\build\Microsoft.WindowsPackageManager.Utils.targets" target="build/Microsoft.WindowsPackageManager.Utils.targets" />
+  </files>
+</package>


### PR DESCRIPTION
Bringing back the nuspec used for creating the Microsoft.WindowsPackageManager.Utils nuget package.
Fix CreateLocalNuget.ps1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4884)