### PR TITLE
Add text file with the release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
 
 - [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
+- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
 - [ ] This pull request is related to an issue.
 
 -----

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,7 +1,7 @@
 ## New in v1.11
 * Dropped support for running on 32-bit ARM
 * Support for [Microsoft Desired State Configuration (DSC) v3](https://learn.microsoft.com/powershell/dsc/overview?view=dsc-3.0).
-* Support for exporting the configuration of the current device. This includes Windows Settings, packages from configured WinGet sources, and  package settings from DSC v3 enabled packages.
+* Support for exporting the configuration of the current device. This includes Windows Settings, packages from configured WinGet sources, and package settings from DSC v3 enabled packages.
 
 ## Experimental Features
 * Experimental support for Fonts

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,0 +1,20 @@
+## New in v1.11
+* Dropped support for running on 32-bit ARM
+* Support for [Microsoft Desired State Configuration (DSC) v3](https://learn.microsoft.com/powershell/dsc/overview?view=dsc-3.0).
+* Support for exporting the configuration of the current device. This includes Windows Settings, packages from configured WinGet sources, and  package settings from DSC v3 enabled packages.
+
+## Experimental Features
+* Experimental support for Fonts
+
+---
+### Experimental support for Fonts
+The following snippet enables experimental support for fonts via `winget settings`. The `winget font list` command will list installed font families and the number of installed font faces.
+```JSON
+{
+  "$schema" "https://aka.ms/winget-settings.schema.json",
+  "experimentalFeatures": {
+    "fonts": true
+  }
+}
+
+```

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -354,3 +354,13 @@ You can enable the feature as shown below.
        "resume": true
    },
 ```
+
+### fonts
+
+This feature enables support for fonts via `winget settings`. The `winget font list` command will list installed font families and the number of installed font faces.
+
+```json
+  "experimentalFeatures": {
+        "fonts": true
+  },
+```

--- a/src/AppInstallerCLI.sln
+++ b/src/AppInstallerCLI.sln
@@ -37,6 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Project", "Project", "{8D53
 		..\cgmanifest.json = ..\cgmanifest.json
 		..\README.md = ..\README.md
 		..\doc\Settings.md = ..\doc\Settings.md
+		..\doc\ReleaseNotes.md = ..\doc\ReleaseNotes.md
 		..\WinGetInProcCom.nuspec = ..\WinGetInProcCom.nuspec
 		..\WinGetUtil.nuspec = ..\WinGetUtil.nuspec
 	EndProjectSection


### PR DESCRIPTION
This adds a text file with the notes we add to each release here in GitHub.
I intend to update the publishing script to include these notes automatically so I don't have to manually copy them each time.

These notes are not intended to be a full changelog of all versions, but rather just about the changes in the current version. (Although maybe we should have a changelog for all major versions at least.)

It would be nice if we manage to keep the notes up to date every time we make a change, but if we forget we can still edit the release after the fact.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5519)