### PR TITLE
Don't put ARP version data into tracking catalog

### DIFF
--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -224,15 +224,11 @@ namespace AppInstaller::Repository
         auto& index = m_implementation->Source->GetIndex();
 
         // Strip ARP version information from the manifest if it is present
-        auto arpVersionRange = manifest.GetArpVersionRange();
-        if (!arpVersionRange.IsEmpty())
+        for (auto& arpRangeRemovedInstaller : manifest.Installers)
         {
-            for (auto& arpRangeRemovedInstaller : manifest.Installers)
+            for (auto& arpRangeRemovedEntry : arpRangeRemovedInstaller.AppsAndFeaturesEntries)
             {
-                for (auto& arpRangeRemovedEntry : arpRangeRemovedInstaller.AppsAndFeaturesEntries)
-                {
-                    arpRangeRemovedEntry.DisplayVersion.clear();
-                }
+                arpRangeRemovedEntry.DisplayVersion.clear();
             }
         }
 

--- a/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
+++ b/src/AppInstallerRepositoryCore/PackageTrackingCatalog.cpp
@@ -214,7 +214,7 @@ namespace AppInstaller::Repository
     }
 
     PackageTrackingCatalog::Version PackageTrackingCatalog::RecordInstall(
-        const Manifest::Manifest& manifest,
+        Manifest::Manifest& manifest,
         const Manifest::ManifestInstaller& installer,
         bool isUpgrade)
     {
@@ -224,16 +224,10 @@ namespace AppInstaller::Repository
         auto& index = m_implementation->Source->GetIndex();
 
         // Strip ARP version information from the manifest if it is present
-        const Manifest::Manifest* effectiveManifest = &manifest;
-        Manifest::Manifest arpRangeRemovedManifest;
-
         auto arpVersionRange = manifest.GetArpVersionRange();
         if (!arpVersionRange.IsEmpty())
         {
-            arpRangeRemovedManifest = manifest;
-            effectiveManifest = &arpRangeRemovedManifest;
-
-            for (auto& arpRangeRemovedInstaller : arpRangeRemovedManifest.Installers)
+            for (auto& arpRangeRemovedInstaller : manifest.Installers)
             {
                 for (auto& arpRangeRemovedEntry : arpRangeRemovedInstaller.AppsAndFeaturesEntries)
                 {
@@ -243,15 +237,15 @@ namespace AppInstaller::Repository
         }
 
         // Check for an existing manifest that matches this one (could be reinstalling)
-        auto manifestIdOpt = index.GetManifestIdByManifest(*effectiveManifest);
+        auto manifestIdOpt = index.GetManifestIdByManifest(manifest);
 
         if (manifestIdOpt)
         {
-            index.UpdateManifest(*effectiveManifest);
+            index.UpdateManifest(manifest);
         }
         else
         {
-            manifestIdOpt = index.AddManifest(*effectiveManifest);
+            manifestIdOpt = index.AddManifest(manifest);
         }
 
         SQLiteIndex::IdType manifestId = manifestIdOpt.value();

--- a/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/PackageTrackingCatalog.h
@@ -59,7 +59,7 @@ namespace AppInstaller::Repository
         };
 
         // Records an installation of the given package.
-        Version RecordInstall(const Manifest::Manifest& manifest, const Manifest::ManifestInstaller& installer, bool isUpgrade);
+        Version RecordInstall(Manifest::Manifest& manifest, const Manifest::ManifestInstaller& installer, bool isUpgrade);
 
         // Records an uninstall of the given package.
         void RecordUninstall(const Utility::LocIndString& packageIdentifier);


### PR DESCRIPTION
## Change
A previous change was made to block overlapping ARP ranges being put into the index.  The fact that this was potentially impactful to the tracking catalog was put off until now.

This change removes ARP version information (when present) from the manifest before placing it into the tracking catalog.  We are not using this data, and I don't see a reason that we would.  Attempting to preserve it would probably require removing all existing ARP version information when adding/updating the tracking manifest.

## Validation
Added a test that to insert an overlapping range into the tracking catalog.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4964)