### PR TITLE
Fix certain msstore source 404 failures by treating them as empty responses

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -224,6 +224,7 @@ IFACEMETHODIMP
 iid
 img
 inet
+innererror
 inproc
 Insta
 installinprogress

--- a/src/AppInstallerCLITests/RestInterface_1_0.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_0.cpp
@@ -475,7 +475,7 @@ TEST_CASE("GetManifests_GoodResponse_404AsEmpty", "[RestSource][Interface_1_0]")
     utility::string_t notFoundResponse = _XPLATSTR(
         R"delimiter({"code":"DataNotFound","data":[],"details":[],"innererror":{"code":"DataNotFound","data":[],"details":[],"message":"Product is not present","source":"StoreEdgeFD"},"message":"Product is not present","source":"StoreEdgeFD"})delimiter");
 
-    HttpClientHelper helper{ GetTestRestRequestHandler(web::http::status_codes::OK, std::move(notFoundResponse)) };
+    HttpClientHelper helper{ GetTestRestRequestHandler(web::http::status_codes::NotFound, std::move(notFoundResponse)) };
     Interface v1{ TestRestUriString, std::move(helper) };
     std::vector<Manifest> manifests = v1.GetManifests("Foo.Bar");
     REQUIRE(manifests.size() == 0);

--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -95,13 +95,23 @@ namespace AppInstaller::Http
         const utility::string_t& uri,
         const web::json::value& body,
         const HttpClientHelper::HttpRequestHeaders& headers,
-        const HttpClientHelper::HttpRequestHeaders& authHeaders) const
+        const HttpClientHelper::HttpRequestHeaders& authHeaders,
+        const HttpResponseHandler& customHandler) const
     {
         web::http::http_response httpResponse;
         Post(uri, body, headers, authHeaders).then([&httpResponse](const web::http::http_response& response)
             {
                 httpResponse = response;
             }).wait();
+
+        if (customHandler)
+        {
+            auto handlerResult = customHandler(httpResponse);
+            if (!handlerResult.UseDefaultHandling)
+            {
+                return std::move(handlerResult.Result);
+            }
+        }
 
         return ValidateAndExtractResponse(httpResponse);
     }
@@ -137,13 +147,23 @@ namespace AppInstaller::Http
     std::optional<web::json::value> HttpClientHelper::HandleGet(
         const utility::string_t& uri,
         const HttpClientHelper::HttpRequestHeaders& headers,
-        const HttpClientHelper::HttpRequestHeaders& authHeaders) const
+        const HttpClientHelper::HttpRequestHeaders& authHeaders,
+        const HttpResponseHandler& customHandler) const
     {
         web::http::http_response httpResponse;
         Get(uri, headers, authHeaders).then([&httpResponse](const web::http::http_response& response)
             {
                 httpResponse = response;
             }).wait();
+
+        if (customHandler)
+        {
+            auto handlerResult = customHandler(httpResponse);
+            if (!handlerResult.UseDefaultHandling)
+            {
+                return std::move(handlerResult.Result);
+            }
+        }
 
         return ValidateAndExtractResponse(httpResponse);
     }

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -13,15 +13,26 @@ namespace AppInstaller::Http
     {
         using HttpRequestHeaders = std::unordered_map<utility::string_t, utility::string_t>;
 
+        struct HttpResponseHandlerResult
+        {
+            // The custom response handler result. Default is empty.
+            std::optional<web::json::value> Result = std::nullopt;
+
+            // Indicates whether to use default handling logic by HttpClientHelper instead (i.e. the custom response handler does not handle the specific response).
+            bool UseDefaultHandling = false;
+        };
+
+        using HttpResponseHandler = std::function<HttpResponseHandlerResult(const web::http::http_response&)>;
+
         HttpClientHelper(std::shared_ptr<web::http::http_pipeline_stage> = {});
 
         pplx::task<web::http::http_response> Post(const utility::string_t& uri, const web::json::value& body, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}) const;
 
-        std::optional<web::json::value> HandlePost(const utility::string_t& uri, const web::json::value& body, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}) const;
+        std::optional<web::json::value> HandlePost(const utility::string_t& uri, const web::json::value& body, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}, const HttpResponseHandler& customHandler = {}) const;
 
         pplx::task<web::http::http_response> Get(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}) const;
 
-        std::optional<web::json::value> HandleGet(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}) const;
+        std::optional<web::json::value> HandleGet(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}, const HttpResponseHandler& customHandler = {}) const;
 
         void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration);
 


### PR DESCRIPTION
When searching for store source with id that's recently taken down, store source will return 404 instead of empty results (what winget-cli-restsource does). This will be treated as a source search error in our code. The fix is to treat 404 response with certain schema as empty result instead of failure.

Tested manually with store source and added unit tests.

fixes #4785, fixes #4784
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5179)