### PR TITLE
Use embedded CsWinRT

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -100,7 +100,9 @@
 ^src/catch2/
 ^src/cpprestsdk/
 ^src/JsonCppLib/
+^src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj$
 ^src/PowerShell/Help/markdownlint\.yaml$
+^src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj$
 ^src/PureLib/
 ^src/SfsClient/
 ^src/UndockedRegFreeWinRT/

--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -214,6 +214,12 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.Management.Deploy
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Management.Deployment.CsWinRTProjection", "Microsoft.Management.Deployment.CsWinRTProjection\Microsoft.Management.Deployment.CsWinRTProjection.csproj", "{9406322E-6272-487E-902A-9953889719EA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "targets", "targets", "{A0B4F808-B190-41C4-97CB-C8EA1932F84F}"
+	ProjectSection(SolutionItems) = preProject
+		targets\EmbeddedCsWinRT.targets = targets\EmbeddedCsWinRT.targets
+		targets\ReferenceEmbeddedCsWinRTProject.targets = targets\ReferenceEmbeddedCsWinRTProject.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -1301,6 +1307,7 @@ Global
 		{5A52D9FC-0059-4A4A-8196-427A7AA0D1C5} = {7C218A3E-9BC8-48FF-B91B-BCACD828C0C9}
 		{1B9077B3-8923-4ECD-8FC9-B3190FCBE4D4} = {60618CAC-2995-4DF9-9914-45C6FC02C995}
 		{76B26B2C-602A-4AD0-9736-4162D3FCA92A} = {1A5D7A7D-5CB2-47D5-B40D-4E61CAEDC798}
+		{A0B4F808-B190-41C4-97CB-C8EA1932F84F} = {8D53D749-D51C-46F8-A162-9371AAA6C2E7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B6FDB70C-A751-422C-ACD1-E35419495857}

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -530,9 +530,6 @@
     <ProjectReference Include="..\YamlCppLib\YamlCppLib.vcxproj">
       <Project>{8bb94bb8-374f-4294-bca1-c7811514a6b7}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -543,18 +543,5 @@
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorTextNuget)', '$(SolutionDir)\packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorTextNuget)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorTextNuget)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <PropertyGroup>
-      <!-- The output path for this project is different on some builds where the RIDs are not used in the output. -->
-      <MicrosoftManagementConfigurationProcessorPath>$(SolutionDir)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.winmd</MicrosoftManagementConfigurationProcessorPath>
-      <MicrosoftManagementConfigurationProcessorPath Condition="!Exists('$(MicrosoftManagementConfigurationProcessorPath)')">$(SolutionDir)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Processor\net8.0-windows10.0.22000.0\win\Microsoft.Management.Configuration.Processor.winmd</MicrosoftManagementConfigurationProcessorPath>
-    </PropertyGroup>
-    <Message Importance="high" Text="Microsoft.Management.Configuration.Processor.winmd -&gt; $(MicrosoftManagementConfigurationProcessorPath)" />
-    <Error Condition="!Exists('$(MicrosoftManagementConfigurationProcessorPath)')" Text="Microsoft.Management.Configuration.Processor.winmd was not found in $(MicrosoftManagementConfigurationProcessorPath)" />
-    <ItemGroup Condition="Exists('$(MicrosoftManagementConfigurationProcessorPath)')">
-      <Reference Include="Microsoft.Management.Configuration.Processor">
-        <HintPath>$(MicrosoftManagementConfigurationProcessorPath)</HintPath>
-        <IsWinMDFile>true</IsWinMDFile>
-      </Reference>
-    </ItemGroup>
   </Target>
 </Project>

