### PR TITLE
Change meaning of AddOrUpdate return bool

### DIFF
--- a/src/AppInstallerCLITests/SQLiteIndex.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndex.cpp
@@ -3918,20 +3918,20 @@ TEST_CASE("SQLiteIndex_AddOrUpdateManifest", "[sqliteindex]")
     {
         SQLiteIndex index = SQLiteIndex::Open(tempFile, SQLiteStorageBase::OpenDisposition::ReadWrite);
 
-        // Update with no updates should return false
+        // Update should return false
         REQUIRE(!index.AddOrUpdateManifest(manifest, manifestPath));
 
         manifest.DefaultLocalization.Add<Localization::Description>("description2");
 
-        // Update with no indexed updates should return false
+        // Update should return false
         REQUIRE(!index.AddOrUpdateManifest(manifest, manifestPath));
 
-        // Update with indexed changes
+        // Update with indexed changes should still return false
         manifest.DefaultLocalization.Add<Localization::PackageName>("Test Name2");
         manifest.Moniker = "testmoniker2";
         manifest.DefaultLocalization.Add<Localization::Tags>({ "t1", "t2", "t3" });
         manifest.Installers[0].Commands = {};
 
-        REQUIRE(index.AddOrUpdateManifest(manifest, manifestPath));
+        REQUIRE(!index.AddOrUpdateManifest(manifest, manifestPath));
     }
 }

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.cpp
@@ -194,7 +194,8 @@ namespace AppInstaller::Repository::Microsoft
 
         if (m_interface->GetManifestIdByManifest(m_dbconn, manifest))
         {
-            return UpdateManifestInternalHoldingLock(manifest, relativePath);
+            UpdateManifestInternalHoldingLock(manifest, relativePath);
+            return false;
         }
         else
         {

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndex.h
@@ -95,15 +95,15 @@ namespace AppInstaller::Repository::Microsoft
         bool UpdateManifest(const Manifest::Manifest& manifest);
 
         // Adds or updates the manifest with matching { Id, Version, Channel } in the index.
-        // The return value indicates whether the index was modified by the function.
+        // The return value indicates whether the manifest was added (true) or updated (false).
         bool AddOrUpdateManifest(const std::filesystem::path& manifestPath, const std::filesystem::path& relativePath);
 
         // Updates the manifest with matching { Id, Version, Channel } in the index.
-        // The return value indicates whether the index was modified by the function.
+        // The return value indicates whether the manifest was added (true) or updated (false).
         bool AddOrUpdateManifest(const Manifest::Manifest& manifest, const std::filesystem::path& relativePath);
 
         // Updates the manifest with matching { Id, Version, Channel } in the index.
-        // The return value indicates whether the index was modified by the function.
+        // The return value indicates whether the manifest was added (true) or updated (false).
         bool AddOrUpdateManifest(const Manifest::Manifest& manifest);
 
         // Removes the manifest with matching { Id, Version, Channel } from the index.

--- a/src/WinGetUtil/WinGetUtil.h
+++ b/src/WinGetUtil/WinGetUtil.h
@@ -159,7 +159,7 @@ extern "C"
         BOOL* indexModified);
 
     // Adds or Updates the manifest with matching { Id, Version, Channel } in the index.
-    // The return value indicates whether the index was modified by the function.
+    // The return value indicates whether the manifest was added (true) or updated (false).
     WINGET_UTIL_API WinGetSQLiteIndexAddOrUpdateManifest(
         WINGET_SQLITE_INDEX_HANDLE index,
         WINGET_STRING manifestPath,

--- a/src/WinGetUtilInterop.UnitTests/APIUnitTests/SQLiteIndexUnitTests.cs
+++ b/src/WinGetUtilInterop.UnitTests/APIUnitTests/SQLiteIndexUnitTests.cs
@@ -188,13 +188,13 @@ namespace WinGetUtilInterop.UnitTests.APIUnitTests
         {
             this.CreateIndexHelperForIndexTest((wrapper) =>
             {
-                // Add manifest.
+                // Add manifest; should return true.
                 string addManifest = Path.Combine(this.indexTestDataPath, PackageTest);
-                wrapper.AddOrUpdateManifest(addManifest, PackageTestRelativePath);
+                Assert.True(wrapper.AddOrUpdateManifest(addManifest, PackageTestRelativePath));
 
-                // Update manifest. name is different, should return true.
+                // Update manifest. name is different, should return false.
                 string updateManifest = Path.Combine(this.indexTestDataPath, PackageTestNewName);
-                Assert.True(wrapper.AddOrUpdateManifest(updateManifest, PackageTestRelativePath));
+                Assert.False(wrapper.AddOrUpdateManifest(updateManifest, PackageTestRelativePath));
 
                 return true;
             });

--- a/src/WinGetUtilInterop/Interfaces/IWinGetSQLiteIndex.cs
+++ b/src/WinGetUtilInterop/Interfaces/IWinGetSQLiteIndex.cs
@@ -67,7 +67,7 @@ namespace Microsoft.WinGetUtil.Interfaces
         /// </summary>
         /// <param name="manifestPath">Path to manifest.</param>
         /// <param name="relativePath">Path of the manifest in the repository.</param>
-        /// <returns>True if index was modified.</returns>
+        /// <returns>True if added; false if updated.</returns>
         bool AddOrUpdateManifest(string manifestPath, string relativePath);
 
         /// <summary>


### PR DESCRIPTION
## Issue
The requestor of this new (1.10) API needs to know whether the operation was an add or an update.  At the same time, the "was the index modified" return value from Update has always been true for any changes since the manifest hash was added.

## Change
Return `true` when adding and `false` when updating.

## Validation
Updated the unit tests to reflect this semantic shift.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4885)