### PR TITLE
Add default module root setting for configuration

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -200,6 +200,21 @@ The `purgePortablePackage` behavior affects the default behavior for uninstallin
     },
 ```
 
+## Configure Behavior
+
+The `configureBehavior` settings affect the default behavior of applying a configuration.
+
+### Default Module Root
+The `defaultModuleRoot` behavior affects the default root directory where modules are installed to. Defaults to `%LOCALAPPDATA%/Microsoft/WinGet/Configuration/Modules` if value is not set or is invalid.
+
+> Note: This setting value must be an absolute path.
+
+```json
+    "configureBehavior": {
+        "defaultModuleRoot": "C:/Program Files/Modules/"
+    },
+```
+
 ## Telemetry
 
 The `telemetry` settings control whether winget writes ETW events that may be sent to Microsoft on a default installation of Windows.

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -198,8 +198,8 @@
         }
       }
     },
-    "ConfigurationBehavior": {
-      "description": "Configuration settings",
+    "ConfigureBehavior": {
+      "description": "Configure settings",
       "type": "object",
       "properties": {
         "defaultModuleRoot": {
@@ -208,7 +208,7 @@
           "maxLength": 32767
         }
       }
-    }
+    },
     "DownloadBehavior": {
       "description": "Download settings",
       "type": "object",

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -198,6 +198,17 @@
         }
       }
     },
+    "ConfigurationBehavior": {
+      "description": "Configuration settings",
+      "type": "object",
+      "properties": {
+        "defaultModuleRoot": {
+          "description": "The default root directory where PowerShell modules are installed to when applying a configuration.",
+          "type": "string",
+          "maxLength": 32767
+        }
+      }
+    }
     "DownloadBehavior": {
       "description": "Download settings",
       "type": "object",

--- a/src/AppInstallerCLICore/ConfigurationCommon.cpp
+++ b/src/AppInstallerCLICore/ConfigurationCommon.cpp
@@ -48,7 +48,7 @@ namespace AppInstaller::CLI
                 }
             }
 
-            std::filesystem::path defaultModuleRoot = Settings::User().Get<Settings::Setting::ConfigurationDefaultModuleRoot>();
+            std::filesystem::path defaultModuleRoot = Settings::User().Get<Settings::Setting::ConfigureDefaultModuleRoot>();
 
             if (!defaultModuleRoot.empty())
             {

--- a/src/AppInstallerCLICore/ConfigurationCommon.cpp
+++ b/src/AppInstallerCLICore/ConfigurationCommon.cpp
@@ -48,6 +48,13 @@ namespace AppInstaller::CLI
                 }
             }
 
+            std::filesystem::path defaultModuleRoot = Settings::User().Get<Settings::Setting::ConfigurationDefaultModuleRoot>();
+
+            if (!defaultModuleRoot.empty())
+            {
+                return { SetProcessorFactory::PwshConfigurationProcessorLocation::Custom, defaultModuleRoot.u8string() };
+            }
+
             return { SetProcessorFactory::PwshConfigurationProcessorLocation::WinGetModulePath, {} };
         }
     }

--- a/src/AppInstallerCLICore/ConfigurationCommon.cpp
+++ b/src/AppInstallerCLICore/ConfigurationCommon.cpp
@@ -21,7 +21,7 @@ namespace AppInstaller::CLI
         struct ModulePathInfo
         {
             SetProcessorFactory::PwshConfigurationProcessorLocation location;
-            std::optional<std::string_view> customLocation;
+            std::optional<std::string> customLocation;
         };
 
         ModulePathInfo GetModulePathInfo(Execution::Args& execArgs)
@@ -44,7 +44,7 @@ namespace AppInstaller::CLI
                 }
                 else
                 {
-                    return { SetProcessorFactory::PwshConfigurationProcessorLocation::Custom, execArgs.GetArg(Execution::Args::Type::ConfigurationModulePath) };
+                    return { SetProcessorFactory::PwshConfigurationProcessorLocation::Custom, std::string(execArgs.GetArg(Execution::Args::Type::ConfigurationModulePath)) };
                 }
             }
 

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -77,6 +77,31 @@ namespace AppInstallerCLIE2ETests
         }
 
         /// <summary>
+        /// Simple test to confirm that the module was installed to the location specified in the DefaultModuleRoot settings.
+        /// </summary>
+        [Test]
+        public void ConfigureFromTestRepo_DefaultModuleRootSetting()
+        {
+            TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
+            string moduleTestDir = TestCommon.GetRandomTestDir();
+            WinGetSettingsHelper.ConfigureConfigureBehavior(Constants.DefaultModuleRoot, moduleTestDir);
+
+            string args = TestCommon.GetTestDataFile("Configuration\\Configure_TestRepo_Location.yml");
+            var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);
+
+            WinGetSettingsHelper.ConfigureConfigureBehavior(Constants.DefaultModuleRoot, string.Empty);
+            bool moduleExists = Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName));
+            if (moduleExists)
+            {
+                // Clean test directory to avoid impacting other tests.
+                Directory.Delete(moduleTestDir, true);
+            }
+
+            Assert.AreEqual(0, result.ExitCode);
+            Assert.True(moduleExists);
+        }
+
+        /// <summary>
         /// Simple test to confirm that the module was installed in the right location.
         /// </summary>
         /// <param name="location">Location to pass.</param>
@@ -113,31 +138,6 @@ namespace AppInstallerCLIE2ETests
             Assert.True(Directory.Exists(Path.Combine(
                 TestCommon.GetExpectedModulePath(location),
                 Constants.SimpleTestModuleName)));
-        }
-
-        /// <summary>
-        /// Simple test to confirm that the module was installed to the location specified in the DefaultModuleRoot settings.
-        /// </summary>
-        // [Test]
-        public void ConfigureFromTestRepo_SettingsDefaultModuleRoot()
-        {
-            TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
-            string moduleTestDir = TestCommon.GetRandomTestDir();
-            WinGetSettingsHelper.ConfigureConfigureBehavior(Constants.DefaultModuleRoot, moduleTestDir);
-
-            string args = TestCommon.GetTestDataFile("Configuration\\Configure_TestRepo_Location.yml");
-            var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);
-
-            WinGetSettingsHelper.ConfigureInstallBehavior(Constants.DefaultModuleRoot, string.Empty);
-            bool moduleExists = Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName));
-            if (moduleExists)
-            {
-                // Clean test directory to avoid impacting other tests.
-                Directory.Delete(moduleTestDir, true);
-            }
-
-            Assert.AreEqual(0, result.ExitCode);
-            Assert.True(moduleExists);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -129,8 +129,15 @@ namespace AppInstallerCLIE2ETests
             var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);
 
             WinGetSettingsHelper.ConfigureInstallBehavior(Constants.DefaultModuleRoot, string.Empty);
+            bool moduleExists = Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName));
+            if (moduleExists)
+            {
+                // Clean test directory to avoid impacting other tests.
+                Directory.Delete(moduleTestDir, true);
+            }
+
             Assert.AreEqual(0, result.ExitCode);
-            Assert.True(Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName)));
+            Assert.True(moduleExists);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -93,6 +93,7 @@ namespace AppInstallerCLIE2ETests
             bool moduleExists = Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName));
             if (moduleExists)
             {
+                // Clean test directory to avoid impacting other tests.
                 Directory.Delete(moduleTestDir, true);
             }
 

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -122,14 +122,14 @@ namespace AppInstallerCLIE2ETests
         public void ConfigureFromTestRepo_SettingsDefaultModuleRoot()
         {
             TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
-
             string moduleTestDir = TestCommon.GetRandomTestDir();
             WinGetSettingsHelper.ConfigureConfigureBehavior(Constants.DefaultModuleRoot, moduleTestDir);
 
             string args = TestCommon.GetTestDataFile("Configuration\\Configure_TestRepo_Location.yml");
             var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);
-            Assert.AreEqual(0, result.ExitCode);
 
+            WinGetSettingsHelper.ConfigureInstallBehavior(Constants.DefaultModuleRoot, string.Empty);
+            Assert.AreEqual(0, result.ExitCode);
             Assert.True(Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName)));
         }
 

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -124,7 +124,7 @@ namespace AppInstallerCLIE2ETests
             TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
 
             string moduleTestDir = TestCommon.GetRandomTestDir();
-            WinGetSettingsHelper.ConfigureConfigurationBehavior(Constants.DefaultModuleRoot, moduleTestDir);
+            WinGetSettingsHelper.ConfigureConfigureBehavior(Constants.DefaultModuleRoot, moduleTestDir);
 
             string args = TestCommon.GetTestDataFile("Configuration\\Configure_TestRepo_Location.yml");
             var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -118,7 +118,7 @@ namespace AppInstallerCLIE2ETests
         /// <summary>
         /// Simple test to confirm that the module was installed to the location specified in the DefaultModuleRoot settings.
         /// </summary>
-        [Test]
+        // [Test]
         public void ConfigureFromTestRepo_SettingsDefaultModuleRoot()
         {
             TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -93,7 +93,6 @@ namespace AppInstallerCLIE2ETests
             bool moduleExists = Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName));
             if (moduleExists)
             {
-                // Clean test directory to avoid impacting other tests.
                 Directory.Delete(moduleTestDir, true);
             }
 

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -116,6 +116,24 @@ namespace AppInstallerCLIE2ETests
         }
 
         /// <summary>
+        /// Simple test to confirm that the module was installed to the location specified in the DefaultModuleRoot settings.
+        /// </summary>
+        [Test]
+        public void ConfigureFromTestRepo_SettingsDefaultModuleRoot()
+        {
+            TestCommon.EnsureModuleState(Constants.SimpleTestModuleName, present: false);
+
+            string moduleTestDir = TestCommon.GetRandomTestDir();
+            WinGetSettingsHelper.ConfigureConfigurationBehavior(Constants.DefaultModuleRoot, moduleTestDir);
+
+            string args = TestCommon.GetTestDataFile("Configuration\\Configure_TestRepo_Location.yml");
+            var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, args);
+            Assert.AreEqual(0, result.ExitCode);
+
+            Assert.True(Directory.Exists(Path.Combine(moduleTestDir, Constants.SimpleTestModuleName)));
+        }
+
+        /// <summary>
         /// One resource fails, but the other is not dependent and should be executed.
         /// </summary>
         [Test]

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -125,6 +125,7 @@ namespace AppInstallerCLIE2ETests
         public const string PortablePackageMachineRoot = "portablePackageMachineRoot";
         public const string InstallBehaviorScope = "scope";
         public const string InstallerTypes = "installerTypes";
+        public const string DefaultModuleRoot = "defaultModuleRoot";
 
         // Configuration
         public const string PSGalleryName = "PSGallery";

--- a/src/AppInstallerCLIE2ETests/ErrorCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ErrorCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ErrorCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -14,6 +14,15 @@ namespace AppInstallerCLIE2ETests
     /// </summary>
     public class ErrorCommand
     {
+        /// <summary>
+        /// Reset settings file to avoid affecting output from error command.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            WinGetSettingsHelper.InitializeWingetSettings();
+        }
+
         /// <summary>
         /// Tests 0.
         /// </summary>

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -113,7 +113,7 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// </summary>
         /// <param name="settingName">Setting name.</param>
         /// <param name="value">Setting value.</param>
-        public static void ConfigureConfigurationBehavior(string settingName, string value)
+        public static void ConfigureConfigureBehavior(string settingName, string value)
         {
             JObject settingsJson = GetJsonSettingsObject("configureBehavior");
             var configureBehavior = settingsJson["configureBehavior"];

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -109,6 +109,20 @@ namespace AppInstallerCLIE2ETests.Helpers
         }
 
         /// <summary>
+        /// Configure the configuration behavior.
+        /// </summary>
+        /// <param name="settingName">Setting name.</param>
+        /// <param name="value">Setting value.</param>
+        public static void ConfigureConfigurationBehavior(string settingName, string value)
+        {
+            JObject settingsJson = GetJsonSettingsObject("configureBehavior");
+            var configureBehavior = settingsJson["configureBehavior"];
+            configureBehavior[settingName] = value;
+
+            SetWingetSettings(settingsJson);
+        }
+
+        /// <summary>
         /// Configure the install behavior preferences.
         /// </summary>
         /// <param name="settingName">Setting name.</param>

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -73,6 +73,12 @@ namespace AppInstallerCLIE2ETests.Helpers
                     {
                     }
                 },
+                {
+                    "configureBehavior",
+                    new Hashtable()
+                    {
+                    }
+                },
             };
 
             // Run winget one time to initialize settings directory

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -526,6 +526,21 @@ TEST_CASE("SettingsDownloadDefaultDirectory", "[settings]")
     }
 }
 
+TEST_CASE("SettingsConfigurationDefaultModuleRoot", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Valid path")
+    {
+        std::string_view json = R"({ "configurationBehavior": { "defaultModuleRoot": "C:/Foo/Bar" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::ConfigurationDefaultModuleRoot>() == "C:/Foo/Bar");
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+}
+
 TEST_CASE("SettingsArchiveExtractionMethod", "[settings]")
 {
     auto again = DeleteUserSettingsFiles();

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -526,17 +526,17 @@ TEST_CASE("SettingsDownloadDefaultDirectory", "[settings]")
     }
 }
 
-TEST_CASE("SettingsConfigurationDefaultModuleRoot", "[settings]")
+TEST_CASE("SettingsConfigureDefaultModuleRoot", "[settings]")
 {
     auto again = DeleteUserSettingsFiles();
 
     SECTION("Valid path")
     {
-        std::string_view json = R"({ "configurationBehavior": { "defaultModuleRoot": "C:/Foo/Bar" } })";
+        std::string_view json = R"({ "configureBehavior": { "defaultModuleRoot": "C:/Foo/Bar" } })";
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
-        REQUIRE(userSettingTest.Get<Setting::ConfigurationDefaultModuleRoot>() == "C:/Foo/Bar");
+        REQUIRE(userSettingTest.Get<Setting::ConfigureDefaultModuleRoot>() == "C:/Foo/Bar");
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
 }

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -187,7 +187,7 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::UninstallPurgePortablePackage, bool, bool, false, ".uninstallBehavior.purgePortablePackage"sv);
         // Download behavior
         SETTINGMAPPING_SPECIALIZATION(Setting::DownloadDefaultDirectory, std::string, std::filesystem::path, {}, ".downloadBehavior.defaultDownloadDirectory"sv);
-        // Configuration behavior
+        // Configure behavior
         SETTINGMAPPING_SPECIALIZATION(Setting::ConfigureDefaultModuleRoot, std::string, std::filesystem::path, {}, ".configureBehavior.defaultModuleRoot"sv);
 
         // Network

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -109,7 +109,7 @@ namespace AppInstaller::Settings
         // Download behavior
         DownloadDefaultDirectory,
         // Configuration behavior
-        ConfigurationDefaultModuleRoot,
+        ConfigureDefaultModuleRoot,
         // Interactivity
         InteractivityDisable,
 #ifndef AICLI_DISABLE_TEST_HOOKS
@@ -188,7 +188,7 @@ namespace AppInstaller::Settings
         // Download behavior
         SETTINGMAPPING_SPECIALIZATION(Setting::DownloadDefaultDirectory, std::string, std::filesystem::path, {}, ".downloadBehavior.defaultDownloadDirectory"sv);
         // Configuration behavior
-        SETTINGMAPPING_SPECIALIZATION(Setting::ConfigurationDefaultModuleRoot, std::string, std::filesystem::path, {}, ".configurationBehavior.defaultModuleRoot"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::ConfigureDefaultModuleRoot, std::string, std::filesystem::path, {}, ".configureBehavior.defaultModuleRoot"sv);
 
         // Network
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDownloader, std::string, InstallerDownloader, InstallerDownloader::Default, ".network.downloader"sv);

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -108,6 +108,8 @@ namespace AppInstaller::Settings
         UninstallPurgePortablePackage,
         // Download behavior
         DownloadDefaultDirectory,
+        // Configuration behavior
+        ConfigurationDefaultModuleRoot,
         // Interactivity
         InteractivityDisable,
 #ifndef AICLI_DISABLE_TEST_HOOKS
@@ -185,6 +187,8 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::UninstallPurgePortablePackage, bool, bool, false, ".uninstallBehavior.purgePortablePackage"sv);
         // Download behavior
         SETTINGMAPPING_SPECIALIZATION(Setting::DownloadDefaultDirectory, std::string, std::filesystem::path, {}, ".downloadBehavior.defaultDownloadDirectory"sv);
+        // Configuration behavior
+        SETTINGMAPPING_SPECIALIZATION(Setting::ConfigurationDefaultModuleRoot, std::string, std::filesystem::path, {}, ".configurationBehavior.defaultModuleRoot"sv);
 
         // Network
         SETTINGMAPPING_SPECIALIZATION(Setting::NetworkDownloader, std::string, InstallerDownloader, InstallerDownloader::Default, ".network.downloader"sv);

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -108,7 +108,7 @@ namespace AppInstaller::Settings
         UninstallPurgePortablePackage,
         // Download behavior
         DownloadDefaultDirectory,
-        // Configuration behavior
+        // Configure behavior
         ConfigureDefaultModuleRoot,
         // Interactivity
         InteractivityDisable,

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -401,7 +401,7 @@ namespace AppInstaller::Settings
             return ValidatePathValue(value);
         }
 
-        WINGET_VALIDATE_SIGNATURE(ConfigurationDefaultModuleRoot)
+        WINGET_VALIDATE_SIGNATURE(ConfigureDefaultModuleRoot)
         {
             return ValidatePathValue(value);
         }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -401,6 +401,11 @@ namespace AppInstaller::Settings
             return ValidatePathValue(value);
         }
 
+        WINGET_VALIDATE_SIGNATURE(ConfigurationDefaultModuleRoot)
+        {
+            return ValidatePathValue(value);
+        }
+
         WINGET_VALIDATE_SIGNATURE(NetworkDownloader)
         {
             static constexpr std::string_view s_downloader_default = "default";


### PR DESCRIPTION
Changes:
- Adds a new settings object for `configureBehavior`
- Adds a new field for `defaultModuleRoot` that determines the default directory where modules are installed to.


Tests:
- Verify settings value is parsed correctly
- Added E2E test to check that the module is installed to the directory specified from the settings.json file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4974)