### PR TITLE
Increase libyaml vcpkg port version

### DIFF
--- a/src/VcpkgPortOverlay/libyaml/vcpkg.json
+++ b/src/VcpkgPortOverlay/libyaml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libyaml",
   "version": "0.2.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "A C library for parsing and emitting YAML.",
   "homepage": "https://github.com/yaml/libyaml",
   "dependencies": [


### PR DESCRIPTION
The latest version of libyaml available from the official vcpkg repo has a vulnerability, and the current recommendation is to manually patch it. To apply the patch I added a port overlay here.

Component Governance is still flagging this as unpatched. This may be because we are using the same port version as the one that is known bad in the official repo, so I'm increasing the port version. Hopefully this will make CG happy; otherwise we'll need to file for an exception.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5504)