### PR TITLE
Add more missing flags for vcpkg

### DIFF
--- a/src/VcpkgCustomTriplets/common.cmake
+++ b/src/VcpkgCustomTriplets/common.cmake
@@ -1,6 +1,6 @@
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_C_FLAGS "/Qspectre /W3 /guard:cf")
-set(VCPKG_CXX_FLAGS "/Qspectre /W3 /guard:cf")
+set(VCPKG_C_FLAGS "/Qspectre /W3 /guard:cf /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
+set(VCPKG_CXX_FLAGS "/Qspectre /W3 /guard:cf /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
 set(VCPKG_INSTALL_OPTIONS, "--debug")
 
 if(PORT MATCHES "cpprestsdk")


### PR DESCRIPTION
Yet another attempt to fix that crash we are seeing 🙃
See #5587

In the past we had added `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` globally to fix a similar crash using `Directory.Build.props`, but that does not flow from MSBuild to vcpkg. This change adds it to all the ports we use.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5592)