### PR TITLE
Convert cpprestsdk to WIL exception for better handling

### DIFF
--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -96,7 +96,7 @@ namespace AppInstaller::Http
         const web::json::value& body,
         const HttpClientHelper::HttpRequestHeaders& headers,
         const HttpClientHelper::HttpRequestHeaders& authHeaders,
-        const HttpResponseHandler& customHandler) const
+        const HttpResponseHandler& customHandler) const try
     {
         web::http::http_response httpResponse;
         Post(uri, body, headers, authHeaders).then([&httpResponse](const web::http::http_response& response)
@@ -114,6 +114,10 @@ namespace AppInstaller::Http
         }
 
         return ValidateAndExtractResponse(httpResponse);
+    }
+    catch (web::http::http_exception& exception)
+    {
+        RethrowAsWilException(exception);
     }
 
     pplx::task<web::http::http_response> HttpClientHelper::Get(
@@ -148,7 +152,7 @@ namespace AppInstaller::Http
         const utility::string_t& uri,
         const HttpClientHelper::HttpRequestHeaders& headers,
         const HttpClientHelper::HttpRequestHeaders& authHeaders,
-        const HttpResponseHandler& customHandler) const
+        const HttpResponseHandler& customHandler) const try
     {
         web::http::http_response httpResponse;
         Get(uri, headers, authHeaders).then([&httpResponse](const web::http::http_response& response)
@@ -166,6 +170,10 @@ namespace AppInstaller::Http
         }
 
         return ValidateAndExtractResponse(httpResponse);
+    }
+    catch (web::http::http_exception& exception)
+    {
+        RethrowAsWilException(exception);
     }
 
     void HttpClientHelper::SetPinningConfiguration(const Certificates::PinningConfiguration& configuration)
@@ -232,5 +240,10 @@ namespace AppInstaller::Http
             !contentType._Starts_with(web::http::details::mime_types::application_json));
 
         return response.extract_json().get();
+    }
+
+    [[noreturn]] void HttpClientHelper::RethrowAsWilException(const web::http::http_exception& exception)
+    {
+        THROW_WIN32_MSG(exception.error_code().value(), "%hs", exception.what());
     }
 }

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -44,6 +44,9 @@ namespace AppInstaller::Http
     private:
         web::http::client::http_client GetClient(const utility::string_t& uri) const;
 
+        // Translates a cpprestsdk http_exception to a WIL exception.
+        static void RethrowAsWilException(const web::http::http_exception& exception);
+
         std::shared_ptr<web::http::http_pipeline_stage> m_defaultRequestHandlerStage;
         web::http::client::http_client_config m_clientConfig;
     };

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/FinderCommand.cs
@@ -150,7 +150,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             }
             else
             {
-                throw new CatalogConnectException();
+                throw new CatalogConnectException(result.ExtendedErrorCode);
             }
         }
 

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/CatalogConnectException.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/CatalogConnectException.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="CatalogConnectException.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -19,8 +19,9 @@ namespace Microsoft.WinGet.Client.Engine.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="CatalogConnectException"/> class.
         /// </summary>
-        public CatalogConnectException()
-            : base(Resources.CatalogConnectExceptionMessage)
+        /// <param name="inner">The exception that lead to this one.</param>
+        public CatalogConnectException(Exception inner)
+            : base(Resources.CatalogConnectExceptionMessage, inner)
         {
         }
     }


### PR DESCRIPTION
## Change
To better expose the underlying result code, convert the `http_exception` to a `ResultException` so that the HRESULT can be properly extracted.

CP #5188 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5195)