### PR TITLE
Update curl to 8.11.1 due to CVE-2024-11053

### DIFF
--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "curl",
-      "version": "8.11.0"
+      "version": "8.11.1"
     },
     {
       "name": "nlohmann-json",
@@ -38,5 +38,5 @@
       "./VcpkgCustomTriplets"
     ]
   },
-  "builtin-baseline": "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
+  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
 }


### PR DESCRIPTION
Using [vcpkg release 2024.12.16](https://github.com/microsoft/vcpkg/releases/tag/2024.12.16)