### PR TITLE
Handle access denied error when setting owner if already owner

### DIFF
--- a/src/AppInstallerSharedLib/Filesystem.cpp
+++ b/src/AppInstallerSharedLib/Filesystem.cpp
@@ -420,7 +420,7 @@ namespace AppInstaller::Filesystem
         DWORD result = SetNamedSecurityInfoW(&path[0], SE_FILE_OBJECT, securityInformation, ownerSID, nullptr, acl.get(), nullptr);
 
         // We can be denied access attempting to set the owner when the owner is already correct.
-        // Determine if the owner is corret; if so, try again without attempting to set the owner.
+        // Determine if the owner is correct; if so, try again without attempting to set the owner.
         if (result == ERROR_ACCESS_DENIED && ownerSID)
         {
             wil::unique_hlocal_security_descriptor securityDescriptor;


### PR DESCRIPTION
Fixes #5276

## Issue
Although I don't understand precisely why, we get access denied when attempting to open a directory with `WRITE_OWNER` even when we are already the owner.  It may have to do with permissions to the parent directory, but the root cause isn't actually important here.

Our directory management code always attempts to set any directory to a known state, including the owner.  It does so without any pre-check to see if the owner is already set to the desired value.

## Change
If we get `ERROR_ACCESS_DENIED` when attempting to set the owner, check if the owner is already correct.  If it is, attempt to set just the DACL.

## Validation
Manual repro and validation that the fix works when the issue is exactly as described.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5282)