--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -16,7 +16,24 @@ using namespace AppInstaller::Settings;
 
 namespace AppInstaller::CLI
 {
-    constexpr Utility::LocIndView s_Command_ArgName_SilentAndInteractive = "silent|interactive"_liv;
+    namespace
+    {
+        constexpr Utility::LocIndView s_Command_ArgName_SilentAndInteractive = "silent|interactive"_liv;
+
+        void LaunchLogsIfRequested(Execution::Context& context)
+        {
+            try
+            {
+                if (context.Args.Contains(Execution::Args::Type::OpenLogs))
+                {
+                    // TODO: Consider possibly adding functionality that if the context contains 'Execution::Args::Type::Log' to open the path provided for the log
+                    // The above was omitted initially as a security precaution to ensure that user input to '--log' wouldn't be passed directly to ShellExecute
+                    ShellExecute(NULL, NULL, Runtime::GetPathTo(Runtime::PathName::DefaultLogLocation).wstring().c_str(), NULL, NULL, SW_SHOWNORMAL);
+                }
+            }
+            CATCH_LOG();
+        }
+    }
 
     Command::Command(
         std::string_view name,
@@ -936,12 +953,7 @@ namespace AppInstaller::CLI
         }
         else
         {
-            if (context.Args.Contains(Execution::Args::Type::OpenLogs))
-            {
-                // TODO: Consider possibly adding functionality that if the context contains 'Execution::Args::Type::Log' to open the path provided for the log
-                // The above was omitted initially as a security precaution to ensure that user input to '--log' wouldn't be passed directly to ShellExecute
-                ShellExecute(NULL, NULL, Runtime::GetPathTo(Runtime::PathName::DefaultLogLocation).wstring().c_str(), NULL, NULL, SW_SHOWNORMAL);
-            }
+            LaunchLogsIfRequested(context);
 
             if (context.Args.Contains(Execution::Args::Type::Wait))
             {
@@ -1030,6 +1042,8 @@ namespace AppInstaller::CLI
         catch (...)
         {
             context.SetTerminationHR(Workflow::HandleException(context, std::current_exception()));
+
+            LaunchLogsIfRequested(context);
         }
     }
 

--- a/src/AppInstallerCLICore/Commands/DebugCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/DebugCommand.cpp
@@ -5,6 +5,7 @@
 #if _DEBUG
 #include "DebugCommand.h"
 #include <winrt/Microsoft.Management.Configuration.h>
+#include <winrt/Microsoft.Management.Configuration.SetProcessorFactory.h>
 #include "AppInstallerDownloader.h"
 #include "Sixel.h"
 
@@ -105,6 +106,7 @@ namespace AppInstaller::CLI
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IConfigurationUnitProcessorDetails2>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IGetAllSettingsConfigurationUnitProcessor>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IConfigurationStatics2>(context);
+        OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>(context);
 
         // TODO: Fix the layering inversion created by the COM deployment API (probably in order to operate winget.exe against the COM server).
         //       Then this code can just have a CppWinRT reference to the deployment API and spit out the interface registrations just like for configuration.

--- a/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
+++ b/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
@@ -7,7 +7,6 @@
 #include <AppInstallerRuntime.h>
 #include <AppInstallerStrings.h>
 #include <winget/ILifetimeWatcher.h>
-#include <winrt/Microsoft.Management.Configuration.Processor.h>
 #include <winrt/Microsoft.Management.Configuration.SetProcessorFactory.h>
 
 using namespace winrt::Windows::Foundation;
@@ -250,7 +249,7 @@ namespace AppInstaller::CLI::ConfigurationRemoting
                 // Create a copy for remote and set remote module paths
                 std::vector<winrt::hstring> newRemotePaths{ newModulePaths };
                 m_remoteAdditionalModulePaths = winrt::single_threaded_vector<winrt::hstring>(std::move(newRemotePaths));
-                m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().AdditionalModulePaths(m_remoteAdditionalModulePaths.GetView());
+                m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().AdditionalModulePaths(m_remoteAdditionalModulePaths.GetView());
 
                 // Store the updated module paths that we were given
                 m_additionalModulePaths = winrt::single_threaded_vector<winrt::hstring>(std::move(newModulePaths));
@@ -258,32 +257,32 @@ namespace AppInstaller::CLI::ConfigurationRemoting
 
             SetProcessorFactory::PwshConfigurationProcessorPolicy Policy() const
             {
-                return Convert(m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().Policy());
+                return m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().Policy();
             }
 
             void Policy(SetProcessorFactory::PwshConfigurationProcessorPolicy value)
             {
-                m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().Policy(Convert(value));
+                m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().Policy(value);
             }
 
             SetProcessorFactory::PwshConfigurationProcessorLocation Location() const
             {
-                return Convert(m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().Location());
+                return m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().Location();
             }
 
             void Location(SetProcessorFactory::PwshConfigurationProcessorLocation value)
             {
-                m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().Location(Convert(value));
+                m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().Location(value);
             }
 
             winrt::hstring CustomLocation() const
             {
-                return m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().CustomLocation();
+                return m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().CustomLocation();
             }
 
             void CustomLocation(winrt::hstring value)
             {
-                m_remoteFactory.as<Processor::IPowerShellConfigurationProcessorFactoryProperties>().CustomLocation(value);
+                m_remoteFactory.as<SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>().CustomLocation(value);
             }
 
             HRESULT STDMETHODCALLTYPE SetLifetimeWatcher(IUnknown* watcher)
@@ -292,30 +291,6 @@ namespace AppInstaller::CLI::ConfigurationRemoting
             }
 
         private:
-            static SetProcessorFactory::PwshConfigurationProcessorPolicy Convert(Processor::PowerShellConfigurationProcessorPolicy policy)
-            {
-                // We have used the same values intentionally; if that changes, update this.
-                return ToEnum<SetProcessorFactory::PwshConfigurationProcessorPolicy>(ToIntegral(policy));
-            }
-
-            static Processor::PowerShellConfigurationProcessorPolicy Convert(SetProcessorFactory::PwshConfigurationProcessorPolicy policy)
-            {
-                // We have used the same values intentionally; if that changes, update this.
-                return ToEnum<Processor::PowerShellConfigurationProcessorPolicy>(ToIntegral(policy));
-            }
-
-            static SetProcessorFactory::PwshConfigurationProcessorLocation Convert(Processor::PowerShellConfigurationProcessorLocation location)
-            {
-                // We have used the same values intentionally; if that changes, update this.
-                return ToEnum<SetProcessorFactory::PwshConfigurationProcessorLocation>(ToIntegral(location));
-            }
-
-            static Processor::PowerShellConfigurationProcessorLocation Convert(SetProcessorFactory::PwshConfigurationProcessorLocation location)
-            {
-                // We have used the same values intentionally; if that changes, update this.
-                return ToEnum<Processor::PowerShellConfigurationProcessorLocation>(ToIntegral(location));
-            }
-
             IConfigurationSetProcessorFactory m_remoteFactory;
             wil::unique_event m_completionEvent;
             Collections::IVector<winrt::hstring> m_additionalModulePaths{ winrt::single_threaded_vector<winrt::hstring>() };

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -244,12 +244,6 @@
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd">
         <PackagePath>Microsoft.Management.Configuration.winmd</PackagePath>
       </WinGetAdditionalPackageFile>
-      <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Processor\**\Microsoft.Management.Configuration.Processor.winmd">
-        <PackagePath>Microsoft.Management.Configuration.Processor.winmd</PackagePath>
-      </WinGetAdditionalPackageFile>
-      <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\AnyCPU\$(Configuration)\Microsoft.Management.Configuration.Projection\**\Microsoft.Management.Configuration.Projection.dll">
-        <PackagePath>ConfigurationRemotingServer\Microsoft.Management.Configuration.Projection.dll</PackagePath>
-      </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net8.0-windows10.0.22000.0\$(ConfigServerRid)\**\*">
         <PackagePath>ConfigurationRemotingServer</PackagePath>
         <Recurse>true</Recurse>

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -116,6 +116,7 @@
         <Interface Name="Microsoft.Management.Configuration.IConfigurationUnitProcessorDetails2" InterfaceId="E89623ED-76E2-5145-B920-D09659554E35" />
         <Interface Name="Microsoft.Management.Configuration.IGetAllSettingsConfigurationUnitProcessor" InterfaceId="72EB8304-D8D3-57D4-9940-7C1C4AD8C40C" />
         <Interface Name="Microsoft.Management.Configuration.IConfigurationStatics2" InterfaceId="540BE073-F2EF-5375-83AA-8E23086B0669" />
+        <Interface Name="Microsoft.Management.Configuration.SetProcessorFactory.IPwshConfigurationSetProcessorFactoryProperties" InterfaceId="2C298A30-BD3B-5D00-BCD1-2EB633AB7E3B" />
       </ProxyStub>
     </Extension>
     <!-- This entry forces the package registration to process the windows.activatableClass.proxyStub extension above. -->

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -10,10 +10,6 @@
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <!--
-    !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
-    -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'x64' ">
@@ -28,9 +24,7 @@
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
-  </ItemGroup>
+  <Import Project="..\targets\ReferenceEmbeddedCsWinRTProject.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj" />

--- a/src/Microsoft.Management.Configuration.Processor/Helpers/TypeHelpers.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Helpers/TypeHelpers.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
     using System.Reflection;
     using Microsoft.Management.Configuration.Processor.Exceptions;
     using Microsoft.Management.Configuration.Processor.Extensions;
+    using Microsoft.Management.Configuration.SetProcessorFactory;
     using Windows.Foundation.Collections;
 
     /// <summary>
@@ -150,6 +151,78 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
 
             // This might be too restrictive but anything else is going to be some object that we don't support anyway.
             throw new UnitPropertyUnsupportedException(value.GetType());
+        }
+
+        /// <summary>
+        /// Converts PowerShellConfigurationProcessorPolicy string value to PwshConfigurationProcessorPolicy.
+        /// </summary>
+        /// <param name="value">PowerShellConfigurationProcessorPolicy value.</param>
+        /// <returns>PwshConfigurationProcessorPolicy.</returns>
+        public static PwshConfigurationProcessorPolicy ToPwshConfigurationProcessorPolicy(PowerShellConfigurationProcessorPolicy value)
+        {
+            return value switch
+            {
+                PowerShellConfigurationProcessorPolicy.Unrestricted => PwshConfigurationProcessorPolicy.Unrestricted,
+                PowerShellConfigurationProcessorPolicy.RemoteSigned => PwshConfigurationProcessorPolicy.RemoteSigned,
+                PowerShellConfigurationProcessorPolicy.AllSigned => PwshConfigurationProcessorPolicy.AllSigned,
+                PowerShellConfigurationProcessorPolicy.Restricted => PwshConfigurationProcessorPolicy.Restricted,
+                PowerShellConfigurationProcessorPolicy.Bypass => PwshConfigurationProcessorPolicy.Bypass,
+                PowerShellConfigurationProcessorPolicy.Undefined => PwshConfigurationProcessorPolicy.Undefined,
+                _ => throw new InvalidOperationException(),
+            };
+        }
+
+        /// <summary>
+        /// Converts PwshConfigurationProcessorPolicy string value to PowerShellConfigurationProcessorPolicy.
+        /// </summary>
+        /// <param name="value">PwshConfigurationProcessorPolicy value.</param>
+        /// <returns>PowerShellConfigurationProcessorPolicy.</returns>
+        public static PowerShellConfigurationProcessorPolicy ToPowerShellConfigurationProcessorPolicy(PwshConfigurationProcessorPolicy value)
+        {
+            return value switch
+            {
+                PwshConfigurationProcessorPolicy.Unrestricted => PowerShellConfigurationProcessorPolicy.Unrestricted,
+                PwshConfigurationProcessorPolicy.RemoteSigned => PowerShellConfigurationProcessorPolicy.RemoteSigned,
+                PwshConfigurationProcessorPolicy.AllSigned => PowerShellConfigurationProcessorPolicy.AllSigned,
+                PwshConfigurationProcessorPolicy.Restricted => PowerShellConfigurationProcessorPolicy.Restricted,
+                PwshConfigurationProcessorPolicy.Bypass => PowerShellConfigurationProcessorPolicy.Bypass,
+                PwshConfigurationProcessorPolicy.Undefined => PowerShellConfigurationProcessorPolicy.Undefined,
+                _ => throw new InvalidOperationException(),
+            };
+        }
+
+        /// <summary>
+        /// Converts PowerShellConfigurationProcessorLocation string value to PwshConfigurationProcessorLocation.
+        /// </summary>
+        /// <param name="value">PowerShellConfigurationProcessorLocation value.</param>
+        /// <returns>PwshConfigurationProcessorLocation.</returns>
+        public static PwshConfigurationProcessorLocation ToPwshConfigurationProcessorLocation(PowerShellConfigurationProcessorLocation value)
+        {
+            return value switch
+            {
+                PowerShellConfigurationProcessorLocation.CurrentUser => PwshConfigurationProcessorLocation.CurrentUser,
+                PowerShellConfigurationProcessorLocation.AllUsers => PwshConfigurationProcessorLocation.AllUsers,
+                PowerShellConfigurationProcessorLocation.WinGetModulePath => PwshConfigurationProcessorLocation.WinGetModulePath,
+                PowerShellConfigurationProcessorLocation.Custom => PwshConfigurationProcessorLocation.Custom,
+                _ => throw new InvalidOperationException(),
+            };
+        }
+
+        /// <summary>
+        /// Converts PwshConfigurationProcessorLocation string value to PowerShellConfigurationProcessorLocation.
+        /// </summary>
+        /// <param name="value">PwshConfigurationProcessorLocation value.</param>
+        /// <returns>PowerShellConfigurationProcessorLocation.</returns>
+        public static PowerShellConfigurationProcessorLocation ToPowerShellConfigurationProcessorLocation(PwshConfigurationProcessorLocation value)
+        {
+            return value switch
+            {
+                PwshConfigurationProcessorLocation.CurrentUser => PowerShellConfigurationProcessorLocation.CurrentUser,
+                PwshConfigurationProcessorLocation.AllUsers => PowerShellConfigurationProcessorLocation.AllUsers,
+                PwshConfigurationProcessorLocation.WinGetModulePath => PowerShellConfigurationProcessorLocation.WinGetModulePath,
+                PwshConfigurationProcessorLocation.Custom => PowerShellConfigurationProcessorLocation.Custom,
+                _ => throw new InvalidOperationException(),
+            };
         }
     }
 }

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -73,29 +73,23 @@
     <CsWinRTComponent>false</CsWinRTComponent>
     <CsWinRTIncludes>
       Microsoft.Management.Configuration;
