### PR TITLE
Make async function actually async

### DIFF
--- a/src/Microsoft.Management.Deployment/PackageCatalog.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalog.cpp
@@ -47,6 +47,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     }
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Management::Deployment::FindPackagesResult> PackageCatalog::FindPackagesAsync(winrt::Microsoft::Management::Deployment::FindPackagesOptions options)
     {
+        co_await resume_background();
         co_return FindPackages(options);
     }
 


### PR DESCRIPTION
## Change
Move to a background thread when running `FindPackagesAsync` to make it actually asynchronous.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5151)