### PR TITLE
Fix crash due to static weak pointer referencing an object in an unloaded DLL

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -123,6 +123,7 @@ deliveryoptimization
 deliveryoptimizationerrors
 DENYWR
 desktopappinstaller
+devblogs
 devhome
 DFX
 dic

--- a/src/AppInstallerRepositoryCore/pch.h
+++ b/src/AppInstallerRepositoryCore/pch.h
@@ -22,6 +22,7 @@
 #include <winsqlite/winsqlite3.h>
 
 #include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Management.Deployment.h>
@@ -42,6 +43,7 @@
 #include <optional>
 #include <random>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <sstream>


### PR DESCRIPTION
Based on https://devblogs.microsoft.com/oldnewthing/20210215-00/

Fixes #5363.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5474)