### PR TITLE
More graceful MSIX enumeration failure handling

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
@@ -90,6 +90,7 @@ namespace AppInstaller::Repository::Microsoft
                     try
                     {
                         packages = packageManager.FindPackagesForUserWithPackageTypes({}, types);
+                        break;
                     }
                     catch (const winrt::hresult_error& hre)
                     {


### PR DESCRIPTION
Fixes #5318
Mitigates many other issues getting 0x80070490 from installed package enumeration

## Change
Check for `IPackageManager9` before using it to prevent an AV on older Windows versions.

Attempt to `FindPackagesForUserWithPackageTypes` with fewer types if it fails with `E_NOT_SET`.  While this is an OS issue, enumerating fewer (or no) packages is generally better than an error that completely blocks usage.

## Validation
Manually tried both user and system scopes to ensure proper mainline functionality.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5329)