### PR TITLE
Fix Repair-WinGetPackageManager cmdlet by retrieving dependencies from GitHub assets

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/CliCommand.cs
@@ -127,7 +127,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         private WinGetCLICommandResult Run(string command, string parameters, int timeOut = 60000)
         {
             var wingetCliWrapper = new WingetCLIWrapper();
-            var result = wingetCliWrapper.RunCommand(command, parameters, timeOut);
+            var result = wingetCliWrapper.RunCommand(this, command, parameters, timeOut);
             result.VerifyExitCode();
 
             return result;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UserSettingsCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/UserSettingsCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="UserSettingsCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -42,7 +42,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             if (winGetSettingsFilePath == null)
             {
                 var wingetCliWrapper = new WingetCLIWrapper();
-                var settingsResult = wingetCliWrapper.RunCommand("settings", "export");
+                var settingsResult = wingetCliWrapper.RunCommand(this, "settings", "export");
 
                 // Read the user settings file property.
                 var userSettingsFile = Utilities.ConvertToHashtable(settingsResult.StdOut)["userSettingsFile"] ?? throw new ArgumentNullException("userSettingsFile");

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/VersionCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/VersionCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="VersionCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -30,7 +30,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// </summary>
         public void Get()
         {
-            this.Write(StreamType.Object, WinGetVersion.InstalledWinGetVersion.TagVersion);
+            this.Write(StreamType.Object, WinGetVersion.InstalledWinGetVersion(this).TagVersion);
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -122,7 +122,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
                     if (seenCategories.Contains(currentCategory))
                     {
-                        this.Write(StreamType.Verbose, $"{currentCategory} encountered previously");
                         throw;
                     }
 
@@ -169,7 +168,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
         private async Task InstallDifferentVersionAsync(WinGetVersion toInstallVersion, bool allUsers, bool force)
         {
-            var installedVersion = WinGetVersion.InstalledWinGetVersion;
+            var installedVersion = WinGetVersion.InstalledWinGetVersion(this);
             bool isDowngrade = installedVersion.CompareAsDeployment(toInstallVersion) > 0;
 
             string message = $"Installed WinGet version '{installedVersion.TagVersion}' " +

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -122,6 +122,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
 
                     if (seenCategories.Contains(currentCategory))
                     {
+                        this.Write(StreamType.Verbose, $"{currentCategory} encountered previously");
                         throw;
                     }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetIntegrity.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -44,7 +44,7 @@ namespace Microsoft.WinGet.Client.Engine.Common
                 // Start by calling winget without its WindowsApp PFN path.
                 // If it succeeds and the exit code is 0 then we are good.
                 var wingetCliWrapper = new WingetCLIWrapper(false);
-                var result = wingetCliWrapper.RunCommand("--version");
+                var result = wingetCliWrapper.RunCommand(pwshCmdlet, "--version");
                 result.VerifyExitCode();
             }
             catch (Win32Exception e)
@@ -68,7 +68,7 @@ namespace Microsoft.WinGet.Client.Engine.Common
             {
                 // This assumes caller knows that the version exist.
                 WinGetVersion expectedWinGetVersion = new WinGetVersion(expectedVersion);
-                var installedVersion = WinGetVersion.InstalledWinGetVersion;
+                var installedVersion = WinGetVersion.InstalledWinGetVersion(pwshCmdlet);
                 if (expectedWinGetVersion.CompareTo(installedVersion) != 0)
                 {
                     throw new WinGetIntegrityException(

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Extensions/ReleaseExtensions.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Extensions/ReleaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ReleaseExtensions.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -24,14 +24,26 @@ namespace Microsoft.WinGet.Client.Engine.Extensions
         /// <returns>The asset.</returns>
         public static ReleaseAsset GetAsset(this Release release, string name)
         {
-            var assets = release.Assets.Where(a => a.Name == name);
+            var asset = TryGetAsset(release, name);
 
-            if (assets.Any())
+            if (asset != null)
             {
-                return assets.First();
+                return asset;
             }
 
             throw new WinGetRepairException(string.Format(Resources.ReleaseAssetNotFound, name));
+        }
+
+        /// <summary>
+        /// Gets the Asset if present.
+        /// </summary>
+        /// <param name="release">GitHub release.</param>
+        /// <param name="name">Name of asset.</param>
+        /// <returns>The asset, or null if not found.</returns>
+        public static ReleaseAsset? TryGetAsset(this Release release, string name)
+        {
+            var assets = release.Assets.Where(a => a.Name == name);
+            return assets.Any() ? assets.First() : null;
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -67,7 +67,6 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
 
         // Assets
         private const string MsixBundleName = "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle";
-        private const string DependenciesAssetName = "DesktopAppInstaller_Dependencies";
         private const string DependenciesJsonName = "DesktopAppInstaller_Dependencies.json";
         private const string DependenciesZipName = "DesktopAppInstaller_Dependencies.zip";
         private const string License = "License1.xml";
@@ -503,7 +502,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
 
                 foreach (var entry in missingDependencies)
                 {
-                    string fullPath = System.IO.Path.Combine(extractedDirectory.FullDirectoryPath, DependenciesAssetName, entry);
+                    string fullPath = System.IO.Path.Combine(extractedDirectory.FullDirectoryPath, entry);
                     if (!File.Exists(fullPath))
                     {
                         this.pwshCmdlet.Write(StreamType.Verbose, $"Package dependency not found in archive: {fullPath}");

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -340,7 +340,8 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
                 // Here we should: if we are in Windows Powershell then run Add-AppxPackage with -DependencyPath
                 // if we are in Core, then start powershell.exe and run the same command. Right now, we just
                 // do Add-AppxPackage for each one.
-                await this.InstallVCLibsDependenciesAsync();
+                // This method no longer works for versions >1.9 as the vclibs url has been deprecated.
+                await this.InstallVCLibsDependenciesFromUriAsync();
                 await this.InstallUiXamlAsync(releaseTag);
             }
         }
@@ -430,7 +431,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
             }
         }
 
-        private async Task InstallVCLibsDependenciesAsync()
+        private async Task InstallVCLibsDependenciesFromUriAsync()
         {
             Dictionary<string, string> vcLibsDependencies = this.GetVCLibsDependencies();
             this.FindMissingDependencies(vcLibsDependencies, VCLibsUWPDesktop, VCLibsUWPDesktopVersion);

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/AppxModuleHelper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         private const string License = "License1.xml";
 
         // Format of a dependency package such as 'x64\Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx'
-        private const string ExtractedDependencyPath = "{0}\\{1}_{2}_{3}.appx";
+        private const string ExtractedDependencyPath = "{0}\\{1}_{2}_{0}.appx";
 
         // Dependencies
         // VCLibs
@@ -350,10 +350,10 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
             Dictionary<string, string> appxPackages = new Dictionary<string, string>();
             var arch = RuntimeInformation.OSArchitecture;
 
-            string appxPackageX64 = string.Format(ExtractedDependencyPath, "x64", dependencies.Name, dependencies.Version, "x64");
-            string appxPackageX86 = string.Format(ExtractedDependencyPath, "x86", dependencies.Name, dependencies.Version, "x86");
-            string appxPackageArm = string.Format(ExtractedDependencyPath, "arm", dependencies.Name, dependencies.Version, "arm");
-            string appxPackageArm64 = string.Format(ExtractedDependencyPath, "arm", dependencies.Name, dependencies.Version, "arm64");
+            string appxPackageX64 = string.Format(ExtractedDependencyPath, "x64", dependencies.Name, dependencies.Version);
+            string appxPackageX86 = string.Format(ExtractedDependencyPath, "x86", dependencies.Name, dependencies.Version);
+            string appxPackageArm = string.Format(ExtractedDependencyPath, "arm", dependencies.Name, dependencies.Version);
+            string appxPackageArm64 = string.Format(ExtractedDependencyPath, "arm", dependencies.Name, dependencies.Version);
 
             if (arch == Architecture.X64)
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/PackageDependency.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/PackageDependency.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------------
+// <copyright file="PackageDependency.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+namespace Microsoft.WinGet.Client.Engine.Helpers
+{
+    /// <summary>
+    /// A single package dependency.
+    /// </summary>
+    internal class PackageDependency
+    {
+        /// <summary>
+        /// Gets or sets the name of the dependency.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the version of the dependency.
+        /// </summary>
+        public string Version { get; set; } = string.Empty;
+    }
+}

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WinGetVersion.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WinGetVersion.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetVersion.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -7,6 +7,7 @@
 namespace Microsoft.WinGet.Client.Engine.Helpers
 {
     using System;
+    using Microsoft.WinGet.Common.Command;
 
     /// <summary>
     /// WinGetVersion. Parse the string version returned by winget --version to allow comparisons.
@@ -49,19 +50,6 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         }
 
         /// <summary>
-        /// Gets the version of the installed winget.
-        /// </summary>
-        public static WinGetVersion InstalledWinGetVersion
-        {
-            get
-            {
-                var wingetCliWrapper = new WingetCLIWrapper();
-                var result = wingetCliWrapper.RunCommand("--version");
-                return new WinGetVersion(result.StdOut.Replace(Environment.NewLine, string.Empty));
-            }
-        }
-
-        /// <summary>
         /// Gets the version as it appears as a tag.
         /// </summary>
         public string TagVersion { get; }
@@ -75,6 +63,18 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// Gets a value indicating whether is this version is a prerelease.
         /// </summary>
         public bool IsPrerelease { get; }
+
+        /// <summary>
+        /// Gets the version of the installed winget.
+        /// </summary>
+        /// <param name="pwshCmdlet">PowerShell cmdlet.</param>
+        /// <returns>The WinGetVersion.</returns>
+        public static WinGetVersion InstalledWinGetVersion(PowerShellCmdlet pwshCmdlet)
+        {
+            var wingetCliWrapper = new WingetCLIWrapper();
+            var result = wingetCliWrapper.RunCommand(pwshCmdlet, "--version");
+            return new WinGetVersion(result.StdOut.Replace(Environment.NewLine, string.Empty));
+        }
 
         /// <summary>
         /// Version.CompareTo taking into account prerelease.

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WingetCLIWrapper.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WingetCLIWrapper.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WingetCLIWrapper.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,6 +11,7 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
     using System.IO;
     using Microsoft.WinGet.Client.Engine.Common;
     using Microsoft.WinGet.Client.Engine.Exceptions;
+    using Microsoft.WinGet.Common.Command;
 
     /// <summary>
     /// Calls winget directly.
@@ -65,17 +66,20 @@ namespace Microsoft.WinGet.Client.Engine.Helpers
         /// <summary>
         /// Runs winget command with parameters.
         /// </summary>
+        /// <param name="pwshCmdlet">PowerShell cmdlet.</param>
         /// <param name="command">Command.</param>
         /// <param name="parameters">Parameters.</param>
         /// <param name="timeOut">Time out.</param>
         /// <returns>WinGetCommandResult.</returns>
-        public WinGetCLICommandResult RunCommand(string command, string? parameters = null, int timeOut = 60000)
+        public WinGetCLICommandResult RunCommand(PowerShellCmdlet pwshCmdlet, string command, string? parameters = null, int timeOut = 60000)
         {
             string args = command;
             if (!string.IsNullOrEmpty(parameters))
             {
                 args += ' ' + parameters;
             }
+
+            pwshCmdlet.Write(StreamType.Verbose, $"Running {this.wingetPath} with {args}");
 
             Process p = new ()
             {

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WingetDependencies.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Helpers/WingetDependencies.cs
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------------
+// <copyright file="WingetDependencies.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+namespace Microsoft.WinGet.Client.Engine.Helpers
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// An object representation of the dependencies json.
+    /// </summary>
+    internal class WingetDependencies
+    {
+        /// <summary>
+        /// Gets or sets a list of required package dependencies.
+        /// </summary>
+        public List<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
+    }
+}

--- a/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
+++ b/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
@@ -66,7 +66,7 @@ class WinGetModule
     [void]PrepareBinaryFiles([string] $buildRoot, [string] $config)
     {
         $copyErrors = $null
-        Copy-Item "$buildRoot\AnyCpu\$config\PowerShell\$($this.Name)\*" $this.Output -Force -Recurse -ErrorVariable copyErrors -ErrorAction SilentlyContinue
+        Copy-Item "$buildRoot\AnyCpu\$config\PowerShell\$($this.Name)" $this.Output -Force -Recurse -ErrorVariable copyErrors -ErrorAction SilentlyContinue
         $copyErrors | ForEach-Object { Write-Warning $_ }
     }
 


### PR DESCRIPTION
This change address an issue with Repair-WinGetPackageManager not installing the correct version of VCLibs before installing winget. The reason this issue came up was because the aka.ms links for the VCLibs package are deprecated and now point to an out of date package. 

The solution here is to include both a `DesktopAppInstaller_Dependencies.json` and  `DesktopAppInstaller_Dependencies.zip` asset along with each release. Repair-WinGetPackageManager will look for those files and check what dependencies are required from the json file. If any of those dependencies are missing, it will download the zip, extract, and install the required binaries based on the system architecture. 

Testing:
Verified with the fresh Windows Sandbox install and trying out the assets on an earlier prerelease.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4923)

Related to:
* #4903 
* #4916