### PR TITLE
Clarify settings behavior

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -129,6 +129,10 @@ Some of the settings are duplicated under `preferences` and `requirements`. `pre
 
 Any arguments passed on the command line will effectively override the matching `requirement` setting for the duration of that command.
 
+> [!NOTE]
+> - These settings are only applied for the `winget install` command.
+> - Other commands like `winget configure` are not affected by these settings.
+
 ### Scope
 
 The `scope` behavior affects the choice between installing a package for the current user or for the entire machine. The matching parameter is `--scope`, and uses the same values (`user` or `machine`).


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to a discussion.

-----

When looking through the discussions, I noticed the following [question](https://github.com/microsoft/winget-cli/discussions/4985) asked by Tristan. After trying out some options, I thought the `ConfigureBehavior` would do the trick. Unfortunately, after trying it out, I took the conclusion from the description that only `winget install` is affected by these settings. This pull request clarifies it a bit more.

