### PR TITLE
For truly async calls we must maintain our lifetime (1.10)

### DIFF
--- a/src/Microsoft.Management.Deployment/PackageCatalog.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalog.cpp
@@ -47,6 +47,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     }
     winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::Management::Deployment::FindPackagesResult> PackageCatalog::FindPackagesAsync(winrt::Microsoft::Management::Deployment::FindPackagesOptions options)
     {
+        auto strong_this = get_strong();
         co_await resume_background();
         co_return FindPackages(options);
     }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -311,6 +311,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             // Check for permissions and get caller info for telemetry
             THROW_IF_FAILED(EnsureComCallerHasCapability(Capability::PackageQuery));
 
+            auto strong_this = get_strong();
             auto report_progress{ co_await winrt::get_progress_token() };
             co_await winrt::resume_background();
 

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -1329,6 +1329,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
             ::AppInstaller::Repository::Source sourceToAdd = CreateSourceFromOptions(options);
 
+            auto strong_this = get_strong();
             auto report_progress{ co_await winrt::get_progress_token() };
             co_await winrt::resume_background();
 
@@ -1367,6 +1368,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             auto matchingSource = GetMatchingSource(winrt::to_string(options.Name()));
             THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST, !matchingSource.has_value());
 
+            auto strong_this = get_strong();
             auto report_progress{ co_await winrt::get_progress_token() };
             co_await winrt::resume_background();
 


### PR DESCRIPTION
## Change
Add forgotten lifetime extension for async function.

## Validation
Changed the sample caller to call `FindPackagesAsync`, then destroy the catalog object.

CP #5199
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5200)