### PR TITLE
[WinGet DSC] Add WinGetConfigRoot cmdlet

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psd1
+++ b/src/PowerShell/Microsoft.WinGet.DSC/Microsoft.WinGet.DSC.psd1
@@ -85,6 +85,7 @@
         'WinGetSource'
         'WinGetPackageManager'
         'WinGetPackage'
+        'WinGetConfigRoot'
     )
     
     # List of all modules packaged with this module

--- a/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
@@ -244,66 +244,34 @@ Describe 'WinGetPackageManager' {
 }
 
 Describe 'WinGetConfigRoot' {
-    It 'WinGetConfigRoot User Variable' {
-        $get = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+    It 'Sets and removes $WinGetConfigRoot by scope' -ForEach 'User','Machine' {
+        $get = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ WinGetScope = $_ }
         $get.WinGetConfigRoot = "WinGetConfigRoot"
         $get.Exist | Should -Be $false
         $get.Path | Should -Be ""
-        $get.Scope | Should -Be 'User'
+        $get.WinGetScope | Should -Be $_
 
-        $test = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $true; Path = 'C:\Foo\Bar' }
+        $test = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $true; Path = 'C:\Foo\Bar'; WinGetScope = $_ }
         $test.InDesiredState | Should -Be $false
 
-        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $true; Path = 'C:\Foo\Bar' }
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $true; Path = 'C:\Foo\Bar'; WinGetScope = $_ }
 
         # Verify that $WinGetConfigRoot variable is set.
-        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = $_}
         $result.Exists | Should -Be $true
         $result.Path | Should -Be 'C:\Foo\Bar'
-        $result.Scope | Should -Be 'User'
+        $result.WinGetScope | Should -Be $_
 
         # Remove $WinGetConfigRoot variable.
-        $test2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $false }
+        $test2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $false; WinGetScope = $_ }
         $test2.InDesiredState | Should -Be $false
 
-        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $false }
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $false; WinGetScope = $_ }
 
-        $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+        $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = $_}
         $result2.WinGetConfigRoot = "WinGetConfigRoot"
         $result2.Exists | Should -Be $false
         $result2.Path | Should -Be ""
-        $result2.Scope | Should -Be 'User'
-    }
-
-    It 'WinGetConfigRoot Machine Variable' {
-        $get = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ WinGetScope = 'Machine'}
-        $get.WinGetConfigRoot = "WinGetConfigRoot"
-        $get.Exist | Should -Be $false
-        $get.Path | Should -Be ""
-        $get.Scope | Should -Be 'Machine'
-
-        $test = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $true; Path = 'C:\Hello\World'; WinGetScope = 'Machine' }
-        $test.InDesiredState | Should -Be $false
-
-        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $true; Path = 'C:\Hello\World'; WinGetScope = 'Machine' }
-
-        # Verify that $WinGetConfigRoot variable is set.
-        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ WinGetScope = 'Machine' }
-        $result.WinGetConfigRoot = "WinGetConfigRoot"
-        $result.Exists | Should -Be $true
-        $result.Path | Should -Be 'C:\Hello\World'
-        $result.Scope | Should -Be 'Machine'
-
-        # Remove $WinGetConfigRoot variable.
-        $test2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $false; WinGetScope = 'Machine' }
-        $test2.InDesiredState | Should -Be $false
-
-        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $false; WinGetScope = 'Machine' }
-
-        $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = 'Machine'}
-        $result2.WinGetConfigRoot = "WinGetConfigRoot"
-        $result2.Exists | Should -Be $false
-        $result2.Path | Should -Be ""
-        $result2.Scope | Should -Be 'Machine'
+        $result2.WinGetScope | Should -Be $_
     }
 }

--- a/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
@@ -242,3 +242,31 @@ Describe 'WinGetPackageManager' {
 
     # TODO: Add test to verify Set method for WinGetPackageManager
 }
+
+Describe 'WinGetConfigRoot' {
+    It 'Get WinGetConfigRoot' {
+        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+        $result.Exists | Should -Be $false
+        $result.Path | Should -Be $null
+        $result.Scope | Should -Be 'User'
+    }
+
+    It 'Test WinGetConfigRoot' {
+        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
+        $result.InDesiredState | Should -Be $false
+    }
+
+    It 'Set WinGetConfigRoot' {
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
+
+        # Verify $winGetConfigRoot is set
+        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
+        $result.Exists | Should -Be $true
+        $result.Path | Should -Be 'C:\Foo\Bar'
+        $result.Scope | Should -Be 'User'
+    }
+
+    AfterAll {
+        InvokeWinGetDSC -Name WinGetPackage -Method Set -Property @{ Ensure = 'Absent' }
+    }
+}

