### PR TITLE
Add securityContext to configuration file

### DIFF
--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -5,6 +5,8 @@ properties:
     - resource: Microsoft.Windows.Developer/DeveloperMode
       directives:
         description: Enable Developer Mode
+        # Requires elevation for the set operation
+        securityContext: elevated
         allowPrerelease: true
       settings:
         Ensure: Present
@@ -12,7 +14,8 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
-        allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -21,6 +24,8 @@ properties:
         - vsPackage
       directives:
         description: Install required VS workloads from project .vsconfig file
+        # Requires elevation for the get and set operations
+        securityContext: elevated
         allowPrerelease: true
       settings:
         productId: Microsoft.VisualStudio.Product.Community

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -10,7 +10,7 @@
   * .NET Desktop Development
   * Desktop Development with C++
   * Universal Windows Platform Development
-  * Check [.vsconfig file](.vsconfig) for full components list
+  * Check [.vsconfig file](../.vsconfig) for full components list
 
 * [Windows SDK for Windows 11 (10.0.22000.194)](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

Setting developer mode, installing Visual Studio 2022 & fetching and installing VS components all require elevation. Added `securityContext: elevated` for these resources. Removed `allowPrerelease: true` for `Microsoft.WinGet.DSC/WinGetPackage` as it's GA now. Also fixed a bad link in the docs


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5309)