### PR TITLE
Expose TestUnit method to COM API

### DIFF
--- a/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
+++ b/src/Microsoft.Management.Configuration/ConfigurationProcessor.h
@@ -92,6 +92,9 @@ namespace winrt::Microsoft::Management::Configuration::implementation
 
         Configuration::ApplyConfigurationUnitResult ApplyUnit(const ConfigurationUnit& unit);
         Windows::Foundation::IAsyncOperation<Configuration::ApplyConfigurationUnitResult> ApplyUnitAsync(const ConfigurationUnit& unit);
+        
+        Configuration::TestConfigurationUnitResult TestUnit(const ConfigurationUnit& unit);
+        Windows::Foundation::IAsyncOperation<Configuration::TestConfigurationUnitResult> TestUnitAsync(const ConfigurationUnit& unit);
 
         HRESULT STDMETHODCALLTYPE SetLifetimeWatcher(IUnknown* watcher);
 
@@ -135,6 +138,8 @@ namespace winrt::Microsoft::Management::Configuration::implementation
         Windows::Foundation::Collections::IVector<Configuration::IConfigurationUnitProcessorDetails> FindUnitProcessorsImpl(const Configuration::FindUnitProcessorsOptions& findOptions, AppInstaller::WinRT::AsyncCancellation cancellation = {});
 
         Configuration::ApplyConfigurationUnitResult ApplyUnitImpl(const ConfigurationUnit& unit, AppInstaller::WinRT::AsyncCancellation cancellation = {});
+
+        Configuration::TestConfigurationUnitResult TestUnitImpl(const ConfigurationUnit& unit, AppInstaller::WinRT::AsyncCancellation cancellation = {});
 
         IConfigurationGroupProcessor GetSetGroupProcessor(const Configuration::ConfigurationSet& configurationSet);
 

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl
@@ -1028,6 +1028,10 @@ namespace Microsoft.Management.Configuration
             // Apply the current configuration unit.
             ApplyConfigurationUnitResult ApplyUnit(ConfigurationUnit unit);
             Windows.Foundation.IAsyncOperation<ApplyConfigurationUnitResult> ApplyUnitAsync(ConfigurationUnit unit);
+            
+            // Test the current configuration unit.
+            TestConfigurationUnitResult TestUnit(ConfigurationUnit unit);
+            Windows.Foundation.IAsyncOperation<TestConfigurationUnitResult> TestUnitAsync(ConfigurationUnit unit);
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new feature to test configuration units in the `ConfigurationProcessor` class. The most important changes include the addition of synchronous and asynchronous methods for testing configuration units, along with their implementation and interface definitions.

### Additions to `ConfigurationProcessor` functionality:
* Added `TestUnit` and `TestUnitAsync` methods to the `ConfigurationProcessor` class for testing configuration units. These methods validate the state of the configuration processor and delegate the logic to the new `TestUnitImpl` method. (`src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp`, [src/Microsoft.Management.Configuration/ConfigurationProcessor.cppR1068-R1132](diffhunk://#diff-87fc2b065652feeac26cfec1a39df0f1b1dfea560ed24e28cc0295c04b5e3915R1068-R1132))
* Implemented `TestUnitImpl` to handle the core logic for testing configuration units, including cancellation support, error handling, and telemetry logging. (`src/Microsoft.Management.Configuration/ConfigurationProcessor.cpp`, [src/Microsoft.Management.Configuration/ConfigurationProcessor.cppR1068-R1132](diffhunk://#diff-87fc2b065652feeac26cfec1a39df0f1b1dfea560ed24e28cc0295c04b5e3915R1068-R1132))

### Updates to class declarations:
* Declared `TestUnit` and `TestUnitAsync` methods in the `ConfigurationProcessor` class header file. (`src/Microsoft.Management.Configuration/ConfigurationProcessor.h`, [src/Microsoft.Management.Configuration/ConfigurationProcessor.hR96-R98](diffhunk://#diff-66deeaacba01100c96b45ea613141901602b80566334b8c40bc4cf3c0e3b3555R96-R98))
* Added a declaration for the `TestUnitImpl` helper method in the `ConfigurationProcessor` class header file. (`src/Microsoft.Management.Configuration/ConfigurationProcessor.h`, [src/Microsoft.Management.Configuration/ConfigurationProcessor.hR142-R143](diffhunk://#diff-66deeaacba01100c96b45ea613141901602b80566334b8c40bc4cf3c0e3b3555R142-R143))

### Interface updates:
* Updated the `Microsoft.Management.Configuration` interface definition to include `TestUnit` and `TestUnitAsync` methods, enabling the new functionality to be exposed through the interface. (`src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idl`, [src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.idlR1031-R1034](diffhunk://#diff-de807bc50b5ee296264a73fe90a25418d5f2149b89659e8a64be0df2b0518057R1031-R1034))<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5520)