### PR TITLE
Use version comparison function rather than string compare in PS

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/Common/PackageCommand.cs
@@ -128,7 +128,9 @@ namespace Microsoft.WinGet.Client.Engine.Commands.Common
             {
                 for (var i = 0; i < package.AvailableVersions.Count; i++)
                 {
-                    if (package.AvailableVersions[i].Version.CompareTo(this.Version) == 0)
+                    PackageVersionInfo versionInfo = package.GetPackageVersionInfo(package.AvailableVersions[i]);
+
+                    if (versionInfo != null && versionInfo.CompareToVersion(this.Version) == CompareResult.Equal)
                     {
                         return package.AvailableVersions[i];
                     }

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -600,6 +600,21 @@ Describe 'Export-WinGetPackage' {
         Test-Path -Path $testDirectory | Should -Be $false
     }
 
+    It 'Download with short Version' {
+        $testDirectory = GetRandomTestDirectory
+        $result = Export-WinGetPackage -Id AppInstallerTest.TestExeInstaller -Version '1' -DownloadDirectory $testDirectory
+        
+        $result | Should -Not -BeNullOrEmpty
+        $result.Id | Should -Be "AppInstallerTest.TestExeInstaller"
+        $result.Name | Should -Be "TestExeInstaller"
+        $result.Source | Should -Be "TestSource"
+        $result.Status | Should -Be 'Ok'
+
+        # Download directory should be created and have exactly two files (installer and manifest file).
+        Test-Path -Path $testDirectory | Should -Be $true
+        (Get-ChildItem -Path $testDirectory -Force | Measure-Object).Count | Should -Be 2
+    }
+
     AfterEach {
         if (Test-Path $testDirectory) {
             Remove-Item $testDirectory -Force -Recurse


### PR DESCRIPTION
## Change
Swap the version finding code in the PowerShell module from using a direct string comparison to using the `CompareToVersion` function.  This enables non-exact version matching, such as "1 == 1.0.0".

## Validation
Adds a test with a short version to validate the change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5323)