### PR TITLE
Ensure required modules for configuration export and import

### DIFF
--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -49,12 +49,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="TestData\Configuration\ShowDetails_TestRepo_0_3.yml" />
-    <None Remove="TestData\Configuration\WithParameters_0_3.yml" />
-    <None Remove="TestData\empty" />
-    <None Remove="TestData\Manifests\TestUpgradeAddsDependency.1.0.yaml" />
-    <None Remove="TestData\Manifests\TestUpgradeAddsDependency.2.0.yaml" />
-    <None Remove="TestData\Manifests\TestUpgradeAddsDependencyDependent.1.0.yaml" />
     <Content Include="..\..\doc\admx\DesktopAppInstaller.admx" Link="TestData\DesktopAppInstaller.admx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -390,6 +390,25 @@ namespace AppInstallerCLIE2ETests
             Assert.AreEqual(0, result.ExitCode);
         }
 
+        /// <summary>
+        /// RunCommandOnSet test.
+        /// </summary>
+        [Test]
+        public void RunCommandOnSetResourceTest()
+        {
+            var testDir = TestCommon.GetRandomTestDir();
+            var testConfigFile = Path.Combine(testDir, "RunCommandOnSet.yml");
+            File.Copy(TestCommon.GetTestDataFile("Configuration\\RunCommandOnSet.yml"), testConfigFile);
+
+            var result = TestCommon.RunAICLICommand(CommandAndAgreementsAndVerbose, TestCommon.GetTestDataFile("Configuration\\RunCommandOnSet.yml"), timeOut: 300000);
+            Assert.AreEqual(0, result.ExitCode);
+
+            // Verify test file created.
+            string targetFilePath = Path.Combine(testDir, "TestFile.txt");
+            FileAssert.Exists(targetFilePath);
+            Assert.AreEqual("TestContent", File.ReadAllText(targetFilePath));
+        }
+
         private void DeleteResourceArtifacts()
         {
             // Delete all .txt files in the test directory; they are placed there by the tests

--- a/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
@@ -154,7 +154,10 @@ namespace AppInstallerCLIE2ETests
             var showResult = TestCommon.RunAICLICommand(ShowCommand, $"-f {exportFile}", timeOut: 1200000);
             Assert.AreEqual(Constants.ErrorCode.S_OK, showResult.ExitCode);
 
+            Assert.True(showResult.StdOut.Contains("Microsoft.PowerShell"));
+
             Assert.True(showResult.StdOut.Contains("Microsoft.WinGet.Dev/UserSettingsFile"));
+            Assert.True(showResult.StdOut.Contains("Microsoft.WinGet.Dev/AdminSettings"));
             Assert.True(showResult.StdOut.Contains("Microsoft.Windows.Settings/WindowsSettings"));
 
             Assert.True(showResult.StdOut.Contains("Microsoft.WinGet.Dev/Source"));

--- a/src/AppInstallerCLIE2ETests/TestData/Configuration/RunCommandOnSet.yml
+++ b/src/AppInstallerCLIE2ETests/TestData/Configuration/RunCommandOnSet.yml
@@ -1,0 +1,15 @@
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  winget:
+    processor: dscv3
+resources:
+  - name: Test RunCommandOnSet
+    type: Microsoft.DSC.Transitional/RunCommandOnSet
+    properties:
+      executable: pwsh
+      arguments:
+        - -NoProfile
+        - -NoLogo
+        - -Command
+        - |
+          Set-Content -Path ${WinGetConfigRoot}\TestFile.txt -Value 'TestContent'


### PR DESCRIPTION
- Added Microsoft.PowerShell as dependent unit of other Predefined modules.
- Use RunCommandOnSet as awork around for ensuring v2 modules before v3 resource is available
- Also added always apply logic for certain units i.e. Microsoft.DSC.Transitional/RunCommandOnSet
- Added and updated tests