### PR TITLE
Formatting changes for localized content

### DIFF
--- a/Localization/Policies/ja-JP/DesktopAppInstaller.adml
+++ b/Localization/Policies/ja-JP/DesktopAppInstaller.adml
@@ -72,7 +72,7 @@
 
 この設定を無効にした場合、または構成しなかった場合は、既定の間隔またはWindows パッケージ マネージャー設定で指定された値が使用されます。
 
-この設定を有効にした場合、指定した分数がWindows パッケージ マネージャーで使用されます。</string>
+この設定を有効にした場合、指定した分数が Windows パッケージ マネージャーで使用されます。</string>
       <string id="EnableAdditionalSources">Windows パッケージ マネージャーの追加のソースを有効にする</string>
       <string id="EnableAdditionalSourcesExplanation">このポリシーは、エンタープライズIT管理者によって提供される追加のソースを制御します。
 
@@ -106,16 +106,16 @@
       <string id="EnableWindowsPackageManagerConfiguration">Windows パッケージ マネージャーの構成を有効にする</string>
       <string id="EnableWindowsPackageManagerConfigurationExplanation">このポリシーでは、Windows パッケージ マネージャー構成機能をユーザーが使用できるかどうかを制御します。
 
-この設定を有効にした場合、または構成しなかった場合、ユーザーはWindows パッケージ マネージャー構成機能を使用できます。
+この設定を有効にした場合、または構成しなかった場合、ユーザーは Windows パッケージ マネージャー構成機能を使用できます。
 
-この設定を無効にすると、ユーザーはWindows パッケージ マネージャー構成機能を使用できなくなります。</string>
+この設定を無効にすると、ユーザーは Windows パッケージ マネージャー構成機能を使用できなくなります。</string>
       <string id="EnableWindowsPackageManagerProxyCommandLineOptions">Windows パッケージ マネージャー Proxy コマンド ライン オプションを有効にする</string>
       <string id="EnableWindowsPackageManagerProxyCommandLineOptionsExplanation">
-        このポリシーでは、ユーザーがコマンド ラインでプロキシのWindows パッケージ マネージャーの使用を構成できるかどうかを制御します。
+        このポリシーでは、ユーザーがコマンド ラインでプロキシの Windows パッケージ マネージャーの使用を構成できるかどうかを制御します。
 
-この設定を有効にした場合、ユーザーはコマンド ラインを使用してWindows パッケージ マネージャーのプロキシの使用を構成できます。
+この設定を有効にした場合、ユーザーはコマンド ラインを使用して Windows パッケージ マネージャーのプロキシの使用を構成できます。
 
-この設定を無効にした場合、または構成しなかった場合、ユーザーはコマンド ラインでWindows パッケージ マネージャーのプロキシの使用を構成できなくなります。</string>
+この設定を無効にした場合、または構成しなかった場合、ユーザーはコマンド ラインで Windows パッケージ マネージャーのプロキシの使用を構成できなくなります。</string>
       <string id="WindowsPackageManagerDefaultProxy">Windows パッケージ マネージャーの既定のプロキシを設定する</string>
       <string id="WindowsPackageManagerDefaultProxyExplanation">このポリシーは、Windows パッケージ マネージャーで使用される既定のプロキシを制御します。
 

--- a/Localization/Policies/ko-KR/DesktopAppInstaller.adml
+++ b/Localization/Policies/ko-KR/DesktopAppInstaller.adml
@@ -133,9 +133,9 @@
       <string id="EnableMsixSmartScreenCheck">MSIX 패키지에 Microsoft SmartScreen 검사 사용</string>
       <string id="EnableMsixSmartScreenCheckExplanation">이 정책은 MSIX 패키지를 설치할 때 앱 설치 관리자 Microsoft SmartScreen 검사를 수행할지 여부를 제어합니다.
 
-이 정책을 사용하거나 구성하지 않으면 설치 전에 Microsoft SmartScreen을 사용하여 패키지 URI가 평가됩니다. 이 검사 인터넷에서 가져온 패키지에 대해서만 수행됩니다.
+이 정책을 사용하거나 구성하지 않으면 설치 전에 Microsoft SmartScreen 을 사용하여 패키지 URI가 평가됩니다. 이 검사 인터넷에서 가져온 패키지에 대해서만 수행됩니다.
 
-사용하지 않도록 설정하면 패키지를 설치하기 전에 Microsoft SmartScreen을 참조하지 않습니다.</string>
+사용하지 않도록 설정하면 패키지를 설치하기 전에 Microsoft SmartScreen 을 참조하지 않습니다.</string>
     </stringTable>
     <presentationTable>
       <presentation id="SourceAutoUpdateInterval">

--- a/Localization/Policies/zh-CN/DesktopAppInstaller.adml
+++ b/Localization/Policies/zh-CN/DesktopAppInstaller.adml
@@ -68,11 +68,11 @@
 
 如果禁用此设置，Windows 程序包管理器的 Microsoft Store 源将不可用。</string>
       <string id="SourceAutoUpdateInterval">设置 Windows 程序包管理器源自动更新间隔(分钟)</string>
-      <string id="SourceAutoUpdateIntervalExplanation">此策略控制基于程序包的源的自动更新间隔。配置Windows 程序包管理器的默认源，以便在本地计算机上缓存包索引。当用户调用命令并且间隔已过时，将下载索引。
+      <string id="SourceAutoUpdateIntervalExplanation">此策略控制基于程序包的源的自动更新间隔。配置 Windows 程序包管理器的默认源，以便在本地计算机上缓存包索引。当用户调用命令并且间隔已过时，将下载索引。
 
-如果禁用或未配置此设置，将使用Windows 程序包管理器设置中指定的默认间隔或值。
+如果禁用或未配置此设置，将使用 Windows 程序包管理器设置中指定的默认间隔或值。
 
-如果启用此设置，则Windows 程序包管理器将使用指定的分钟数。</string>
+如果启用此设置，则 Windows 程序包管理器将使用指定的分钟数。</string>
       <string id="EnableAdditionalSources">启用 Windows 程序包管理器其他源</string>
       <string id="EnableAdditionalSourcesExplanation">此策略控制企业 IT 管理员提供的其他源。
 
@@ -104,20 +104,20 @@
 
        此策略不会替代 “启用应用安装程序” 策略。</string>
       <string id="EnableWindowsPackageManagerConfiguration">启用 Windows 程序包管理器配置</string>
-      <string id="EnableWindowsPackageManagerConfigurationExplanation">此策略控制用户是否可以使用Windows 程序包管理器配置功能。
+      <string id="EnableWindowsPackageManagerConfigurationExplanation">此策略控制用户是否可以使用 Windows 程序包管理器配置功能。
 
-如果启用或未配置此设置，则用户将能够使用Windows 程序包管理器配置功能。
+如果启用或未配置此设置，则用户将能够使用 Windows 程序包管理器配置功能。
 
-如果禁用此设置，则用户将无法使用Windows 程序包管理器配置功能。</string>
-      <string id="EnableWindowsPackageManagerProxyCommandLineOptions">启用Windows 程序包管理器代理命令行选项</string>
+如果禁用此设置，则用户将无法使用 Windows 程序包管理器配置功能。</string>
+      <string id="EnableWindowsPackageManagerProxyCommandLineOptions">启用 Windows 程序包管理器代理命令行选项</string>
       <string id="EnableWindowsPackageManagerProxyCommandLineOptionsExplanation">
         此策略控制用户是否可以通过命令行配置代理的Windows 程序包管理器使用情况。
 
-如果启用此设置，则用户将能够通过命令行配置Windows 程序包管理器使用代理。
+如果启用此设置，则用户将能够通过命令行配置 Windows 程序包管理器使用代理。
 
-如果禁用或未配置此设置，则用户将无法通过命令行配置Windows 程序包管理器使用代理。</string>
+如果禁用或未配置此设置，则用户将无法通过命令行配置 Windows 程序包管理器使用代理。</string>
       <string id="WindowsPackageManagerDefaultProxy">设置 Windows 程序包管理器默认代理</string>
-      <string id="WindowsPackageManagerDefaultProxyExplanation">此策略控制Windows 程序包管理器使用的默认代理。
+      <string id="WindowsPackageManagerDefaultProxyExplanation">此策略控制 Windows 程序包管理器使用的默认代理。
 
 如果禁用或未配置此设置，则默认情况下不会使用任何代理。
 
@@ -131,11 +131,11 @@
       <string id="ZoneAllowed">允许</string>
       <string id="ZoneBlocked">阻止</string>
       <string id="EnableMsixSmartScreenCheck">为 MSIX 包启用 Microsoft SmartScreen 检查</string>
