### PR TITLE
Add missing top-level exception handling for arg validation

### DIFF
--- a/src/AppInstallerCLICore/Core.cpp
+++ b/src/AppInstallerCLICore/Core.cpp
@@ -173,6 +173,10 @@ namespace AppInstaller::CLI
             context.Reporter.Error() << Resource::String::DisabledByGroupPolicy(policy.PolicyName()) << std::endl;
             return APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY;
         }
+        catch (...)
+        {
+            return Workflow::HandleException(context, std::current_exception());
+        }
 
         return Execute(context, command);
     }


### PR DESCRIPTION
The CLI arg validation code has gotten more complicated and now there is more room for exceptions to occur. For example, if there is an error when reading the admin settings or group policies that determine if an argument is available.

This adds generic exception handling at the top-level of arg validation so that we can exit gracefully and show an error, instead of just crashing.

Partial fix for #5098. This addresses the no output, but not the cause of the error

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5111)