### PR TITLE
Ensure all vcpkgs use our custom triplets

### DIFF
--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -183,6 +183,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VcpkgCustomTriplets", "Vcpk
 		VcpkgCustomTriplets\arm64-release-static.cmake = VcpkgCustomTriplets\arm64-release-static.cmake
 		VcpkgCustomTriplets\arm64-release.cmake = VcpkgCustomTriplets\arm64-release.cmake
 		VcpkgCustomTriplets\arm64.cmake = VcpkgCustomTriplets\arm64.cmake
+		VcpkgCustomTriplets\common.cmake = VcpkgCustomTriplets\common.cmake
 		VcpkgCustomTriplets\x64-release-static.cmake = VcpkgCustomTriplets\x64-release-static.cmake
 		VcpkgCustomTriplets\x64-release.cmake = VcpkgCustomTriplets\x64-release.cmake
 		VcpkgCustomTriplets\x64.cmake = VcpkgCustomTriplets\x64.cmake

--- a/src/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.vcxproj
+++ b/src/AppInstallerTestExeInstaller/AppInstallerTestExeInstaller.vcxproj
@@ -76,6 +76,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <Import Project="$(ProjectDir)\..\vcpkg.props" />
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/PureLib/PureLib.vcxproj
+++ b/src/PureLib/PureLib.vcxproj
@@ -47,6 +47,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(ProjectDir)\..\vcpkg.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/src/VcpkgCustomTriplets/arm64-release-static.cmake
+++ b/src/VcpkgCustomTriplets/arm64-release-static.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE arm64)
+include("${CMAKE_CURRENT_SOURCE_DIR}/arm64.cmake")
 set(VCPKG_CRT_LINKAGE static)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/arm64-release.cmake
+++ b/src/VcpkgCustomTriplets/arm64-release.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE arm64)
+include("${CMAKE_CURRENT_LIST_DIR}/arm64.cmake")
 set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/arm64.cmake
+++ b/src/VcpkgCustomTriplets/arm64.cmake
@@ -1,3 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")
 set(VCPKG_TARGET_ARCHITECTURE arm64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)

--- a/src/VcpkgCustomTriplets/common.cmake
+++ b/src/VcpkgCustomTriplets/common.cmake
@@ -1,0 +1,5 @@
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_C_FLAGS "/Qspectre /W3 /guard:cf")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3 /guard:cf")
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_INSTALL_OPTIONS, "--debug")

--- a/src/VcpkgCustomTriplets/x64-release-static.cmake
+++ b/src/VcpkgCustomTriplets/x64-release-static.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
+include("${CMAKE_CURRENT_LIST_DIR}/x64.cmake")
 set(VCPKG_CRT_LINKAGE static)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x64-release.cmake
+++ b/src/VcpkgCustomTriplets/x64-release.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
+include("${CMAKE_CURRENT_LIST_DIR}/x64.cmake")
 set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x64.cmake
+++ b/src/VcpkgCustomTriplets/x64.cmake
@@ -1,3 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")
 set(VCPKG_TARGET_ARCHITECTURE x64)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)

--- a/src/VcpkgCustomTriplets/x86-release-static.cmake
+++ b/src/VcpkgCustomTriplets/x86-release-static.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE x86)
-set(VCPKG_CRT_LINKAGE static)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)
+include("${CMAKE_CURRENT_LIST_DIR}/x86.cmake")
+set(VCPKG_CRT_LINKAGE dynamic)

--- a/src/VcpkgCustomTriplets/x86-release.cmake
+++ b/src/VcpkgCustomTriplets/x86-release.cmake
@@ -1,6 +1,2 @@
-set(VCPKG_TARGET_ARCHITECTURE x86)
+include("${CMAKE_CURRENT_LIST_DIR}/x86.cmake")
 set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3")
-set(VCPKG_BUILD_TYPE release)

--- a/src/VcpkgCustomTriplets/x86.cmake
+++ b/src/VcpkgCustomTriplets/x86.cmake
@@ -1,3 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")
 set(VCPKG_TARGET_ARCHITECTURE x86)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)

--- a/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -47,7 +47,6 @@
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
   </PropertyGroup>
-  <Import Project="$(ProjectDir)\..\..\..\..\..\vcpkg.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -76,6 +75,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <Import Project="$(ProjectDir)\..\..\..\..\..\vcpkg.props" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <TargetName>winrtact</TargetName>

--- a/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
+++ b/src/Xlang/UndockedRegFreeWinRT/src/UndockedRegFreeWinRT/UndockedRegFreeWinRT/UndockedRegFreeWinRT.vcxproj
@@ -47,6 +47,7 @@
     <BuildPlatform>$(Platform)</BuildPlatform>
     <BuildPlatform Condition="'$(Platform)'=='Win32'">x86</BuildPlatform>
   </PropertyGroup>
+  <Import Project="$(ProjectDir)\..\..\..\..\..\vcpkg.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/src/cpprestsdk/cpprestsdk.vcxproj
+++ b/src/cpprestsdk/cpprestsdk.vcxproj
@@ -47,6 +47,7 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(ProjectDir)\..\vcpkg.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>


### PR DESCRIPTION
After the change to have our dependencies use vcpkgs instead of checking in a clone of the code, we got BinSkim alerts due to some of them not using our custom triplets with the compilation flags that we need. This PR ensures that all projects include the `vcpkg.props` that makes CMake use our custom triplets instead of the default `{arch}-windows` ones.

It is unclear to me why this happened. For example, why the test installer exe was building the vcpkgs at all, but the logs show that as one of the root projects for the issue.

Besides importing `vcpkg.props` in more projects, this also does a little refactor of the triplets to reduce duplication and have the required flags in a single place
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5423)