### PR TITLE
Use windows-latest agents in localization pipeline

### DIFF
--- a/azure-pipelines.loc.yml
+++ b/azure-pipelines.loc.yml
@@ -15,7 +15,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Localize
   pool:
-    vmImage: windows-2019
+    vmImage: windows-latest
   variables:
     skipComponentGovernanceDetection: true
     tdbuildTeamId: 8343


### PR DESCRIPTION
The loc pipeline uses windows-2019 agents that are being deprecated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5538)