### PR TITLE
Update primary index when moving package

### DIFF
--- a/src/AppInstallerRepositoryCore/CompositeSource.cpp
+++ b/src/AppInstallerRepositoryCore/CompositeSource.cpp
@@ -1299,6 +1299,7 @@ namespace AppInstaller::Repository
                             {
                                 currentMatch.Package = std::move(Matches[latestPrimaryAvailable->PrimaryPackageIndex.value()].Package);
                                 Matches[latestPrimaryAvailable->PrimaryPackageIndex.value()].Package.reset();
+                                latestPrimaryAvailable->PrimaryPackageIndex = i;
                             }
                             continue;
                         }


### PR DESCRIPTION
## Change
When moving the primary package to a new location, update the index so any future attempts to reference it target the correct location.

CP from #5204 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5206)