### PR TITLE
Refresh PATH in configuration remoting server

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,6 @@ jobs:
     buildOutDirAnyCpu: $(Build.SourcesDirectory)\src\AnyCPU\$(buildConfiguration)
     artifactsDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)
     appxPackageDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)\AppxPackages
-    packageLayoutDir: $(Build.BinariesDirectory)\WingetPackageLayout
 
   steps:
   - task: NuGetToolInstaller@1
@@ -153,7 +152,6 @@ jobs:
     displayName: 'Copy specific build artifacts'
     inputs:
       Contents: |
-          $(buildOutDir)\WindowsPackageManager\WindowsPackageManager.pdb
           $(buildOutDir)\WinGetUtil\WinGetUtil.dll
           $(buildOutDir)\WinGetUtil\WinGetUtil.pdb
       TargetFolder: '$(artifactsDir)'
@@ -162,20 +160,8 @@ jobs:
     displayName: Create Package Layout
     inputs:
       filePath: 'src\AppInstallerCLIPackage\Execute-AppxRecipe.ps1'
-      arguments: '-AppxRecipePath AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration)\AppInstallerCLIPackage.build.appxrecipe -LayoutPath $(packageLayoutDir) -Force -Verbose'
+      arguments: '-AppxRecipePath AppInstallerCLIPackage\bin\$(buildPlatform)\$(buildConfiguration)\AppInstallerCLIPackage.build.appxrecipe -LayoutPath $(artifactsDir)\DevPackage -Force -Verbose'
       workingDirectory: 'src'
-
-  - task: CopyFiles@2
-    displayName: 'Copy Dev Package (Loose Files)'
-    inputs:
-      SourceFolder: '$(packageLayoutDir)'
-      TargetFolder: '$(artifactsDir)\DevPackage'
-
-  - task: DeleteFiles@1
-    displayName: Clean up Package Layout after copy
-    inputs:
-      SourceFolder: '$(packageLayoutDir)'
-      Contents: '**/*'
 
   - task: CopyFiles@2
     displayName: 'Copy native binaries for Microsoft.WinGet.Client (net8)'

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
     using System.Diagnostics;
     using System.Text;
     using System.Threading;
+    using Microsoft.Management.Configuration.Processor.Helpers;
 
     /// <summary>
     /// Wrapper for a single process execution and its output.
@@ -134,7 +135,13 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
                 throw new InvalidOperationException("Process has already been started.");
             }
 
-            ProcessStartInfo startInfo = new ProcessStartInfo(this.ExecutablePath, this.SerializedArguments);
+            ProcessStartInfo startInfo;
+
+            lock (PathEnvironmentVariableHandler.Lock)
+            {
+                startInfo = new ProcessStartInfo(this.ExecutablePath, this.SerializedArguments);
+            }
+
             this.Process = new Process() { StartInfo = startInfo };
 
             startInfo.UseShellExecute = false;

--- a/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
         /// </summary>
         public static void UpdatePath()
         {
-            List<string> paths = new List<string>(Environment.GetEnvironmentVariable(PathEnvironmentVariable)?.Split(';') ?? Array.Empty<string>());
+            HashSet<string> paths = new HashSet<string>(Environment.GetEnvironmentVariable(PathEnvironmentVariable)?.Split(';') ?? Array.Empty<string>());
             var originalPathsSize = paths.Count;
 
             AddPathsIfNotExist(paths, Environment.GetEnvironmentVariable(PathEnvironmentVariable, EnvironmentVariableTarget.Machine)?.Split(';'));
@@ -47,8 +47,11 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
             }
         }
 
+        // TODO: Currently it always adds new paths to the end. The "proper" thing to do would probably be to calculate
+        // the full new list of paths (what one would expect to get from a new process launch) and use a line merge algorithm
+        // with a strategy that puts the ephemeral entries before the new permanent ones.
 #pragma warning disable SA1011 // Closing square brackets should be spaced correctly
-        private static void AddPathsIfNotExist(List<string> currentPaths, string[]? paths)
+        private static void AddPathsIfNotExist(HashSet<string> currentPaths, string[]? paths)
 #pragma warning restore SA1011 // Closing square brackets should be spaced correctly
         {
             if (paths is not null)

--- a/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Management.Configuration.Processor.Helpers
             }
         }
 
+#pragma warning disable SA1011 // Closing square brackets should be spaced correctly
         private static void AddPathsIfNotExist(List<string> currentPaths, string[]? paths)
+#pragma warning restore SA1011 // Closing square brackets should be spaced correctly
         {
             if (paths is not null)
             {

--- a/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
+++ b/src/Microsoft.Management.Configuration.Processor/Public/PathEnvironmentVariableHandler.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------------
+// <copyright file="PathEnvironmentVariableHandler.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.Management.Configuration.Processor.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Class for handling PATH environment variable.
+    /// </summary>
+    public static class PathEnvironmentVariableHandler
+    {
+        private const string PathEnvironmentVariable = "PATH";
+
+        private static readonly object EnvironmentVariableLock = new object();
+
+        /// <summary>
+        /// Gets the lock to read or write PATH environment variable.
+        /// </summary>
+        public static object Lock
+        {
+            get { return EnvironmentVariableLock; }
+        }
+
+        /// <summary>
+        /// Updates the process's PATH environment variable if new paths added.
+        /// Only adds new paths since we add to PATH in other code which may not be in the registry.
+        /// </summary>
+        public static void UpdatePath()
+        {
+            List<string> paths = new List<string>(Environment.GetEnvironmentVariable(PathEnvironmentVariable)?.Split(';') ?? Array.Empty<string>());
+            var originalPathsSize = paths.Count;
+
+            AddPathsIfNotExist(paths, Environment.GetEnvironmentVariable(PathEnvironmentVariable, EnvironmentVariableTarget.Machine)?.Split(';'));
+            AddPathsIfNotExist(paths, Environment.GetEnvironmentVariable(PathEnvironmentVariable, EnvironmentVariableTarget.User)?.Split(';'));
+
+            if (paths.Count > originalPathsSize)
+            {
+                lock (Lock)
+                {
+                    Environment.SetEnvironmentVariable(PathEnvironmentVariable, string.Join(';', paths));
+                }
+            }
+        }
+
+        private static void AddPathsIfNotExist(List<string> currentPaths, string[]? paths)
+        {
+            if (paths is not null)
+            {
+                foreach (var path in paths)
+                {
+                    if (!currentPaths.Contains(path))
+                    {
+                        currentPaths.Add(path);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a hidden window to listen for UserPreferenceChanged event (WM_SETTINGCHANGE) and update the process's PATH if needed.

Manually validated by running a configuration file with multiple resources, change the env var during the run, and verified in logs file that new path got included in runs after the change.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5511)