### PR TITLE
Store information result in RestSourceReference for reuse

### DIFF
--- a/src/AppInstallerCLITests/CustomHeader.cpp
+++ b/src/AppInstallerCLITests/CustomHeader.cpp
@@ -41,6 +41,14 @@ namespace
         })delimiter");
 }
 
+// In RestClient.cpp tests
+extern RestClient CreateRestClient(
+    const std::string& restApi,
+    const std::optional<std::string>& customHeader,
+    std::string_view caller,
+    const Http::HttpClientHelper& helper,
+    const Authentication::AuthenticationArguments& authArgs = {});
+
 TEST_CASE("RestClient_CustomHeader", "[RestSource][CustomHeader]")
 {
     utility::string_t sample = _XPLATSTR(
@@ -55,7 +63,7 @@ TEST_CASE("RestClient_CustomHeader", "[RestSource][CustomHeader]")
     std::optional<std::string> customHeader = "Testing custom header";
     auto header = std::make_pair<>(CustomHeaderName, JSON::GetUtilityString(customHeader.value()));
     HttpClientHelper helper{ GetHeaderVerificationHandler(web::http::status_codes::OK, sample, header) };
-    RestClient client = RestClient::Create(utility::conversions::to_utf8string("https://restsource.com/api"), customHeader, {}, std::move(helper), {});
+    RestClient client = CreateRestClient(utility::conversions::to_utf8string("https://restsource.com/api"), customHeader, {}, helper);
     REQUIRE(client.GetSourceIdentifier() == "Source123");
 }
 
@@ -104,7 +112,7 @@ TEST_CASE("RestSourceSearch_CustomHeaderExceedingSize", "[RestSource][CustomHead
     auto header = std::make_pair<>(CustomHeaderName, JSON::GetUtilityString(customHeader));
     HttpClientHelper helper{ GetHeaderVerificationHandler(web::http::status_codes::OK, sampleSearchResponse, header) };
 
-    REQUIRE_THROWS_HR(RestClient::Create(utility::conversions::to_utf8string("https://restsource.com/api"), customHeader, {}, std::move(helper), {}),
+    REQUIRE_THROWS_HR(CreateRestClient(utility::conversions::to_utf8string("https://restsource.com/api"), customHeader, {}, helper),
         APPINSTALLER_CLI_ERROR_CUSTOMHEADER_EXCEEDS_MAXLENGTH);
 }
 
@@ -122,7 +130,7 @@ TEST_CASE("RestClient_CustomUserAgentHeader", "[RestSource][CustomHeader]")
     std::string testCaller = "TestCaller";
     auto header = std::make_pair<>(web::http::header_names::user_agent, JSON::GetUtilityString(Runtime::GetUserAgent(testCaller)));
     HttpClientHelper helper{ GetHeaderVerificationHandler(web::http::status_codes::OK, sample, header) };
-    RestClient client = RestClient::Create(utility::conversions::to_utf8string("https://restsource.com/api"), {}, testCaller, std::move(helper), {});
+    RestClient client = CreateRestClient(utility::conversions::to_utf8string("https://restsource.com/api"), {}, testCaller, helper);
     REQUIRE(client.GetSourceIdentifier() == "Source123");
 }
 
@@ -139,6 +147,6 @@ TEST_CASE("RestClient_DefaultUserAgentHeader", "[RestSource][CustomHeader]")
 
     auto header = std::make_pair<>(web::http::header_names::user_agent, JSON::GetUtilityString(Runtime::GetDefaultUserAgent()));
     HttpClientHelper helper{ GetHeaderVerificationHandler(web::http::status_codes::OK, sample, header) };
-    RestClient client = RestClient::Create(utility::conversions::to_utf8string("https://restsource.com/api"), {}, {}, std::move(helper), {});
+    RestClient client = CreateRestClient(utility::conversions::to_utf8string("https://restsource.com/api"), {}, {}, helper);
     REQUIRE(client.GetSourceIdentifier() == "Source123");
 }

--- a/src/AppInstallerCLITests/RestClient.cpp
+++ b/src/AppInstallerCLITests/RestClient.cpp
@@ -273,7 +273,7 @@ TEST_CASE("GetInformation_Fail_InvalidMicrosoftEntraIdInfo", "[RestSource]")
         }})delimiter");
 
     HttpClientHelper helper3{ GetTestRestRequestHandler(web::http::status_codes::OK, sample3) };
