### PR TITLE
Don't rely on parameter order when creating VersionRange

### DIFF
--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -373,7 +373,7 @@ TEST_CASE("VersionRange", "[versions]")
     // Create
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "2.0" } });
     REQUIRE_NOTHROW(VersionRange{ Version{ "1.0" }, Version{ "1.0" } });
-    REQUIRE_THROWS(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
+    REQUIRE_NOTHROW(VersionRange{ Version{ "2.0" }, Version{ "1.0" } });
 
     // Overlaps
     REQUIRE(VersionRange{ Version{ "1.0" }, Version{ "2.0" } }.Overlaps(VersionRange{ Version{ "2.0" }, Version{ "3.0" } }));

--- a/src/AppInstallerSharedLib/Versions.cpp
+++ b/src/AppInstallerSharedLib/Versions.cpp
@@ -533,11 +533,18 @@ namespace AppInstaller::Utility
         return m_buildMetadata;
     }
       
-    VersionRange::VersionRange(Version minVersion, Version maxVersion)
+    VersionRange::VersionRange(Version first, Version second)
     {
-        THROW_HR_IF(E_INVALIDARG, minVersion > maxVersion);
-        m_minVersion = std::move(minVersion);
-        m_maxVersion = std::move(maxVersion);
+        if (first < second)
+        {
+            m_minVersion = std::move(first);
+            m_maxVersion = std::move(second);
+        }
+        else
+        {
+            m_minVersion = std::move(second);
+            m_maxVersion = std::move(first);
+        }
     }
 
     bool VersionRange::Overlaps(const VersionRange& other) const


### PR DESCRIPTION
Instead of relying on the parameters to be in the correct order for minimum and maximum when creating a VersionRange, the code can instead just put them in the right order.

CP from #5213 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5226)