### PR TITLE
Only download during COM download

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -609,7 +609,7 @@ namespace AppInstaller::CLI::Workflow
             Workflow::GetDependenciesFromInstaller <<
             Workflow::ReportDependencies(Resource::String::PackageRequiresDependencies) <<
             Workflow::CreateDependencySubContexts(Resource::String::PackageRequiresDependencies) <<
-            Workflow::ProcessMultiplePackages(Resource::String::PackageRequiresDependencies, APPINSTALLER_CLI_ERROR_DOWNLOAD_DEPENDENCIES, {}, true, true, true, false);
+            Workflow::ProcessMultiplePackages(Resource::String::PackageRequiresDependencies, APPINSTALLER_CLI_ERROR_DOWNLOAD_DEPENDENCIES, {}, true, true, true, false, true);
     }
 
     void InstallSinglePackage(Execution::Context& context)
@@ -682,7 +682,7 @@ namespace AppInstaller::CLI::Workflow
             return;
         }
 
-        bool downloadInstallerOnly = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerDownloadOnly);
+        bool downloadInstallerOnly = m_downloadOnly ? true : WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerDownloadOnly);
 
         // Show all prompts needed for every package before installing anything
         context << Workflow::ShowPromptsForMultiplePackages(m_ensurePackageAgreements, downloadInstallerOnly);

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.h
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.h
@@ -174,7 +174,8 @@ namespace AppInstaller::CLI::Workflow
             bool ensurePackageAgreements = true,
             bool ignoreDependencies = false,
             bool stopOnFailure = false,
-            bool refreshPathVariable = false):
+            bool refreshPathVariable = false,
+            bool downloadOnly = false):
             WorkflowTask("ProcessMultiplePackages"),
             m_dependenciesReportMessage(dependenciesReportMessage),
             m_resultOnFailure(resultOnFailure),
@@ -182,7 +183,8 @@ namespace AppInstaller::CLI::Workflow
             m_ignorePackageDependencies(ignoreDependencies),
             m_ensurePackageAgreements(ensurePackageAgreements),
             m_stopOnFailure(stopOnFailure),
-            m_refreshPathVariable(refreshPathVariable){}
+            m_refreshPathVariable(refreshPathVariable),
+            m_downloadOnly(downloadOnly){}
 
         void operator()(Execution::Context& context) const override;
 
@@ -194,6 +196,7 @@ namespace AppInstaller::CLI::Workflow
         bool m_ensurePackageAgreements;
         bool m_stopOnFailure;
         bool m_refreshPathVariable;
+        bool m_downloadOnly;
     };
 
     // Stores the existing set of packages in ARP.


### PR DESCRIPTION
Fixes #4661

## Issue
When `download` was added, the COM download and install split for dependencies was accidentally implemented.  But it was validated only with download in mind, so the download part worked for download intent.  With dependencies, the split basically attempted to install the dependencies twice, causing a failure on the second attempt due to internal assertions.

## Change
For the COM download command, explicitly force that we are only downloading.

## Validation
Added a test that reproduces the double install attempt and verified that it failed at the attempt to move backward in execution phase.  Test succeeds after the change.