--- a/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
@@ -244,29 +244,66 @@ Describe 'WinGetPackageManager' {
 }
 
 Describe 'WinGetConfigRoot' {
-    It 'Get WinGetConfigRoot' {
+    It 'WinGetConfigRoot User Variable' {
+        $get = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+        $get.WinGetConfigRoot = "WinGetConfigRoot"
+        $get.Exist | Should -Be $false
+        $get.Path | Should -Be ""
+        $get.Scope | Should -Be 'User'
+
+        $test = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $true; Path = 'C:\Foo\Bar' }
+        $test.InDesiredState | Should -Be $false
+
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $true; Path = 'C:\Foo\Bar' }
+
+        # Verify that $WinGetConfigRoot variable is set.
         $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
-        $result.Exists | Should -Be $false
-        $result.Path | Should -Be $null
-        $result.Scope | Should -Be 'User'
-    }
-
-    It 'Test WinGetConfigRoot' {
-        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
-        $result.InDesiredState | Should -Be $false
-    }
-
-    It 'Set WinGetConfigRoot' {
-        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
-
-        # Verify $winGetConfigRoot is set
-        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ Exists = $true; Path = 'C:\Foo\Bar' }
         $result.Exists | Should -Be $true
         $result.Path | Should -Be 'C:\Foo\Bar'
         $result.Scope | Should -Be 'User'
+
+        # Remove $WinGetConfigRoot variable.
+        $test2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $false }
+        $test2.InDesiredState | Should -Be $false
+
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $false }
+
+        $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{}
+        $result2.WinGetConfigRoot = "WinGetConfigRoot"
+        $result2.Exists | Should -Be $false
+        $result2.Path | Should -Be ""
+        $result2.Scope | Should -Be 'User'
     }
 
-    AfterAll {
-        InvokeWinGetDSC -Name WinGetPackage -Method Set -Property @{ Ensure = 'Absent' }
+    It 'WinGetConfigRoot Machine Variable' {
+        $get = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ WinGetScope = 'Machine'}
+        $get.WinGetConfigRoot = "WinGetConfigRoot"
+        $get.Exist | Should -Be $false
+        $get.Path | Should -Be ""
+        $get.Scope | Should -Be 'Machine'
+
+        $test = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $true; Path = 'C:\Hello\World'; WinGetScope = 'Machine' }
+        $test.InDesiredState | Should -Be $false
+
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $true; Path = 'C:\Hello\World'; WinGetScope = 'Machine' }
+
+        # Verify that $WinGetConfigRoot variable is set.
+        $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{ WinGetScope = 'Machine' }
+        $result.WinGetConfigRoot = "WinGetConfigRoot"
+        $result.Exists | Should -Be $true
+        $result.Path | Should -Be 'C:\Hello\World'
+        $result.Scope | Should -Be 'Machine'
+
+        # Remove $WinGetConfigRoot variable.
+        $test2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Test -Property @{ Exist = $false; WinGetScope = 'Machine' }
+        $test2.InDesiredState | Should -Be $false
+
+        InvokeWinGetDSC -Name WinGetConfigRoot -Method Set -Property @{ Exist = $false; WinGetScope = 'Machine' }
+
+        $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = 'Machine'}
+        $result2.WinGetConfigRoot = "WinGetConfigRoot"
+        $result2.Exists | Should -Be $false
+        $result2.Path | Should -Be ""
+        $result2.Scope | Should -Be 'Machine'
     }
 }

--- a/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
@@ -32,9 +32,9 @@ BeforeAll {
 
 Describe 'List available DSC resources'{
     It 'Shows DSC Resources'{
-        $expectedDSCResources = "WinGetAdminSettings", "WinGetPackage", "WinGetPackageManager", "WinGetSource", "WinGetUserSettings"
+        $expectedDSCResources = "WinGetAdminSettings", "WinGetPackage", "WinGetPackageManager", "WinGetSource", "WinGetUserSettings", "WinGetConfigRoot"
         $availableDSCResources = (Get-DscResource -Module Microsoft.WinGet.DSC).Name
-        $availableDSCResources.length | Should -Be 5
+        $availableDSCResources.length | Should -Be 6
         $availableDSCResources | Where-Object {$expectedDSCResources -notcontains $_} | Should -BeNullOrEmpty -ErrorAction Stop
     }
 }
@@ -258,7 +258,7 @@ Describe 'WinGetConfigRoot' {
 
         # Verify that $WinGetConfigRoot variable is set.
         $result = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = $_}
-        $result.Exists | Should -Be $true
+        $result.Exist | Should -Be $true
         $result.Path | Should -Be 'C:\Foo\Bar'
         $result.WinGetScope | Should -Be $_
 
@@ -270,7 +270,7 @@ Describe 'WinGetConfigRoot' {
 
         $result2 = InvokeWinGetDSC -Name WinGetConfigRoot -Method Get -Property @{WinGetScope = $_}
         $result2.WinGetConfigRoot = "WinGetConfigRoot"
-        $result2.Exists | Should -Be $false
+        $result2.Exist | Should -Be $false
         $result2.Path | Should -Be ""
         $result2.WinGetScope | Should -Be $_
     }


### PR DESCRIPTION
Added a new dsc resource for ensuring that the $WinGetConfigRoot environment variable exists and is set. Added pester tests to verify that variables are set for both user and machine scope.

Some commands I tried out:

`Invoke-DscResource -Name WinGetConfigRoot -Method Get -ModuleName Microsoft.WinGet.DSC -Property @{ Exist=0; Path="C:\Foo\Bar"; WinGetScope='User' }`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/4990)