### PR TITLE
Improve COM static store usage

### DIFF
--- a/src/AppInstallerCLICore/Commands/TestCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/TestCommand.cpp
@@ -30,7 +30,7 @@ namespace AppInstaller::CLI
         HRESULT WaitForShutdown(Execution::Context& context)
         {
             LogAndReport(context, "Waiting for app shutdown event");
-            if (!ShutdownMonitoring::TerminationSignalHandler::Instance().WaitForAppShutdownEvent())
+            if (!ShutdownMonitoring::TerminationSignalHandler::Instance()->WaitForAppShutdownEvent())
             {
                 LogAndReport(context, "Failed getting app shutdown event");
                 return APPINSTALLER_CLI_ERROR_INTERNAL_ERROR;
@@ -42,7 +42,7 @@ namespace AppInstaller::CLI
 
         HRESULT AppShutdownWindowMessage(Execution::Context& context)
         {
-            auto windowHandle = ShutdownMonitoring::TerminationSignalHandler::Instance().GetWindowHandle();
+            auto windowHandle = ShutdownMonitoring::TerminationSignalHandler::Instance()->GetWindowHandle();
 
             if (windowHandle == NULL)
             {

--- a/src/AppInstallerCLICore/Public/ShutdownMonitoring.h
+++ b/src/AppInstallerCLICore/Public/ShutdownMonitoring.h
@@ -5,6 +5,7 @@
 #include <AppInstallerProgress.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <wil/resource.h>
+#include <memory>
 #include <mutex>
 
 namespace AppInstaller::ShutdownMonitoring
@@ -12,8 +13,12 @@ namespace AppInstaller::ShutdownMonitoring
     // Type to contain the CTRL signal and window messages handler.
     struct TerminationSignalHandler
     {
+        TerminationSignalHandler();
+
+        ~TerminationSignalHandler();
+
         // Gets the singleton handler.
-        static TerminationSignalHandler& Instance();
+        static std::shared_ptr<TerminationSignalHandler> Instance();
 
         // Add a termination listener.
         void AddListener(ICancellable* cancellable);
@@ -33,10 +38,6 @@ namespace AppInstaller::ShutdownMonitoring
 #endif
 
     private:
-        TerminationSignalHandler();
-
-        ~TerminationSignalHandler();
-
         void StartAppShutdown();
 
         static BOOL WINAPI StaticCtrlHandlerFunction(DWORD ctrlType);

--- a/src/AppInstallerCLICore/ShutdownMonitoring.cpp
+++ b/src/AppInstallerCLICore/ShutdownMonitoring.cpp
@@ -34,8 +34,14 @@ namespace AppInstaller::ShutdownMonitoring
         std::lock_guard<std::mutex> lock{ m_listenersLock };
 
         auto itr = std::find(m_listeners.begin(), m_listeners.end(), cancellable);
-        THROW_HR_IF(E_NOT_VALID_STATE, itr == m_listeners.end());
-        m_listeners.erase(itr);
+        if (itr == m_listeners.end())
+        {
+            AICLI_LOG(CLI, Warning, << "TerminationSignalHandler::RemoveListener did not find requested object");
+        }
+        else
+        {
+            m_listeners.erase(itr);
+        }
     }
 
     void TerminationSignalHandler::EnableListener(bool enabled, ICancellable* cancellable)

--- a/src/AppInstallerCLICore/ShutdownMonitoring.cpp
+++ b/src/AppInstallerCLICore/ShutdownMonitoring.cpp
@@ -5,13 +5,19 @@
 #include <AppInstallerErrors.h>
 #include <AppInstallerLogging.h>
 #include <AppInstallerRuntime.h>
+#include <winget/COMStaticStorage.h>
 
 namespace AppInstaller::ShutdownMonitoring
 {
-    TerminationSignalHandler& TerminationSignalHandler::Instance()
+    std::shared_ptr<TerminationSignalHandler> TerminationSignalHandler::Instance()
     {
-        static TerminationSignalHandler s_instance;
-        return s_instance;
+        struct Singleton : public WinRT::COMStaticStorageBase<TerminationSignalHandler>
+        {
+            Singleton() : COMStaticStorageBase(L"WindowsPackageManager.TerminationSignalHandler") {}
+        };
+
+        static Singleton s_instance;
+        return s_instance.Get();
     }
 
     void TerminationSignalHandler::AddListener(ICancellable* cancellable)
@@ -36,11 +42,11 @@ namespace AppInstaller::ShutdownMonitoring
     {
         if (enabled)
         {
-            Instance().AddListener(cancellable);
+            Instance()->AddListener(cancellable);
         }
         else
         {
-            Instance().RemoveListener(cancellable);
+            Instance()->RemoveListener(cancellable);
         }
     }
 
@@ -109,7 +115,7 @@ namespace AppInstaller::ShutdownMonitoring
 
     BOOL WINAPI TerminationSignalHandler::StaticCtrlHandlerFunction(DWORD ctrlType)
     {
-        return Instance().CtrlHandlerFunction(ctrlType);
+        return Instance()->CtrlHandlerFunction(ctrlType);
     }
 
     LRESULT WINAPI TerminationSignalHandler::WindowMessageProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -118,7 +124,7 @@ namespace AppInstaller::ShutdownMonitoring
         {
         case WM_QUERYENDSESSION:
             AICLI_LOG(CLI, Verbose, << "Received WM_QUERYENDSESSION");
-            Instance().StartAppShutdown();
+            Instance()->StartAppShutdown();
             return TRUE;
         case WM_ENDSESSION:
         case WM_CLOSE:
@@ -294,12 +300,12 @@ namespace AppInstaller::ShutdownMonitoring
 
     ServerShutdownSynchronization::ServerShutdownSynchronization()
     {
-        TerminationSignalHandler::Instance().AddListener(this);
+        TerminationSignalHandler::Instance()->AddListener(this);
     }
 
     ServerShutdownSynchronization::~ServerShutdownSynchronization()
     {
-        TerminationSignalHandler::Instance().RemoveListener(this);
+        TerminationSignalHandler::Instance()->RemoveListener(this);
         if (m_shutdownThread.joinable())
         {
             m_shutdownThread.detach();

--- a/src/AppInstallerCLICore/pch.h
+++ b/src/AppInstallerCLICore/pch.h
@@ -57,4 +57,5 @@
 #pragma warning( pop )
 
 #include <wrl/client.h>
+#include <wrl/implements.h>
 #include <AppxPackaging.h>

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -95,5 +95,15 @@ namespace AppInstallerCLIE2ETests
             // Look for the output.
             Assert.True(testCmdTask.Result.StdOut.Contains("Succeeded waiting for app shutdown event"));
         }
+
+        /// <summary>
+        /// Runs winget test canunloadnow expecting that it cannot be unloaded.
+        /// </summary>
+        [Test]
+        public void CanUnloadNowTest()
+        {
+            var result = TestCommon.RunAICLICommand("test", "canunloadnow --verbose");
+            Assert.True(result.StdOut.Contains("DllCannotUnloadNow"));
+        }
     }
 }

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -102,8 +102,17 @@ namespace AppInstallerCLIE2ETests
         [Test]
         public void CanUnloadNowTest()
         {
-            var result = TestCommon.RunAICLICommand("test", "canunloadnow --verbose");
-            Assert.True(result.StdOut.Contains("DllCannotUnloadNow"));
+            var result = TestCommon.RunAICLICommand("test", "can-unload-now --verbose");
+
+            var lines = result.StdOut.Split();
+
+            Assert.AreEqual(5, lines.Length);
+            Assert.True(lines[0].Contains("Internal objects:"));
+            Assert.False(lines[0].Contains("Internal objects: 0"));
+            Assert.True(lines[1].Contains("External objects: 0"));
+            Assert.True(lines[2].Contains("DllCanUnloadNow"));
+            Assert.True(lines[3].Contains("Internal objects: 0"));
+            Assert.True(lines[4].Contains("External objects: 0"));
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -7,6 +7,7 @@
 namespace AppInstallerCLIE2ETests
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,6 +34,12 @@ namespace AppInstallerCLIE2ETests
             if (!TestCommon.ExecutingAsAdministrator && TestCommon.IsCIEnvironment)
             {
                 Assert.Ignore("This test won't work on Window Server as non-admin");
+            }
+
+            if (!Environment.Is64BitProcess)
+            {
+                // My guess is that HAM terminates us faster after the CTRL-C on x86...
+                Assert.Ignore("This test is flaky when run as x86.");
             }
 
             if (string.IsNullOrEmpty(TestSetup.Parameters.AICLIPackagePath))
@@ -104,7 +111,7 @@ namespace AppInstallerCLIE2ETests
         {
             var result = TestCommon.RunAICLICommand("test", "can-unload-now --verbose");
 
-            var lines = result.StdOut.Split();
+            var lines = result.StdOut.Split('\n', StringSplitOptions.TrimEntries);
 
             Assert.AreEqual(5, lines.Length);
             Assert.True(lines[0].Contains("Internal objects:"));

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -97,7 +97,7 @@ namespace AppInstallerCLIE2ETests
         }
 
         /// <summary>
-        /// Runs winget test canunloadnow expecting that it cannot be unloaded.
+        /// Runs winget test can-unload-now expecting that it cannot be unloaded.
         /// </summary>
         [Test]
         public void CanUnloadNowTest()

--- a/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
+++ b/src/AppInstallerCLIE2ETests/AppShutdownTests.cs
@@ -111,7 +111,7 @@ namespace AppInstallerCLIE2ETests
         {
             var result = TestCommon.RunAICLICommand("test", "can-unload-now --verbose");
 
-            var lines = result.StdOut.Split('\n', StringSplitOptions.TrimEntries);
+            var lines = result.StdOut.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
             Assert.AreEqual(5, lines.Length);
             Assert.True(lines[0].Contains("Internal objects:"));

--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
@@ -294,7 +294,7 @@ namespace AppInstaller::Repository::Microsoft
 
                     auto value = winrt::make_self<Holder>();
 
-                    const std::shared_lock lock{ m_lock };
+                    const winrt::slim_lock_guard lock{ m_lock };
                     if (auto cachedIndex = m_weak.lock())
                     {
                         return cachedIndex;

--- a/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PredefinedInstalledSourceFactory.cpp
@@ -6,7 +6,7 @@
 #include "Microsoft/SQLiteIndex.h"
 #include "Microsoft/SQLiteIndexSource.h"
 #include <winget/ManifestInstaller.h>
-
+#include <winget/COMStaticStorage.h>
 #include <winget/Registry.h>
 #include <AppInstallerArchitecture.h>
 #include <winget/ExperimentalFeature.h>
@@ -270,41 +270,9 @@ namespace AppInstaller::Repository::Microsoft
 
         struct CachedInstalledIndex
         {
-            // https://devblogs.microsoft.com/oldnewthing/20210215-00/?p=104865
-            struct Singleton
+            struct Singleton : public WinRT::COMStaticStorageBase<CachedInstalledIndex>
             {
-                struct Holder : public winrt::implements<Holder, winrt::Windows::Foundation::IInspectable>
-                {
-                    static constexpr std::wstring_view Guid{ L"{48c47064-4fff-4eca-812c-dbb4f33a8fcb}" };
-                    std::shared_ptr<CachedInstalledIndex> m_shared{ std::make_shared<CachedInstalledIndex>() };
-                };
-
-                std::weak_ptr<CachedInstalledIndex> m_weak;
-                winrt::slim_mutex m_lock;
-
-                std::shared_ptr<CachedInstalledIndex> Get()
-                {
-                    {
-                        const std::shared_lock lock{ m_lock };
-                        if (auto cachedIndex = m_weak.lock())
-                        {
-                            return cachedIndex;
-                        }
-                    }
-
-                    auto value = winrt::make_self<Holder>();
-
-                    const winrt::slim_lock_guard lock{ m_lock };
-                    if (auto cachedIndex = m_weak.lock())
-                    {
-                        return cachedIndex;
-                    }
-
-                    winrt::Windows::ApplicationModel::Core::CoreApplication::Properties().Insert(Holder::Guid, value.as<winrt::Windows::Foundation::IInspectable>());
-
-                    m_weak = value->m_shared;
-                    return value->m_shared;
-                }
+                Singleton() : COMStaticStorageBase(L"WindowsPackageManager.CachedInstalledIndex") {}
             };
 
             CachedInstalledIndex()

--- a/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj
+++ b/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj
@@ -349,6 +349,7 @@
     <ClInclude Include="Public\winget\AsyncTokens.h" />
     <ClInclude Include="Public\winget\Certificates.h" />
     <ClInclude Include="Public\winget\Compression.h" />
+    <ClInclude Include="Public\winget\COMStaticStorage.h" />
     <ClInclude Include="Public\winget\ConfigurationSetProcessorHandlers.h" />
     <ClInclude Include="Public\winget\Filesystem.h" />
     <ClInclude Include="Public\winget\GroupPolicy.h" />
@@ -379,6 +380,7 @@
     <ClCompile Include="AppInstallerStrings.cpp" />
     <ClCompile Include="Certificates.cpp" />
     <ClCompile Include="Compression.cpp" />
+    <ClCompile Include="COMStaticStorage.cpp" />
     <ClCompile Include="DateTime.cpp" />
     <ClCompile Include="Errors.cpp" />
     <ClCompile Include="Filesystem.cpp" />

--- a/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj.filters
+++ b/src/AppInstallerSharedLib/AppInstallerSharedLib.vcxproj.filters
@@ -140,6 +140,9 @@
     <ClInclude Include="Public\winget\ModuleCountBase.h">
       <Filter>Public\winget</Filter>
     </ClInclude>
+    <ClInclude Include="Public\winget\COMStaticStorage.h">
+      <Filter>Public\winget</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -228,6 +231,9 @@
     </ClCompile>
     <ClCompile Include="SQLiteDynamicStorage.cpp">
       <Filter>SQLite</Filter>
+    </ClCompile>
+    <ClCompile Include="COMStaticStorage.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerSharedLib/COMStaticStorage.cpp
+++ b/src/AppInstallerSharedLib/COMStaticStorage.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Public/winget/COMStaticStorage.h"
+
+namespace AppInstaller::WinRT
+{
+    COMStaticStorageStatics& COMStaticStorageStatics::Instance()
+    {
+        static COMStaticStorageStatics s_instance;
+        return s_instance;
+    }
+
+    void COMStaticStorageStatics::AddStaticStorageItem(const winrt::hstring& name, const winrt::Windows::Foundation::IInspectable& item)
+    {
+        COMStaticStorageStatics& instance = Instance();
+        const winrt::slim_lock_guard lock{ instance.m_lock };
+        winrt::Windows::ApplicationModel::Core::CoreApplication::Properties().Insert(name, item);
+        instance.m_items.emplace(std::wstring{ name });
+    }
+
+    void COMStaticStorageStatics::ResetAll() try
+    {
+        COMStaticStorageStatics& instance = Instance();
+        std::set<std::wstring> localItems;
+
+        {
+            const winrt::slim_lock_guard lock{ instance.m_lock };
+            instance.m_items.swap(localItems);
+        }
+
+        for (const auto& item : localItems)
+        {
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Properties().TryRemove(item);
+        }
+    }
+    CATCH_LOG();
+}

--- a/src/AppInstallerSharedLib/Public/winget/COMStaticStorage.h
+++ b/src/AppInstallerSharedLib/Public/winget/COMStaticStorage.h
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include <winrt/Windows.ApplicationModel.Core.h>
+#include <memory>
+#include <shared_mutex>
+#include <set>
+#include <string>
+#include <string_view>
+
+namespace AppInstaller::WinRT
+{
+    // Contains registration for static storage so that they can be cleared.
+    struct COMStaticStorageStatics
+    {
+        // Adds a static storage key to the set of known items.
+        static void AddStaticStorageItem(const winrt::hstring& name, const winrt::Windows::Foundation::IInspectable& item);
+
+        // Removes all known static storage items.
+        static void ResetAll();
+
+    private:
+        COMStaticStorageStatics() = default;
+
+        static COMStaticStorageStatics& Instance();
+
+        winrt::slim_mutex m_lock;
+        std::set<std::wstring> m_items;
+    };
+
+    // https://devblogs.microsoft.com/oldnewthing/20210215-00/?p=104865
+    // Base class for an object that needs to live in the COM static store.
+    // An object needs to use this if it has:
+    //  - static lifetime
+    //  - references to externally implemented COM objects
+    //
+    // Additionally, it should *not* contain references to WRL counted objects implemented by this module.
+    // If it does, it will prevent the module from being unloaded until COM is uninitialized, which is often never.
+    template <typename DataType>
+    struct COMStaticStorageBase
+    {
+    private:
+        struct DataHolder : public winrt::implements<DataHolder, winrt::Windows::Foundation::IInspectable>
+        {
+            std::shared_ptr<DataType> m_shared{ std::make_shared<DataType>() };
+        };
+
+        std::weak_ptr<DataType> m_weak;
+        winrt::slim_mutex m_lock;
+        winrt::hstring m_name;
+
+    public:
+        COMStaticStorageBase(std::wstring_view name) : m_name(name) {}
+
+        std::shared_ptr<DataType> Get()
+        {
+            {
+                const std::shared_lock lock{ m_lock };
+                if (auto cached = m_weak.lock())
+                {
+                    return cached;
+                }
+            }
+
+            auto value = winrt::make_self<DataHolder>();
+
+            const winrt::slim_lock_guard lock{ m_lock };
+            if (auto cached = m_weak.lock())
+            {
+                return cached;
+            }
+
+            COMStaticStorageStatics::AddStaticStorageItem(m_name, value.as<winrt::Windows::Foundation::IInspectable>());
+            m_weak = value->m_shared;
+            return value->m_shared;
+        }
+
+        void Reset()
+        {
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Properties().TryRemove(m_name);
+        }
+    };
+}

--- a/src/AppInstallerSharedLib/pch.h
+++ b/src/AppInstallerSharedLib/pch.h
@@ -59,7 +59,9 @@
 #pragma warning( pop )
 
 #include <wil/cppwinrt.h>
+#include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.ApplicationModel.Resources.h>
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Globalization.h>
 #include <winrt/Windows.System.Profile.h>


### PR DESCRIPTION
## Issue
The use of the COM static store was causing crashes on long lived processes because the implementation of `DllCanUnloadNow` did not count those objects, nor did it clean them up.  This led to our module being unloaded, then when it was reloaded, the recreation of the static store object would invoke the deletion of the old one, which was pointing to the old, unloaded module location.

## Design Considerations
WindowsPackageManager.dll serves many purposes, making the lifetime of statics complex.
- It serves as "in-proc" for the CLI
- It is the core implementation for the in-proc COM
- It is the core implementation for the OOP COM

In order to support in-proc COM, we must put static lifetime COM objects in the static store.  But in order to support unloading, we must also clean them up.  Additionally, we don't want to claim to be in use if the only active objects are our statics (which are typically just event handlers and their owners).

We already use the WRL object count to track OOP COM server lifetime, and similarly we use it to implement `DllCanUnloadNow`.  This is the count externally owned objects; those that the client has requested directly or indirectly.

## Change
The major change is to remove all of our static store objects when WRL says we have no more externally owned.  This is achieved by tracking the names of the objects that we insert and attempting to remove them when appropriate.

The original change to use the static store was templatized and reused to hold the termination signal handler.

## Validation
The new test uses the CLI to validate that the implementation for `DllCanUnloadNow` (`WindowsPackageManagerInProcModuleTerminate`) detects the unload state and properly destroys the relevant objects.  This is done by checking that there are internal objects allocated before the call, but none after.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5680)