### PR TITLE
Enable intellisense for all user settings fields

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -310,6 +310,12 @@
   "allOf": [
     {
       "properties": {
+        "source": { "$ref": "#/definitions/Source" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
         "visual": { "$ref": "#/definitions/Visual" }
       },
       "additionalItems": true
@@ -322,13 +328,31 @@
     },
     {
       "properties": {
-        "source": { "$ref": "#/definitions/Source" }
+        "installPrefReq": { "$ref": "#/definitions/InstallPrefReq" }
       },
       "additionalItems": true
     },
     {
       "properties": {
         "installBehavior": { "$ref": "#/definitions/InstallBehavior" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "uninstallBehavior": { "$ref": "#/definitions/UninstallBehavior" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "configureBehavior": { "$ref": "#/definitions/ConfigureBehavior" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "downloadBehavior": { "$ref": "#/definitions/DownloadBehavior" }
       },
       "additionalItems": true
     },


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

In VSCode, I don't get Intellisense for all user settings fields. This seems to be because all fields are not defined under `allOf:`. PR adds missing fields under `allOf:` to enable intellisense. The diffs may be weird as it seems the file contains mixed line endings. I just let everything be in `LF` to avoid showing the whole file changed in git diff. Moved Source field up in `allOf:` to follow the same ordering as defined under `definitions:`

## Validation

Manually validated that I'm getting intellisense for missing fields against the URL in my branch

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5031)