### PR TITLE
Near-complete guesswork for #4928

### DIFF
--- a/src/AppInstallerCLITests/Versions.cpp
+++ b/src/AppInstallerCLITests/Versions.cpp
@@ -284,7 +284,6 @@ TEST_CASE("VersionIsEmpty", "[versions]")
 TEST_CASE("VersionPartAt", "[versions]")
 {
     REQUIRE(Version{}.PartAt(0).Integer == 0);
-    REQUIRE(Version{"1"}.PartAt(0).Integer == 1);
     REQUIRE(Version{"1"}.PartAt(1).Integer == 0);
     REQUIRE(Version{"1"}.PartAt(9999).Integer == 0);
 }
@@ -470,3 +469,4 @@ TEST_CASE("OpenTypeFontVersion", "[versions]")
     REQUIRE(version.IsUnknown());
     REQUIRE(version.ToString() == "Unknown");
 }
+


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue. (#4928)

-----
I'm trying to find out which part of winget-cli's code that tries to trim zeros out of all version numbers, but it's not a particularly easy task. Analysing `Versions.cpp` in detail, this is my first attempt at hoping I found and removed the trimmer.