### PR TITLE
Attempt to use DSCv3 resources even if they were not found

### DIFF
--- a/src/AppInstallerCLICore/ConfigurationDynamicRuntimeFactory.cpp
+++ b/src/AppInstallerCLICore/ConfigurationDynamicRuntimeFactory.cpp
@@ -436,12 +436,8 @@ namespace AppInstaller::CLI::ConfigurationRemoting
                             }
                         });
 
-                    auto factoryMap = factory.try_as<Collections::IMap<winrt::hstring, winrt::hstring>>();
-                    if (factoryMap)
-                    {
-                        winrt::hstring propertyName = ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::DiagnosticTraceEnabled);
-                        factoryMap.Insert(propertyName, m_dynamicFactory->GetFactoryMapValue(propertyName));
-                    }
+                    winrt::hstring propertyName = ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::DiagnosticTraceEnabled);
+                    factory.as<Collections::IMap<winrt::hstring, winrt::hstring>>().Insert(propertyName, m_dynamicFactory->GetFactoryMapValue(propertyName));
                 }
 
                 return m_setProcessors.emplace(integrityLevel, DynamicProcessorInfo{ factory, factory.CreateSetProcessor(m_configurationSet), std::move(factoryDiagnosticsEventRevoker) }).first;

--- a/src/AppInstallerCLICore/ConfigurationDynamicRuntimeFactory.cpp
+++ b/src/AppInstallerCLICore/ConfigurationDynamicRuntimeFactory.cpp
@@ -435,6 +435,13 @@ namespace AppInstaller::CLI::ConfigurationRemoting
                                 strong_this->m_dynamicFactory->SendDiagnostics(information);
                             }
                         });
+
+                    auto factoryMap = factory.try_as<Collections::IMap<winrt::hstring, winrt::hstring>>();
+                    if (factoryMap)
+                    {
+                        winrt::hstring propertyName = ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::DiagnosticTraceEnabled);
+                        factoryMap.Insert(propertyName, m_dynamicFactory->GetFactoryMapValue(propertyName));
+                    }
                 }
 
                 return m_setProcessors.emplace(integrityLevel, DynamicProcessorInfo{ factory, factory.CreateSetProcessor(m_configurationSet), std::move(factoryDiagnosticsEventRevoker) }).first;

--- a/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
+++ b/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
@@ -300,12 +300,14 @@ namespace AppInstaller::CLI::ConfigurationRemoting
 
             bool Insert(winrt::hstring key, winrt::hstring value)
             {
-                return m_remoteFactory.as<Collections::IMap<winrt::hstring, winrt::hstring>>().Insert(key, value);
+                auto map = m_remoteFactory.try_as<Collections::IMap<winrt::hstring, winrt::hstring>>();
+                return map ? map.Insert(key, value) : false;
             }
 
             winrt::hstring Lookup(winrt::hstring key)
             {
-                return m_remoteFactory.as<Collections::IMap<winrt::hstring, winrt::hstring>>().Lookup(key);
+                auto map = m_remoteFactory.try_as<Collections::IMap<winrt::hstring, winrt::hstring>>();
+                return map ? map.Lookup(key) : winrt::hstring{};
             }
 
             HRESULT STDMETHODCALLTYPE SetLifetimeWatcher(IUnknown* watcher)

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorRunSettings.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorRunSettings.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// </summary>
         /// <param name="resourceDetails">The resource details to be used.</param>
         /// <returns>A ProcessorRunSettings.</returns>
-        public static ProcessorRunSettings CreateFromResourceDetails(ResourceDetails resourceDetails)
+        public static ProcessorRunSettings CreateFromResourceDetails(ResourceDetails? resourceDetails)
         {
             return new ProcessorRunSettings
             {
-                ResourceSearchPaths = Path.GetDirectoryName(resourceDetails.Path) ?? string.Empty,
+                ResourceSearchPaths = Path.GetDirectoryName(resourceDetails?.Path) ?? string.Empty,
                 ResourceSearchPathsExclusive = false,
             };
         }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Set/DSCv3ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Set/DSCv3ConfigurationSetProcessor.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Set
             if (resourceDetails == null)
             {
                 this.OnDiagnostics(DiagnosticLevel.Verbose, $"Resource not found: {configurationUnitInternal.QualifiedName}");
-                throw new Exceptions.FindDscResourceNotFoundException(configurationUnitInternal.QualifiedName, null);
+
+                // Don't throw when the resource is not found until https://github.com/PowerShell/DSC/issues/786 is resolved
+                // throw new Exceptions.FindDscResourceNotFoundException(configurationUnitInternal.QualifiedName, null);
             }
 
             return new DSCv3ConfigurationUnitProcessor(this.processorSettings, resourceDetails, configurationUnitInternal, this.IsLimitMode) { SetProcessorFactory = this.SetProcessorFactory };

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Unit/DSCv3ConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Unit/DSCv3ConfigurationUnitProcessor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Unit
     internal sealed partial class DSCv3ConfigurationUnitProcessor : ConfigurationUnitProcessorBase, IConfigurationUnitProcessor, IGetAllSettingsConfigurationUnitProcessor, IGetAllUnitsConfigurationUnitProcessor, IDiagnosticsSink
     {
         private readonly ProcessorSettings processorSettings;
-        private readonly ResourceDetails resourceDetails;
+        private readonly ResourceDetails? resourceDetails;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DSCv3ConfigurationUnitProcessor"/> class.
@@ -30,7 +30,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Unit
         /// <param name="resourceDetails">The resource to use.</param>
         /// <param name="unitInternal">Internal unit.</param>
         /// <param name="isLimitMode">Whether it is under limit mode.</param>
-        internal DSCv3ConfigurationUnitProcessor(ProcessorSettings processorSettings, ResourceDetails resourceDetails, ConfigurationUnitInternal unitInternal, bool isLimitMode = false)
+        internal DSCv3ConfigurationUnitProcessor(ProcessorSettings processorSettings, ResourceDetails? resourceDetails, ConfigurationUnitInternal unitInternal, bool isLimitMode = false)
             : base(unitInternal, isLimitMode)
         {
             this.processorSettings = processorSettings;

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/DSCv3ProcessorTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/DSCv3ProcessorTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         /// <summary>
         /// Test for unit processor creation requiring resource to be found.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Disable this test while we have the bypass in place")]
         public void Set_ResourceNotFoundIsError()
         {
             var (factory, dsc) = CreateTestFactory();


### PR DESCRIPTION
## Change
Even if not found, attempt to use DSCv3 resources.  This is largely to avoid PowerShell/DSC#786, which only seems to affect dsc.exe's ability to run processes when listing adapted resources.

Also applies the `DiagnosticTraceEnabled` state to the elevated processor.  This is set when the config logging area is enabled and set to verbose.

## Validation
When running manually, the logs indicate that the adapted `list` invocations are failing, but the attempt to use the resource still succeeds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5443)