-    REQUIRE_THROWS_HR(RestClient::GetInformation(TestRestUri, {}, {}, std::move(helper3)), APPINSTALLER_CLI_ERROR_UNSUPPORTED_RESTSOURCE);
+    REQUIRE_THROWS_HR(RestClient::GetInformation(TestRestUri, {}, {}, helper3), APPINSTALLER_CLI_ERROR_UNSUPPORTED_RESTSOURCE);
 
     utility::string_t sample4 = _XPLATSTR(
         R"delimiter({
@@ -291,7 +291,7 @@ TEST_CASE("GetInformation_Fail_InvalidMicrosoftEntraIdInfo", "[RestSource]")
     Authentication::AuthenticationArguments authArgs;
     authArgs.Mode = Authentication::AuthenticationMode::Silent;
     Version version_1_7{ "1.7.0" };
-    REQUIRE_THROWS_HR(RestClient::GetSupportedInterface(TestRestUri, {}, RestClient::GetInformation(TestRestUri, {}, {}, std::move(helper4)), authArgs, version_1_7, {}), APPINSTALLER_CLI_ERROR_AUTHENTICATION_TYPE_NOT_SUPPORTED);
+    REQUIRE_THROWS_HR(RestClient::GetSupportedInterface(TestRestUri, {}, RestClient::GetInformation(TestRestUri, {}, {}, helper4), authArgs, version_1_7, {}), APPINSTALLER_CLI_ERROR_AUTHENTICATION_TYPE_NOT_SUPPORTED);
 }
 
 TEST_CASE("RestClientCreate_UnsupportedVersion", "[RestSource]")