-      Windows.ApplicationModel;
-      Windows.Data;
-      Windows.Devices;
+      Windows.Data.Text.TextSegmen;
+      Windows.Devices.Geolocation;
       Windows.Foundation;
-      Windows.Globalization;
-      Windows.Graphics;
-      Windows.Management;
-      Windows.Media;
-      Windows.Networking;
-      Windows.Perception;
-      Windows.Security;
-      Windows.Services;
+      Windows.Globalization.DayOfWee;
+      Windows.Networking.Connectivity;
+      Windows.Networking.DomainNameTyp;
+      Windows.Networking.EndpointPai;
+      Windows.Networking.IEndpointPai;
+      Windows.Networking.HostNam;
+      Windows.Networking.IHostNam;
+      Windows.Security.Cryptography.Certificates;
       Windows.Storage;
-      Windows.System;
-      Windows.UI;
-      Windows.Web;
+      Windows.System.Use;
+      Windows.System.IUse;
     </CsWinRTIncludes>
     <CsWinRTExcludes>
-      Windows.ApplicationModel.Store.Preview;
-      Windows.Devices.PointOfService;
       Windows.Foundation.PropertyType;
-      Windows.UI.Input.Preview;
-      Windows.UI.Xaml;
     </CsWinRTExcludes>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -22,7 +22,7 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
-    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
+    <WinGetCsWinRTEmbedded Condition="'$(WinGetCsWinRTEmbedded)'==''">true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -31,8 +31,6 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
-    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -77,7 +77,6 @@
       Windows.Data;
       Windows.Devices;
       Windows.Foundation;
-      Windows.Gaming;
       Windows.Globalization;
       Windows.Graphics;
       Windows.Management;
@@ -92,7 +91,11 @@
       Windows.Web;
     </CsWinRTIncludes>
     <CsWinRTExcludes>
+      Windows.ApplicationModel.Store.Preview;
+      Windows.Devices.PointOfService;
       Windows.Foundation.PropertyType;
+      Windows.UI.Input.Preview;
+      Windows.UI.Xaml;
     </CsWinRTExcludes>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -22,6 +22,7 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -30,6 +31,8 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
+    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -52,13 +55,52 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'!='true'">
     <ProjectReference Include="..\Microsoft.Management.Configuration.Projection\Microsoft.Management.Configuration.Projection.csproj">
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ReferenceOutputAssembly>True</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'=='true'">
+    <ProjectReference Include="..\Microsoft.Management.Configuration\Microsoft.Management.Configuration.vcxproj">
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+  
+  <PropertyGroup Condition="'$(WinGetCsWinRTEmbedded)'=='true'">
+    <DefineConstants>$(DefineConstants);WinGetCsWinRTEmbedded</DefineConstants>
+    <CsWinRTComponent>false</CsWinRTComponent>
+    <CsWinRTIncludes>
+      Microsoft.Management.Configuration;
+      Windows.ApplicationModel;
+      Windows.Data;
+      Windows.Devices;
+      Windows.Foundation;
+      Windows.Gaming;
+      Windows.Globalization;
+      Windows.Graphics;
+      Windows.Management;
+      Windows.Media;
+      Windows.Networking;
+      Windows.Perception;
+      Windows.Security;
+      Windows.Services;
+      Windows.Storage;
+      Windows.System;
+      Windows.UI;
+      Windows.Web;
+    </CsWinRTIncludes>
+    <CsWinRTExcludes>
+      Windows.Foundation.PropertyType;
+    </CsWinRTExcludes>
+    <!-- Ensure Support for Windows 10, Version 1809 -->
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+  </PropertyGroup>
+
+  <Import Project="..\targets\EmbeddedCsWinRT.targets" Condition="'$(WinGetCsWinRTEmbedded)'=='true'" />
 
   <Target Name="MicrosoftManagementConfigurationPathTarget" BeforeTargets="CsWinRTSetAuthoringWinMDs">
     <PropertyGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
@@ -15,6 +15,12 @@ using System.Runtime.Versioning;
 // Needed to allow us mock internal interfaces.
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
+#if WinGetCsWinRTEmbedded
+// Allow our consuming assemblies access when built embedded.
+[assembly: InternalsVisibleTo("Microsoft.WinGet.Configuration.Engine")]
+[assembly: InternalsVisibleTo("ConfigurationRemotingServer")]
+#endif
+
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
 [assembly: TargetPlatform("Windows10.0.22000.0")]

--- a/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
@@ -15,12 +15,17 @@ namespace Microsoft.Management.Configuration.Processor
     using Microsoft.Management.Configuration;
     using Microsoft.Management.Configuration.Processor.ProcessorEnvironments;
     using Microsoft.Management.Configuration.Processor.Set;
+    using Microsoft.Management.Configuration.SetProcessorFactory;
     using static Microsoft.Management.Configuration.Processor.Constants.PowerShellConstants;
 
     /// <summary>
     /// ConfigurationSetProcessorFactory implementation.
     /// </summary>
-    public sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties
+#if WinGetCsWinRTEmbedded
+    internal sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties, IPwshConfigurationSetProcessorFactoryProperties
+#else
+    public sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties, IPwshConfigurationSetProcessorFactoryProperties
+#endif
     {
         private bool isCreateProcessorInvoked = false;
 
@@ -201,6 +206,15 @@ namespace Microsoft.Management.Configuration.Processor
         }
 
         /// <summary>
+        /// Gets or sets the configuration policy.
+        /// </summary>
+        PwshConfigurationProcessorPolicy IPwshConfigurationSetProcessorFactoryProperties.Policy
+        {
+            get { return Helpers.TypeHelpers.ToPwshConfigurationProcessorPolicy(this.Policy); }
+            set { this.Policy = Helpers.TypeHelpers.ToPowerShellConfigurationProcessorPolicy(value); }
+        }
+
+        /// <summary>
         /// Gets or sets the module location.
         /// </summary>
         public PowerShellConfigurationProcessorLocation Location
@@ -219,6 +233,15 @@ namespace Microsoft.Management.Configuration.Processor
 
                 this.location = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the module location.
+        /// </summary>
+        PwshConfigurationProcessorLocation IPwshConfigurationSetProcessorFactoryProperties.Location
+        {
+            get { return Helpers.TypeHelpers.ToPwshConfigurationProcessorLocation(this.Location); }
+            set { this.Location = Helpers.TypeHelpers.ToPowerShellConfigurationProcessorLocation(value); }
         }
 
         /// <summary>

--- a/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PowerShellConfigurationSetProcessorFactory.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Management.Configuration.Processor
     /// ConfigurationSetProcessorFactory implementation.
     /// </summary>
 #if WinGetCsWinRTEmbedded
-    internal sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties, IPwshConfigurationSetProcessorFactoryProperties
+    internal
 #else
-    public sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties, IPwshConfigurationSetProcessorFactoryProperties
+    public
 #endif
