### PR TITLE
Resolve nuget package graph for .NET projects together

### DIFF
--- a/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
+++ b/src/AppInstallerCLICore/ConfigurationSetProcessorFactoryRemoting.cpp
@@ -20,7 +20,7 @@ namespace AppInstaller::CLI::ConfigurationRemoting
     namespace
     {
         // The executable file name for the remote server process.
-        constexpr std::wstring_view s_RemoteServerFileName = L"ConfigurationRemotingServer\\ConfigurationRemotingServer.exe"sv;
+        constexpr std::wstring_view s_RemoteServerFileName = L"DotNet\\ConfigurationRemotingServer.exe"sv;
 
         constexpr std::wstring_view s_ProcessorEngine_PowerShell = L"pwsh"sv;
         constexpr std::wstring_view s_ProcessorEngine_DSCv3 = L"dscv3"sv;

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -227,6 +227,7 @@
   <Target Name="WinGetIncludeAdditionalFilesInPackage" AfterTargets="_ComputeAppxPackagePayload">
     <PropertyGroup>
       <WinGetAdditionalPackageFileRoot>$(SolutionDir)</WinGetAdditionalPackageFileRoot>
+      <WinGetDotNetDirectoryName>DotNet</WinGetDotNetDirectoryName>
     </PropertyGroup>
     <Message Importance="normal" Text="WinGetAdditionalPackageFileRoot = $(WinGetAdditionalPackageFileRoot)" />
     <ItemGroup>
@@ -243,11 +244,11 @@
         <PackagePath>Microsoft.Management.Configuration.winmd</PackagePath>
       </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\ConfigurationRemotingServer\net8.0-windows10.0.26100.0\$(ConfigServerRid)\**\*">
-        <PackagePath>ConfigurationRemotingServer</PackagePath>
+        <PackagePath>$(WinGetDotNetDirectoryName)</PackagePath>
         <Recurse>true</Recurse>
       </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Deployment.OutOfProc\Microsoft.Management.Deployment.OutOfProc.dll">
-        <PackagePath>ConfigurationRemotingServer\Microsoft.Management.Deployment.dll</PackagePath>
+        <PackagePath>$(WinGetDotNetDirectoryName)\Microsoft.Management.Deployment.dll</PackagePath>
       </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(SolutionDir)\PowerShell\ExternalModules\**\*">
         <PackagePath>ExternalModules</PackagePath>

--- a/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
+++ b/src/AppInstallerCLIPackage/AppInstallerCLIPackage.wapproj
@@ -246,12 +246,8 @@
         <PackagePath>ConfigurationRemotingServer</PackagePath>
         <Recurse>true</Recurse>
       </WinGetAdditionalPackageFile>
-      <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\WinGetMCPServer\net8.0-windows10.0.26100.0\$(ConfigServerRid)\**\*">
-        <PackagePath>WinGetMCPServer</PackagePath>
-        <Recurse>true</Recurse>
-      </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(WinGetAdditionalPackageFileRoot)\$(PlatformTarget)\$(Configuration)\Microsoft.Management.Deployment.OutOfProc\Microsoft.Management.Deployment.OutOfProc.dll">
-        <PackagePath>WinGetMCPServer\Microsoft.Management.Deployment.dll</PackagePath>
+        <PackagePath>ConfigurationRemotingServer\Microsoft.Management.Deployment.dll</PackagePath>
       </WinGetAdditionalPackageFile>
       <WinGetAdditionalPackageFile Include="$(SolutionDir)\PowerShell\ExternalModules\**\*">
         <PackagePath>ExternalModules</PackagePath>

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -97,7 +97,7 @@
         </com:Extension>
       </Extensions>
     </Application>
-    <Application Id="WinGetMCPServer" Executable="WinGetMCPServer\WinGetMCPServer.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="WinGetMCPServer" Executable="ConfigurationRemotingServer\WinGetMCPServer.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="WinGet Dev MCP Server" Square150x150Logo="Images\MedTile.png" Square44x44Logo="Images\AppList.png" Description="The WinGet MCP server." BackgroundColor="#0078d7" AppListEntry="none" >
         <uap:DefaultTile/>
       </uap:VisualElements >

--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -97,7 +97,7 @@
         </com:Extension>
       </Extensions>
     </Application>
-    <Application Id="WinGetMCPServer" Executable="ConfigurationRemotingServer\WinGetMCPServer.exe" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="WinGetMCPServer" Executable="DotNet\WinGetMCPServer.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="WinGet Dev MCP Server" Square150x150Logo="Images\MedTile.png" Square44x44Logo="Images\AppList.png" Description="The WinGet MCP server." BackgroundColor="#0078d7" AppListEntry="none" >
         <uap:DefaultTile/>
       </uap:VisualElements >

--- a/src/AppInstallerCommonCore/SelfManagement.cpp
+++ b/src/AppInstallerCommonCore/SelfManagement.cpp
@@ -15,7 +15,7 @@ namespace AppInstaller::SelfManagement
 
     // Always use AppInstaller's package family name for wingetdev
     static constexpr std::wstring_view s_AppInstallerPfn = L"Microsoft.DesktopAppInstaller_8wekyb3d8bbwe"sv;
-    constexpr std::wstring_view s_RemoteServerFileName = L"ConfigurationRemotingServer\\ConfigurationRemotingServer.exe";
+    constexpr std::wstring_view s_RemoteServerFileName = L"DotNet\\ConfigurationRemotingServer.exe";
 
     bool IsStubPreferred()
     {

--- a/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
+++ b/src/ConfigurationRemotingServer/ConfigurationRemotingServer.csproj
@@ -33,6 +33,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Management.Configuration.Processor\Microsoft.Management.Configuration.Processor.csproj" />
     <ProjectReference Include="..\Microsoft.Management.Configuration\Microsoft.Management.Configuration.vcxproj" />
+    <!-- Pull in any other .NET projects that need to ship with the package so that they can resolve the nuget graph together and land in the same output location. -->
+    <ProjectReference Include="..\WinGetMCPServer\WinGetMCPServer.csproj" />
   </ItemGroup>
 
   <Target Name="PwshFiles" AfterTargets="AfterBuild">

--- a/src/targets/ReferenceEmbeddedCsWinRTProject.targets
+++ b/src/targets/ReferenceEmbeddedCsWinRTProject.targets
@@ -17,7 +17,7 @@
       <!--Do not publish projection source winmd files, but do include implementation dlls -->
       <ReferenceCopyLocalPaths Remove="@(WinGetRemovedReferences)" />
       <ReferenceCopyLocalPaths Include="@(WinGetRemovedReferences->'%(RootDir)%(Directory)%(DestinationSubDirectory)%(Implementation)')"
-                               Condition="'%(WinGetRemovedReferences.Implementation)' != '' AND Exists('%(WinGetRemovedReferences.RootDir)%(WinGetRemovedReferences.Directory)%(WinGetRemovedReferences.DestinationSubDirectory)%(WinGetRemovedReferences.Implementation)')" />
+                               Condition="'%(WinGetRemovedReferences.Implementation)' != '' AND '$([System.IO.Path]::GetExtension(%(WinGetRemovedReferences.Implementation)))' == '.dll' AND Exists('%(WinGetRemovedReferences.RootDir)%(WinGetRemovedReferences.Directory)%(WinGetRemovedReferences.DestinationSubDirectory)%(WinGetRemovedReferences.Implementation)')" />
       <!--Remove winmd references from deps.json to prevent CLR failing unit test execution-->
       <ReferenceDependencyPaths Remove="@(ReferenceDependencyPaths)" Condition="%(ReferenceDependencyPaths.Extension) == '.winmd'"/>
     </ItemGroup>
@@ -34,6 +34,13 @@
       <Reference Remove="WinRT.Runtime" /> 
       <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="'%(DestinationSubPath)' == 'WinRT.Runtime.dll'"/>
       <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'$([System.IO.Path]::GetFileName(%(HintPath)))' == 'WinRT.Runtime.dll'"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- Remove any items from ReferenceCopyLocalPaths that have CopyLocal set to false. -->
+  <Target Name="WinGetRemoveCopyLocalReferencesAsNeeded" AfterTargets="WinGetRemoveWinMDReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="%(ReferenceCopyLocalPaths.CopyLocal) == 'false'" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Issue
When trying to create the actual package containing the MCP server, we found issues in merging the directory contents.  Specifically, some common nuget packages were used at different versions.

## Change
Reference the MCP project from the configuration server project, forcing the nuget package resolution to consider them as one unit.  This also helpfully outputs them as merged already.

Also change the name of the directory in the package to reflect the expanded contents.

## Validation
My locally built package works for both MCP and configuration scenarios.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5627)