### PR TITLE
Use SDK 26100 in CommonCore project

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
+++ b/src/AppInstallerCommonCore/AppInstallerCommonCore.vcxproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{5890d6ed-7c3b-40f3-b436-b54f640d9e65}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AppInstallerLoggingCore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>


### PR DESCRIPTION
The last couple of builds have failed due to a missing SDK version 10.0.22621.0, presumably due to the agent images being updated to remove this. The only project where we use this version is CommonCore, everywhere else we use 26100 already. This PR updates CommonCore to use the same SDK version as all the other projects.