### PR TITLE
Added 3 aliases: ShowCommand.h

### DIFF
--- a/src/AppInstallerCLICore/Commands/ShowCommand.h
+++ b/src/AppInstallerCLICore/Commands/ShowCommand.h
@@ -7,7 +7,7 @@ namespace AppInstaller::CLI
 {
     struct ShowCommand final : public Command
     {
-        ShowCommand(std::string_view parent) : Command("show", { "view" }, parent) {}
+        ShowCommand(std::string_view parent) : Command("show", { "view", "info", "information", "details" }, parent) {}
 
         std::vector<Argument> GetArguments() const override;
 
@@ -23,3 +23,4 @@ namespace AppInstaller::CLI
         void ExecuteInternal(AppInstaller::CLI::Execution::Context& context) const override;
     };
 }
+


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----
I felt like commands like `winget info Bitwarden.Bitwarden` and `winget details Bitwarden.Bitwarden` would seem intuitive when looking up info about a package.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5660)