### PR TITLE
Better DefaultInstallVersion

### DIFF
--- a/src/Microsoft.Management.Deployment/CatalogPackage.h
+++ b/src/Microsoft.Management.Deployment/CatalogPackage.h
@@ -38,12 +38,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         bool m_updateAvailable = false;
         Windows::Foundation::Collections::IVector<winrt::Microsoft::Management::Deployment::PackageVersionId> m_availableVersions{ winrt::single_threaded_vector<winrt::Microsoft::Management::Deployment::PackageVersionId>() };
         winrt::Microsoft::Management::Deployment::PackageVersionInfo m_installedVersion{ nullptr };
-        winrt::Microsoft::Management::Deployment::PackageVersionInfo m_defaultInstallVersion{ nullptr };
+        winrt::Microsoft::Management::Deployment::PackageVersionInfo m_latestApplicableVersion{ nullptr };
         std::once_flag m_installedVersionOnceFlag;
         std::once_flag m_availableVersionsOnceFlag;
-        std::once_flag m_defaultInstallVersionOnceFlag;
+        std::once_flag m_latestApplicableVersionOnceFlag;
 
-        void InitializeDefaultInstallVersion();
+        void InitializeLatestApplicableVersion();
 #endif
     };
 }


### PR DESCRIPTION
DefaultInstallVersion being null causes larger than expected issues. The change proposes to return latest applicable version if exists, to minimize duplicate installs/ upgrade failures. If no latest applicable version, return latest available version if exists.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5389)