### PR TITLE
Remove attribute in DSC (#4932)

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psm1
+++ b/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psm1
@@ -190,7 +190,6 @@ class WinGetAdminSettings
 class WinGetSource
 {
     [DscProperty(Key, Mandatory)]
-    [ValidateNotNullOrWhiteSpace()]
     [string]$Name
     
     [DscProperty(Mandatory)]
@@ -210,6 +209,11 @@ class WinGetSource
 
     [WinGetSource] Get()
     {
+        if ([String]::IsNullOrWhiteSpace($this.Name))
+        {
+            throw "A value must be provided for WinGetSource::Name"
+        }
+
         $currentSource = $null
 
         try {
@@ -446,7 +450,6 @@ class WinGetPackageManager
 class WinGetPackage
 {
     [DscProperty(Key, Mandatory)]
-    [ValidateNotNullOrWhiteSpace()]
     [string]$Id
 
     [DscProperty(Key)]
@@ -471,6 +474,11 @@ class WinGetPackage
 
     [WinGetPackage] Get()
     {
+        if ([String]::IsNullOrWhiteSpace($this.Id))
+        {
+            throw "A value must be provided for WinGetPackage::Id"
+        }
+
         $result = [WinGetPackage]::new()
 
         $hashArgs = @{


### PR DESCRIPTION
## Change
Removes the attribute `ValidateNotNullOrWhiteSpace` as it is only available starting in 7.4. The attributes also only validate when the value is assigned, so enforcing that a value is set is more complete.

## Validation
Loads in PS 7.2.8 now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4933)