### PR TITLE
Make UndockedRegFreeWinRT use same vcpkg_installed directory

### DIFF
--- a/src/vcpkg.props
+++ b/src/vcpkg.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
-    <VcpkgInstalledDir>$(ProjectDir)..\vcpkg_installed</VcpkgInstalledDir>
+    <VcpkgInstalledDir>$(MSBuildThisFileDirectory)\vcpkg_installed</VcpkgInstalledDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgTriplet>x64</VcpkgTriplet>


### PR DESCRIPTION
When setting the path for the vcpkg installed directory in the shared props file, we were using `$(ProjectDir)\..\`. This works fine for most projects because they are one level under the `src` directory, but `UndockedRegFreeWinRT` is deeper in the tree so it would end up having its own separata vcpkg_installed directory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5454)