### PR TITLE
Use release dscv3 package in release build

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
@@ -203,12 +203,12 @@ namespace AppInstaller::CLI::Workflow
                         auto previousThreadGlobals = installDscContext.SetForCurrentThread();
 
                         Manifest::ManifestInstaller dscInstaller;
-// TEMP: Until DSCv3 support is not experimental, allow the preview build to be installed automatically.
-// #ifndef AICLI_DISABLE_TEST_HOOKS
+
+#ifndef AICLI_DISABLE_TEST_HOOKS
                         dscInstaller.ProductId = "9PCX3HX4HZ0Z";
-// #else
-//                      dscInstaller.ProductId = "9NVTPZWRC6KQ";
-// #endif
+#else
+                        dscInstaller.ProductId = "9NVTPZWRC6KQ";
+#endif
                         installDscContext.Add<Execution::Data::Installer>(std::move(dscInstaller));
                         installDscContext.Args.AddArg(Execution::Args::Type::InstallScope, Manifest::ScopeToString(Manifest::ScopeEnum::User));
                         installDscContext.Args.AddArg(Execution::Args::Type::Silent);

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorRunSettings.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorRunSettings.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// </summary>
         /// <param name="resourceDetails">The resource details to be used.</param>
         /// <returns>A ProcessorRunSettings.</returns>
-        public static ProcessorRunSettings CreateFromResourceDetails(ResourceDetails? resourceDetails)
+        public static ProcessorRunSettings CreateFromResourceDetails(ResourceDetails resourceDetails)
         {
             return new ProcessorRunSettings
             {
-                ResourceSearchPaths = Path.GetDirectoryName(resourceDetails?.Path) ?? string.Empty,
+                ResourceSearchPaths = Path.GetDirectoryName(resourceDetails.Path) ?? string.Empty,
                 ResourceSearchPathsExclusive = false,
             };
         }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorSettings.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessorSettings.cs
@@ -121,13 +121,13 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
             // To start, only attempt to find the package and launch it via app execution alias.
             // In the future, consider discovering it through %PATH% searching, but probably don't allow that from an elevated process.
             // That probably means creating another read property for finding the secure path.
-            // TEMP: Until DSCv3 support is not experimental, allow the preview build to be found automatically.
-// #if !AICLI_DISABLE_TEST_HOOKS
+#if !AICLI_DISABLE_TEST_HOOKS
             string? result = GetDscExecutablePathForPackage("Microsoft.DesiredStateConfiguration-Preview_8wekyb3d8bbwe");
             if (result != null)
             {
                 return result;
             }
+#endif
 
             return GetDscExecutablePathForPackage("Microsoft.DesiredStateConfiguration_8wekyb3d8bbwe");
         }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Set/DSCv3ConfigurationSetProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Set/DSCv3ConfigurationSetProcessor.cs
@@ -41,9 +41,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Set
             if (resourceDetails == null)
             {
                 this.OnDiagnostics(DiagnosticLevel.Verbose, $"Resource not found: {configurationUnitInternal.QualifiedName}");
-
-                // Don't throw when the resource is not found until https://github.com/PowerShell/DSC/issues/786 is resolved
-                // throw new Exceptions.FindDscResourceNotFoundException(configurationUnitInternal.QualifiedName, null);
+                throw new Exceptions.FindDscResourceNotFoundException(configurationUnitInternal.QualifiedName, null);
             }
 
             return new DSCv3ConfigurationUnitProcessor(this.processorSettings, resourceDetails, configurationUnitInternal, this.IsLimitMode) { SetProcessorFactory = this.SetProcessorFactory };

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Unit/DSCv3ConfigurationUnitProcessor.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Unit/DSCv3ConfigurationUnitProcessor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Unit
     internal sealed partial class DSCv3ConfigurationUnitProcessor : ConfigurationUnitProcessorBase, IConfigurationUnitProcessor, IGetAllSettingsConfigurationUnitProcessor, IGetAllUnitsConfigurationUnitProcessor, IDiagnosticsSink
     {
         private readonly ProcessorSettings processorSettings;
-        private readonly ResourceDetails? resourceDetails;
+        private readonly ResourceDetails resourceDetails;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DSCv3ConfigurationUnitProcessor"/> class.
@@ -30,7 +30,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Unit
         /// <param name="resourceDetails">The resource to use.</param>
         /// <param name="unitInternal">Internal unit.</param>
         /// <param name="isLimitMode">Whether it is under limit mode.</param>
-        internal DSCv3ConfigurationUnitProcessor(ProcessorSettings processorSettings, ResourceDetails? resourceDetails, ConfigurationUnitInternal unitInternal, bool isLimitMode = false)
+        internal DSCv3ConfigurationUnitProcessor(ProcessorSettings processorSettings, ResourceDetails resourceDetails, ConfigurationUnitInternal unitInternal, bool isLimitMode = false)
             : base(unitInternal, isLimitMode)
         {
             this.processorSettings = processorSettings;

--- a/src/Microsoft.Management.Configuration.UnitTests/Tests/DSCv3ProcessorTests.cs
+++ b/src/Microsoft.Management.Configuration.UnitTests/Tests/DSCv3ProcessorTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Management.Configuration.UnitTests.Tests
         /// <summary>
         /// Test for unit processor creation requiring resource to be found.
         /// </summary>
-        [Fact(Skip = "Disable this test while we have the bypass in place")]
+        [Fact]
         public void Set_ResourceNotFoundIsError()
         {
             var (factory, dsc) = CreateTestFactory();


### PR DESCRIPTION
This reverts several workaround code previously in preview builds.

Next are 2 separate prs for "Ensuring dsc v2 modules used in export/import" and "path env variable updater"