### PR TITLE
Fix arm64-release-static vcpkg triplet

### DIFF
--- a/src/VcpkgCustomTriplets/arm64-release-static.cmake
+++ b/src/VcpkgCustomTriplets/arm64-release-static.cmake
@@ -1,4 +1,4 @@
-include("${CMAKE_CURRENT_SOURCE_DIR}/common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/common.cmake")
 set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
In #5423 I used a wrong variable for the arm64-release-static vcpkg triplet. Didn't notice it until running on internal builds because we don't build that configuration in CI builds here...
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5431)