### PR TITLE
Fix configure export test tear down

### DIFF
--- a/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
@@ -37,9 +37,9 @@ namespace AppInstallerCLIE2ETests
         [OneTimeTearDown]
         public void BaseTeardown()
         {
+            TestCommon.RunAICLICommand("uninstall", "AppInstallerTest.TestPackageExport");
             TestCommon.TearDownTestSource();
             WinGetSettingsHelper.ConfigureFeature("configureExport", false);
-            TestCommon.RunAICLICommand("uninstall", "AppInstallerTest.TestPackageExport");
         }
 
         /// <summary>


### PR DESCRIPTION
When I was reviewing the pipeline runs, I always saw configure export test tear down time out when uninstalling the test package. Then I realized the test source was reset before we call uninstall and causing the package to be not found.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5184)