### PR TITLE
Handle not finding metadata

### DIFF
--- a/src/AppInstallerCLIE2ETests/Interop/FindPackagesInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/FindPackagesInterop.cs
@@ -216,5 +216,22 @@ namespace AppInstallerCLIE2ETests.Interop
             Assert.AreEqual("en-GB", catalogPackageMetadata2.Locale);
             Assert.AreEqual("packageNameUK", catalogPackageMetadata2.PackageName);
         }
+
+        /// <summary>
+        /// Verifies that GetCatalogPackageMetadata returns the correct metadata based on the specified locale.
+        /// </summary>
+        [Test]
+        public void FindPackagesGetVersionMetadata()
+        {
+            var searchResult = this.FindAllPackages(this.testSource, PackageMatchField.Id, PackageFieldMatchOption.Equals, "AppInstallerTest.MultipleLocale");
+            Assert.AreEqual(1, searchResult.Count);
+
+            var catalogPackage = searchResult[0].CatalogPackage;
+            var packageVersionId = catalogPackage.AvailableVersions[0];
+            var packageVersionInfo = catalogPackage.GetPackageVersionInfo(packageVersionId);
+
+            string metadata = packageVersionInfo.GetMetadata(PackageVersionMetadataField.SilentUninstallCommand);
+            Assert.IsEmpty(metadata);
+        }
     }
 }

--- a/src/Microsoft.Management.Deployment/PackageVersionInfo.cpp
+++ b/src/Microsoft.Management.Deployment/PackageVersionInfo.cpp
@@ -39,6 +39,11 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         ::AppInstaller::Repository::PackageVersionMetadata metadataKey = GetRepositoryPackageVersionMetadata(metadataField);
         ::AppInstaller::Repository::IPackageVersion::Metadata metadata = m_packageVersion->GetMetadata();
         auto result = metadata.find(metadataKey);
+        if (result == metadata.end())
+        {
+            return {};
+        }
+
         hstring resultString = winrt::to_hstring(result->second);
         // The api uses "System" rather than "Machine" for install scope.
         if (metadataField == PackageVersionMetadataField::InstalledScope && resultString == L"Machine")


### PR DESCRIPTION
Fixes #5349

## Change
Return an empty `hstring` if we don't find a metadata key rather than attempting to dereference an invalid iterator.

Thanks @luke-patchblox for pointing out the issue precisely (although you took all the fun out of diagnosing it 😝)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5350)