--- a/src/AppInstallerCommonCore/Rest.cpp
+++ b/src/AppInstallerCommonCore/Rest.cpp
@@ -7,10 +7,9 @@
 
 namespace AppInstaller::Rest
 {
-    utility::string_t GetRestAPIBaseUri(std::string restApiUri)
+    utility::string_t GetRestAPIBaseUri(std::string uri)
     {
         // Trim
-        std::string uri = restApiUri;
         if (!uri.empty())
         {
             uri = AppInstaller::Utility::Trim(uri);

--- a/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
@@ -30,7 +30,7 @@ namespace AppInstaller::Repository::Rest
 
     namespace
     {
-        HttpClientHelper::HttpRequestHeaders GetHeaders(std::optional<std::string> customHeader, std::string_view caller)
+        HttpClientHelper::HttpRequestHeaders GetHeaders(const std::optional<std::string>& customHeader, std::string_view caller)
         {
             HttpClientHelper::HttpRequestHeaders headers;
 
@@ -135,7 +135,7 @@ namespace AppInstaller::Repository::Rest
         return *commonVersions.rbegin();
     }
 
-    Schema::IRestClient::Information RestClient::GetInformation(const std::string& restApi, std::optional<std::string> customHeader, std::string_view caller, const HttpClientHelper& helper)
+    Schema::IRestClient::Information RestClient::GetInformation(const std::string& restApi, const std::optional<std::string>& customHeader, std::string_view caller, const HttpClientHelper& helper)
     {
         utility::string_t restEndpoint = AppInstaller::Rest::GetRestAPIBaseUri(restApi);
         THROW_HR_IF(APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_URL, !AppInstaller::Rest::IsValidUri(restEndpoint));
@@ -185,14 +185,19 @@ namespace AppInstaller::Repository::Rest
         THROW_HR(APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_VERSION);
     }
 
-    RestClient RestClient::Create(const std::string& restApi, std::optional<std::string> customHeader, std::string_view caller, const HttpClientHelper& helper, const Authentication::AuthenticationArguments& authArgs)
+    RestClient RestClient::Create(
+        const std::string& restApi,
+        const std::optional<std::string>& customHeader,
+        std::string_view caller,
+        const HttpClientHelper& helper,
+        const Schema::IRestClient::Information& information,
+        const Authentication::AuthenticationArguments& authArgs)
     {
         utility::string_t restEndpoint = AppInstaller::Rest::GetRestAPIBaseUri(restApi);
         THROW_HR_IF(APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_URL, !AppInstaller::Rest::IsValidUri(restEndpoint));
 
         auto headers = GetHeaders(customHeader, caller);
 
-        IRestClient::Information information = GetInformationInternal(restEndpoint, headers, helper);
         std::optional<Version> latestCommonVersion = GetLatestCommonVersion(information.ServerSupportedVersions, WingetSupportedContracts);
         THROW_HR_IF(APPINSTALLER_CLI_ERROR_UNSUPPORTED_RESTSOURCE, !latestCommonVersion);
 

--- a/src/AppInstallerRepositoryCore/Rest/RestClient.h
+++ b/src/AppInstallerRepositoryCore/Rest/RestClient.h
@@ -28,7 +28,7 @@ namespace AppInstaller::Repository::Rest
         static std::optional<AppInstaller::Utility::Version> GetLatestCommonVersion(const std::vector<std::string>& serverSupportedVersions, const std::set<AppInstaller::Utility::Version>& wingetSupportedVersions);
 
         // Responsible for getting the source information contracts with minimal validation. Does not try to create a rest interface out of it.
-        static Schema::IRestClient::Information GetInformation(const std::string& restApi, std::optional<std::string> customHeader, std::string_view caller, const Http::HttpClientHelper& helper);
+        static Schema::IRestClient::Information GetInformation(const std::string& restApi, const std::optional<std::string>& customHeader, std::string_view caller, const Http::HttpClientHelper& helper);
 
         static std::unique_ptr<Schema::IRestClient> GetSupportedInterface(
             const std::string& restApi,
@@ -39,7 +39,13 @@ namespace AppInstaller::Repository::Rest
             const Http::HttpClientHelper& helper);
 
         // Creates the rest client. Full validation performed (just as opening the source)
-        static RestClient Create(const std::string& restApi, std::optional<std::string> customHeader, std::string_view caller, const Http::HttpClientHelper& helper, const Authentication::AuthenticationArguments& authArgs = {});
+        static RestClient Create(
+            const std::string& restApi,
+            const std::optional<std::string>& customHeader,
+            std::string_view caller,
+            const Http::HttpClientHelper& helper,
+            const Schema::IRestClient::Information& information,
+            const Authentication::AuthenticationArguments& authArgs = {});
     private:
         RestClient(std::unique_ptr<Schema::IRestClient> supportedInterface, std::string sourceIdentifier);
 

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -50,7 +50,7 @@ namespace AppInstaller::Repository::Rest
             std::shared_ptr<ISource> Open(IProgressCallback&) override
             {
                 Initialize();
-                RestClient restClient = RestClient::Create(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper, m_authArgs);
+                RestClient restClient = RestClient::Create(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper, m_restClientInformation, m_authArgs);
                 return std::make_shared<RestSource>(m_details, m_information, std::move(restClient));
             }
 
@@ -61,28 +61,29 @@ namespace AppInstaller::Repository::Rest
                     [&]()
                     {
                         m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration);
-                        auto sourceInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
+                        m_restClientInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
 
-                        m_details.Identifier = sourceInformation.SourceIdentifier;
+                        m_details.Identifier = m_restClientInformation.SourceIdentifier;
 
-                        m_information.UnsupportedPackageMatchFields = sourceInformation.UnsupportedPackageMatchFields;
-                        m_information.RequiredPackageMatchFields = sourceInformation.RequiredPackageMatchFields;
-                        m_information.UnsupportedQueryParameters = sourceInformation.UnsupportedQueryParameters;
-                        m_information.RequiredQueryParameters = sourceInformation.RequiredQueryParameters;
+                        m_information.UnsupportedPackageMatchFields = m_restClientInformation.UnsupportedPackageMatchFields;
+                        m_information.RequiredPackageMatchFields = m_restClientInformation.RequiredPackageMatchFields;
+                        m_information.UnsupportedQueryParameters = m_restClientInformation.UnsupportedQueryParameters;
+                        m_information.RequiredQueryParameters = m_restClientInformation.RequiredQueryParameters;
 
-                        m_information.SourceAgreementsIdentifier = sourceInformation.SourceAgreementsIdentifier;
-                        for (auto const& agreement : sourceInformation.SourceAgreements)
+                        m_information.SourceAgreementsIdentifier = m_restClientInformation.SourceAgreementsIdentifier;
+                        for (auto const& agreement : m_restClientInformation.SourceAgreements)
                         {
                             m_information.SourceAgreements.emplace_back(agreement.Label, agreement.Text, agreement.Url);
                         }
 
-                        m_information.Authentication = sourceInformation.Authentication;
+                        m_information.Authentication = m_restClientInformation.Authentication;
                     });
             }
 
             SourceDetails m_details;
             Http::HttpClientHelper m_httpClientHelper;
             SourceInformation m_information;
+            Schema::IRestClient::Information m_restClientInformation;
             std::optional<std::string> m_customHeader;
             std::string m_caller;
             Authentication::AuthenticationArguments m_authArgs;


### PR DESCRIPTION
## Change
When the `RestSourceReference` retrieves the information, store it and pass it along to `RestClient::Create` so that it can reuse the value rather than calling again.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5112)