### PR TITLE
Move to proper signal for dev/not-dev

### DIFF
--- a/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
+++ b/src/AppInstallerCLICore/AppInstallerCLICore.vcxproj
@@ -279,6 +279,11 @@
       <SubSystem Condition="'$(Configuration)|$(Platform)'=='ReleaseStatic|x64'">Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(UseProdCLSIDs)' == 'true'">
+    <ClCompile>
+      <PreprocessorDefinitions>USE_PROD_CLSIDS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(WingetDisableTestHooks)'=='true'">
     <ClCompile>
       <PreprocessorDefinitions>AICLI_DISABLE_TEST_HOOKS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/AppInstallerCLICore/Commands/DscCommandBase.cpp
+++ b/src/AppInstallerCLICore/Commands/DscCommandBase.cpp
@@ -113,7 +113,7 @@ namespace AppInstaller::CLI
 
             Json::Value result{ Json::ValueType::objectValue };
 
-#ifndef AICLI_DISABLE_TEST_HOOKS
+#ifndef USE_PROD_CLSIDS
             result["executable"] = "wingetdev";
 #else
             result["executable"] = "winget";

--- a/src/AppInstallerCLICore/Commands/DscCommandBase.h
+++ b/src/AppInstallerCLICore/Commands/DscCommandBase.h
@@ -5,7 +5,7 @@
 #include <json/json.h>
 #include <optional>
 
-#ifndef AICLI_DISABLE_TEST_HOOKS
+#ifndef USE_PROD_CLSIDS
 #define WINGET_DSCV3_MODULE_NAME "Microsoft.WinGet.Dev"
 #define WINGET_DSCV3_MODULE_NAME_WIDE L"Microsoft.WinGet.Dev"
 #else


### PR DESCRIPTION
## Change
Use `UseProdCLSIDs` rather than `WingetDisableTestHooks` to drive the dev/not-dev decision in DSC v3 resources.  This only matters to the internal local builds; everywhere else they are the same value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5552)