### PR TITLE
Fix it twice

### DIFF
--- a/src/AppInstallerCLICore/ContextOrchestrator.cpp
+++ b/src/AppInstallerCLICore/ContextOrchestrator.cpp
@@ -58,7 +58,7 @@ namespace AppInstaller::CLI::Execution
         const auto supportedConcurrentThreads = std::thread::hardware_concurrency();
         const UINT32 maxDownloadThreads = 3;
         const UINT32 operationThreads = 1;
-        const UINT32 downloadThreads = std::min(supportedConcurrentThreads ? supportedConcurrentThreads - 1 : 1, maxDownloadThreads);
+        const UINT32 downloadThreads = std::min(supportedConcurrentThreads > 1 ? supportedConcurrentThreads - 1 : 1, maxDownloadThreads);
 
         AddCommandQueue(COMDownloadCommand::CommandName, downloadThreads);
         AddCommandQueue(OperationCommandQueueName, operationThreads);
@@ -207,8 +207,8 @@ namespace AppInstaller::CLI::Execution
         SetThreadpoolCallbackPool(&m_threadPoolCallbackEnviron, m_threadPool.get());
         SetThreadpoolCallbackCleanupGroup(&m_threadPoolCallbackEnviron, m_threadPoolCleanupGroup.get(), nullptr);
 
-        THROW_LAST_ERROR_IF(!SetThreadpoolThreadMinimum(m_threadPool.get(), 1));
         SetThreadpoolThreadMaximum(m_threadPool.get(), m_allowedThreads);
+        THROW_LAST_ERROR_IF(!SetThreadpoolThreadMinimum(m_threadPool.get(), 1));
     }
 
     OrchestratorQueue::~OrchestratorQueue()


### PR DESCRIPTION
Fixes #5365

## Change
Fix the issue in two ways:

1. Only use `- 1` if `supportedConcurrentThreads` is greater than 1.
2. Swap the order of setting min and max thread counts on the pool so that setting the minimum thread count to 1 overrides a "bad" allowed thread count of 0 (there are better ways to not do something than creating a thread pool that isn't allowed any threads).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5381)