### PR TITLE
Validate against NestedInstaller / Base Installer is not Archive

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -1055,6 +1055,12 @@
     <CopyFileToFolders Include="TestData\ManifestV1_10-Bad-SchemaHeaderURLPatternMismatch.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NonArchive-NestedInstallerType.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NonArchive-NestedInstallerFiles.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLICore\AppInstallerCLICore.vcxproj">

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -1066,6 +1066,12 @@
       <Filter>TestData</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\ManifestV1_10-Bad-SchemaHeaderURLPatternMismatch.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NonArchive-NestedInstallerType.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NonArchive-NestedInstallerFiles.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
   </ItemGroup>

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-NonArchive-NestedInstallerFiles.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-NonArchive-NestedInstallerFiles.yaml
@@ -1,0 +1,20 @@
+# Bad manifest. NestedInstallerFiles used with non-archive InstallerType
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/winget-cli/refs/heads/master/schemas/JSON/manifests/v1.10.0/manifest.singleton.1.10.0.json
+PackageIdentifier: AppInstallerCliTest.TestMsixInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test MSIX Installer
+ShortDescription: AppInstaller Test MSIX Installer
+Publisher: Microsoft Corporation
+Moniker: AICLITestMsix
+License: Test
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/microsoft/msix-packaging/blob/master/src/test/testData/unpack/TestAppxPackage_x64.appx?raw=true
+    InstallerType: msix
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    PackageFamilyName: 20477fca-282d-49fb-b03e-371dca074f0f_8wekyb3d8bbwe
+    NestedInstallerFiles:
+    - RelativeFilePath: Test
+ManifestType: singleton
+ManifestVersion: 1.10.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-NonArchive-NestedInstallerType.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-NonArchive-NestedInstallerType.yaml
@@ -1,0 +1,19 @@
+# Bad manifest. NestedInstallerType used with non-archive InstallerType
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/winget-cli/refs/heads/master/schemas/JSON/manifests/v1.10.0/manifest.singleton.1.10.0.json
+PackageIdentifier: AppInstallerCliTest.TestMsixInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test MSIX Installer
+ShortDescription: AppInstaller Test MSIX Installer
+Publisher: Microsoft Corporation
+Moniker: AICLITestMsix
+License: Test
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/microsoft/msix-packaging/blob/master/src/test/testData/unpack/TestAppxPackage_x64.appx?raw=true
+    InstallerType: msix
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    PackageFamilyName: 20477fca-282d-49fb-b03e-371dca074f0f_8wekyb3d8bbwe
+    NestedInstallerType: portable
+ManifestType: singleton
+ManifestVersion: 1.10.0

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -839,6 +839,8 @@ TEST_CASE("ReadBadManifests", "[ManifestValidation]")
         { "InstallFlowTest_LicenseAgreement.yaml", "Field usage requires verified publishers. [Agreement]", false, GetTestManifestValidateOption(false, true) },
         { "Manifest-Bad-ApproximateVersionInPackageVersion.yaml", "Approximate version not allowed. [PackageVersion]" },
         { "Manifest-Bad-ApproximateVersionInArpVersion.yaml", "Approximate version not allowed. [DisplayVersion]" },
+        { "Manifest-Bad-NonArchive-NestedInstallerType.yaml", "Field usage requires InstallerType to be an archive type. [NestedInstallerType]" },
+        { "Manifest-Bad-NonArchive-NestedInstallerFiles.yaml", "Field usage requires InstallerType to be an archive type. [NestedInstallerFiles]" },
     };
 
     for (auto const& testCase : TestCases)

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -71,6 +71,7 @@ namespace AppInstaller::Manifest
                 { AppInstaller::Manifest::ManifestError::SchemaHeaderManifestTypeMismatch , "The manifest type in the schema header does not match the ManifestType property value in the manifest."sv },
                 { AppInstaller::Manifest::ManifestError::SchemaHeaderManifestVersionMismatch, "The manifest version in the schema header does not match the ManifestVersion property value in the manifest."sv },
                 { AppInstaller::Manifest::ManifestError::SchemaHeaderUrlPatternMismatch, "The schema header URL does not match the expected pattern."sv },
+                { AppInstaller::Manifest::ManifestError::InvalidArchiveField, "Field usage requires InstallerType to be an archive type."sv },
             };
 
             return ErrorIdToMessageMap;
@@ -331,6 +332,18 @@ namespace AppInstaller::Manifest
                         resultErrors.emplace_back(ManifestError::DuplicatePortableCommandAlias, "PortableCommandAlias");
                         break;
                     }
+                }
+            }
+            else
+            {
+                // If base installer is not an archive type, NestedInstaller fields should not be present
+                if (installer.NestedInstallerType != InstallerTypeEnum::Unknown)
+                {
+                    resultErrors.emplace_back(ManifestError::InvalidArchiveField, "NestedInstallerType");
+                }
+                if (installer.NestedInstallerFiles.size() != 0)
+                {
+                    resultErrors.emplace_back(ManifestError::InvalidArchiveField, "NestedInstallerFiles");
                 }
             }
 

--- a/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
@@ -73,6 +73,7 @@ namespace AppInstaller::Manifest
         WINGET_DEFINE_RESOURCE_STRINGID(SchemaHeaderManifestTypeMismatch);
         WINGET_DEFINE_RESOURCE_STRINGID(SchemaHeaderManifestVersionMismatch);
         WINGET_DEFINE_RESOURCE_STRINGID(SchemaHeaderUrlPatternMismatch);
+        WINGET_DEFINE_RESOURCE_STRINGID(InvalidArchiveField);
     }
 
     struct ValidationError


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.
  - Resolves #4633

## Description:
This PR adds validation to ensure that `NestedInstallerType` and `NestedInstallerFiles` are not present for the installer if the base installer type is not an archive type. This will avoid confusion as the fields have no effect if the base installer type is not an archive.

![{1108C44F-4E40-4275-8522-359E5EB58893}](https://github.com/user-attachments/assets/57723523-5f01-4221-a921-9bb6e812752a)


-----