-      <string id="EnableMsixSmartScreenCheckExplanation">此策略控制应用安装程序在安装 MSIX 包时是否执行Microsoft SmartScreen 检查。
+      <string id="EnableMsixSmartScreenCheckExplanation">此策略控制应用安装程序在安装 MSIX 包时是否执行 Microsoft SmartScreen 检查。
 
 如果启用或未配置此策略，则在安装之前，将使用 Microsoft SmartScreen 评估包 URI。此检查仅适用于来自 Internet 的程序包。
 
-如果禁用，则在安装包之前，不会咨询Microsoft SmartScreen。</string>
+如果禁用，则在安装包之前，不会咨询 Microsoft SmartScreen。</string>
     </stringTable>
     <presentationTable>
       <presentation id="SourceAutoUpdateInterval">

--- a/Localization/Policies/zh-CN/DesktopAppInstaller.adml
+++ b/Localization/Policies/zh-CN/DesktopAppInstaller.adml
@@ -31,7 +31,7 @@
 如果启用或未配置此设置，则用户可以使用 Windows 程序包管理器在本地清单中安装包。
 
 如果禁用此设置，则用户将无法使用 Windows 程序包管理器在本地清单中安装包。</string>
-      <string id="EnableBypassCertificatePinningForMicrosoftStore">启用Windows 程序包管理器Microsoft Store源证书验证绕过</string>
+      <string id="EnableBypassCertificatePinningForMicrosoftStore">启用 Windows 程序包管理器 Microsoft Store 源证书验证绕过</string>
       <string id="EnableBypassCertificatePinningForMicrosoftStoreExplanation">此策略控制 Windows 程序包管理器在发起与 Microsoft Store 源的连接时是否验证 Microsoft Store 证书哈希与已知的 Microsoft Store 证书的匹配情况。
 如果启用此策略，Windows 程序包管理器将绕过 Microsoft Store 证书验证。
 
@@ -44,7 +44,7 @@
 如果启用或未配置此策略，则用户将能够在 Windows 程序包管理器设置中启用覆盖 SHA256 安全验证的能力。
 
 如果禁用此策略，则用户将无法在 Windows 程序包管理器设置中启用覆盖 SHA256 安全验证的能力。</string>
-      <string id="EnableLocalArchiveMalwareScanOverride">启用Windows 程序包管理器本地存档恶意软件扫描替代</string>
+      <string id="EnableLocalArchiveMalwareScanOverride">启用 Windows 程序包管理器本地存档恶意软件扫描替代</string>
       <string id="EnableLocalArchiveMalwareScanOverrideExplanation">此策略控制在使用命令行参数通过本地清单安装存档文件时替代恶意软件漏洞扫描的能力。
 如果启用此策略，则用户可以在对存档文件执行本地清单安装时替代恶意软件扫描。
 

--- a/Localization/Policies/zh-TW/DesktopAppInstaller.adml
+++ b/Localization/Policies/zh-TW/DesktopAppInstaller.adml
@@ -50,7 +50,7 @@
 
 如果您停用這個原則，使用者將無法在使用本機資訊清單安裝時覆寫封存檔案的惡意程式碼掃描。
 
-如果您未設定這個原則，則會遵循Windows 封裝管理員系統管理員設定。</string>
+如果您未設定這個原則，則會遵循 Windows 封裝管理員系統管理員設定。</string>
       <string id="EnableDefaultSource">設定 Windows 封裝管理員預設來源</string>
       <string id="EnableDefaultSourceExplanation">此原則控制 Windows 封裝管理員隨附的預設來源。
 
@@ -104,20 +104,20 @@
 
        此原則不會覆寫 [啟用應用程式安裝程式] 原則。</string>
       <string id="EnableWindowsPackageManagerConfiguration">啟用 Windows 封裝管理員設定</string>
-      <string id="EnableWindowsPackageManagerConfigurationExplanation">此原則控制使用者是否可以使用Windows 封裝管理員設定功能。
+      <string id="EnableWindowsPackageManagerConfigurationExplanation">此原則控制使用者是否可以使用 Windows 封裝管理員設定功能。
 
-如果您啟用或未設定這個設定，使用者將可以使用Windows 封裝管理員設定功能。
+如果您啟用或未設定這個設定，使用者將可以使用 Windows 封裝管理員設定功能。
 
-如果您停用這個設定，使用者將無法使用Windows 封裝管理員設定功能。</string>
-      <string id="EnableWindowsPackageManagerProxyCommandLineOptions">啟用Windows 封裝管理員 Proxy 命令行選項</string>
+如果您停用這個設定，使用者將無法使用 Windows 封裝管理員設定功能。</string>
+      <string id="EnableWindowsPackageManagerProxyCommandLineOptions">啟用 Windows 封裝管理員 Proxy 命令行選項</string>
       <string id="EnableWindowsPackageManagerProxyCommandLineOptionsExplanation">
-        此原則控制使用者是否可以透過命令行設定 proxy 的Windows 封裝管理員使用方式。
+        此原則控制使用者是否可以透過命令行設定 proxy 的 Windows 封裝管理員使用方式。
 
-如果您啟用這個設定，使用者將可以透過命令行設定Windows 封裝管理員使用 Proxy。
+如果您啟用這個設定，使用者將可以透過命令行設定 Windows 封裝管理員使用 Proxy。
 
-如果您停用或未設定這個設定，用戶將無法透過命令行設定Windows 封裝管理員使用 Proxy。</string>
+如果您停用或未設定這個設定，用戶將無法透過命令行設定 Windows 封裝管理員使用 Proxy。</string>
       <string id="WindowsPackageManagerDefaultProxy">設定 Windows 封裝管理員預設 Proxy</string>
-      <string id="WindowsPackageManagerDefaultProxyExplanation">此原則控制Windows 封裝管理員使用的預設 Proxy。
+      <string id="WindowsPackageManagerDefaultProxyExplanation">此原則控制 Windows 封裝管理員使用的預設 Proxy。
 
 如果停用或未設定此設定，則預設不會使用任何 Proxy。
 

--- a/Localization/Resources/de-DE/winget.resw
+++ b/Localization/Resources/de-DE/winget.resw
@@ -2659,7 +2659,7 @@ Geben Sie eine Option für --source an, um den Vorgang fortzusetzen.</value>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>Der Fortsetzungszustand ist nicht vorhanden: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>Im Fortsetzungszustand wurden keine Daten gefunden.</value>

--- a/Localization/Resources/es-ES/winget.resw
+++ b/Localization/Resources/es-ES/winget.resw
@@ -2659,7 +2659,7 @@ Especifique uno de ellos con la opción --source para continuar.</value>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>El estado de reanudación no existe: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>No se encontraron datos en el estado de reanudación.</value>

