### PR TITLE
Don't rely on parameter order when creating VersionRange

### DIFF
--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -372,12 +372,12 @@ TEST_CASE("VersionRange", "[versions]")
 {
     // Create
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "2.0" } });
+    REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "1.0" } });
     REQUIRE_NOTHROW(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
-    REQUIRE_THROWS(VersionRange{ Version{ "2.0" }, Version{ "2.0" } });
 
     // Overlaps
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.0" }, Version{ "3.0" } }));
-    REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "1.0" }, Version{ "1.1" } }));
+    REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "1.0" }, Version{ "1.0" } }));
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "0.5" }, Version{ "1.5" } }));
     REQUIRE_FALSE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.1" }, Version{ "3.0" } }));
     REQUIRE_FALSE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{}));

--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -373,7 +373,8 @@ TEST_CASE("VersionRange", "[versions]")
     // Create
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "2.0" } });
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "1.0" } });
-    REQUIRE_THROWS(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
+    REQUIRE_NOTHROW(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
+    REQUIRE_THROWS(VersionRange{ Version{ "2.0" }, Version{ "2.0" } });
 
     // Overlaps
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.0" }, Version{ "3.0" } }));

--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -372,13 +372,12 @@ TEST_CASE("VersionRange", "[versions]")
 {
     // Create
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "2.0" } });
-    REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "1.0" } });
     REQUIRE_NOTHROW(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
     REQUIRE_THROWS(VersionRange{ Version{ "2.0" }, Version{ "2.0" } });
 
     // Overlaps
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.0" }, Version{ "3.0" } }));
-    REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "1.0" }, Version{ "1.0" } }));
+    REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "1.0" }, Version{ "1.1" } }));
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "0.5" }, Version{ "1.5" } }));
     REQUIRE_FALSE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.1" }, Version{ "3.0" } }));
     REQUIRE_FALSE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{}));

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -535,7 +535,6 @@ namespace AppInstaller::Utility
       
     VersionRange::VersionRange(Version first, Version second)
     {
-        //THROW_HR_IF(E_INVALIDARG, first == second);
         if (first < second)
         {
             m_minVersion = std::move(first);

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -533,11 +533,19 @@ namespace AppInstaller::Utility
         return m_buildMetadata;
     }
       
-    VersionRange::VersionRange(Version minVersion, Version maxVersion)
+    VersionRange::VersionRange(Version first, Version second)
     {
-        THROW_HR_IF(E_INVALIDARG, minVersion > maxVersion);
-        m_minVersion = std::move(minVersion);
-        m_maxVersion = std::move(maxVersion);
+        THROW_HR_IF(E_INVALIDARG, first == second);
+        if (first < second)
+        {
+            m_minVersion = std::move(first);
+            m_maxVersion = std::move(second);
+        }
+        else
+        {
+            m_minVersion = std::move(second);
+            m_maxVersion = std::move(first);
+        }
     }
 
     bool VersionRange::Overlaps(const VersionRange& other) const

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -535,7 +535,7 @@ namespace AppInstaller::Utility
       
     VersionRange::VersionRange(Version first, Version second)
     {
-        THROW_HR_IF(E_INVALIDARG, first == second);
+        //THROW_HR_IF(E_INVALIDARG, first == second);
         if (first < second)
         {
             m_minVersion = std::move(first);


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - #5211

I don't know whether or not this will resolve the above issue, but I also don't think it can hurt?

Instead of relying on the parameters to be in the correct order for minimum and maximum when creating a VersionRange, the code can instead just put them in the right order.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5213)