### PR TITLE
Add validateset attribute for relevant cmdlets

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AddSourceCmdlet.cs
@@ -42,6 +42,9 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
         [Parameter(
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
+        [ValidateSet(
+            "Microsoft.Rest",
+            "Microsoft.PreIndexed.Package")]
         public string Type { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
@@ -25,6 +25,12 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
+        [ValidateSet(
+            "LocalManifestFiles",
+            "BypassCertificatePinningForMicrosoftStore",
+            "InstallerHashOverride",
+            "LocalArchiveMalwareScanOverride",
+            "ProxyCommandLineOptions")]
         public string Name { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
@@ -25,6 +25,12 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
+        [ValidateSet(
+            "LocalManifestFiles",
+            "BypassCertificatePinningForMicrosoftStore",
+            "InstallerHashOverride",
+            "LocalArchiveMalwareScanOverride",
+            "ProxyCommandLineOptions")]
         public string Name { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

This pull request adds the `ValidateSet` attribute for three cmdlets, which will help users quickly discover the available types or setting names. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5073)