### PR TITLE
Fixes for older OSes

### DIFF
--- a/src/AppInstallerCLIPackage/Package.appxmanifest
+++ b/src/AppInstallerCLIPackage/Package.appxmanifest
@@ -7,7 +7,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
-  IgnorableNamespaces="uap uap3 uap5 rescap">
+  IgnorableNamespaces="uap uap3 uap5 rescap desktop6">
   <Identity Name="WinGetDevCLI" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.2.0" />
   <Properties>
     <DisplayName>WinGet Dev CLI</DisplayName>
@@ -137,11 +137,14 @@
         <Interface Name="Microsoft.Management.Configuration.SetProcessorFactory.IPwshConfigurationSetProcessorFactoryProperties" InterfaceId="2C298A30-BD3B-5D00-BCD1-2EB633AB7E3B" />
       </ProxyStub>
     </Extension>
-    <!-- This entry forces the package registration to process the windows.activatableClass.proxyStub extension above. -->
     <Extension Category="windows.activatableClass.inProcessServer">
       <InProcessServer>
-        <Path>WindowsPackageManager.dll</Path>
-        <ActivatableClass ActivatableClassId="Placeholder.Activatable.Class.Do.Not.Use" ThreadingModel="STA" />
+        <Path>Microsoft.Management.Configuration.dll</Path>
+        <ActivatableClass ActivatableClassId="Microsoft.Management.Configuration.ConfigurationUnit" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Management.Configuration.ConfigurationSet" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Management.Configuration.ConfigurationProcessor" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Management.Configuration.ConfigurationParameter" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="Microsoft.Management.Configuration.FindUnitProcessorsOptions" ThreadingModel="both" />
       </InProcessServer>
     </Extension>
   </Extensions>

--- a/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
+++ b/src/Microsoft.Management.Configuration/Microsoft.Management.Configuration.vcxproj
@@ -119,7 +119,7 @@
       <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
       <ModuleDefinitionFile>Microsoft_Management_Configuration.def</ModuleDefinitionFile>
       <WindowsMetadataFile>$(OutDir)$(ProjectName).winmd</WindowsMetadataFile>
-      <AdditionalDependencies>Advapi32.lib;onecoreuap.lib;winsqlite3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;icuuc.lib;icuin.lib;onecoreuap.lib;winsqlite3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
Fixes #5259 

## Change
Register the configuration class names in the manifest to support proper activation (not C++/WinRT fallback behavior).

Change the configuration link inputs to use the older `icu*.dll` files rather than the one that comes in the umbrella of `onecoreuap.lib` [`icu.lib`].

## Validation
Test build works on RS5 VM.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5691)