### PR TITLE
Allows setting WinGet proxy setting as SFS Client Proxy

### DIFF
--- a/src/AppInstallerCommonCore/MSStoreDownload.cpp
+++ b/src/AppInstallerCommonCore/MSStoreDownload.cpp
@@ -6,11 +6,12 @@
 #include <AppinstallerLogging.h>
 #include "AppInstallerMsixInfo.h"
 #include "AppInstallerRuntime.h"
-#include "winget/Locale.h"
-#include "winget/JsonUtil.h"
-#include "winget/MSStoreDownload.h"
-#include "winget/Rest.h"
 #include "winget/HttpClientHelper.h"
+#include "winget/JsonUtil.h"
+#include "winget/Locale.h"
+#include "winget/MSStoreDownload.h"
+#include "winget/NetworkSettings.h"
+#include "winget/Rest.h"
 #include "winget/UserSettings.h"
 #ifndef WINGET_DISABLE_FOR_FUZZING
 #include <sfsclient/SFSClient.h>
@@ -910,6 +911,12 @@ namespace AppInstaller::MSStore
             {
                 SFS::RequestParams sfsClientRequest;
                 sfsClientRequest.productRequests = { {std::string{ wuCategoryId }, {}} };
+                const auto& proxyUri = AppInstaller::Settings::Network().GetProxyUri();
+                if (proxyUri)
+                {
+                    AICLI_LOG(Core, Info, << "Passing proxy to SFS client " << *proxyUri);
+                    sfsClientRequest.proxy = *proxyUri;
+                }
 
                 auto requestResult = GetSfsClientInstance()->GetLatestAppDownloadInfo(sfsClientRequest, appContents);
                 if (!requestResult)

--- a/src/AppInstallerCommonCore/Public/winget/NetworkSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/NetworkSettings.h
@@ -16,7 +16,7 @@ namespace AppInstaller::Settings
     {
         static NetworkSettings& Instance();
 
-        const std::optional<std::string> GetProxyUri() const { return m_proxyUri; }
+        const std::optional<std::string>& GetProxyUri() const { return m_proxyUri; }
         // Sets the proxy URI; may do nothing depending on admin settings and group policy
         void SetProxyUri(const std::optional<std::string>& proxyUri);
 


### PR DESCRIPTION
Allows setting WinGet proxy setting as the SFS Client Proxy.

Fixes the issue below
[WinGet download doesn't work through a proxy #5030](https://github.com/microsoft/winget-cli/issues/5030)

This PR requires SfsClient subtree updated to 1.1.0
[SfsClient update 1.1.0 for proxy support #5052](https://github.com/microsoft/winget-cli/pull/5052)

Which brings especially
[Adding support for a custom proxy input #218](https://github.com/microsoft/sfs-client/pull/218)

This PR replaces closed PR below
[Allows setting WinGet proxy setting as SFS Client Proxy #5032](https://github.com/microsoft/winget-cli/pull/5032)

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5054)