### PR TITLE
Add configuration modules path to '--info'

### DIFF
--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -154,6 +154,7 @@ namespace AppInstaller::CLI
             keyDirectories.OutputLine({ Resource::LocString{ Resource::String::PortableRoot }, Runtime::GetPathTo(Runtime::PathName::PortablePackageMachineRoot, true).u8string() });
             keyDirectories.OutputLine({ Resource::LocString{ Resource::String::PortableRoot86 }, Runtime::GetPathTo(Runtime::PathName::PortablePackageMachineRootX86, true).u8string() });
             keyDirectories.OutputLine({ Resource::LocString{ Resource::String::InstallerDownloads }, Runtime::GetPathTo(Runtime::PathName::UserProfileDownloads, true).u8string() });
+            keyDirectories.OutputLine({ Resource::LocString{ Resource::String::ConfigurationModules }, Runtime::GetPathTo(Runtime::PathName::ConfigurationModules, true).u8string() });
             keyDirectories.Complete();
             context.Reporter.Info() << std::endl;
         }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -94,6 +94,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationModuleNameOnly);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationModulePath);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationModulePathArgError);
+        WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationModules);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationModuleWithDetails);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationNotEnabledMessage);
         WINGET_DEFINE_RESOURCE_STRINGID(ConfigurationNoTestRun);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1812,7 +1812,7 @@ Please specify one of them using the --source option to proceed.</value>
   <data name="ConfigurationSuccessfullyApplied" xml:space="preserve">
     <value>Configuration successfully applied.</value>
   </data>
-	<data name="ConfigurationUnitSuccessfullyApplied" xml:space="preserve">
+  <data name="ConfigurationUnitSuccessfullyApplied" xml:space="preserve">
     <value>Unit successfully applied.</value>
   </data>
   <data name="ConfigurationWaitingOnAnother" xml:space="preserve">
@@ -3147,7 +3147,7 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="InstallerZeroByteFile" xml:space="preserve">
     <value>Downloaded zero byte installer; ensure that your network connection is working properly.</value>
-  </data>  
+  </data>
   <data name="FontCommandShortDescription" xml:space="preserve">
     <value>Manage fonts</value>
   </data>
@@ -3182,5 +3182,8 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="FontVersion" xml:space="preserve">
     <value>Version</value>
+  </data>
+  <data name="ConfigurationModules" xml:space="preserve">
+    <value>Configuration Modules</value>
   </data>
 </root>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -3185,5 +3185,6 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="ConfigurationModules" xml:space="preserve">
     <value>Configuration Modules</value>
+    <comment>PowerShell Modules that are used for the Configuration feature</comment>
   </data>
 </root>

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -50,6 +50,8 @@ namespace AppInstaller::Runtime
         SelfPackageRoot,
         // The location where user downloads are stored.
         UserProfileDownloads,
+        // The location where configuration modules are stored.
+        ConfigurationModules,
         // The location where checkpoints are stored.
         CheckpointsLocation,
         // The location of the CLI executable file.

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -30,6 +30,7 @@ namespace AppInstaller::Runtime
         constexpr std::string_view s_PortablePackagesDirectory = "Packages"sv;
         constexpr std::string_view s_LinksDirectory = "Links"sv;
         constexpr std::string_view s_FontsInstallDirectory = "Microsoft\\Windows\\Fonts"sv;
+        constexpr std::string_view s_ConfigurationModulesDirectory = "Configuration\\Modules"sv;
 // Use production CLSIDs as a surrogate for repository location.
 #if USE_PROD_CLSIDS
         constexpr std::string_view s_ImageAssetsDirectoryRelative = "Assets\\WinGet"sv;
@@ -240,6 +241,16 @@ namespace AppInstaller::Runtime
         case PathName::FontsMachineInstallLocation:
             result.Path = GetKnownFolderPath(FOLDERID_Fonts);
             break;
+        case PathName::ConfigurationModules:
+            result.Path = Settings::User().Get<Setting::ConfigureDefaultModuleRoot>();
+            if (result.Path.empty())
+            {
+                result.Path = GetKnownFolderPath(FOLDERID_LocalAppData);
+                result.Path /= s_SecureSettings_Base;
+                result.Path /= s_ConfigurationModulesDirectory;
+            }
+            mayBeInProfilePath = true;
+            break;
         default:
             THROW_HR(E_UNEXPECTED);
         }
@@ -316,6 +327,7 @@ namespace AppInstaller::Runtime
         case PathName::UserProfileDownloads:
         case PathName::FontsUserInstallLocation:
         case PathName::FontsMachineInstallLocation:
+        case PathName::ConfigurationModules:
             result = GetPathDetailsCommon(path, forDisplay);
             break;
         case PathName::SelfPackageRoot:
@@ -422,6 +434,7 @@ namespace AppInstaller::Runtime
         case PathName::UserProfileDownloads:
         case PathName::FontsUserInstallLocation:
         case PathName::FontsMachineInstallLocation:
+        case PathName::ConfigurationModules:
             result = GetPathDetailsCommon(path, forDisplay);
             break;
         case PathName::SelfPackageRoot:


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.


Adds the WinGet configuration modules location to `--info` table


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5023)