### PR TITLE
Add missing ReturnResponseUrl to WinGetUtilInterop manifest

### DIFF
--- a/src/WinGetUtilInterop.UnitTests/ManifestUnitTest/V1ManifestReadTest.cs
+++ b/src/WinGetUtilInterop.UnitTests/ManifestUnitTest/V1ManifestReadTest.cs
@@ -264,6 +264,8 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
 
                 Assert.True(manifest.DisplayInstallWarnings);
                 Assert.True(manifest.DownloadCommandProhibited);
+
+                Assert.Equal("https://defaultReturnResponseUrl.com", manifest.ExpectedReturnCodes[0].ReturnResponseUrl);
             }
 
             if (manifestVersion >= TestManifestVersion.V170)
@@ -373,6 +375,8 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
 
                 Assert.True(installer1.DisplayInstallWarnings);
                 Assert.True(installer1.DownloadCommandProhibited);
+
+                Assert.Equal("https://returnResponseUrl.com", installer1.ExpectedReturnCodes[0].ReturnResponseUrl);
             }
 
             if (manifestVersion >= TestManifestVersion.V170)

--- a/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_1ManifestMerged.yaml
+++ b/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_1ManifestMerged.yaml
@@ -34,7 +34,6 @@ ExpectedReturnCodes:
   ReturnResponse: contactSupport
 - InstallerReturnCode: 3
   ReturnResponse: custom
-  ReturnResponseUrl: https://defaultReturnResponseUrl.com
 FileExtensions:
 - appx
 - msix

--- a/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_6ManifestMerged.yaml
+++ b/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_6ManifestMerged.yaml
@@ -106,9 +106,9 @@ Markets:
 ExpectedReturnCodes:
     - InstallerReturnCode: 2
       ReturnResponse: contactSupport
+      ReturnResponseUrl: https://defaultReturnResponseUrl.com
     - InstallerReturnCode: 3
       ReturnResponse: custom
-      ReturnResponseUrl: https://defaultReturnResponseUrl.com
 UnsupportedArguments:
   - log
 NestedInstallerType: msi
@@ -225,8 +225,9 @@ Installers:
       ExcludedMarkets:
         - "US"
     ExpectedReturnCodes:
-    - InstallerReturnCode: 2
-      ReturnResponse: contactSupport
+      - InstallerReturnCode: 2
+        ReturnResponse: contactSupport
+        ReturnResponseUrl: https://returnResponseUrl.com
     DownloadCommandProhibited: true
     InstallationMetadata:
       DefaultInstallLocation: "%ProgramFiles%\\TestApp"

--- a/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_7ManifestMerged.yaml
+++ b/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_7ManifestMerged.yaml
@@ -107,9 +107,9 @@ Markets:
 ExpectedReturnCodes:
     - InstallerReturnCode: 2
       ReturnResponse: contactSupport
+      ReturnResponseUrl: https://defaultReturnResponseUrl.com
     - InstallerReturnCode: 3
       ReturnResponse: custom
-      ReturnResponseUrl: https://defaultReturnResponseUrl.com
 UnsupportedArguments:
   - log
 NestedInstallerType: msi
@@ -228,8 +228,9 @@ Installers:
       ExcludedMarkets:
         - "US"
     ExpectedReturnCodes:
-    - InstallerReturnCode: 2
-      ReturnResponse: contactSupport
+      - InstallerReturnCode: 2
+        ReturnResponse: contactSupport
+        ReturnResponseUrl: https://returnResponseUrl.com
     DownloadCommandProhibited: true
     RepairBehavior: modify
     InstallationMetadata:

--- a/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_9ManifestMerged.yaml
+++ b/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_9ManifestMerged.yaml
@@ -107,9 +107,9 @@ Markets:
 ExpectedReturnCodes:
     - InstallerReturnCode: 2
       ReturnResponse: contactSupport
+      ReturnResponseUrl: https://defaultReturnResponseUrl.com
     - InstallerReturnCode: 3
       ReturnResponse: custom
-      ReturnResponseUrl: https://defaultReturnResponseUrl.com
 UnsupportedArguments:
   - log
 NestedInstallerType: msi
@@ -229,8 +229,9 @@ Installers:
       ExcludedMarkets:
         - "US"
     ExpectedReturnCodes:
-    - InstallerReturnCode: 2
-      ReturnResponse: contactSupport
+      - InstallerReturnCode: 2
+        ReturnResponse: contactSupport
+        ReturnResponseUrl: https://returnResponseUrl.com
     DownloadCommandProhibited: true
     ArchiveBinariesDependOnPath: false
     RepairBehavior: modify

--- a/src/WinGetUtilInterop/Manifest/V1/InstallerExpectedReturnCode.cs
+++ b/src/WinGetUtilInterop/Manifest/V1/InstallerExpectedReturnCode.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="InstallerExpectedReturnCode.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -20,5 +20,10 @@ namespace Microsoft.WinGetUtil.Models.V1
         /// Gets or sets the corresponding response category.
         /// </summary>
         public string ReturnResponse { get; set; }
+
+        /// <summary>
+        /// Gets or sets the corresponding response url.
+        /// </summary>
+        public string ReturnResponseUrl { get; set; }
     }
 }


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5035)