+        sealed class PowerShellConfigurationSetProcessorFactory : IConfigurationSetProcessorFactory, IPowerShellConfigurationProcessorFactoryProperties, IPwshConfigurationSetProcessorFactoryProperties
     {
         private bool isCreateProcessorInvoked = false;
 

--- a/src/Microsoft.Management.Configuration.UnitTests/Fixtures/UnitTestFixture.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Fixtures/UnitTestFixture.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Fixtures
         /// <summary>
         /// Gets the configuration statics object to use.
         /// </summary>
-        public IConfigurationStatics2 ConfigurationStatics { get; private init; }
+        internal IConfigurationStatics2 ConfigurationStatics { get; private init; }
 
         /// <summary>
         /// Creates a runspace adding the test module path.

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/ConfigurationProcessorTestBase.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/ConfigurationProcessorTestBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// </summary>
         /// <param name="factory">The factory to use.</param>
         /// <returns>The new <see cref="ConfigurationProcessor"/> object.</returns>
-        protected ConfigurationProcessor CreateConfigurationProcessorWithDiagnostics(IConfigurationSetProcessorFactory? factory = null)
+        internal ConfigurationProcessor CreateConfigurationProcessorWithDiagnostics(IConfigurationSetProcessorFactory? factory = null)
         {
             ConfigurationProcessor result = this.Fixture.ConfigurationStatics.CreateConfigurationProcessor(factory);
             result.Diagnostics += this.EventSink.DiagnosticsHandler;
@@ -62,7 +62,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// </summary>
         /// <param name="contents">The contents that the stream should contain.</param>
         /// <returns>The created stream.</returns>
-        protected IInputStream CreateStream(string contents)
+        internal IInputStream CreateStream(string contents)
         {
             InMemoryRandomAccessStream result = new InMemoryRandomAccessStream();
 
@@ -83,7 +83,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// </summary>
         /// <param name="stream">The output stream.</param>
         /// <returns>The created string.</returns>
-        protected string ReadStream(InMemoryRandomAccessStream stream)
+        internal string ReadStream(InMemoryRandomAccessStream stream)
         {
             string result = string.Empty;
             using (DataReader reader = new DataReader(stream.GetInputStreamAt(0)))
@@ -105,7 +105,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// Creates a configuration unit via the configuration statics object.
         /// </summary>
         /// <returns>A new configuration unit.</returns>
-        protected ConfigurationUnit ConfigurationUnit()
+        internal ConfigurationUnit ConfigurationUnit()
         {
             return this.Fixture.ConfigurationStatics.CreateConfigurationUnit();
         }
@@ -114,7 +114,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// Creates a configuration parameter via the configuration statics object.
         /// </summary>
         /// <returns>A new configuration parameter.</returns>
-        protected ConfigurationParameter ConfigurationParameter()
+        internal ConfigurationParameter ConfigurationParameter()
         {
             return this.Fixture.ConfigurationStatics.CreateConfigurationParameter();
         }
@@ -123,7 +123,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// Creates a configuration set via the configuration statics object.
         /// </summary>
         /// <returns>A new configuration set.</returns>
-        protected ConfigurationSet ConfigurationSet()
+        internal ConfigurationSet ConfigurationSet()
         {
             return this.Fixture.ConfigurationStatics.CreateConfigurationSet();
         }
@@ -134,7 +134,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// <param name="configurationSet">The configuration set.</param>
         /// <param name="setResult">The set result.</param>
         /// <param name="resultSource">The result source.</param>
-        protected void VerifySummaryEvent(ConfigurationSet configurationSet, ApplyConfigurationSetResult setResult, ConfigurationUnitResultSource resultSource)
+        internal void VerifySummaryEvent(ConfigurationSet configurationSet, ApplyConfigurationSetResult setResult, ConfigurationUnitResultSource resultSource)
         {
             TelemetryEvent summary = this.VerifySummaryEventShared(configurationSet, ConfigurationUnitIntent.Apply, resultSource == ConfigurationUnitResultSource.None ? 0 : setResult.ResultCode.HResult, resultSource);
 
@@ -159,7 +159,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// <param name="setResult">The set result.</param>
         /// <param name="resultCode">The result code.</param>
         /// <param name="resultSource">The result source.</param>
-        protected void VerifySummaryEvent(ConfigurationSet configurationSet, TestConfigurationSetResult setResult, int resultCode, ConfigurationUnitResultSource resultSource)
+        internal void VerifySummaryEvent(ConfigurationSet configurationSet, TestConfigurationSetResult setResult, int resultCode, ConfigurationUnitResultSource resultSource)
         {
             TelemetryEvent summary = this.VerifySummaryEventShared(configurationSet, ConfigurationUnitIntent.Assert, resultCode, resultSource);
 

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/DiagnosticsEventSink.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/DiagnosticsEventSink.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="DiagnosticsEventSink.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -40,7 +40,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
         /// </summary>
         /// <param name="sender">The object sending the information.</param>
         /// <param name="e">The diagnostic information.</param>
-        public void DiagnosticsHandler(object? sender, IDiagnosticInformation e)
+        internal void DiagnosticsHandler(object? sender, IDiagnosticInformation e)
         {
             if (e.Message.Contains(TelemetryEvent.Preamble))
             {

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -7,10 +7,6 @@
     <Platforms>x64;x86;arm64</Platforms>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <!--
-    !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
-    -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -23,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
@@ -46,11 +41,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Management.Configuration.Projection\Microsoft.Management.Configuration.Projection.csproj">
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ReferenceOutputAssembly>True</ReferenceOutputAssembly>
-    </ProjectReference>
     <ProjectReference Include="..\Microsoft.Management.Configuration\Microsoft.Management.Configuration.vcxproj">
       <Private>True</Private>
     </ProjectReference>
@@ -59,6 +49,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
   </ItemGroup>
+
+  <Import Project="..\targets\ReferenceEmbeddedCsWinRTProject.targets" />
 
   <Target Name="PwshFiles" AfterTargets="AfterBuild">
     <ItemGroup>

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationSetProcessorTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationSetProcessorTests.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         [InlineData(ConfigurationUnitDetailFlags.Local)]
         [InlineData(ConfigurationUnitDetailFlags.ReadOnly)]
         [InlineData(ConfigurationUnitDetailFlags.Download)]
-        public void GetUnitProcessorDetails_Local(ConfigurationUnitDetailFlags detailFlags)
+        public void GetUnitProcessorDetails_Local(object detailFlags)
         {
             var unit = this.CreateConfigurationUnit();
             var (dscResourceInfo, psModuleInfo) = this.GetResourceAndModuleInfo(unit);
@@ -498,7 +498,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
 
             var configurationUnitProcessorDetails = configurationSetProcessor.GetUnitProcessorDetails(
                 unit,
-                detailFlags);
+                Assert.IsType<ConfigurationUnitDetailFlags>(detailFlags));
 
             Assert.NotNull(configurationUnitProcessorDetails);
             Assert.Equal(dscResourceInfo.Name, configurationUnitProcessorDetails.UnitType);

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationUnitProcessorTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/ConfigurationUnitProcessorTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         [InlineData(ConfigurationUnitIntent.Inform)]
         [InlineData(ConfigurationUnitIntent.Assert)]
         [InlineData(ConfigurationUnitIntent.Apply)]
-        public void GetSettings_Test(ConfigurationUnitIntent intent)
+        public void GetSettings_Test(object intent)
         {
             string theKey = "key";
             string theValue = "value";
@@ -69,7 +69,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
                 .Returns(valueGetResult)
                 .Verifiable();
 
-            var unitResource = this.CreateUnitResource(intent);
+            var unitResource = this.CreateUnitResource(Assert.IsType<ConfigurationUnitIntent>(intent));
 
             var unitProcessor = new ConfigurationUnitProcessor(processorEnvMock.Object, unitResource);
 
@@ -165,7 +165,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         [InlineData(ConfigurationUnitIntent.Apply, false)]
         [InlineData(ConfigurationUnitIntent.Assert, true)]
         [InlineData(ConfigurationUnitIntent.Apply, true)]
-        public void TestSettings_TestSucceeded(ConfigurationUnitIntent intent, bool invokeTestResult)
+        public void TestSettings_TestSucceeded(object intent, bool invokeTestResult)
         {
             var processorEnvMock = new Mock<IProcessorEnvironment>();
             processorEnvMock.Setup(m => m.InvokeTestResource(
@@ -175,7 +175,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
                 .Returns(invokeTestResult)
                 .Verifiable();
 
-            var unitResource = this.CreateUnitResource(intent);
+            var unitResource = this.CreateUnitResource(Assert.IsType<ConfigurationUnitIntent>(intent));
 
             var unitProcessor = new ConfigurationUnitProcessor(processorEnvMock.Object, unitResource);
 
@@ -261,10 +261,10 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         [Theory]
         [InlineData(ConfigurationUnitIntent.Inform)]
         [InlineData(ConfigurationUnitIntent.Assert)]
-        public void ApplySettings_InvalidIntent(ConfigurationUnitIntent intent)
+        public void ApplySettings_InvalidIntent(object intent)
         {
             var processorEnvMock = new Mock<IProcessorEnvironment>();
-            var unitResource = this.CreateUnitResource(intent);
+            var unitResource = this.CreateUnitResource(Assert.IsType<ConfigurationUnitIntent>(intent));
 
             var unitProcessor = new ConfigurationUnitProcessor(processorEnvMock.Object, unitResource);
 

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/OpenConfigurationSetTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/OpenConfigurationSetTests.cs
@@ -717,9 +717,9 @@ resources:
         [InlineData("object", "42", 42, Windows.Foundation.PropertyType.Inspectable)]
         [InlineData("secureobject", "string", "string", Windows.Foundation.PropertyType.Inspectable, true)]
         [InlineData("secureobject", "42", 42, Windows.Foundation.PropertyType.Inspectable, true)]
-        public void Parameters_DefaultValue_Success(string type, string defaultValue, object expectedValue, Windows.Foundation.PropertyType expectedType, bool secure = false)
+        public void Parameters_DefaultValue_Success(string type, string defaultValue, object expectedValue, object expectedType, bool secure = false)
         {
-            this.TestParameterDefaultValue(type, defaultValue, expectedValue, expectedType, secure);
+            this.TestParameterDefaultValue(type, defaultValue, expectedValue, Assert.IsType<Windows.Foundation.PropertyType>(expectedType), secure);
         }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -7,11 +7,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
-    <CsWinRTCcwLookupTableGeneratorEnabled>false</CsWinRTCcwLookupTableGeneratorEnabled>
-    <!--
-    !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
-    -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,14 +51,43 @@
     <RuntimeIdentifier>win</RuntimeIdentifier>
   </PropertyGroup>
 
-  <!-- This project doesn't reference it directly, but if I don't add it here it will fail with NETSDK1130 *.winmd cannot be referenced. -->
-  <ItemGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.WinGet.Client.Engine\Microsoft.WinGet.Client.Engine.csproj" />
   </ItemGroup>
+
+  <!-- Prevent .winmd files from being referenced transitively. -->
+  <Target Name="CopiedFromCsWinRTRemoveWinMDReferences" BeforeTargets="BeforeCompile" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <!--Move winmd references into private item group to prevent subsequent winmd reference errors-->
+      <CsWinRTRemovedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
+
+      <!--Prevent NETSDK1130 errors from winmd references-->
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
+      <ReferencePathWithRefAssemblies Remove="@(CsWinRTRemovedReferences)"
+        Condition="'%(CsWinRTRemovedReferences.Filename)%(CsWinRTRemovedReferences.Extension)' == '%(ReferencePathWithRefAssemblies.Filename)%(ReferencePathWithRefAssemblies.Extension)'" />
+      <!--Do not publish projection source winmds, but do include implementation dlls -->
+      <ReferenceCopyLocalPaths Remove="@(CsWinRTRemovedReferences)" />
+      <ReferenceCopyLocalPaths Include="@(CsWinRTRemovedReferences->'%(RootDir)%(Directory)%(DestinationSubDirectory)%(Implementation)')"
+                               Condition="'%(CsWinRTRemovedReferences.Implementation)' != '' AND Exists('%(CsWinRTRemovedReferences.RootDir)%(CsWinRTRemovedReferences.Directory)%(CsWinRTRemovedReferences.DestinationSubDirectory)%(CsWinRTRemovedReferences.Implementation)')" />
+      <!--Remove winmd references from deps.json to prevent CLR failing unit test execution-->
+      <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- Prevent WinRT.Runtime from being referenced. -->
+  <Target Name="CopiedFromCsWinRTRemoveWinRTRuntimeReference" 
+          Inputs="@(RuntimeCopyLocalItems)" 
+          AfterTargets="ResolvePackageAssets" 
+          Outputs="@(RuntimeCopyLocalItems)">
+
+    <ItemGroup>
+      <Reference Remove="WinRT.Runtime" /> 
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="'%(DestinationSubPath)' == 'WinRT.Runtime.dll'"/>
+      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(HintPath)' == '$(CsWinRTPath)lib\net6.0\WinRT.Runtime.dll'"/>
+      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(HintPath)' == '$(CsWinRTPath)lib\net8.0\WinRT.Runtime.dll'"/>
+    </ItemGroup>
+
+  </Target>
 
   <!-- This project doesn't reference CSWinRT, but specify this everywhere it will fail with NETSDK1130 and MSB3271. -->
   <PropertyGroup>
@@ -115,8 +140,6 @@
       <ManagedDependency Include="$(OutputPath)Newtonsoft.Json.dll" />
       <ManagedDependency Include="$(OutputPath)Octokit.dll" />
       <ManagedDependency Include="$(OutputPath)Microsoft.WinGet.SharedLib.dll" />
-      <ManagedDependency Include="$(OutputPath)Microsoft.Windows.SDK.NET.dll" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
-      <ManagedDependency Include="$(OutputPath)WinRT.Runtime.dll" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
       <ManagedDependency Include="$(OutputPath)Microsoft.Win32.Registry.dll" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
       <ManagedDependency Include="$(OutputPath)Semver.dll" />
     </ItemGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -7,7 +7,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
-    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,39 +54,7 @@
     <ProjectReference Include="..\Microsoft.WinGet.Client.Engine\Microsoft.WinGet.Client.Engine.csproj" />
   </ItemGroup>
 
-  <!-- Prevent .winmd files from being referenced transitively. -->
-  <Target Name="CopiedFromCsWinRTRemoveWinMDReferences" BeforeTargets="BeforeCompile" AfterTargets="ResolveReferences">
-    <ItemGroup>
-      <!--Move winmd references into private item group to prevent subsequent winmd reference errors-->
-      <CsWinRTRemovedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
-
-      <!--Prevent NETSDK1130 errors from winmd references-->
-      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
-      <ReferencePathWithRefAssemblies Remove="@(CsWinRTRemovedReferences)"
-        Condition="'%(CsWinRTRemovedReferences.Filename)%(CsWinRTRemovedReferences.Extension)' == '%(ReferencePathWithRefAssemblies.Filename)%(ReferencePathWithRefAssemblies.Extension)'" />
-      <!--Do not publish projection source winmd files, but do include implementation dlls -->
-      <ReferenceCopyLocalPaths Remove="@(CsWinRTRemovedReferences)" />
-      <ReferenceCopyLocalPaths Include="@(CsWinRTRemovedReferences->'%(RootDir)%(Directory)%(DestinationSubDirectory)%(Implementation)')"
-                               Condition="'%(CsWinRTRemovedReferences.Implementation)' != '' AND Exists('%(CsWinRTRemovedReferences.RootDir)%(CsWinRTRemovedReferences.Directory)%(CsWinRTRemovedReferences.DestinationSubDirectory)%(CsWinRTRemovedReferences.Implementation)')" />
-      <!--Remove winmd references from deps.json to prevent CLR failing unit test execution-->
-      <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'"/>
-    </ItemGroup>
-  </Target>
-
-  <!-- Prevent WinRT.Runtime from being referenced. -->
-  <Target Name="CopiedFromCsWinRTRemoveWinRTRuntimeReference" 
-          Inputs="@(RuntimeCopyLocalItems)" 
-          AfterTargets="ResolvePackageAssets" 
-          Outputs="@(RuntimeCopyLocalItems)">
-
-    <ItemGroup>
-      <Reference Remove="WinRT.Runtime" /> 
-      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="'%(DestinationSubPath)' == 'WinRT.Runtime.dll'"/>
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(HintPath)' == '$(CsWinRTPath)lib\net6.0\WinRT.Runtime.dll'"/>
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(HintPath)' == '$(CsWinRTPath)lib\net8.0\WinRT.Runtime.dll'"/>
-    </ItemGroup>
-
-  </Target>
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets"  Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
 
   <!-- This project doesn't reference CSWinRT, but specify this everywhere it will fail with NETSDK1130 and MSB3271. -->
   <PropertyGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -54,7 +54,7 @@
     <ProjectReference Include="..\Microsoft.WinGet.Client.Engine\Microsoft.WinGet.Client.Engine.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets"  Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
 
   <!-- This project doesn't reference CSWinRT, but specify this everywhere it will fail with NETSDK1130 and MSB3271. -->
   <PropertyGroup>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -65,7 +65,7 @@
       <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
       <ReferencePathWithRefAssemblies Remove="@(CsWinRTRemovedReferences)"
         Condition="'%(CsWinRTRemovedReferences.Filename)%(CsWinRTRemovedReferences.Extension)' == '%(ReferencePathWithRefAssemblies.Filename)%(ReferencePathWithRefAssemblies.Extension)'" />
-      <!--Do not publish projection source winmds, but do include implementation dlls -->
+      <!--Do not publish projection source winmd files, but do include implementation dlls -->
       <ReferenceCopyLocalPaths Remove="@(CsWinRTRemovedReferences)" />
       <ReferenceCopyLocalPaths Include="@(CsWinRTRemovedReferences->'%(RootDir)%(Directory)%(DestinationSubDirectory)%(Implementation)')"
                                Condition="'%(CsWinRTRemovedReferences.Implementation)' != '' AND Exists('%(CsWinRTRemovedReferences.RootDir)%(CsWinRTRemovedReferences.Directory)%(CsWinRTRemovedReferences.DestinationSubDirectory)%(CsWinRTRemovedReferences.Implementation)')" />

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Attributes/FilterAttribute.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Attributes/FilterAttribute.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="FilterAttribute.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -15,7 +15,7 @@ namespace Microsoft.WinGet.Client.Engine.Attributes
     /// attribute are added to the <see cref="FindPackagesOptions" /> object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public class FilterAttribute : Attribute
+    internal class FilterAttribute : Attribute
     {
         /// <summary>
         /// Gets or sets the field that the filter will be matching against.

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="FinderCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -78,7 +78,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="limit">The limit on the number of matches returned.</param>
         /// <param name="match">The match option.</param>
         /// <returns>A list of <see cref="MatchResult" /> objects.</returns>
-        protected IReadOnlyList<MatchResult> FindPackages(
+        internal IReadOnlyList<MatchResult> FindPackages(
             CompositeSearchBehavior behavior,
             uint limit,
             PackageFieldMatchOption match)
@@ -97,7 +97,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="options">The options object.</param>
         /// <param name="match">The match type as string.</param>
         /// <param name="value">The query value.</param>
-        protected virtual void SetQueryInFindPackagesOptions(
+        internal virtual void SetQueryInFindPackagesOptions(
             ref FindPackagesOptions options,
             string match,
             string? value)

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderExtendedCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderExtendedCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="FinderExtendedCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -50,7 +50,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="behavior">A <see cref="CompositeSearchBehavior" /> value.</param>
         /// <param name="match">The match option.</param>
         /// <returns>A list of <see cref="MatchResult" /> objects.</returns>
-        protected IReadOnlyList<MatchResult> FindPackages(CompositeSearchBehavior behavior, PackageFieldMatchOption match)
+        internal IReadOnlyList<MatchResult> FindPackages(CompositeSearchBehavior behavior, PackageFieldMatchOption match)
         {
             return this.FindPackages(behavior, this.Count, match);
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/InstallCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/InstallCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="InstallCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -74,7 +74,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="version">The <see cref="PackageVersionId" /> to install.</param>
         /// <param name="mode">Package install mode as string.</param>
         /// <returns>An <see cref="InstallOptions" /> instance.</returns>
-        protected virtual InstallOptions GetInstallOptions(PackageVersionId? version, string mode)
+        internal virtual InstallOptions GetInstallOptions(PackageVersionId? version, string mode)
         {
             InstallOptions options = ManagementDeploymentFactory.Instance.CreateInstallOptions();
             options.AllowHashMismatch = this.AllowHashMismatch;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/ManagementDeploymentCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/ManagementDeploymentCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ManagementDeploymentCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -41,6 +41,28 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         }
 
         /// <summary>
+        /// Retrieves the specified source or all sources if <paramref name="source" /> is null.
+        /// </summary>
+        /// <returns>A list of <see cref="PackageCatalogReference" /> instances.</returns>
+        /// <param name="source">The name of the source to retrieve. If null, then all sources are returned.</param>
+        /// <exception cref="ArgumentException">The source does not exist.</exception>
+        internal IReadOnlyList<PackageCatalogReference> GetPackageCatalogReferences(string? source)
+        {
+            if (string.IsNullOrEmpty(source))
+            {
+                return PackageManagerWrapper.Instance.GetPackageCatalogs();
+            }
+            else
+            {
+                return new List<PackageCatalogReference>()
+                {
+                    PackageManagerWrapper.Instance.GetPackageCatalogByName(source!)
+                        ?? throw new InvalidSourceException(source!),
+                };
+            }
+        }
+
+        /// <summary>
         /// Executes the cmdlet. All cmdlets that uses the COM APIs and don't call async functions MUST use this method.
         /// The inproc COM API may deadlock on an STA thread.
         /// </summary>
@@ -73,28 +95,6 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
 
             this.Wait(runningTask);
             return runningTask.Result;
-        }
-
-        /// <summary>
-        /// Retrieves the specified source or all sources if <paramref name="source" /> is null.
-        /// </summary>
-        /// <returns>A list of <see cref="PackageCatalogReference" /> instances.</returns>
-        /// <param name="source">The name of the source to retrieve. If null, then all sources are returned.</param>
-        /// <exception cref="ArgumentException">The source does not exist.</exception>
-        protected IReadOnlyList<PackageCatalogReference> GetPackageCatalogReferences(string? source)
-        {
-            if (string.IsNullOrEmpty(source))
-            {
-                return PackageManagerWrapper.Instance.GetPackageCatalogs();
-            }
-            else
-            {
-                return new List<PackageCatalogReference>()
-                {
-                    PackageManagerWrapper.Instance.GetPackageCatalogByName(source!)
-                        ?? throw new InvalidSourceException(source!),
-                };
-            }
         }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="PackageCommand.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -52,7 +52,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="match">The match option.</param>
         /// <param name="callback">The method to call after retrieving the package and version to operate upon.</param>
         /// <returns>Result of the callback.</returns>
-        protected async Task<Tuple<TResult, CatalogPackage>?> GetPackageAndExecuteAsync<TResult>(
+        internal async Task<Tuple<TResult, CatalogPackage>?> GetPackageAndExecuteAsync<TResult>(
             CompositeSearchBehavior behavior,
             PackageFieldMatchOption match,
             Func<CatalogPackage, PackageVersionId?, Task<TResult>> callback)
@@ -78,7 +78,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         /// <param name="options">The options object.</param>
         /// <param name="match">The match type.</param>
         /// <param name="value">The query value.</param>
-        protected override void SetQueryInFindPackagesOptions(
+        internal override void SetQueryInFindPackagesOptions(
             ref FindPackagesOptions options,
             string match,
             string? value)

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/FindPackagesException.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/FindPackagesException.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="FindPackagesException.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -15,7 +15,7 @@ namespace Microsoft.WinGet.Client.Engine.Exceptions
     /// Raised when there is an error searching for packages.
     /// </summary>
     [Serializable]
-    public class FindPackagesException : RuntimeException
+    internal class FindPackagesException : RuntimeException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FindPackagesException"/> class.

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/VagueCriteriaException.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/VagueCriteriaException.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="VagueCriteriaException.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -17,7 +17,7 @@ namespace Microsoft.WinGet.Client.Engine.Exceptions
     /// Raised when search criteria for installing or updating a package is too vague.
     /// </summary>
     [Serializable]
-    public class VagueCriteriaException : RuntimeException
+    internal class VagueCriteriaException : RuntimeException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VagueCriteriaException"/> class.

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -13,6 +13,7 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -84,6 +85,25 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
+  <!-- Disable warnings from embedded/generated CsWinRT files. -->
+  <Target Name="DisableCsWinRTWarnings" AfterTargets="CsWinRTAddEmbeddedRuntime_Net5Sources">
+    <ItemGroup>
+      <WinGetCsWinRTGeneratedFiles Include="$(CsWinRTGeneratedFilesDir)*.cs" />
+    </ItemGroup>
+    <WriteLinesToFile File="%(WinGetCsWinRTGeneratedFiles.FullPath)"
+        Condition="$([System.IO.File]::Exists(%(WinGetCsWinRTGeneratedFiles.FullPath))) AND !$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)).StartsWith(&quot;// &lt;auto-generated /&gt;&quot;))"
+        Lines="$([System.String]::Concat(&quot;// &lt;auto-generated /&gt;&#xA;#pragma warning disable&#xA;&#xA;&quot;,$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)))))"
+        Overwrite="true"
+        Encoding="Unicode" />
+  </Target>
+
+  <!-- Remove the embedded module file that contains an unversioned SupportedOSPlatform attribute. -->
+  <Target Name="RemoveCsWinRTModuleFile" AfterTargets="CsWinRTIncludeProjection">
+    <ItemGroup>
+      <Compile Remove="$(CsWinRTGeneratedFilesDir)Module.cs" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -97,6 +117,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(DesktopFramework)'">
+    <LangVersion>10</LangVersion>
     <DefineConstants>$(DefineConstants);POWERSHELL_WINDOWS</DefineConstants>
   </PropertyGroup>
 
@@ -118,7 +139,29 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
     <CsWinRTEmbedded>true</CsWinRTEmbedded>
-    <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
+    <CsWinRTIncludes>
+      Microsoft.Management.Deployment;
+      Windows.ApplicationModel;
+      Windows.Data;
+      Windows.Devices;
+      Windows.Foundation;
+      Windows.Gaming;
+      Windows.Globalization;
+      Windows.Graphics;
+      Windows.Management;
+      Windows.Media;
+      Windows.Networking;
+      Windows.Perception;
+      Windows.Security;
+      Windows.Services;
+      Windows.Storage;
+      Windows.System;
+      Windows.UI;
+      Windows.Web;
+    </CsWinRTIncludes>
+    <CsWinRTExcludes>
+      Windows.Foundation.PropertyType;
+    </CsWinRTExcludes>
     <CsWinRTWindowsMetadata>$(TargetWindowsVersion)</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -122,23 +122,21 @@
   <PropertyGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
     <CsWinRTIncludes>
       Microsoft.Management.Deployment;
-      Windows.ApplicationModel;
-      Windows.Data;
-      Windows.Devices;
+      Windows.Data.Text.TextSegmen;
+      Windows.Devices.Geolocation;
       Windows.Foundation;
-      Windows.Gaming;
-      Windows.Globalization;
-      Windows.Graphics;
-      Windows.Management;
-      Windows.Media;
-      Windows.Networking;
-      Windows.Perception;
-      Windows.Security;
-      Windows.Services;
+      Windows.Globalization.DayOfWee;
+      Windows.Networking.Connectivity;
+      Windows.Networking.DomainNameTyp;
+      Windows.Networking.EndpointPai;
+      Windows.Networking.IEndpointPai;
+      Windows.Networking.HostNam;
+      Windows.Networking.IHostNam;
+      Windows.Security.Cryptography.Certificates;
       Windows.Storage;
-      Windows.System;
-      Windows.UI;
-      Windows.Web;
+      Windows.System.ProcessorArchitectur;
+      Windows.System.Use;
+      Windows.System.IUse;
     </CsWinRTIncludes>
     <CsWinRTExcludes>
       Windows.Foundation.PropertyType;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -118,6 +118,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
+    <CsWinRTEmbedded>true</CsWinRTEmbedded>
     <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
     <CsWinRTWindowsMetadata>$(TargetWindowsVersion)</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -13,7 +13,6 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
-    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -85,25 +84,6 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
-  <!-- Disable warnings from embedded/generated CsWinRT files. -->
-  <Target Name="DisableCsWinRTWarnings" AfterTargets="CsWinRTAddEmbeddedRuntime_Net5Sources">
-    <ItemGroup>
-      <WinGetCsWinRTGeneratedFiles Include="$(CsWinRTGeneratedFilesDir)*.cs" />
-    </ItemGroup>
-    <WriteLinesToFile File="%(WinGetCsWinRTGeneratedFiles.FullPath)"
-        Condition="$([System.IO.File]::Exists(%(WinGetCsWinRTGeneratedFiles.FullPath))) AND !$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)).StartsWith(&quot;// &lt;auto-generated /&gt;&quot;))"
-        Lines="$([System.String]::Concat(&quot;// &lt;auto-generated /&gt;&#xA;#pragma warning disable&#xA;&#xA;&quot;,$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)))))"
-        Overwrite="true"
-        Encoding="Unicode" />
-  </Target>
-
-  <!-- Remove the embedded module file that contains an unversioned SupportedOSPlatform attribute. -->
-  <Target Name="RemoveCsWinRTModuleFile" AfterTargets="CsWinRTIncludeProjection">
-    <ItemGroup>
-      <Compile Remove="$(CsWinRTGeneratedFilesDir)Module.cs" />
-    </ItemGroup>
-  </Target>
-
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -137,8 +117,9 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <Import Project="..\..\targets\EmbeddedCsWinRT.targets"  Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
+
   <PropertyGroup Condition="'$(TargetFramework)' == '$(CoreFramework)'">
-    <CsWinRTEmbedded>true</CsWinRTEmbedded>
     <CsWinRTIncludes>
       Microsoft.Management.Deployment;
       Windows.ApplicationModel;

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -17,7 +17,6 @@
 
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <LangVersion>10</LangVersion>
     <BuildOutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</BuildOutputDirectory>
     <OutputPath>$(BuildOutputDirectory)$(MSBuildProjectName)</OutputPath>
     <TargetFrameworks>$(CoreFramework);$(DesktopFramework)</TargetFrameworks>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSRepairResult.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/PSObjects/PSRepairResult.cs
@@ -22,7 +22,7 @@ namespace Microsoft.WinGet.Client.Engine.PSObjects
         /// </summary>
         /// <param name="repairResult">The Repair result COM Object.</param>
         /// <param name="catalogPackage">The catalog package COM Object.</param>
-        public PSRepairResult(RepairResult repairResult, CatalogPackage catalogPackage)
+        internal PSRepairResult(RepairResult repairResult, CatalogPackage catalogPackage)
         {
             this.repairResult = repairResult;
             this.catalogPackage = catalogPackage;

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -16,6 +16,7 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -24,6 +25,8 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
+    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,10 +49,12 @@
   <PropertyGroup>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
-  
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'!='true'">
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
   </ItemGroup>
+
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" Condition="'$(WinGetCsWinRTEmbedded)'=='true'" />
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.WinGet.Configuration.Engine\Microsoft.WinGet.Configuration.Engine.csproj" />
@@ -95,8 +100,8 @@
   <Target Name="CopySharedDependencies" AfterTargets="AfterBuild" Condition="'$(Platform)' != 'ARM'">
     <ItemGroup>
       <ModuleSharedDependency Include="$(OutputPath)Microsoft.Management.Configuration.Processor.dll" />
-      <ModuleSharedDependency Include="$(OutputPath)Microsoft.Windows.SDK.NET.dll" />
-      <ModuleSharedDependency Include="$(OutputPath)WinRT.Runtime.dll" />
+      <ModuleSharedDependency Include="$(OutputPath)Microsoft.Windows.SDK.NET.dll" Condition="'$(WinGetCsWinRTEmbedded)'!='true'" />
+      <ModuleSharedDependency Include="$(OutputPath)WinRT.Runtime.dll" Condition="'$(WinGetCsWinRTEmbedded)'!='true'" />
       <ModuleSharedDependency Include="$(OutputPath)Microsoft.WinGet.SharedLib.dll" />
     </ItemGroup>
     <Message Importance="high" Text="Copying shared dependencies: '@(ModuleSharedDependency)'" />

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -11,12 +11,6 @@
     <BuildOutputDirectory>$(SolutionDir)$(Platform)\$(Configuration)\</BuildOutputDirectory>
     <RootNamespace>Microsoft.WinGet.Configuration</RootNamespace>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
-    <CsWinRTCcwLookupTableGeneratorEnabled>false</CsWinRTCcwLookupTableGeneratorEnabled>
-    <!--
-    !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
-    -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
-    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -25,8 +19,6 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
-    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,16 +37,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- This project doesn't reference CSWinRT, but specify this everywhere it will fail with NETSDK1130 and MSB3271. -->
-  <PropertyGroup>
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'!='true'">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
-  </ItemGroup>
-
-  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" Condition="'$(WinGetCsWinRTEmbedded)'=='true'" />
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.WinGet.Configuration.Engine\Microsoft.WinGet.Configuration.Engine.csproj" />
@@ -100,8 +83,6 @@
   <Target Name="CopySharedDependencies" AfterTargets="AfterBuild" Condition="'$(Platform)' != 'ARM'">
     <ItemGroup>
       <ModuleSharedDependency Include="$(OutputPath)Microsoft.Management.Configuration.Processor.dll" />
-      <ModuleSharedDependency Include="$(OutputPath)Microsoft.Windows.SDK.NET.dll" Condition="'$(WinGetCsWinRTEmbedded)'!='true'" />
-      <ModuleSharedDependency Include="$(OutputPath)WinRT.Runtime.dll" Condition="'$(WinGetCsWinRTEmbedded)'!='true'" />
       <ModuleSharedDependency Include="$(OutputPath)Microsoft.WinGet.SharedLib.dll" />
     </ItemGroup>
     <Message Importance="high" Text="Copying shared dependencies: '@(ModuleSharedDependency)'" />

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/Utilities.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Helpers/Utilities.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="Utilities.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -85,7 +85,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Helpers
         }
 
         /// <summary>
-        /// Converts ConfigurationTestResult string value to PSConfigurationTestResult.
+        /// Converts ConfigurationTestResult value to PSConfigurationTestResult.
         /// </summary>
         /// <param name="value">ConfigurationTestResult value.</param>
         /// <returns>PSConfigurationTestResult.</returns>
@@ -103,7 +103,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Helpers
         }
 
         /// <summary>
-        /// Converts ConfigurationUnitState string value to PSConfigurationUnitState.
+        /// Converts ConfigurationUnitState value to PSConfigurationUnitState.
         /// </summary>
         /// <param name="value">ConfigurationUnitState value.</param>
         /// <returns>PSConfigurationUnitState.</returns>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -15,6 +15,7 @@
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
     <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -23,6 +24,8 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
+    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,10 +49,12 @@
   <PropertyGroup>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
-  
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'!='true'">
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
   </ItemGroup>
+
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" Condition="'$(WinGetCsWinRTEmbedded)'=='true'" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj" />

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -10,12 +10,6 @@
     <DocumentationFile>$(OutputPath)\$(MSBuildProjectName).xml</DocumentationFile>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>
-    <CsWinRTCcwLookupTableGeneratorEnabled>false</CsWinRTCcwLookupTableGeneratorEnabled>
-    <!--
-    !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
-    -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
-    <WinGetCsWinRTEmbedded>true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -24,8 +18,6 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='ReleaseStatic'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- From the name, ReleaseStatic would be a better fit for embedded. However, we will use embedded at all times except the inproc nuget package release, so it is better if it is in this configuration. -->
-    <WinGetCsWinRTEmbedded>false</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,17 +36,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
-  <!-- This project doesn't reference CSWinRT, but specify this everywhere it will fail with NETSDK1130 and MSB3271. -->
-  <PropertyGroup>
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-  </PropertyGroup>
 
-  <ItemGroup Condition="'$(WinGetCsWinRTEmbedded)'!='true'">
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
-  </ItemGroup>
-
-  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" Condition="'$(WinGetCsWinRTEmbedded)'=='true'" />
+  <Import Project="..\..\targets\ReferenceEmbeddedCsWinRTProject.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj" />

--- a/src/targets/EmbeddedCsWinRT.targets
+++ b/src/targets/EmbeddedCsWinRT.targets
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CsWinRTEmbedded>true</CsWinRTEmbedded>
+    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
+  </PropertyGroup>
+
+  <!-- Disable warnings from embedded/generated CsWinRT files. -->
+  <!-- Runs after the last target from https://github.com/microsoft/CsWinRT/blob/master/nuget/Microsoft.Windows.CsWinRT.Embedded.targets -->
+  <Target Name="DisableCsWinRTWarnings" AfterTargets="CsWinRTAddEmbeddedRuntime_Net5Sources">
+    <ItemGroup>
+      <WinGetCsWinRTGeneratedFiles Include="$(CsWinRTGeneratedFilesDir)*.cs" />
+    </ItemGroup>
+    <WriteLinesToFile File="%(WinGetCsWinRTGeneratedFiles.FullPath)"
+        Condition="$([System.IO.File]::Exists(%(WinGetCsWinRTGeneratedFiles.FullPath))) AND !$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)).StartsWith(&quot;// &lt;auto-generated /&gt;&quot;))"
+        Lines="$([System.String]::Concat(&quot;// &lt;auto-generated /&gt;&#xA;#pragma warning disable&#xA;&#xA;&quot;,$([System.IO.File]::ReadAllText(%(WinGetCsWinRTGeneratedFiles.FullPath)))))"
+        Overwrite="true"
+        Encoding="Unicode" />
+  </Target>
+
+  <!-- Remove the embedded module file that contains an unversioned SupportedOSPlatform attribute. -->
+  <Target Name="WinGetRemoveCsWinRTModuleFile" AfterTargets="CsWinRTIncludeProjection">
+    <ItemGroup>
+      <Compile Remove="$(CsWinRTGeneratedFilesDir)Module.cs" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/targets/ReferenceEmbeddedCsWinRTProject.targets
+++ b/src/targets/ReferenceEmbeddedCsWinRTProject.targets
@@ -1,0 +1,39 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IncludeWindowsSDKRefFrameworkReferences>false</IncludeWindowsSDKRefFrameworkReferences>
+  </PropertyGroup>
+
+  <!-- Prevent .winmd files from being referenced transitively. -->
+  <!-- Adapted from https://github.com/microsoft/CsWinRT/blob/master/nuget/Microsoft.Windows.CsWinRT.targets -->
+  <Target Name="WinGetRemoveWinMDReferences" BeforeTargets="BeforeCompile" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <!--Move winmd references into private item group to prevent subsequent winmd reference errors-->
+      <WinGetRemovedReferences Include="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
+
+      <!--Prevent NETSDK1130 errors from winmd references-->
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Extension)' == '.winmd'" />
+      <ReferencePathWithRefAssemblies Remove="@(WinGetRemovedReferences)"
+        Condition="'%(WinGetRemovedReferences.Filename)%(WinGetRemovedReferences.Extension)' == '%(ReferencePathWithRefAssemblies.Filename)%(ReferencePathWithRefAssemblies.Extension)'" />
+      <!--Do not publish projection source winmd files, but do include implementation dlls -->
+      <ReferenceCopyLocalPaths Remove="@(WinGetRemovedReferences)" />
+      <ReferenceCopyLocalPaths Include="@(WinGetRemovedReferences->'%(RootDir)%(Directory)%(DestinationSubDirectory)%(Implementation)')"
+                               Condition="'%(WinGetRemovedReferences.Implementation)' != '' AND Exists('%(WinGetRemovedReferences.RootDir)%(WinGetRemovedReferences.Directory)%(WinGetRemovedReferences.DestinationSubDirectory)%(WinGetRemovedReferences.Implementation)')" />
+      <!--Remove winmd references from deps.json to prevent CLR failing unit test execution-->
+      <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- Prevent WinRT.Runtime from being referenced. -->
+  <!-- Adapted from https://github.com/microsoft/CsWinRT/blob/master/nuget/Microsoft.Windows.CsWinRT.Embedded.targets -->
+  <Target Name="WinGetRemoveWinRTRuntimeReference" 
+          Inputs="@(RuntimeCopyLocalItems)" 
+          AfterTargets="ResolvePackageAssets" 
+          Outputs="@(RuntimeCopyLocalItems)">
+
+    <ItemGroup>
+      <Reference Remove="WinRT.Runtime" /> 
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="'%(DestinationSubPath)' == 'WinRT.Runtime.dll'"/>
+      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'$([System.IO.Path]::GetFileName(%(HintPath)))' == 'WinRT.Runtime.dll'"/>
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
## Issue
Updating the version of CsWinRT that we use lead to a problem with conflicting WinRT.Runtime assemblies (microsoft/winget-dsc#140).  While that issue was mitigated by delisting the offending version, in order to ship any release with the newer version of CsWinRT, we need to embed the WinRT.Runtime in our assemblies.

## Change
Move to use embedded CsWinRT, specifically in `Microsoft.WinGet.Client.Engine` and `Microsoft.Management.Configuration.Processor`.  The dependent projects are updated to no longer reference CsWinRT, but requires some special handling to prevent errors.

Since the configuration code was leveraging a projection assembly, it is being replaced by the processor.  The projected types are shared out to those dependent binaries via `InternalsVisibleTo`.

Also fixes an annoying behavior where an exception escaping from a command execution would prevent the `--logs` option from opening the log location (error cases being more likely to be the time one would want the logs of course).

## Validation
Minor local validation that things work. Build regression tests will be the true test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5178)