### PR TITLE
Add tests for ensuring integers are parsed correctly with leading zeroes

### DIFF
--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -179,6 +179,7 @@ TEST_CASE("VersionCompare", "[versions]")
     // Ensure whitespace doesn't affect equality
     RequireEqual("1.0", "1.0 ");
     RequireEqual("1.0", "1. 0");
+    RequireEqual("1.0", "1.0.");
 
     // Ensure versions with preambles are sorted correctly
     RequireEqual("1.0", "Version 1.0");

--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -170,6 +170,12 @@ TEST_CASE("VersionCompare", "[versions]")
 
     RequireEqual("1.0", "1.0.0");
 
+    // Ensure that integers are parsed correctly when there is a leading zero
+    RequireEqual("1.2.00.3", "1.2.0.3");
+    RequireEqual("1.2.003.4", "1.2.3.4");
+    RequireEqual("01.02.03.04", "1.2.3.4");
+    RequireEqual("1.2.03-beta", "1.2.3-beta");
+
     // Ensure whitespace doesn't affect equality
     RequireEqual("1.0", "1.0 ");
     RequireEqual("1.0", "1. 0");


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

I wasn't sure offhand if these versions would parse to be equal. I went to look at the test cases and found there were no tests that ensured that leading zeroes were parsed correctly. This PR adds the tests for clarity

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5013)