### PR TITLE
Update YamlDotNet to Latest

### DIFF
--- a/src/WinGetUtilInterop/WinGetUtilInterop.csproj
+++ b/src/WinGetUtilInterop/WinGetUtilInterop.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

I know that NuGet packages are typically not updated unless there are CVEs, important bug fixes, or other specific need to. However, when reviewing the list of NuGet packages installed, I saw that YamlDotNet was several versions out of date. This package directly affects the parsing of manifests within WinGet and the associated utilities. Given that, I thought it best to update it, especially given the fact that 1.10 is preparing to go through the release cycle, which would give these changes enough time to be tested in the 1.11 previews and testing cycles.

This change only directly updates the top-level project - `WinGetUtilInterop`. I'm expecting that all the other projects which have this NuGet package as a transient dependency will pick up this new version, as all of them have a Project Dependency on `WinGetUtilInterop`.

The projects which consume this change -

### Top-Level
* WinGetUtilInterop
### Transitive
* AppInstallerCLIE2ETests
* Tool\IndexCreationTool
* Tool\LocalhostWebServer
* WinGetSourceCreator
* WinGetUtilInterop.UnitTests

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5191)