### PR TITLE
Handle installer download cancelled case before retrying on zero byte download

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -428,6 +428,13 @@ namespace AppInstaller::CLI::Workflow
                     std::placeholders::_1,
                     downloadInfo));
 
+                // User cancelled.
+                if (downloadResult.Sha256Hash.empty())
+                {
+                    context.Reporter.Info() << Resource::String::Cancelled << std::endl;
+                    AICLI_TERMINATE_CONTEXT(E_ABORT);
+                }
+
                 if (downloadResult.SizeInBytes == 0)
                 {
                     AICLI_LOG(CLI, Info, << "Got zero byte file; retrying download after a short wait...");
@@ -480,12 +487,6 @@ namespace AppInstaller::CLI::Workflow
             {
                 break;
             }
-        }
-
-        if (downloadResult.Sha256Hash.empty())
-        {
-            context.Reporter.Info() << Resource::String::Cancelled << std::endl;
-            AICLI_TERMINATE_CONTEXT(E_ABORT);
         }
 
         context.Add<Execution::Data::DownloadHashInfo>(std::make_pair(installer.Sha256, downloadResult));


### PR DESCRIPTION
Manually validated cancel works without retrying.

Fixes #4943
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5141)