### PR TITLE
Expand environment variables in override argument

### DIFF
--- a/src/AppInstallerCLICore/Commands/InstallCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/InstallCommand.cpp
@@ -118,6 +118,12 @@ namespace AppInstaller::CLI
     void InstallCommand::ExecuteInternal(Context& context) const
     {
         context.SetFlags(ContextFlag::ShowSearchResultsOnPartialFailure);
+        auto overrideArg = context.Args.GetArg(Execution::Args::Type::Override);
+        if (overrideArg)
+        {
+            std::wstring expanded = wil::ExpandEnvironmentStringsW<std::wstring>(overrideArg.value());
+            context.Args.SetArg(Execution::Args::Type::Override, expanded);
+        }
 
         context << InitializeInstallerDownloadAuthenticatorsMap;
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----

## Summary of Changes

This pull request adds support to expand environment variables passed in the --override argument during execution. The update ensures that any environment variable (e.g., %ProgramFiles% or $HOME) used in the override value is properly expanded before proceeding with the install process.


## Motivation

Previously, environment variables in the override argument were not resolved, potentially leading to incorrect paths or failed executions. This change improves user experience by handling environment expansion automatically, aligning with common CLI expectations and improving script compatibility.

I have read the CLA Document and I hereby sign the CLA.

@microsoft-github-policy-service agree

