### PR TITLE
Move to official DSC v3 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -377,9 +377,9 @@ jobs:
     displayName: Clean up Sysinternals PsTools
     condition: succeededOrFailed()
 
-    # Install DSC v3 preview until the DSC v3 processor handles that on its own
+    # Install DSC v3 until the DSC v3 processor handles that on its own
   - powershell: |
-      Install-WinGetPackage -Id Microsoft.DSC.Preview -Source winget
+      Install-WinGetPackage -Id 9NVTPZWRC6KQ -Source msstore -MatchOption -Equals
     displayName: Install DSC v3
     condition: succeededOrFailed()
 

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorSettings.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorSettings.cs
@@ -6,8 +6,8 @@
 
 namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
 {
+    using System;
     using System.IO;
-    using System.Linq;
     using System.Text;
     using Microsoft.Management.Configuration.Processor.DSCv3.Model;
 
@@ -109,28 +109,18 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// <returns>The full path to the dsc.exe executable, or null if not found.</returns>
         public static string? FindDscExecutablePath()
         {
-            // To start, only attempt to find the package and launch it via the app execution fallback handler.
-            // In the future, discover it through %PATH% searching, but probably don't allow that from an elevated process.
+            // To start, only attempt to find the package and launch it via app execution alias.
+            // In the future, consider discovering it through %PATH% searching, but probably don't allow that from an elevated process.
             // That probably means creating another read property for finding the secure path.
-            Windows.Management.Deployment.PackageManager packageManager = new Windows.Management.Deployment.PackageManager();
-
-            // Until there is a non-preview of this package, use the preview version.
-            var packages = packageManager.FindPackagesForUser(null, "Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe");
-
-            if (packages == null)
+#if !AICLI_DISABLE_TEST_HOOKS
+            string? result = GetDscExecutablePathForPackage("Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe");
+            if (result != null)
             {
-                return null;
+                return result;
             }
+#endif
 
-            string packageInstallLocation = packages.First().InstalledLocation.Path;
-            string result = Path.Combine(packageInstallLocation, DscExecutableFileName);
-
-            if (!Path.Exists(result))
-            {
-                return null;
-            }
-
-            return result;
+            return GetDscExecutablePathForPackage("Microsoft.DesiredStateConfiguration_8wekyb3d8bbwe");
         }
 
         /// <summary>
@@ -165,6 +155,19 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
             sb.Append(this.DiagnosticTraceLevel);
 
             return sb.ToString();
+        }
+
+        private static string? GetDscExecutablePathForPackage(string packageFamilyName)
+        {
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string result = Path.Combine(localAppData, "Microsoft\\WindowsApps", packageFamilyName, DscExecutableFileName);
+
+            if (!Path.Exists(result))
+            {
+                return null;
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Change
Install the release version from the Store in the pipeline.
In the processor, find `dsc.exe` by the alias location.  Support the preview version for test builds (anything from winget-cli).

## Validation
Running tests locally continues to work.