### PR TITLE
Fixes for pipeline stability

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -50,7 +50,7 @@
     "Microsoft.VisualStudio.Component.VC.ASAN",
     "Microsoft.VisualStudio.Component.Vcpkg",
     "Microsoft.VisualStudio.Component.Windows10SDK.19041",
-    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
+    "Microsoft.VisualStudio.Component.Windows11SDK.26100",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ pr:
     - schemas/JSON/manifests/*
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2025'
 
 variables:
   solution: 'src\AppInstallerCLI.sln'
@@ -365,7 +365,7 @@ jobs:
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()
 
-  - powershell: |
+  - pwsh: |
       $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
       PsExec -accepteula -s -i $(buildOutDir)\AppInstallerCLITests\AppInstallerCLITests.exe -logto $(artifactsDir)\AICLI-Unpackaged-System.log -s -r junit -o $(artifactsDir)\TEST-AppInstallerCLI-Unpackaged-System.xml
     displayName: Run Unit Tests Unpackaged Under System Context

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -351,13 +351,7 @@ jobs:
     inputs:
       packageFeedSelector: 'nugetOrg'
 
-  # TODO: Repair-WinGetPackageManager will fail because it tries to install x64 for an x86 build machine.
-  # Remove manual installation of VCLibs (x64) once this is fixed.
   - powershell: |
-      if ("$(buildPlatform)" -eq "x86") {
-        iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.appx
-        Add-AppxPackage Microsoft.VCLibs.x64.appx
-      }
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
       Repair-WingetPackageManager -AllUsers -Latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -186,7 +186,7 @@ jobs:
           Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd
           WindowsPackageManager\WindowsPackageManager.dll
           UndockedRegFreeWinRT\winrtact.dll
-      TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Client\net8.0-windows10.0.22000.0\SharedDependencies\$(BuildPlatform)
+      TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Client\net8.0-windows10.0.26100.0\SharedDependencies\$(BuildPlatform)
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -215,7 +215,7 @@ jobs:
     inputs:
       SourceFolder: $(buildOutDirAnyCpu)
       Contents: |
-          Microsoft.Management.Configuration.Projection\net8.0-windows10.0.22000.0\Microsoft.Management.Configuration.Projection.dll
+          Microsoft.Management.Configuration.Projection\net8.0-windows10.0.26100.0\Microsoft.Management.Configuration.Projection.dll
       TargetFolder: $(buildOutDirAnyCpu)\PowerShell\Microsoft.WinGet.Configuration\SharedDependencies\$(BuildPlatform)
       flattenFolders: true
 

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -12,10 +12,10 @@
   * Universal Windows Platform Development
   * Check [.vsconfig file](../.vsconfig) for full components list
 
-* [Windows SDK for Windows 11 (10.0.22000.194)](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
+* [Windows SDK for Windows 11 (10.0.26100)](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/)
 
 > [!NOTE]
-> You can also get it through `winget install Microsoft.WindowsSDK --version 10.0.22000.832` (use --force if you have a newer version installed) or via Visual Studio > Get Tools and Features > Individual Components > Windows 10 SDK (10.0.22000.0)
+> You can also get it through `winget install Microsoft.WindowsSDK.10.0.26100` or via Visual Studio > Get Tools and Features > Individual Components > Windows 10 SDK (10.0.26100.0)
 
 * The following extensions:
 

--- a/src/AppInstallerCLI/AppInstallerCLI.vcxproj
+++ b/src/AppInstallerCLI/AppInstallerCLI.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{5b6f90df-fd19-4bae-83d9-24dad128e777}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerCLI</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{1c6e0108-2860-4b17-9f7e-fa5c6c1f3d3d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerCLICore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/AppInstallerCLICore/Commands/DebugCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/DebugCommand.cpp
@@ -106,6 +106,7 @@ namespace AppInstaller::CLI
         OutputProxyStubInterfaceRegistration<winrt::Windows::Foundation::Collections::IIterable<winrt::Microsoft::Management::Configuration::ConfigurationEnvironment>>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IConfigurationUnitProcessorDetails2>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IGetAllSettingsConfigurationUnitProcessor>(context);
+        OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IGetAllUnitsConfigurationUnitProcessor>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::IConfigurationStatics2>(context);
         OutputProxyStubInterfaceRegistration<winrt::Microsoft::Management::Configuration::SetProcessorFactory::IPwshConfigurationSetProcessorFactoryProperties>(context);
 

--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
@@ -551,6 +551,8 @@ namespace AppInstaller::CLI::Workflow
                     m_context.Reporter.Info() << "  "_liv << Resource::String::ConfigurationSettings << '\n';
                     OutputValueSet(settings, 4);
                 }
+
+                m_context.Reporter.Info() << std::flush;
             }
 
         private:

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -11,7 +11,7 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -43,7 +43,7 @@
 
   <!-- CsWinRT properties -->
   <PropertyGroup>
-    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -43,7 +43,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>6aa3791a-0713-4548-a357-87a323e7ac3a</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
@@ -236,7 +236,7 @@
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd">
         <PackagePath>Microsoft.Management.Configuration.winmd</PackagePath>
       </WinGetAdditionalPackageFile>
-      <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net8.0-windows10.0.22000.0\$(ConfigServerRid)\**\*">
+      <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net8.0-windows10.0.26100.0\$(ConfigServerRid)\**\*">
         <PackagePath>ConfigurationRemotingServer</PackagePath>
         <Recurse>true</Recurse>
       </WinGetAdditionalPackageFile>

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -116,6 +116,7 @@
         <Interface Name="Windows.Foundation.Collections.IIterable`1&lt;Microsoft.Management.Configuration.ConfigurationEnvironment&gt;" InterfaceId="47B18106-976B-5532-8E81-F58D304DFA43" />
         <Interface Name="Microsoft.Management.Configuration.IConfigurationUnitProcessorDetails2" InterfaceId="E89623ED-76E2-5145-B920-D09659554E35" />
         <Interface Name="Microsoft.Management.Configuration.IGetAllSettingsConfigurationUnitProcessor" InterfaceId="72EB8304-D8D3-57D4-9940-7C1C4AD8C40C" />
+        <Interface Name="Microsoft.Management.Configuration.IGetAllUnitsConfigurationUnitProcessor" InterfaceId="D5CB3357-8AD6-5A3C-8695-057C01867D5F" />
         <Interface Name="Microsoft.Management.Configuration.IConfigurationStatics2" InterfaceId="540BE073-F2EF-5375-83AA-8E23086B0669" />
         <Interface Name="Microsoft.Management.Configuration.SetProcessorFactory.IPwshConfigurationSetProcessorFactoryProperties" InterfaceId="2C298A30-BD3B-5D00-BCD1-2EB633AB7E3B" />
       </ProxyStub>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -10,7 +10,7 @@
     <ProjectGuid>{89b1aab4-2bbc-4b65-9ed7-a01d5cf88230}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerCLITests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ProjectName>AppInstallerCLITests</ProjectName>
   </PropertyGroup>

--- a/src/AppInstallerCLITests/Downloader.cpp
+++ b/src/AppInstallerCLITests/Downloader.cpp
@@ -82,7 +82,7 @@ TEST_CASE("HttpStream_ReadLastFullPage", "[HttpStream]")
 
     for (size_t i = 0; i < 10; ++i)
     {
-        stream = GetReadOnlyStreamFromURI("https://cdn.winget.microsoft.com/cache/source.msix");
+        stream = GetReadOnlyStreamFromURI("https://cdn.winget.microsoft.com/cache/source2.msix");
 
         stat = { 0 };
         REQUIRE(stream->Stat(&stat, STATFLAG_NONAME) == S_OK);
@@ -96,7 +96,7 @@ TEST_CASE("HttpStream_ReadLastFullPage", "[HttpStream]")
     }
 
     {
-        INFO("https://cdn.winget.microsoft.com/cache/source.msix gave back a 0 byte file");
+        INFO("https://cdn.winget.microsoft.com/cache/source2.msix gave back a 0 byte file");
         REQUIRE(stream);
     }
 

--- a/src/AppInstallerCLITests/MsixInfo.cpp
+++ b/src/AppInstallerCLITests/MsixInfo.cpp
@@ -84,7 +84,7 @@ TEST_CASE("MsixInfo_ValidateMsixTrustInfo", "[msixinfo]")
 
     TestCommon::TempFile microsoftSigned{ "testIndex"s, ".msix"s };
     ProgressCallback callback;
-    Utility::Download("https://cdn.winget.microsoft.com/cache/source.msix", microsoftSigned.GetPath(), Utility::DownloadType::Index, callback);
+    Utility::Download("https://cdn.winget.microsoft.com/cache/source2.msix", microsoftSigned.GetPath(), Utility::DownloadType::Index, callback);
 
     Msix::WriteLockedMsixFile microsoftSignedWriteLocked{ microsoftSigned };
     REQUIRE(microsoftSignedWriteLocked.ValidateTrustInfo(true));

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{5eb88068-5fb9-4e69-89b2-72dbc5e068f9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerRepositoryCore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj
+++ b/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj
@@ -8,7 +8,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{F3F6E699-BC5D-4950-8A05-E49DD9EB0D51}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.vcxproj
+++ b/src/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.vcxproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{6CB84692-5994-407D-B9BD-9216AF77FE83}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerTestExeInstaller</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/AppInstallerTestMsixInstaller/AppInstallerTestMsixInstaller.wapproj
+++ b/src/AppInstallerTestMsixInstaller/AppInstallerTestMsixInstaller.wapproj
@@ -43,7 +43,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>3e2cba31-ceba-4d63-bf52-49c0718e19ea</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/src/JsonCppLib/JsonCppLib.vcxproj
+++ b/src/JsonCppLib/JsonCppLib.vcxproj
@@ -51,7 +51,7 @@
     <ProjectGuid>{82B39FDA-E86B-4713-A873-9D56DE00247A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Microsoft.Management.Configuration.OutOfProc.vcxproj
@@ -8,7 +8,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>MicrosoftManagementConfigurationOutOfProc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
+++ b/src/Microsoft.Management.Configuration.OutOfProc/Prepare-ConfigurationOOPTests.ps1
@@ -9,13 +9,13 @@ param(
 
 # Copy the winmd into the unit test directory since it will be needed for marshalling
 $Local:winmdSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration\Microsoft.Management.Configuration.winmd"
-$Local:winmdTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.22000.0\Microsoft.Management.Configuration.winmd"
+$Local:winmdTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.26100.0\Microsoft.Management.Configuration.winmd"
 
 Copy-Item $Local:winmdSourcePath $Local:winmdTargetPath -Force
 
 # Copy the OOP helper dll into the unit test directory to make activation look the same as in-proc
 $Local:dllSourcePath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.OutOfProc\Microsoft.Management.Configuration.OutOfProc.dll"
-$Local:dllTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.22000.0\Microsoft.Management.Configuration.dll"
+$Local:dllTargetPath = Join-Path $BuildOutputPath "Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.26100.0\Microsoft.Management.Configuration.dll"
 
 Copy-Item $Local:dllSourcePath $Local:dllTargetPath -Force
 

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -89,6 +89,8 @@
       Windows.ApplicationModel.AppInstallerPolicySourc;
       Windows.ApplicationModel.AddResourcePackageOption;
       Windows.ApplicationModel.IAddResourcePackageOption;
+      Windows.ApplicationModel.FindRelatedPackagesOption;
+      Windows.ApplicationModel.IFindRelatedPackagesOption;
       Windows.ApplicationModel.Packag;
       Windows.ApplicationModel.IPackag;
       Windows.ApplicationModel.Core.AppListEntr;
@@ -106,12 +108,14 @@
       Windows.Networking.IHostNam;
       Windows.Security.Cryptography.Certificates;
       Windows.Storage;
+      Windows.Storage.Provider.FileUpdateStatu;
       Windows.System.ProcessorArchitectur;
       Windows.System.Use;
       Windows.System.IUse;
     </CsWinRTIncludes>
     <CsWinRTExcludes>
       Windows.Foundation.PropertyType;
+      Windows.Storage.Provider;
     </CsWinRTExcludes>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>

--- a/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
+++ b/src/Microsoft.Management.Configuration.Processor/Microsoft.Management.Configuration.Processor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DotNetVersion>net8.0</DotNetVersion>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>$(DotNetVersion)-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>$(DotNetVersion)-windows10.0.26100.0</TargetFramework>
     <Nullable>enable</Nullable>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
@@ -21,7 +21,7 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
     <WinGetCsWinRTEmbedded Condition="'$(WinGetCsWinRTEmbedded)'==''">true</WinGetCsWinRTEmbedded>
   </PropertyGroup>
 
@@ -39,7 +39,7 @@
 
   <PropertyGroup>
     <CsWinRTComponent>true</CsWinRTComponent>
-    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.Versioning;
 
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
-[assembly: TargetPlatform("Windows10.0.22000.0")]
+[assembly: TargetPlatform("Windows10.0.26100.0")]
 [assembly: SupportedOSPlatform("Windows10.0.17763.0")]

--- a/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
+++ b/src/Microsoft.Management.Configuration.Projection/Microsoft.Management.Configuration.Projection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <Platform>AnyCpu</Platform>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -11,13 +11,13 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <CsWinRTIncludes>Microsoft.Management.Configuration</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Helpers/OutOfProcAttribute.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Helpers
             // The test runner is located somewhere like this:
             //  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform
             // and the command line from there is:
-            //  .\vstest.console.exe "<location of your repo>\src\x64\Debug\Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.22000.0\Microsoft.Management.Configuration.UnitTests.dll" --TestCaseFilter:Category=OutOfProc
+            //  .\vstest.console.exe "<location of your repo>\src\x64\Debug\Microsoft.Management.Configuration.UnitTests\net8.0-windows10.0.26100.0\Microsoft.Management.Configuration.UnitTests.dll" --TestCaseFilter:Category=OutOfProc
         }
     }
 }

--- a/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
+++ b/src/Microsoft.Management.Configuration.UnitTests/Microsoft.Management.Configuration.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <Nullable>enable</Nullable>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Platforms>x64;x86;arm64</Platforms>

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/Microsoft.Management.Deployment.CsWinRTProjection/Microsoft.Management.Deployment.CsWinRTProjection.csproj
+++ b/src/Microsoft.Management.Deployment.CsWinRTProjection/Microsoft.Management.Deployment.CsWinRTProjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-windows10.0.22000.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.26100.0</TargetFrameworks>
     <Platform>AnyCpu</Platform>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -13,13 +13,13 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/src/Microsoft.Management.Deployment.InProc/Microsoft.Management.Deployment.InProc.vcxproj
+++ b/src/Microsoft.Management.Deployment.InProc/Microsoft.Management.Deployment.InProc.vcxproj
@@ -9,7 +9,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{9ac3c6a4-1875-4d3e-bf9c-c31e81eff6b4}</ProjectGuid>
     <RootNamespace>MicrosoftManagementDeploymentInProc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/src/Microsoft.Management.Deployment.OutOfProc/Microsoft.Management.Deployment.OutOfProc.vcxproj
+++ b/src/Microsoft.Management.Deployment.OutOfProc/Microsoft.Management.Deployment.OutOfProc.vcxproj
@@ -8,7 +8,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>MicrosoftManagementDeploymentOutOfProc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -10,7 +10,7 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +19,7 @@
 
   <!-- CsWinRT properties -->
   <PropertyGroup>
-    <CsWinRTWindowsMetadata>10.0.22000.0</CsWinRTWindowsMetadata>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
     <CsWinRTIncludes>Microsoft.Management.Deployment;Windows.Foundation;Windows.System.ProcessorArchitecture</CsWinRTIncludes>
     <CsWinRTExcludes>Windows.Foundation.Diagnostics</CsWinRTExcludes>
   </PropertyGroup>

--- a/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
+++ b/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <CppWinRTParameters>-library Microsoft_Management_Deployment</CppWinRTParameters>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Microsoft.WinGet.Client.Cmdlets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- If these target frameworks are updated, make sure to also update the .psd1 and .nuspec files.-->
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <CoreFramework>net8.0-windows10.0.22000.0</CoreFramework>
+    <CoreFramework>net8.0-windows10.0.26100.0</CoreFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
     <Configurations>Debug;Release;ReleaseStatic</Configurations>

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -134,12 +134,14 @@
       Windows.Networking.IHostNam;
       Windows.Security.Cryptography.Certificates;
       Windows.Storage;
+      Windows.Storage.Provider.FileUpdateStatu;
       Windows.System.ProcessorArchitectur;
       Windows.System.Use;
       Windows.System.IUse;
     </CsWinRTIncludes>
     <CsWinRTExcludes>
       Windows.Foundation.PropertyType;
+      Windows.Storage.Provider;
     </CsWinRTExcludes>
     <CsWinRTWindowsMetadata>$(TargetWindowsVersion)</CsWinRTWindowsMetadata>
     <!-- Ensure Support for Windows 10, Version 1809 -->

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Microsoft.WinGet.Client.Engine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- If these target frameworks are updated, make sure to also update the .psd1 and .nuspec files.-->
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetWindowsVersion>10.0.22000.0</TargetWindowsVersion>
+    <TargetWindowsVersion>10.0.26100.0</TargetWindowsVersion>
     <CoreFramework>net8.0-windows$(TargetWindowsVersion)</CoreFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DesktopFramework>net48</DesktopFramework>
@@ -12,7 +12,7 @@
     <!--
     !!! Remove or update this on the next Microsoft.Windows.CsWinRT package version update. !!!
     -->
-    <WindowsSdkPackageVersion>10.0.22000.53</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.53</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -54,7 +54,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" Condition="'$(TargetFramework)' == '$(CoreFramework)'" />
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.22000.196" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.1742" PrivateAssets="all" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == '$(DesktopFramework)'" />
   </ItemGroup>
 

--- a/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Microsoft.WinGet.Client.psd1
+++ b/src/PowerShell/Microsoft.WinGet.Client/ModuleFiles/Microsoft.WinGet.Client.psd1
@@ -9,7 +9,7 @@
 # Script module or binary module file associated with this manifest.
 RootModule = if ($PSEdition -like 'Core')
 {
-    "net8.0-windows10.0.22000.0\Microsoft.WinGet.Client.Cmdlets.dll"
+    "net8.0-windows10.0.26100.0\Microsoft.WinGet.Client.Cmdlets.dll"
 }
 else
 {

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Cmdlets/Microsoft.WinGet.Configuration.Cmdlets.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>net8.0-windows10.0.22000</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Microsoft.WinGet.Configuration.Engine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Keep in sync with attributes in AssemblyInfo.cs -->
-    <TargetFramework>net8.0-windows10.0.22000</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutputPath>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Properties/AssemblyInfo.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.Versioning;
 
 // Forcibly set the target and supported platforms due to the internal build setup.
 // Keep in sync with project versions.
-[assembly: TargetPlatform("Windows10.0.22000.0")]
+[assembly: TargetPlatform("Windows10.0.26100.0")]
 [assembly: SupportedOSPlatform("Windows10.0.18362.0")]
 
 #endif

--- a/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
+++ b/src/PowerShell/scripts/Initialize-LocalWinGetModules.ps1
@@ -202,7 +202,7 @@ if ($moduleToConfigure.HasFlag([ModuleType]::Client))
         "WindowsPackageManager\WindowsPackageManager.dll"
         "UndockedRegFreeWinRT\winrtact.dll"
     )
-    $module.AddArchSpecificFiles($additionalFiles, "net8.0-windows10.0.22000.0\SharedDependencies", $BuildRoot, $Configuration)
+    $module.AddArchSpecificFiles($additionalFiles, "net8.0-windows10.0.26100.0\SharedDependencies", $BuildRoot, $Configuration)
     $module.AddArchSpecificFiles($additionalFiles, "net48\SharedDependencies", $BuildRoot, $Configuration)
     $modules += $module
 }
@@ -226,7 +226,7 @@ if ($moduleToConfigure.HasFlag([ModuleType]::Configuration))
     )
     $module.AddArchSpecificFiles($additionalFiles, "SharedDependencies", $BuildRoot, $Configuration)
     $additionalFiles = @(
-        "Microsoft.Management.Configuration.Projection\net8.0-windows10.0.22000.0\Microsoft.Management.Configuration.Projection.dll"
+        "Microsoft.Management.Configuration.Projection\net8.0-windows10.0.26100.0\Microsoft.Management.Configuration.Projection.dll"
     )
     $module.AddAnyCpuSpecificFilesToArch($additionalFiles, "SharedDependencies", $BuildRoot, $Configuration)
     $modules += $module

--- a/src/PureLib/PureLib.vcxproj
+++ b/src/PureLib/PureLib.vcxproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{BB14D603-F44E-4415-8770-BF3E13F4C17F}</ProjectGuid>
     <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">

--- a/src/SfsClient/SfsClient.vcxproj
+++ b/src/SfsClient/SfsClient.vcxproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{1B9077B3-8923-4ECD-8FC9-B3190FCBE4D4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/WinGetServer/WinGetServer.vcxproj
+++ b/src/WinGetServer/WinGetServer.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{2b00d362-ac92-41f3-a8d2-5b1599bdca01}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinGetServer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <ProjectName>WinGetServer</ProjectName>

--- a/src/WinGetUtil/WinGetUtil.vcxproj
+++ b/src/WinGetUtil/WinGetUtil.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{FB313532-38B0-4676-9303-AB200AA13576}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinGetUtil</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>

--- a/src/WindowsPackageManager/WindowsPackageManager.vcxproj
+++ b/src/WindowsPackageManager/WindowsPackageManager.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{2046B5AF-666D-4CE8-8D3E-C32C57908A56}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WindowsPackageManager</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
     <CppWinRTGenerateWindowsMetadata>false</CppWinRTGenerateWindowsMetadata>

--- a/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -43,7 +43,7 @@
     <ProjectGuid>{31ED69A8-5310-45A9-953F-56C351D2C3E1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>UndockedRegFreeWinRT</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
   </PropertyGroup>

--- a/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/detours/detours.vcxproj
+++ b/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/detours/detours.vcxproj
@@ -59,7 +59,7 @@
     <ProjectGuid>{787EC629-C0FB-4BA9-9746-4A82CD06B73E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>detours</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ProjectName>Detours</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/YamlCppLib/YamlCppLib.vcxproj
+++ b/src/YamlCppLib/YamlCppLib.vcxproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{8BB94BB8-374F-4294-BCA1-C7811514A6B7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">

--- a/src/cpprestsdk/cpprestsdk.vcxproj
+++ b/src/cpprestsdk/cpprestsdk.vcxproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{866C3F06-636F-4BE8-BC24-5F86ECC606A1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj
+++ b/tools/SampleWinGetUWPCaller/AppInstallerCaller/AppInstallerCaller.vcxproj
@@ -14,7 +14,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
## Issue
Due to an issue with dsc.exe creating child processes (which after much investigation appears to be a race that only occurs on older OS versions), we get arbitrary failures.

We also occasionally get spurious failures of configuration tests.

## Change
Move to `windows-2025` to avoid the process creation failures from dsc.exe.
Move to Windows 11 SDK 26100 as 22000 is not installed by default on `windows-2025`.
Flush output at the end of a configuration unit info dump.
Add missing interface to manifest (@yao-msft was right).
Use `pwsh` task at least once to ensure that it is present.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5359)