### PR TITLE
Swallow provisioned package errors

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
@@ -75,7 +75,15 @@ namespace AppInstaller::Repository::Microsoft
                 IPackageManager9 packageManager9 = packageManager.try_as<IPackageManager9>();
                 if (packageManager9)
                 {
-                    packages = packageManager.FindProvisionedPackages();
+                    try
+                    {
+                        packages = packageManager.FindProvisionedPackages();
+                    }
+                    catch (const winrt::hresult_error& hre)
+                    {
+                        // Historically this API has not been accessible unelevated; if it fails, try to carry on
+                        AICLI_LOG(Repo, Warning, << "FindProvisionedPackages failed, bypassing provisioned packages: 0x" << Logging::SetHRFormat << hre.code());
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #4410 

## Change
Catch errors coming from `FindProvisionedPackages` and ignore them.  This is most likely to happen when the caller is not elevated.

## Validation
```PowerShell
> winget install notepad++.notepad++ --scope machine
Failed to open the predefined source; please report to winget maintainers.
An unexpected error occurred while executing the command:
0x80070005 : Access is denied.

> wingetdev install notepad++.notepad++ --scope machine
Found Notepad++ [Notepad++.Notepad++] Version 8.8.3
This application is licensed to you by its owner.
Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.
Downloading https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.8.3/npp.8.8.3.Installer.x64.exe
  ██████████████████████████████  6.52 MB / 6.52 MB
Successfully verified installer hash
Starting package install...
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5595)