### PR TITLE
[draft] Install-WinGetPackage cmdlet: add AcceptPackageAgreements, AcceptSourceAgreements switches

### DIFF
--- a/src/PowerShell/Help/Microsoft.WinGet.Client/Install-WinGetPackage.md
+++ b/src/PowerShell/Help/Microsoft.WinGet.Client/Install-WinGetPackage.md
@@ -22,7 +22,7 @@ Install-WinGetPackage [-Mode <PSPackageInstallMode>] [-Override <String>] [-Cust
  [-Architecture <PSProcessorArchitecture>] [-InstallerType <PSPackageInstallerType>] [-Locale <String>]
  [-Scope <PSPackageInstallScope>] [-SkipDependencies] [-Version <String>] [-Id <String>] [-Name <String>]
  [-Moniker <String>] [-Source <String>] [[-Query] <String[]>] [-MatchOption <PSPackageFieldMatchOption>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm] [-AcceptPackageAgreements] [-AcceptSourceAgreements] [<CommonParameters>]
 ```
 
 ### GivenSet
@@ -32,7 +32,7 @@ Install-WinGetPackage [-Mode <PSPackageInstallMode>] [-Override <String>] [-Cust
  [-Location <String>] [-Log <String>] [-Force] [-Header <String>] [-AllowHashMismatch]
  [-Architecture <PSProcessorArchitecture>] [-InstallerType <PSPackageInstallerType>] [-Locale <String>]
  [-Scope <PSPackageInstallScope>] [-SkipDependencies] [[-PSCatalogPackage] <PSCatalogPackage>]
- [-Version <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Version <String>] [-WhatIf] [-Confirm] [-AcceptPackageAgreements] [-AcceptSourceAgreements [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
@@ -47,7 +47,9 @@ namespace Microsoft.WinGet.Client.Commands
                         this.Moniker,
                         this.Source,
                         this.Query,
-                        this.SkipDependencies.ToBool());
+                        this.SkipDependencies.ToBool(),
+                        this.AcceptPackageAgreements.ToBool(),
+                        this.AcceptSourceAgreements.ToBool());
 
             this.command.Install(this.MatchOption.ToString(), this.Scope.ToString(), this.Architecture.ToString(), this.Mode.ToString(), this.InstallerType.ToString());
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/InstallerSelectionCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/InstallerSelectionCmdlet.cs
@@ -51,5 +51,17 @@ namespace Microsoft.WinGet.Client.Commands
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public SwitchParameter SkipDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept all license agreements for packages.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public SwitchParameter AcceptPackageAgreements { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept all source agreements during source operations.
+        /// </summary>
+        [Parameter(ValueFromPipelineByPropertyName = true)]
+        public SwitchParameter AcceptSourceAgreements { get; set; }
     }
 }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/InstallCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/InstallCommand.cs
@@ -36,6 +36,16 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
         protected bool SkipDependencies { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to accept all license agreements for packages.
+        /// </summary>
+        protected bool AcceptPackageAgreements { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept all source agreements during source operations.
+        /// </summary>
+        protected bool AcceptSourceAgreements { get; set; }
+
+        /// <summary>
         /// Gets or sets the override arguments to be passed on to the installer.
         /// </summary>
         protected string? Override { get; set; }
@@ -79,6 +89,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             InstallOptions options = ManagementDeploymentFactory.Instance.CreateInstallOptions();
             options.AllowHashMismatch = this.AllowHashMismatch;
             options.SkipDependencies = this.SkipDependencies;
+            options.AcceptPackageAgreements = this.AcceptPackageAgreements;
+            options.AcceptSourceAgreements = this.AcceptSourceAgreements;
             options.Force = this.Force;
             options.PackageInstallMode = PSEnumHelpers.ToPackageInstallMode(mode);
             if (version != null)

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/InstallerPackageCommand.cs
@@ -39,6 +39,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands
         /// <param name="source">Source to search. If null, all are searched.</param>
         /// <param name="query">Match against any field of a package.</param>
         /// <param name="skipDependencies">To skip package dependencies.</param>
+        /// <param name="acceptPackageAgreements">To accept all license agreements for packages.</param>
+        /// <param name="acceptSourceAgreements">To accept all license agreements for sources.</param>
         public InstallerPackageCommand(
             PSCmdlet psCmdlet,
             string @override,
@@ -55,7 +57,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             string moniker,
             string source,
             string[] query,
-            bool skipDependencies)
+            bool skipDependencies,
+            bool acceptPackageAgreements,
+            bool acceptSourceAgreements)
             : base(psCmdlet)
         {
             // InstallCommand.
@@ -66,6 +70,8 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             this.Header = header;
             this.AllowHashMismatch = allowHashMismatch;
             this.SkipDependencies = skipDependencies;
+            this.AcceptPackageAgreements = acceptPackageAgreements;
+            this.acceptSourceAgreements = acceptSourceAgreements;
             this.Log = log;
 
             // PackageCommand.


### PR DESCRIPTION
This is work in progress, do not merge yet.

PR proposes to add `AcceptPackageAgreements` and `AcceptSourceAgreements` switches to the `Install-WinGetPackage` cmdlet, analogous the the winget CLI flags `--accept-package-agreements` and `--accept-source-agreements`.

Resolves #4671 

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [X] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [X] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5270)