### PR TITLE
Fix catalog connection failure due to AppCapability::CreateWithProcessIdForUser throwing E_INVALIDARG when called with a null user on Windows 10 v1903

### DIFF
--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -92,7 +92,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             {
                 status = capability.CheckAccess();
 
-                return (status == winrt::Windows::Security::Authorization::AppCapabilityAccess::AppCapabilityAccessStatus::Allowed);
+                return ((status == winrt::Windows::Security::Authorization::AppCapabilityAccess::AppCapabilityAccessStatus::Allowed) ? S_OK : E_ACCESSDENIED);
             }
         }
 

--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -69,12 +69,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         }
     }
 
-    bool HasPackageId()
-    {
-        std::uint32_t bufferLength{};
-        return GetCurrentPackageId(&bufferLength, nullptr) != APPMODEL_ERROR_NO_PACKAGE;
-    }
-
     HRESULT EnsureProcessHasCapability(Capability requiredCapability, DWORD callerProcessId)
     {
         bool allowed = false;


### PR DESCRIPTION
`AppCapability::CreateWithProcessIdForUser` does not accept a null user on Windows 10 v1903. Treat this case as if the API didn't exist.

Fixes #5378.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5475)