--- a/Localization/Resources/fr-FR/winget.resw
+++ b/Localization/Resources/fr-FR/winget.resw
@@ -2659,7 +2659,7 @@ Spécifiez l’un d’entre eux à l’aide de l’option --source pour continue
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>L’état de reprise n’existe pas : {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>Données introuvables dans l’état de reprise.</value>

--- a/Localization/Resources/it-IT/winget.resw
+++ b/Localization/Resources/it-IT/winget.resw
@@ -2659,7 +2659,7 @@ Specificarne uno utilizzando l'opzione --source per continuare.</value>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>Lo stato di ripresa non esiste: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>Non sono stati trovati dati nello stato di ripresa.</value>

--- a/Localization/Resources/ja-JP/winget.resw
+++ b/Localization/Resources/ja-JP/winget.resw
@@ -2659,7 +2659,7 @@
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>再開状態が存在しません: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>再開状態のデータが見つかりません。</value>

--- a/Localization/Resources/ko-KR/winget.resw
+++ b/Localization/Resources/ko-KR/winget.resw
@@ -2659,7 +2659,7 @@
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>다시 시작 상태가 없습니다. {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>다시 시작 상태에서 데이터를 찾을 수 없습니다.</value>

--- a/Localization/Resources/pt-BR/winget.resw
+++ b/Localization/Resources/pt-BR/winget.resw
@@ -2659,7 +2659,7 @@ Especifique um deles usando a opção --source para continuar.</value>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>O estado de retomada não existe: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>Nenhum dado encontrado no estado do retomada.</value>

--- a/Localization/Resources/ru-RU/winget.resw
+++ b/Localization/Resources/ru-RU/winget.resw
@@ -2659,7 +2659,7 @@
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>Состояние возобновления не существует: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>Не найдены данные в состоянии возобновления.</value>

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -126,11 +126,11 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides an adjoined flag alias argument that was not found. {0} is a placeholder replaced by the user input argument (e.g. '-ab').</comment>
   </data>
   <data name="AvailableArguments" xml:space="preserve">
-    <value>以下参数可用：</value>
+    <value>以下参数可用: </value>
     <comment>Message displayed to inform the user about the available command line arguments.</comment>
   </data>
   <data name="AvailableCommandAliases" xml:space="preserve">
-    <value>以下命令别名可用：</value>
+    <value>以下命令别名可用: </value>
     <comment>Message displayed to inform the user about the available command line alias arguments.</comment>
   </data>
   <data name="AvailableCommands" xml:space="preserve">
@@ -142,11 +142,11 @@
     <comment>As in "a new version is available to upgrade to".</comment>
   </data>
   <data name="AvailableOptions" xml:space="preserve">
-    <value>下列选项可用：</value>
+    <value>下列选项可用: </value>
     <comment>Message displayed to inform the user about the available options.</comment>
   </data>
   <data name="AvailableSubcommands" xml:space="preserve">
-    <value>以下子命令可用：</value>
+    <value>以下子命令可用: </value>
     <comment>Message displayed to inform the user about the available nested commands that run in context of the selected command.</comment>
   </data>
   <data name="AvailableUpgrades" xml:space="preserve">
@@ -202,7 +202,7 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides an extra positional argument when none was expected. {0} is a placeholder replaced by the user's extra argument input.</comment>
   </data>
   <data name="FeatureDisabledMessage" xml:space="preserve">
-    <value>此功能是一项正在进行的工作，将来可能会发生显著更改或完全删除。若要启用它，请编辑设置 ('winget settings')以包括实验性功能： '{0}'</value>
+    <value>此功能是一项正在进行的工作，将来可能会发生显著更改或完全删除。若要启用它，请编辑设置 ('winget settings')以包括实验性功能: '{0}'</value>
     <comment>{Locked="winget settings","{0}"}. Error message displayed when the user uses an experimental feature that is disabled. {0} is a placeholder replaced by the experimental feature name.</comment>
   </data>
   <data name="FeaturesCommandLongDescription" xml:space="preserve">
@@ -482,7 +482,7 @@
     <value>版本</value>
   </data>
   <data name="SettingLoadFailure" xml:space="preserve">
-    <value>发现以下故障以验证设置：</value>
+    <value>发现以下故障以验证设置: </value>
   </data>
   <data name="SettingsCommandLongDescription" xml:space="preserve">
     <value>在默认 json 文本编辑器中打开设置。如果未配置任何编辑器，请在记事本中打开设置。有关可用设置，请参阅 https://aka.ms/winget-settings。此命令还可用于通过提供 --enable 或 --disable 参数来设置管理员设置</value>
@@ -631,7 +631,7 @@
     <value>强制重置源</value>
   </data>
   <data name="SourceResetListAndOverridePreamble" xml:space="preserve">
-    <value>如果指定了--force 选项，则将重置以下源：</value>
+    <value>如果指定了--force 选项，则将重置以下源: </value>
     <comment>{Locked="--force"}</comment>
   </data>
   <data name="SourceResetOne" xml:space="preserve">
@@ -681,7 +681,7 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides more than one execution behavior argument when installing an application package. {0} is a placeholder replaced by the user specified execution behaviors (e.g. 'silent|interactive').</comment>
   </data>
   <data name="UnexpectedErrorExecutingCommand" xml:space="preserve">
-    <value>执行此命令时发生意外错误：</value>
+    <value>执行此命令时发生意外错误: </value>
   </data>
   <data name="UninstallPreviousArgumentDescription" xml:space="preserve">
     <value>升级期间卸载以前版本的程序包</value>
@@ -783,7 +783,7 @@
     <value>防病毒产品报告安装程序受感染</value>
   </data>
   <data name="SourceOpenWithFailedUpdate" xml:space="preserve">
-    <value>尝试更新源失败： {0}</value>
+    <value>尝试更新源失败: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when an attempt to update the repository source fails. {0} is a placeholder replaced by the repository source name.</comment>
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
@@ -836,7 +836,7 @@
     <value>无法安装一个或多个导入的程序包</value>
   </data>
   <data name="ImportSourceNotInstalled" xml:space="preserve">
-    <value>未安装导入所需的源： {0}</value>
+    <value>未安装导入所需的源: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when the user attempts to import application package(s) from a repository source that is not installed. {0} is a placeholder replaced by the repository source name.</comment>
   </data>
   <data name="InstalledPackageNotAvailable" xml:space="preserve">
@@ -875,11 +875,11 @@
     <comment>{Locked="user","machine"} This argument allows the user to select between installing for just the user or for the entire machine.</comment>
   </data>
   <data name="InvalidArgumentValueError" xml:space="preserve">
-    <value>为 '{0}' 参数提供的值无效;有效值为： {1}</value>
+    <value>为 '{0}' 参数提供的值无效;有效值为: {1}</value>
     <comment>{Locked="{0}","{1}"} Error message displayed when the user provides an invalid command line argument value. {0} is a placeholder replaced by the argument name. {1} is a placeholder replaced by a list of valid options.</comment>
   </data>
   <data name="DisabledByGroupPolicy" xml:space="preserve">
-    <value>组策略禁用此操作： {0}</value>
+    <value>组策略禁用此操作: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when the user performs a command operation that is disabled by a group policy. {0} is a placeholder replaced by a group policy description.</comment>
   </data>
   <data name="PolicyAdditionalSources" xml:space="preserve">
@@ -980,11 +980,11 @@
     <value>外部</value>
   </data>
   <data name="ImportCommandReportDependencies" xml:space="preserve">
-    <value>在此导入中找到的包具有以下依赖项：</value>
+    <value>在此导入中找到的包具有以下依赖项: </value>
     <comment>Import command sentence showed before reporting dependencies</comment>
   </data>
   <data name="PackageRequiresDependencies" xml:space="preserve">
-    <value>此包需要以下依赖项：</value>
+    <value>此包需要以下依赖项: </value>
     <comment>Message shown before reporting dependencies</comment>
   </data>
   <data name="DependenciesFlowInstall" xml:space="preserve">
@@ -1018,7 +1018,7 @@
     <comment>Dependency graph has loop</comment>
   </data>
   <data name="DependenciesFlowNoSuitableInstallerFound" xml:space="preserve">
-    <value>找不到适用于清单的安装程序： {0} 版本 {1}</value>
+    <value>找不到适用于清单的安装程序: {0} 版本 {1}</value>
     <comment>{Locked="{0}","{1}"} Error message displayed when an attempt to get a preferred installer for a manifest fails. {0} is a placeholder replaced by the manifest identifier. {1} is a placeholder replaced by the manifest version.</comment>
   </data>
   <data name="DependenciesManagementError" xml:space="preserve">
@@ -1032,11 +1032,11 @@
     <value>程序包</value>
   </data>
   <data name="UninstallCommandReportDependencies" xml:space="preserve">
-    <value>此包具有可能不再需要的依赖项：</value>
+    <value>此包具有可能不再需要的依赖项: </value>
     <comment>Uninstall command sentence showed before reporting dependencies</comment>
   </data>
   <data name="ValidateCommandReportDependencies" xml:space="preserve">
-    <value>清单具有以下未验证的依赖项;确保它们有效：</value>
+    <value>清单具有以下未验证的依赖项;确保它们有效: </value>
     <comment>Validate command sentence showed before reporting dependencies</comment>
   </data>
   <data name="WindowsFeaturesDependencies" xml:space="preserve">
@@ -1056,7 +1056,7 @@
     <value>接受包的所有许可协议</value>
   </data>
   <data name="ExportedPackageRequiresLicenseAgreement" xml:space="preserve">
-    <value>导出的包需要安装许可协议： {0}</value>
+    <value>导出的包需要安装许可协议: {0}</value>
     <comment>{Locked="{0}"} Warning message displayed when an exported application package requires license agreement to install. {0} is a placeholder replaced by the package name.</comment>
   </data>
   <data name="PackageAgreementsPrompt" xml:space="preserve">
@@ -1067,7 +1067,7 @@
     <value>未同意包协议。操作已取消。</value>
   </data>
   <data name="ShowLabelAgreements" xml:space="preserve">
-    <value>协议：</value>
+    <value>协议: </value>
   </data>
   <data name="ShowLabelAuthor" xml:space="preserve">
     <value>作者:</value>
@@ -1076,22 +1076,22 @@
     <value>描述:</value>
   </data>
   <data name="ShowLabelInstaller" xml:space="preserve">
-    <value>安装：</value>
+    <value>安装: </value>
   </data>
   <data name="ShowLabelInstallerLocale" xml:space="preserve">
-    <value>安装程序区域设置：</value>
+    <value>安装程序区域设置: </value>
   </data>
   <data name="ShowLabelInstallerProductId" xml:space="preserve">
-    <value>应用商店产品 ID：</value>
+    <value>应用商店产品 ID: </value>
   </data>
   <data name="ShowLabelInstallerSha256" xml:space="preserve">
-    <value>安装程序 SHA256：</value>
+    <value>安装程序 SHA256: </value>
   </data>
   <data name="ShowLabelInstallerType" xml:space="preserve">
-    <value>安装程序类型：</value>
+    <value>安装程序类型: </value>
   </data>
   <data name="ShowLabelInstallerUrl" xml:space="preserve">
-    <value>安装程序 URL：</value>
+    <value>安装程序 URL: </value>
   </data>
   <data name="ShowLabelLicense" xml:space="preserve">
     <value>许可证:</value>
@@ -1100,7 +1100,7 @@
     <value>许可证 URL:</value>
   </data>
   <data name="ShowLabelMoniker" xml:space="preserve">
-    <value>绰号：</value>
+    <value>绰号: </value>
   </data>
   <data name="ShowLabelPackageUrl" xml:space="preserve">
     <value>主页:</value>
@@ -1109,7 +1109,7 @@
     <value>发布者:</value>
   </data>
   <data name="ShowLabelTags" xml:space="preserve">
-    <value>标记：</value>
+    <value>标记: </value>
   </data>
   <data name="ShowLabelVersion" xml:space="preserve">
     <value>版本:</value>
@@ -1177,7 +1177,7 @@
     <value>发布服务器 URL:</value>
   </data>
   <data name="ShowLabelPurchaseUrl" xml:space="preserve">
-    <value>购买 URL：</value>
+    <value>购买 URL: </value>
   </data>
   <data name="ShowLabelPublisherSupportUrl" xml:space="preserve">
     <value>发布服务器支持 URL:</value>
@@ -1198,7 +1198,7 @@
     <value>发行说明 URL:</value>
   </data>
   <data name="SearchFailureWarning" xml:space="preserve">
-    <value>搜索源时失败;结果将不包括在内： {0}</value>
+    <value>搜索源时失败;结果将不包括在内: {0}</value>
     <comment>{Locked="{0}"} Warning message displayed when searching a repository source fails. {0} is a placeholder replaced by the repository source name.</comment>
   </data>
   <data name="SearchFailureError" xml:space="preserve">
@@ -1405,7 +1405,7 @@
     <value>未提供包选择参数；有关查找包的详细信息，请参阅帮助。</value>
   </data>
   <data name="PortableAliasAdded" xml:space="preserve">
-    <value>添加了命令行别名：</value>
+    <value>添加了命令行别名: </value>
   </data>
   <data name="PortableLinksMachine" xml:space="preserve">
     <value>可移植链接目录(计算机)</value>
@@ -1454,7 +1454,7 @@
     <comment>{Locked="{0}"} Label displayed for installation notes. {0} is a placeholder replaced by installation notes.</comment>
   </data>
   <data name="ShowLabelInstallationNotes" xml:space="preserve">
-    <value>安装说明：</value>
+    <value>安装说明: </value>
   </data>
   <data name="UnsupportedArgument" xml:space="preserve">
     <value>此程序包不支持提供的参数</value>
@@ -1463,7 +1463,7 @@
     <value>未能提取存档内容</value>
   </data>
   <data name="NestedInstallerNotFound" xml:space="preserve">
-    <value>嵌套安装程序文件不存在。确保嵌套安装程序的指定相对路径匹配： {0}</value>
+    <value>嵌套安装程序文件不存在。确保嵌套安装程序的指定相对路径匹配: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when nested installer file does not exist. {0} is a placeholder replaced by the nested installer file path.</comment>
   </data>
   <data name="InvalidPathToNestedInstaller" xml:space="preserve">
@@ -1482,7 +1482,7 @@
     <value>仅列出具有可用升级的包</value>
   </data>
   <data name="UpgradeAvailableForPinned" xml:space="preserve">
-    <value>以下程序包有可用的升级，但需要显式目标才能进行升级：</value>
+    <value>以下程序包有可用的升级，但需要显式目标才能进行升级: </value>
     <comment>"require explicit targeting for upgrade" means that the package will not be upgraded with all others unless an extra flag is added, or the package is mentioned explicitly</comment>
   </data>
   <data name="Downloading" xml:space="preserve">
@@ -1499,13 +1499,13 @@
     <value>此程序包需要安装位置</value>
   </data>
   <data name="InstallersAbortTerminal" xml:space="preserve">
-    <value>已知以下安装程序重启终端或 shell：</value>
+    <value>已知以下安装程序重启终端或 shell: </value>
   </data>
   <data name="InstallersRequireInstallLocation" xml:space="preserve">
-    <value>以下安装程序需要安装位置：</value>
+    <value>以下安装程序需要安装位置: </value>
   </data>
   <data name="PromptForInstallRoot" xml:space="preserve">
-    <value>指定安装根目录：</value>
+    <value>指定安装根目录: </value>
   </data>
   <data name="PromptToProceed" xml:space="preserve">
     <value>是否继续?</value>
@@ -1639,7 +1639,7 @@
     <value>正在重置所有当前包钉。</value>
   </data>
   <data name="PinResetUseForceArg" xml:space="preserve">
-    <value>使用--force参数重置所有固定。将删除以下 PIN：</value>
+    <value>使用--force参数重置所有固定。将删除以下 PIN: </value>
     <comment>{Locked="--force"}</comment>
   </data>
   <data name="PinType" xml:space="preserve">
@@ -1777,7 +1777,7 @@
     <comment>Indicates that this item is used to check/assert the state rather than write to it</comment>
   </data>
   <data name="ConfigurationDependencies" xml:space="preserve">
-    <value>依赖项：{0}</value>
+    <value>依赖项: {0}</value>
     <comment>{Locked="{0}"} Label displaying a list of dependencies. {0} is replaced with a space separated list of identifiers referencing other items.</comment>
   </data>
   <data name="ConfigurationFailedToApply" xml:space="preserve">
@@ -1795,15 +1795,15 @@
     <comment>Used to indicate that the item is present on the device.</comment>
   </data>
   <data name="ConfigurationModuleNameOnly" xml:space="preserve">
-    <value>模块：{0}</value>
+    <value>模块: {0}</value>
     <comment>{Locked="{0}"} Label displaying a module name. {0} is replaced with the name of the module from the user input file.</comment>
   </data>
   <data name="ConfigurationModuleWithDetails" xml:space="preserve">
-    <value>模块：{0} 由 {1} [{2}]</value>
+    <value>模块: {0} 由 {1} [{2}]</value>
     <comment>{Locked="{0}","{1}","{2}"} Label displaying module information. {0} is replaced by the module name. {1} is replaced by the module author. {2} is replaced by a string indicating the source of the module.</comment>
   </data>
   <data name="ConfigurationSettings" xml:space="preserve">
-    <value>设置：</value>
+    <value>设置: </value>
     <comment>Label for the values that are used as inputs for this item when applying state</comment>
   </data>
   <data name="ConfigurationSuccessfullyApplied" xml:space="preserve">
@@ -1880,11 +1880,11 @@
     <value>系统未处于配置声明的所需状态。</value>
   </data>
   <data name="ConfigurationUnitFailed" xml:space="preserve">
-    <value>由于未知原因，此配置单元失败： {0}</value>
+    <value>由于未知原因，此配置单元失败: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedConfigSet" xml:space="preserve">
-    <value>配置单元因配置而失败： {0}</value>
+    <value>配置单元因配置而失败: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedDuringGet" xml:space="preserve">
@@ -1897,19 +1897,19 @@
     <value>尝试测试当前系统状态时配置单元失败。</value>
   </data>
   <data name="ConfigurationUnitFailedInternal" xml:space="preserve">
-    <value>由于内部错误，配置单元失败： {0}</value>
+    <value>由于内部错误，配置单元失败: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedPrecondition" xml:space="preserve">
-    <value>配置单元失败，因为前提条件无效： {0}</value>
+    <value>配置单元失败，因为前提条件无效: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedSystemState" xml:space="preserve">
-    <value>配置单元因系统状态而失败： {0}</value>
+    <value>配置单元因系统状态而失败: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedUnitProcessing" xml:space="preserve">
-    <value>尝试运行配置单元时失败： {0}</value>
+    <value>尝试运行配置单元时失败: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitHasDuplicateIdentifier" xml:space="preserve">
@@ -1948,7 +1948,7 @@
     <value>配置单元在执行过程中返回了意外结果。</value>
   </data>
   <data name="ConfigurationUnitSkipped" xml:space="preserve">
-    <value>由于未知原因，未运行此配置单元： {0}</value>
+    <value>由于未知原因，未运行此配置单元: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationFieldInvalidValue" xml:space="preserve">
@@ -2654,7 +2654,7 @@
     <value>要恢复的已保存状态的唯一标识符</value>
   </data>
   <data name="ClientVersionMismatchError" xml:space="preserve">
-    <value>不支持从其他客户端版本恢复状态： {0}</value>
+    <value>不支持从其他客户端版本恢复状态: {0}</value>
     <comment>{Locked= "{0}"} Message displayed to inform the user that the client version of the resume state does not match the current client version. {0} is a placeholder for the client version that created the resume state.</comment>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
@@ -2696,11 +2696,11 @@
     <comment>{Locked="{0}"} {0} is a placeholder replaced by the input winget configure resource unit type.</comment>
   </data>
   <data name="WinGetResourceUnitMissingRequiredArg" xml:space="preserve">
-    <value>{0} 配置单元缺少必需的参数： {1}</value>
+    <value>{0} 配置单元缺少必需的参数: {1}</value>
     <comment>{Locked="{0},{1}"} {0} is a placeholder for the input winget configure resource unit type. {1} is placeholder for the missing arg.</comment>
   </data>
   <data name="WinGetResourceUnitMissingRecommendedArg" xml:space="preserve">
-    <value>{0} 配置单元缺少建议的参数： {1}</value>
+    <value>{0} 配置单元缺少建议的参数: {1}</value>
     <comment>{Locked="{0},{1}"} {0} is a placeholder for the input winget configure resource unit type. {1} is placeholder for the missing arg.</comment>
   </data>
   <data name="WinGetResourceUnitKnownSourceConfliction" xml:space="preserve">
@@ -2708,39 +2708,39 @@
     <comment>{Locked="WinGetSource,{0}"} {0} is a placeholder for the input winget source in the configuration unit settings.</comment>
   </data>
   <data name="WinGetResourceUnitThirdPartySourceAssertion" xml:space="preserve">
-    <value>第三方源上的 WinGetSource 配置单元声明： {0}</value>
+    <value>第三方源上的 WinGetSource 配置单元声明: {0}</value>
     <comment>{Locked="WinGetSource,{0}"} {0} is a placeholder for the input winget source in the configuration unit settings.</comment>
   </data>
   <data name="WinGetResourceUnitBothPackageVersionAndUseLatest" xml:space="preserve">
-    <value>WinGetPackage 声明 UseLatest 和 Version。包 ID： {0}</value>
+    <value>WinGetPackage 声明 UseLatest 和 Version。包 ID: {0}</value>
     <comment>{Locked="WinGetPackage,UseLatest,Version,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitThirdPartySourceAssertionForPackage" xml:space="preserve">
-    <value>WinGetPackage 配置单元声明来自第三方源的包。包 ID： {0};源： {1}</value>
+    <value>WinGetPackage 配置单元声明来自第三方源的包。包 ID: {0};源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitDependencySourceNotConfigured" xml:space="preserve">
-    <value>WinGetPackage 配置单元包依赖于以前未配置的第三方源。包 ID： {0};源： {1}</value>
+    <value>WinGetPackage 配置单元包依赖于以前未配置的第三方源。包 ID: {0};源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitDependencySourceNotDeclaredAsDependency" xml:space="preserve">
-    <value>WinGetPackage 配置单元包依赖于第三方源。建议在 uni dependsOn 节中声明依赖项。包 ID： {0};源： {1}</value>
+    <value>WinGetPackage 配置单元包依赖于第三方源。建议在 uni dependsOn 节中声明依赖项。包 ID: {0};源: {1}</value>
     <comment>{Locked="WinGetPackage,dependsOn,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageSourceOpenFailed" xml:space="preserve">
-    <value>无法验证 WinGetPackage 配置单元包。源打开失败。包 ID： {0};源： {1}</value>
+    <value>无法验证 WinGetPackage 配置单元包。源打开失败。包 ID: {0};源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageNotFound" xml:space="preserve">
-    <value>无法验证 WinGetPackage 配置单元包。找不到包。包 ID： {0}</value>
+    <value>无法验证 WinGetPackage 配置单元包。找不到包。包 ID: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageMultipleFound" xml:space="preserve">
-    <value>无法验证 WinGetPackage 配置单元包。找到多个包。包 ID： {0}</value>
+    <value>无法验证 WinGetPackage 配置单元包。找到多个包。包 ID: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageVersionNotFound" xml:space="preserve">
-    <value>无法验证 WinGetPackage 配置单元包。找不到包版本。包 ID： {0};版本 {1}</value>
+    <value>无法验证 WinGetPackage 配置单元包。找不到包版本。包 ID: {0};版本 {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitPackageVersionSpecifiedWithOnlyOnePackageVersion" xml:space="preserve">
@@ -2748,7 +2748,7 @@
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackage" xml:space="preserve">
-    <value>无法验证 WinGetPackage 配置单元包。包 ID： {0}</value>
+    <value>无法验证 WinGetPackage 配置单元包。包 ID: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="AuthenticationModeArgumentDescription" xml:space="preserve">

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -3112,21 +3112,21 @@
     <value>尽可能禁止显示初始配置详细信息</value>
   </data>
   <data name="MSStoreDownloadMultiplePackagesNotice" xml:space="preserve">
-    <value>可以针对不同的平台和体系结构下载多个Microsoft Store包。--platform，--architecture 可用于筛选包。</value>
+    <value>可以针对不同的平台和体系结构下载多个 Microsoft Store 包。--platform，--architecture 可用于筛选包。</value>
     <comment>{Locked="--platform--architecture"}</comment>
   </data>
   <data name="MSStoreDownloadGetLicenseForbidden" xml:space="preserve">
-    <value>无法检索Microsoft Store包许可证。Microsoft Entra ID 帐户不是全局管理员、用户管理员或许可证管理员的成员。使用 --skip-license 跳过检索Microsoft Store包许可证。</value>
+    <value>无法检索 Microsoft Store 包许可证。Microsoft Entra ID 帐户不是全局管理员、用户管理员或许可证管理员的成员。使用 --skip-license 跳过检索Microsoft Store包许可证。</value>
     <comment>{Locked="Global Administrator,User Administrator,License Administrator,--skip-license"}</comment>
   </data>
   <data name="MSStoreDownloadPackageDownloadNotSupported" xml:space="preserve">
-    <value>Microsoft Store包不支持下载。</value>
+    <value>Microsoft Store 包不支持下载。</value>
   </data>
   <data name="APPINSTALLER_CLI_ERROR_SFSCLIENT_PACKAGE_NOT_SUPPORTED" xml:space="preserve">
-    <value>Microsoft Store包不支持下载。</value>
+    <value>Microsoft Store 包不支持下载。</value>
   </data>
   <data name="APPINSTALLER_CLI_ERROR_LICENSING_API_FAILED_FORBIDDEN" xml:space="preserve">
-    <value>无法检索Microsoft Store包许可证。Microsoft Entra ID 帐户没有所需的权限。</value>
+    <value>无法检索 Microsoft Store 包许可证。Microsoft Entra ID 帐户没有所需的权限。</value>
   </data>
   <data name="WINGET_CONFIG_ERROR_PARAMETER_INTEGRITY_BOUNDARY" xml:space="preserve">
     <value>无法跨完整性边界传递参数。</value>
@@ -3147,14 +3147,14 @@
     <value>家庭</value>
   </data>
   <data name="FontFaces" xml:space="preserve">
-    <value>脸</value>
+    <value>Faces</value>
     <comment>"Faces" represents the typeface of the font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFamilyNameArgumentDescription" xml:space="preserve">
     <value>按家庭名称筛选结果</value>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>脸</value>
+    <value>Face</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -2902,7 +2902,7 @@
     <value>无法获取 Microsoft Store 程序包下载信息。</value>
   </data>
   <data name="APPINSTALLER_CLI_ERROR_NO_APPLICABLE_SFSCLIENT_PACKAGE" xml:space="preserve">
-    <value>找不到适用于下载的Microsoft Store包。</value>
+    <value>找不到适用于下载的 Microsoft Store 包。</value>
   </data>
   <data name="APPINSTALLER_CLI_ERROR_LICENSING_API_FAILED" xml:space="preserve">
     <value>无法检索 Microsoft Store 程序包许可证。</value>
@@ -2954,7 +2954,7 @@
     <comment>{Locked="--rename"}</comment>
   </data>
   <data name="MSStoreDownloadAuthenticationNotice" xml:space="preserve">
-    <value>Microsoft Store包下载需要Microsoft Entra ID 身份验证。必要时可能会显示身份验证提示。将与Microsoft 服务共享经过身份验证的信息以进行访问授权。对于Microsoft Store包授权，Microsoft Entra ID 帐户必须是全局管理员、用户管理员或许可证管理员的成员。</value>
+    <value>Microsoft Store 包下载需要 Microsoft Entra ID 身份验证。必要时可能会显示身份验证提示。将与 Microsoft 服务共享经过身份验证的信息以进行访问授权。对于 Microsoft Store 包授权，Microsoft Entra ID 帐户必须是全局管理员、用户管理员或许可证管理员的成员。</value>
     <comment>{Locked="Global Administrator,User Administrator,License Administrator"}</comment>
   </data>
   <data name="SkipMicrosoftStorePackageLicenseArgumentDescription" xml:space="preserve">
@@ -2992,7 +2992,7 @@
     <value>导出配置失败。</value>
   </data>
   <data name="ConfigureExportUnitDescription" xml:space="preserve">
-    <value>配置{0}</value>
+    <value>配置 {0}</value>
     <comment>{Locked="{0}"}</comment>
   </data>
   <data name="ConfigureExportUnitInstallDescription" xml:space="preserve">
@@ -3007,7 +3007,7 @@
     <comment>Keep some form of separator like the "&lt;&gt;" around the text so that it stands out from the preceding text.</comment>
   </data>
   <data name="ConfigureListCommandLongDescription" xml:space="preserve">
-    <value>显示已应用于系统的配置的高级别详细信息。然后，此数据可与 `configure` 命令一起使用以获取更多详细信息。</value>
+    <value>显示已应用于系统的配置的高级别详细信息。然后，此数据可与 “configure” 命令一起使用以获取更多详细信息。</value>
     <comment>{Locked="`configure`"}</comment>
   </data>
   <data name="ConfigureListCommandShortDescription" xml:space="preserve">
@@ -3109,7 +3109,7 @@
     <value>该包与当前 Windows 版本或平台不兼容。</value>
   </data>
   <data name="ConfigurationSuppressPrologueArgumentDescription" xml:space="preserve">
-    <value>尽可能禁止显示初始配置详细信息</value>
+    <value>尽可能不显示初始配置详细信息</value>
   </data>
   <data name="MSStoreDownloadMultiplePackagesNotice" xml:space="preserve">
     <value>可以针对不同的平台和体系结构下载多个 Microsoft Store 包。--platform，--architecture 可用于筛选包。</value>
@@ -3144,17 +3144,17 @@
     <value>使用子命令管理字体。可以安装、升级或卸载与 package 类似的字体。 </value>
   </data>
   <data name="FontFamily" xml:space="preserve">
-    <value>家庭</value>
+    <value>字体集</value>
   </data>
   <data name="FontFaces" xml:space="preserve">
-    <value>Faces</value>
+    <value>字体样式</value>
     <comment>"Faces" represents the typeface of the font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFamilyNameArgumentDescription" xml:space="preserve">
-    <value>按家庭名称筛选结果</value>
+    <value>按字体集名称筛选结果</value>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>Face</value>
+    <value>字体样式</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">

--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -2659,7 +2659,7 @@
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>恢复状态不存在: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>在恢复状态下找不到数据。</value>

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -3154,7 +3154,7 @@
     <value>依家庭名稱篩選結果</value>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>臉</value>
+    <value>Face</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -202,7 +202,7 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides an extra positional argument when none was expected. {0} is a placeholder replaced by the user's extra argument input.</comment>
   </data>
   <data name="FeatureDisabledMessage" xml:space="preserve">
-    <value>此功能正在進行中，未來可能會大幅變更或全部移除。若要啟用，請編輯您的設定 ('winget settings')以包含實驗性功能： '{0}'</value>
+    <value>此功能正在進行中，未來可能會大幅變更或全部移除。若要啟用，請編輯您的設定 ('winget settings')以包含實驗性功能: '{0}'</value>
     <comment>{Locked="winget settings","{0}"}. Error message displayed when the user uses an experimental feature that is disabled. {0} is a placeholder replaced by the experimental feature name.</comment>
   </data>
   <data name="FeaturesCommandLongDescription" xml:space="preserve">
@@ -482,7 +482,7 @@
     <value>版本</value>
   </data>
   <data name="SettingLoadFailure" xml:space="preserve">
-    <value>驗證設定時發現下列失誤：</value>
+    <value>驗證設定時發現下列失誤: </value>
   </data>
   <data name="SettingsCommandLongDescription" xml:space="preserve">
     <value>在預設 json 文字編輯器中開啟設定。如果未設定任何編輯器，則會在記事本中開啟設定。如需可用的設定，請參閱 https://aka.ms/winget-settings 此命令透過提供 --enable 或 --disable 引數，可用於設定系統管理員設定。</value>
@@ -516,16 +516,16 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides more than a single character command line alias argument after an alias argument specifier '-'. {0} is a placeholder replaced by the user's argument input.</comment>
   </data>
   <data name="SourceAddAlreadyExistsDifferentArg" xml:space="preserve">
-    <value>具有給定名稱的來源已存在，且參照到不同的位置：</value>
+    <value>具有給定名稱的來源已存在，且參照到不同的位置: </value>
   </data>
   <data name="SourceAddAlreadyExistsDifferentName" xml:space="preserve">
-    <value>具有不同名稱的來源已參照到此位置：</value>
+    <value>具有不同名稱的來源已參照到此位置: </value>
   </data>
   <data name="SourceAddAlreadyExistsMatch" xml:space="preserve">
-    <value>具有給定名稱的來源已存在，且參照到同樣的位置：</value>
+    <value>具有給定名稱的來源已存在，且參照到同樣的位置: </value>
   </data>
   <data name="SourceAddBegin" xml:space="preserve">
-    <value>新增的來源：</value>
+    <value>新增的來源: </value>
   </data>
   <data name="SourceAddCommandLongDescription" xml:space="preserve">
     <value>新增來源。來源會為您提供資料，以便您探索和安裝套件。只有在您信任其為安全位置時，才會新增來源。</value>
@@ -631,7 +631,7 @@
     <value>強制重設來源</value>
   </data>
   <data name="SourceResetListAndOverridePreamble" xml:space="preserve">
-    <value>若已給定 --force 選項，將重設下列來源：</value>
+    <value>若已給定 --force 選項，將重設下列來源: </value>
     <comment>{Locked="--force"}</comment>
   </data>
   <data name="SourceResetOne" xml:space="preserve">
@@ -677,11 +677,11 @@
     <comment>{Locked="{0}"} Error message displayed when the user provides a command line argument more times than it is allowed. {0} is a placeholder replaced by the user's argument name input.</comment>
   </data>
   <data name="TooManyBehaviorsError" xml:space="preserve">
-    <value>提供了多個執行行為引數： '{0}'</value>
+    <value>提供了多個執行行為引數: '{0}'</value>
     <comment>{Locked="{0}"} Error message displayed when the user provides more than one execution behavior argument when installing an application package. {0} is a placeholder replaced by the user specified execution behaviors (e.g. 'silent|interactive').</comment>
   </data>
   <data name="UnexpectedErrorExecutingCommand" xml:space="preserve">
-    <value>執行命令時，發生意外的錯誤：</value>
+    <value>執行命令時，發生意外的錯誤: </value>
   </data>
   <data name="UninstallPreviousArgumentDescription" xml:space="preserve">
     <value>在升級期間卸載舊版的套件</value>
@@ -749,7 +749,7 @@
     <comment>{Locked="{0}"} Error message displayed when the user attempts to install or upgrade an application package from a repository source that was not found. {0} is a placeholder replaced by the user's repository source name input.</comment>
   </data>
   <data name="OpenSourceFailedNoMatchHelp" xml:space="preserve">
-    <value>設定的來源為：</value>
+    <value>設定的來源為: </value>
   </data>
   <data name="OpenSourceFailedNoSourceDefined" xml:space="preserve">
     <value>未定義來源；使用 [source add]，以進行新增，或使用 [source reset] 將之重設成預設值</value>
@@ -783,7 +783,7 @@
     <value>防毒程式產品報告安裝程式中有感染</value>
   </data>
   <data name="SourceOpenWithFailedUpdate" xml:space="preserve">
-    <value>嘗試更新來源失敗： {0}</value>
+    <value>嘗試更新來源失敗: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when an attempt to update the repository source fails. {0} is a placeholder replaced by the repository source name.</comment>
   </data>
   <data name="UninstallCommandLongDescription" xml:space="preserve">
@@ -836,7 +836,7 @@
     <value>無法安裝一或多個匯入的套件</value>
   </data>
   <data name="ImportSourceNotInstalled" xml:space="preserve">
-    <value>未安裝匯入所需的來源： {0}</value>
+    <value>未安裝匯入所需的來源: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when the user attempts to import application package(s) from a repository source that is not installed. {0} is a placeholder replaced by the repository source name.</comment>
   </data>
   <data name="InstalledPackageNotAvailable" xml:space="preserve">
@@ -879,7 +879,7 @@
     <comment>{Locked="{0}","{1}"} Error message displayed when the user provides an invalid command line argument value. {0} is a placeholder replaced by the argument name. {1} is a placeholder replaced by a list of valid options.</comment>
   </data>
   <data name="DisabledByGroupPolicy" xml:space="preserve">
-    <value>群組原則已停用此作業： {0}</value>
+    <value>群組原則已停用此作業: {0}</value>
     <comment>{Locked="{0}"} Error message displayed when the user performs a command operation that is disabled by a group policy. {0} is a placeholder replaced by a group policy description.</comment>
   </data>
   <data name="PolicyAdditionalSources" xml:space="preserve">
@@ -980,11 +980,11 @@
     <value>外部</value>
   </data>
   <data name="ImportCommandReportDependencies" xml:space="preserve">
-    <value>在此匯入中找到的套件具有下列相依性：</value>
+    <value>在此匯入中找到的套件具有下列相依性: </value>
     <comment>Import command sentence showed before reporting dependencies</comment>
   </data>
   <data name="PackageRequiresDependencies" xml:space="preserve">
-    <value>此套件需要下列相依性：</value>
+    <value>此套件需要下列相依性: </value>
     <comment>Message shown before reporting dependencies</comment>
   </data>
   <data name="DependenciesFlowInstall" xml:space="preserve">
@@ -1018,7 +1018,7 @@
     <comment>Dependency graph has loop</comment>
   </data>
   <data name="DependenciesFlowNoSuitableInstallerFound" xml:space="preserve">
-    <value>找不到適合指令清單的安裝程式： {0} 版本 {1}</value>
+    <value>找不到適合指令清單的安裝程式: {0} 版本 {1}</value>
     <comment>{Locked="{0}","{1}"} Error message displayed when an attempt to get a preferred installer for a manifest fails. {0} is a placeholder replaced by the manifest identifier. {1} is a placeholder replaced by the manifest version.</comment>
   </data>
   <data name="DependenciesManagementError" xml:space="preserve">
@@ -1032,11 +1032,11 @@
     <value>套件</value>
   </data>
   <data name="UninstallCommandReportDependencies" xml:space="preserve">
-    <value>此套件具有可能不再需要的相依性：</value>
+    <value>此套件具有可能不再需要的相依性: </value>
     <comment>Uninstall command sentence showed before reporting dependencies</comment>
   </data>
   <data name="ValidateCommandReportDependencies" xml:space="preserve">
-    <value>資訊清單具有下列未驗證的相依性;請確認它們有效：</value>
+    <value>資訊清單具有下列未驗證的相依性;請確認它們有效: </value>
     <comment>Validate command sentence showed before reporting dependencies</comment>
   </data>
   <data name="WindowsFeaturesDependencies" xml:space="preserve">
@@ -1056,7 +1056,7 @@
     <value>接受套件的所有授權合約</value>
   </data>
   <data name="ExportedPackageRequiresLicenseAgreement" xml:space="preserve">
-    <value>匯出的套件需要授權合約才能安裝： {0}</value>
+    <value>匯出的套件需要授權合約才能安裝: {0}</value>
     <comment>{Locked="{0}"} Warning message displayed when an exported application package requires license agreement to install. {0} is a placeholder replaced by the package name.</comment>
   </data>
   <data name="PackageAgreementsPrompt" xml:space="preserve">
@@ -1067,13 +1067,13 @@
     <value>未同意套件合約。作業已取消。</value>
   </data>
   <data name="ShowLabelAgreements" xml:space="preserve">
-    <value>合約：</value>
+    <value>合約: </value>
   </data>
   <data name="ShowLabelAuthor" xml:space="preserve">
     <value>作者:</value>
   </data>
   <data name="ShowLabelDescription" xml:space="preserve">
-    <value>描述：</value>
+    <value>描述: </value>
   </data>
   <data name="ShowLabelInstaller" xml:space="preserve">
     <value>安裝程式:</value>
@@ -1082,7 +1082,7 @@
     <value>安裝程式地區設定:</value>
   </data>
   <data name="ShowLabelInstallerProductId" xml:space="preserve">
-    <value>Store 產品識別碼：</value>
+    <value>Store 產品識別碼: </value>
   </data>
   <data name="ShowLabelInstallerSha256" xml:space="preserve">
     <value>安裝程式 SHA256:</value>
@@ -1103,7 +1103,7 @@
     <value>綽號:</value>
   </data>
   <data name="ShowLabelPackageUrl" xml:space="preserve">
-    <value>首頁：</value>
+    <value>首頁: </value>
   </data>
   <data name="ShowLabelPublisher" xml:space="preserve">
     <value>發行者:</value>
@@ -1164,7 +1164,7 @@
     <value>略過選用標頭，因為它不適用於此來源。</value>
   </data>
   <data name="HeaderArgumentNotApplicableWithoutSource" xml:space="preserve">
-    <value>選擇性標頭不適用，但未指定來源： '{0}'</value>
+    <value>選擇性標頭不適用，但未指定來源: '{0}'</value>
     <comment>{Locked="{0}"} Error message displayed when the user performs an operation (e.g install) and provides the HTTP 'header' argument without specifying the repository source. {0} is a placeholder replaced by the header argument name.</comment>
   </data>
   <data name="ShowLabelInstallerReleaseDate" xml:space="preserve">
@@ -1174,28 +1174,28 @@
     <value>支援離線散發:</value>
   </data>
   <data name="ShowLabelPublisherUrl" xml:space="preserve">
-    <value>發行者 URL：</value>
+    <value>發行者 URL: </value>
   </data>
   <data name="ShowLabelPurchaseUrl" xml:space="preserve">
     <value>購買 Url:</value>
   </data>
   <data name="ShowLabelPublisherSupportUrl" xml:space="preserve">
-    <value>發行者支援 URL：</value>
+    <value>發行者支援 URL: </value>
   </data>
   <data name="ShowLabelPrivacyUrl" xml:space="preserve">
-    <value>隱私權 Url：</value>
+    <value>隱私權 Url: </value>
   </data>
   <data name="ShowLabelCopyright" xml:space="preserve">
     <value>著作權:</value>
   </data>
   <data name="ShowLabelCopyrightUrl" xml:space="preserve">
-    <value>著作權 Url：</value>
+    <value>著作權 Url: </value>
   </data>
   <data name="ShowLabelReleaseNotes" xml:space="preserve">
-    <value>版本資訊：</value>
+    <value>版本資訊: </value>
   </data>
   <data name="ShowLabelReleaseNotesUrl" xml:space="preserve">
-    <value>版本資訊 Url：</value>
+    <value>版本資訊 Url: </value>
   </data>
   <data name="SearchFailureWarning" xml:space="preserve">
     <value>搜尋來源時失敗; 將不會包含結果: {0}</value>
@@ -1639,7 +1639,7 @@
     <value>重設目前所有釘選。</value>
   </data>
   <data name="PinResetUseForceArg" xml:space="preserve">
-    <value>使用--force引數重設所有釘選。將移除下列 PIN：</value>
+    <value>使用--force引數重設所有釘選。將移除下列 PIN: </value>
     <comment>{Locked="--force"}</comment>
   </data>
   <data name="PinType" xml:space="preserve">
@@ -1880,11 +1880,11 @@
     <value>系統不是設定所宣告的預期狀態。</value>
   </data>
   <data name="ConfigurationUnitFailed" xml:space="preserve">
-    <value>此設定單位失敗，原因不明： {0}</value>
+    <value>此設定單位失敗，原因不明: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedConfigSet" xml:space="preserve">
-    <value>設定單位失敗，因為設定： {0}</value>
+    <value>設定單位失敗，因為設定: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedDuringGet" xml:space="preserve">
@@ -1897,19 +1897,19 @@
     <value>嘗試測試目前的系統狀態時，組態單位失敗。</value>
   </data>
   <data name="ConfigurationUnitFailedInternal" xml:space="preserve">
-    <value>設定單位失敗，因為發生內部錯誤： {0}</value>
+    <value>設定單位失敗，因為發生內部錯誤: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedPrecondition" xml:space="preserve">
-    <value>設定單位失敗，因為先決條件無效： {0}</value>
+    <value>設定單位失敗，因為先決條件無效: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedSystemState" xml:space="preserve">
-    <value>設定單位失敗，因為系統狀態： {0}</value>
+    <value>設定單位失敗，因為系統狀態: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitFailedUnitProcessing" xml:space="preserve">
-    <value>嘗試執行時設定單位失敗： {0}</value>
+    <value>嘗試執行時設定單位失敗: {0}</value>
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationUnitHasDuplicateIdentifier" xml:space="preserve">
@@ -1952,7 +1952,7 @@
     <comment>{Locked="{0}"} {0} is a placeholder for the unrecognized error code.</comment>
   </data>
   <data name="ConfigurationFieldInvalidValue" xml:space="preserve">
-    <value>欄位'{0}'具有不正確值： {1}</value>
+    <value>欄位'{0}'具有不正確值: {1}</value>
     <comment>{Locked="{0}","{1}"} An error in reading a configuration file. {0} is a placeholder replaced by the field name from the file. {1} is a placeholder for the invalid value.</comment>
   </data>
   <data name="ConfigurationFieldMissing" xml:space="preserve">
@@ -2654,7 +2654,7 @@
     <value>要繼續之儲存狀態的唯一標識符</value>
   </data>
   <data name="ClientVersionMismatchError" xml:space="preserve">
-    <value>不支援從不同的用戶端版本繼續狀態： {0}</value>
+    <value>不支援從不同的用戶端版本繼續狀態: {0}</value>
     <comment>{Locked= "{0}"} Message displayed to inform the user that the client version of the resume state does not match the current client version. {0} is a placeholder for the client version that created the resume state.</comment>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
@@ -2696,51 +2696,51 @@
     <comment>{Locked="{0}"} {0} is a placeholder replaced by the input winget configure resource unit type.</comment>
   </data>
   <data name="WinGetResourceUnitMissingRequiredArg" xml:space="preserve">
-    <value>{0} 組態單位遺漏必要的自變數： {1}</value>
+    <value>{0} 組態單位遺漏必要的自變數: {1}</value>
     <comment>{Locked="{0},{1}"} {0} is a placeholder for the input winget configure resource unit type. {1} is placeholder for the missing arg.</comment>
   </data>
   <data name="WinGetResourceUnitMissingRecommendedArg" xml:space="preserve">
-    <value>{0} 組態單位遺漏建議的自變數： {1}</value>
+    <value>{0} 組態單位遺漏建議的自變數: {1}</value>
     <comment>{Locked="{0},{1}"} {0} is a placeholder for the input winget configure resource unit type. {1} is placeholder for the missing arg.</comment>
   </data>
   <data name="WinGetResourceUnitKnownSourceConfliction" xml:space="preserve">
-    <value>WinGetSource 組態單位與已知來源衝突： {0}</value>
+    <value>WinGetSource 組態單位與已知來源衝突: {0}</value>
     <comment>{Locked="WinGetSource,{0}"} {0} is a placeholder for the input winget source in the configuration unit settings.</comment>
   </data>
   <data name="WinGetResourceUnitThirdPartySourceAssertion" xml:space="preserve">
-    <value>第三方來源的 WinGetSource 組態單位判斷提示： {0}</value>
+    <value>第三方來源的 WinGetSource 組態單位判斷提示: {0}</value>
     <comment>{Locked="WinGetSource,{0}"} {0} is a placeholder for the input winget source in the configuration unit settings.</comment>
   </data>
   <data name="WinGetResourceUnitBothPackageVersionAndUseLatest" xml:space="preserve">
-    <value>WinGetPackage 宣告 UseLatest 和 Version。套件識別碼： {0}</value>
+    <value>WinGetPackage 宣告 UseLatest 和 Version。套件識別碼: {0}</value>
     <comment>{Locked="WinGetPackage,UseLatest,Version,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitThirdPartySourceAssertionForPackage" xml:space="preserve">
-    <value>WinGetPackage 組態單位在來自第三方來源的封裝上宣告。套件標識碼： {0};來源： {1}</value>
+    <value>WinGetPackage 組態單位在來自第三方來源的封裝上宣告。套件標識碼: {0};來源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitDependencySourceNotConfigured" xml:space="preserve">
-    <value>WinGetPackage 設定單元套件相依於先前未設定的第三方來源。套件標識碼： {0};來源： {1}</value>
+    <value>WinGetPackage 設定單元套件相依於先前未設定的第三方來源。套件標識碼: {0};來源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitDependencySourceNotDeclaredAsDependency" xml:space="preserve">
-    <value>WinGetPackage 設定單元套件相依於第三方來源。建議您在 uni dependsOn 區段中宣告相依性。套件標識碼： {0};來源： {1}</value>
+    <value>WinGetPackage 設定單元套件相依於第三方來源。建議您在 uni dependsOn 區段中宣告相依性。套件標識碼: {0};來源: {1}</value>
     <comment>{Locked="WinGetPackage,dependsOn,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageSourceOpenFailed" xml:space="preserve">
-    <value>無法驗證 WinGetPackage 設定單元套件。來源開啟失敗。套件標識碼： {0};來源： {1}</value>
+    <value>無法驗證 WinGetPackage 設定單元套件。來源開啟失敗。套件標識碼: {0};來源: {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageNotFound" xml:space="preserve">
-    <value>無法驗證 WinGetPackage 設定單元套件。找不到套件。套件識別碼： {0}</value>
+    <value>無法驗證 WinGetPackage 設定單元套件。找不到套件。套件識別碼: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageMultipleFound" xml:space="preserve">
-    <value>無法驗證 WinGetPackage 設定單元套件。找到多個套件。套件識別碼： {0}</value>
+    <value>無法驗證 WinGetPackage 設定單元套件。找到多個套件。套件識別碼: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackageVersionNotFound" xml:space="preserve">
-    <value>無法驗證 WinGetPackage 設定單元套件。找不到套件版本。套件標識碼： {0};版本 {1}</value>
+    <value>無法驗證 WinGetPackage 設定單元套件。找不到套件版本。套件標識碼: {0};版本 {1}</value>
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitPackageVersionSpecifiedWithOnlyOnePackageVersion" xml:space="preserve">
@@ -2748,7 +2748,7 @@
     <comment>{Locked="WinGetPackage,{0},{1}"}</comment>
   </data>
   <data name="WinGetResourceUnitFailedToValidatePackage" xml:space="preserve">
-    <value>無法驗證 WinGetPackage 設定單元套件。套件識別碼： {0}</value>
+    <value>無法驗證 WinGetPackage 設定單元套件。套件識別碼: {0}</value>
     <comment>{Locked="WinGetPackage,{0}"}</comment>
   </data>
   <data name="AuthenticationModeArgumentDescription" xml:space="preserve">

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -2659,7 +2659,7 @@
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>恢復狀態不存在: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>在恢復狀態中找不到任何資料。</value>

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -3144,17 +3144,17 @@
     <value>使用子命令管理字型。可以安裝、升級或卸載類似封裝的字型。 </value>
   </data>
   <data name="FontFamily" xml:space="preserve">
-    <value>家庭</value>
+    <value>字體集</value>
   </data>
   <data name="FontFaces" xml:space="preserve">
-    <value>表情</value>
+    <value>字體樣式</value>
     <comment>"Faces" represents the typeface of the font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFamilyNameArgumentDescription" xml:space="preserve">
-    <value>依家庭名稱篩選結果</value>
+    <value>依字体集名稱篩選結果</value>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>Face</value>
+    <value>字體樣式</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -2662,7 +2662,7 @@ Please specify one of them using the --source option to proceed.</value>
   </data>
   <data name="ResumeIdNotFoundError" xml:space="preserve">
     <value>The resume state does not exist: {0}</value>
-    <comment>{Locked="{0}" Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
+    <comment>{Locked="{0}"} Error message displayed when the user provides a guid that does not correspond to a valid saved state. {0} is a placeholder replaced by the provided guid string.</comment>
   </data>
   <data name="ResumeStateDataNotFoundError" xml:space="preserve">
     <value>No data found in the resume state.</value>


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

### Harmonization of `:` in zh-CN and zh-TW localization
`： ` → `: `
`：` → `: `

### Completion of missing left and right spaces
For example:
`...将使用Windows 程序包管理器设置中指定的...` → `...将使用 Windows 程序包管理器设置中指定的...`

**See comments and commit messages below for other changes.**

-----

- Superseded by #5192

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5170)