### PR TITLE
Add RestSource and tests for Manifest v1.12

### DIFF
--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -278,6 +278,7 @@
     <ClCompile Include="RestInterface_1_0.cpp" />
     <ClCompile Include="RestInterface_1_1.cpp" />
     <ClCompile Include="RestInterface_1_10.cpp" />
+    <ClCompile Include="RestInterface_1_12.cpp" />
     <ClCompile Include="RestInterface_1_4.cpp" />
     <ClCompile Include="RestInterface_1_5.cpp" />
     <ClCompile Include="RestInterface_1_6.cpp" />

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -377,6 +377,9 @@
     <ClCompile Include="RestInterface_1_10.cpp">
       <Filter>Source Files\Repository</Filter>
     </ClCompile>
+    <ClCompile Include="RestInterface_1_12.cpp">
+      <Filter>Source Files\Repository</Filter>
+    </ClCompile>
     <ClCompile Include="ManifestComparator.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>

--- a/src/AppInstallerCLITests/RestClient.cpp
+++ b/src/AppInstallerCLITests/RestClient.cpp
@@ -61,7 +61,7 @@ TEST_CASE("GetSupportedInterface", "[RestSource]")
     REQUIRE(RestClient::GetSupportedInterface(TestRestUri, {}, info, {}, version, {})->GetVersion() == version);
 
     // Update this test to next version so that we don't forget to add to supported versions before rest e2e tests are available.
-    Version invalid{ "1.11.0" };
+    Version invalid{ "1.13.0" };
     REQUIRE_THROWS_HR(RestClient::GetSupportedInterface(TestRestUri, {}, info, {}, invalid, {}), APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_VERSION);
 
     Authentication::AuthenticationArguments authArgs;

--- a/src/AppInstallerCLITests/RestInterface_1_12.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_12.cpp
@@ -1,0 +1,411 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "TestCommon.h"
+#include "TestRestRequestHandler.h"
+#include <Rest/Schema/1_12/Interface.h>
+#include <Rest/Schema/IRestClient.h>
+#include <AppInstallerVersions.h>
+#include <AppInstallerErrors.h>
+
+using namespace TestCommon;
+using namespace AppInstaller::Http;
+using namespace AppInstaller::Utility;
+using namespace AppInstaller::Manifest;
+using namespace AppInstaller::Repository;
+using namespace AppInstaller::Repository::Rest;
+using namespace AppInstaller::Repository::Rest::Schema;
+using namespace AppInstaller::Repository::Rest::Schema::V1_12;
+
+namespace
+{
+    const std::string TestRestUriString = "http://restsource.com/api";
+
+    struct GoodManifest_AllFields
+    {
+        utility::string_t GetSampleManifest_AllFields()
+        {
+            return _XPLATSTR(
+                R"delimiter(
+        {
+          "Data": {
+            "PackageIdentifier": "Foo.Bar",
+            "Versions": [
+              {
+                "PackageVersion": "3.0.0abc",
+                "DefaultLocale": {
+                  "PackageLocale": "en-US",
+                  "Publisher": "Foo",
+                  "PublisherUrl": "http://publisher.net",
+                  "PublisherSupportUrl": "http://publisherSupport.net",
+                  "PrivacyUrl": "http://packagePrivacyUrl.net",
+                  "Author": "FooBar",
+                  "PackageName": "Bar",
+                  "PackageUrl": "http://packageUrl.net",
+                  "License": "Foo Bar License",
+                  "LicenseUrl": "http://licenseUrl.net",
+                  "Copyright": "Foo Bar Copyright",
+                  "CopyrightUrl": "http://copyrightUrl.net",
+                  "ShortDescription": "Foo bar is a foo bar.",
+                  "Description": "Foo bar is a placeholder.",
+                  "Tags": [
+                    "FooBar",
+                    "Foo",
+                    "Bar"
+                  ],
+                  "Moniker": "FooBarMoniker",
+                  "ReleaseNotes": "Default release notes",
+                  "ReleaseNotesUrl": "https://DefaultReleaseNotes.net",
+                  "Agreements": [{
+                    "AgreementLabel": "DefaultLabel",
+                    "Agreement": "DefaultText",
+                    "AgreementUrl": "https://DefaultAgreementUrl.net"
+                  }],
+                  "PurchaseUrl": "http://DefaultPurchaseUrl.net",
+                  "InstallationNotes": "Default Installation Notes",
+                  "Documentations": [{
+                    "DocumentLabel": "Default Document Label",
+                    "DocumentUrl": "http://DefaultDocumentUrl.net"
+                  }],
+                  "Icons": [{
+                    "IconUrl": "https://DefaultTestIcon",
+                    "IconFileType": "ico",
+                    "IconResolution": "custom",
+                    "IconTheme": "default",
+                    "IconSha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8123"
+                  }]
+                },
+                "Channel": "",
+                "Locales": [
+                  {
+                    "PackageLocale": "fr-Fr",
+                    "Publisher": "Foo French",
+                    "PublisherUrl": "http://publisher-fr.net",
+                    "PublisherSupportUrl": "http://publisherSupport-fr.net",
+                    "PrivacyUrl": "http://packagePrivacyUrl-fr.net",
+                    "Author": "FooBar French",
+                    "PackageName": "Bar",
+                    "PackageUrl": "http://packageUrl-fr.net",
+                    "License": "Foo Bar License",
+                    "LicenseUrl": "http://licenseUrl-fr.net",
+                    "Copyright": "Foo Bar Copyright",
+                    "CopyrightUrl": "http://copyrightUrl-fr.net",
+                    "ShortDescription": "Foo bar is a foo bar French.",
+                    "Description": "Foo bar is a placeholder French.",
+                    "Tags": [
+                      "FooBarFr",
+                      "FooFr",
+                      "BarFr"
+                    ],
+                    "ReleaseNotes": "Release notes",
+                    "ReleaseNotesUrl": "https://ReleaseNotes.net",
+                    "Agreements": [{
+                      "AgreementLabel": "Label",
+                      "Agreement": "Text",
+                      "AgreementUrl": "https://AgreementUrl.net"
+                    }],
+                    "PurchaseUrl": "http://purchaseUrl.net",
+                    "InstallationNotes": "Installation Notes",
+                    "Documentations": [{
+                      "DocumentLabel": "Document Label",
+                      "DocumentUrl": "http://documentUrl.net"
+                    }],
+                    "Icons": [{
+                      "IconUrl": "https://testIcon",
+                      "IconFileType": "png",
+                      "IconResolution": "32x32",
+                      "IconTheme": "light",
+                      "IconSha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8321"
+                    }]
+                  }
+                ],)delimiter") _XPLATSTR(R"delimiter(
+                "Installers": [
+                  {
+                    "InstallerSha256": "011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6",
+                    "InstallerUrl": "http://foobar.zip",
+                    "Architecture": "x86",
+                    "InstallerLocale": "en-US",
+                    "Platform": [
+                      "Windows.Desktop"
+                    ],
+                    "MinimumOSVersion": "1078",
+                    "InstallerType": "zip",
+                    "Scope": "user",
+                    "InstallModes": [
+                      "interactive"
+                    ],
+                    "InstallerSwitches": {
+                      "Silent": "/s",
+                      "SilentWithProgress": "/s",
+                      "Interactive": "/i",
+                      "InstallLocation": "C:\\Users\\User1",
+                      "Log": "/l",
+                      "Upgrade": "/u",
+                      "Custom": "/custom",
+                      "Repair": "/repair"
+                    },
+                    "InstallerSuccessCodes": [
+                      0
+                    ],
+                    "UpgradeBehavior": "deny",
+                    "Commands": [
+                      "command1"
+                    ],
+                    "Protocols": [
+                       "protocol1"
+                    ],
+                    "FileExtensions": [
+                      ".file-extension"
+                    ],
+                    "Dependencies": {
+                      "WindowsFeatures": [
+                        "feature1"
+                      ],
+                      "WindowsLibraries": [
+                        "library1"
+                      ],
+                      "PackageDependencies": [
+                        {
+                          "PackageIdentifier": "Foo.Baz",
+                          "MinimumVersion": "2.0.0"
+                        }
+                      ],
+                      "ExternalDependencies": [
+                        "FooBarBaz"
+                      ]
+                    },
+                    "ProductCode": "5b6e0f8a-3bbf-4a17-aefd-024c2b3e075d",
+                    "ReleaseDate": "2021-01-01",
+                    "InstallerAbortsTerminal": true,
+                    "InstallLocationRequired": true,
+                    "RequireExplicitUpgrade": true,
+                    "UnsupportedOSArchitectures": [ "arm" ],
+                    "ElevationRequirement": "elevatesSelf",
+                    "AppsAndFeaturesEntries": [{
+                      "DisplayName": "DisplayName",
+                      "DisplayVersion": "DisplayVersion",
+                      "Publisher": "Publisher",
+                      "ProductCode": "ProductCode",
+                      "UpgradeCode": "UpgradeCode",
+                      "InstallerType": "exe"
+                    }],
+                    "Markets" : {
+                      "AllowedMarkets": [ "US" ]
+                    },
+                    "ExpectedReturnCodes": [{
+                      "InstallerReturnCode": 3,
+                      "ReturnResponse": "custom",
+                      "ReturnResponseUrl": "http://returnResponseUrl.net"
+                    }],
+                    "NestedInstallerType": "portable",
+                    "DisplayInstallWarnings": true,
+                    "UnsupportedArguments": [ "log" ],
+                    "NestedInstallerFiles": [{
+                      "RelativeFilePath": "test\\app.exe",
+                      "PortableCommandAlias": "test.exe"
+                    }],
+                    "InstallationMetadata": {
+                      "DefaultInstallLocation": "%TEMP%\\DefaultInstallLocation",
+                      "Files": [{
+                        "RelativeFilePath": "test\\app.exe",
+                        "FileSha256": "011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6",
+                        "FileType": "launch",
+                        "InvocationParameter": "/parameter",
+                        "DisplayName": "test"
+                      }]
+                    },
+                    "DownloadCommandProhibited": true,
+                    "RepairBehavior": "uninstaller",
+                    "ArchiveBinariesDependOnPath": true,
+                    "Authentication": {
+                      "AuthenticationType": "microsoftEntraId",
+                      "MicrosoftEntraIdAuthenticationInfo" : {
+                        "Resource": "TestResource",
+                        "Scope" : "TestScope"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "ContinuationToken": "abcd"
+        })delimiter");
+        }
+
+        void VerifyLocalizations_AllFields(const AppInstaller::Manifest::Manifest& manifest)
+        {
+            REQUIRE(manifest.DefaultLocalization.Locale == "en-US");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Publisher>() == "Foo");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PublisherUrl>() == "http://publisher.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PublisherSupportUrl>() == "http://publisherSupport.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PrivacyUrl>() == "http://packagePrivacyUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Author>() == "FooBar");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PackageName>() == "Bar");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PackageUrl>() == "http://packageUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::License>() == "Foo Bar License");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::LicenseUrl>() == "http://licenseUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Copyright>() == "Foo Bar Copyright");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::CopyrightUrl>() == "http://copyrightUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::ShortDescription>() == "Foo bar is a foo bar.");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Description>() == "Foo bar is a placeholder.");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Tags>().size() == 3);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Tags>().at(0) == "FooBar");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Tags>().at(1) == "Foo");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Tags>().at(2) == "Bar");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::ReleaseNotes>() == "Default release notes");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::ReleaseNotesUrl>() == "https://DefaultReleaseNotes.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Agreements>().size() == 1);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Agreements>().at(0).Label == "DefaultLabel");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Agreements>().at(0).AgreementText == "DefaultText");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Agreements>().at(0).AgreementUrl == "https://DefaultAgreementUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::PurchaseUrl>() == "http://DefaultPurchaseUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::InstallationNotes>() == "Default Installation Notes");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Documentations>().size() == 1);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Documentations>().at(0).DocumentLabel == "Default Document Label");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Documentations>().at(0).DocumentUrl == "http://DefaultDocumentUrl.net");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().size() == 1);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().at(0).Url == "https://DefaultTestIcon");
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().at(0).FileType == IconFileTypeEnum::Ico);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().at(0).Resolution == IconResolutionEnum::Custom);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().at(0).Theme == IconThemeEnum::Default);
+            REQUIRE(manifest.DefaultLocalization.Get<Localization::Icons>().at(0).Sha256 == AppInstaller::Utility::SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8123"));
+
+            REQUIRE(manifest.Localizations.size() == 1);
+            ManifestLocalization frenchLocalization = manifest.Localizations.at(0);
+            REQUIRE(frenchLocalization.Locale == "fr-Fr");
+            REQUIRE(frenchLocalization.Get<Localization::Publisher>() == "Foo French");
+            REQUIRE(frenchLocalization.Get<Localization::PublisherUrl>() == "http://publisher-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::PublisherSupportUrl>() == "http://publisherSupport-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::PrivacyUrl>() == "http://packagePrivacyUrl-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::Author>() == "FooBar French");
+            REQUIRE(frenchLocalization.Get<Localization::PackageName>() == "Bar");
+            REQUIRE(frenchLocalization.Get<Localization::PackageUrl>() == "http://packageUrl-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::License>() == "Foo Bar License");
+            REQUIRE(frenchLocalization.Get<Localization::LicenseUrl>() == "http://licenseUrl-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::Copyright>() == "Foo Bar Copyright");
+            REQUIRE(frenchLocalization.Get<Localization::CopyrightUrl>() == "http://copyrightUrl-fr.net");
+            REQUIRE(frenchLocalization.Get<Localization::ShortDescription>() == "Foo bar is a foo bar French.");
+            REQUIRE(frenchLocalization.Get<Localization::Description>() == "Foo bar is a placeholder French.");
+            REQUIRE(frenchLocalization.Get<Localization::Tags>().size() == 3);
+            REQUIRE(frenchLocalization.Get<Localization::Tags>().at(0) == "FooBarFr");
+            REQUIRE(frenchLocalization.Get<Localization::Tags>().at(1) == "FooFr");
+            REQUIRE(frenchLocalization.Get<Localization::Tags>().at(2) == "BarFr");
+            REQUIRE(frenchLocalization.Get<Localization::ReleaseNotes>() == "Release notes");
+            REQUIRE(frenchLocalization.Get<Localization::ReleaseNotesUrl>() == "https://ReleaseNotes.net");
+            REQUIRE(frenchLocalization.Get<Localization::Agreements>().size() == 1);
+            REQUIRE(frenchLocalization.Get<Localization::Agreements>().at(0).Label == "Label");
+            REQUIRE(frenchLocalization.Get<Localization::Agreements>().at(0).AgreementText == "Text");
+            REQUIRE(frenchLocalization.Get<Localization::Agreements>().at(0).AgreementUrl == "https://AgreementUrl.net");
+            REQUIRE(frenchLocalization.Get<Localization::PurchaseUrl>() == "http://purchaseUrl.net");
+            REQUIRE(frenchLocalization.Get<Localization::InstallationNotes>() == "Installation Notes");
+            REQUIRE(frenchLocalization.Get<Localization::Documentations>().size() == 1);
+            REQUIRE(frenchLocalization.Get<Localization::Documentations>().at(0).DocumentLabel == "Document Label");
+            REQUIRE(frenchLocalization.Get<Localization::Documentations>().at(0).DocumentUrl == "http://documentUrl.net");
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().size() == 1);
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().at(0).Url == "https://testIcon");
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().at(0).FileType == IconFileTypeEnum::Png);
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().at(0).Resolution == IconResolutionEnum::Square32);
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().at(0).Theme == IconThemeEnum::Light);
+            REQUIRE(frenchLocalization.Get<Localization::Icons>().at(0).Sha256 == AppInstaller::Utility::SHA256::ConvertToBytes("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8321"));
+        }
+
+        void VerifyInstallers_AllFields(const AppInstaller::Manifest::Manifest& manifest)
+        {
+            REQUIRE(manifest.Installers.size() == 1);
+
+            ManifestInstaller actualInstaller = manifest.Installers.at(0);
+            REQUIRE(actualInstaller.Sha256 == AppInstaller::Utility::SHA256::ConvertToBytes("011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6"));
+            REQUIRE(actualInstaller.Url == "http://foobar.zip");
+            REQUIRE(actualInstaller.Arch == Architecture::X86);
+            REQUIRE(actualInstaller.Locale == "en-US");
+            REQUIRE(actualInstaller.Platform.size() == 1);
+            REQUIRE(actualInstaller.Platform[0] == PlatformEnum::Desktop);
+            REQUIRE(actualInstaller.MinOSVersion == "1078");
+            REQUIRE(actualInstaller.BaseInstallerType == InstallerTypeEnum::Zip);
+            REQUIRE(actualInstaller.Scope == ScopeEnum::User);
+            REQUIRE(actualInstaller.InstallModes.size() == 1);
+            REQUIRE(actualInstaller.InstallModes.at(0) == InstallModeEnum::Interactive);
+            REQUIRE(actualInstaller.Switches.size() == 8);
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Silent) == "/s");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::SilentWithProgress) == "/s");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Interactive) == "/i");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::InstallLocation) == "C:\\Users\\User1");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Log) == "/l");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Update) == "/u");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Custom) == "/custom");
+            REQUIRE(actualInstaller.Switches.at(InstallerSwitchType::Repair) == "/repair");
+            REQUIRE(actualInstaller.InstallerSuccessCodes.size() == 1);
+            REQUIRE(actualInstaller.InstallerSuccessCodes.at(0) == 0);
+            REQUIRE(actualInstaller.UpdateBehavior == UpdateBehaviorEnum::Deny);
+            REQUIRE(actualInstaller.Commands.at(0) == "command1");
+            REQUIRE(actualInstaller.Protocols.at(0) == "protocol1");
+            REQUIRE(actualInstaller.FileExtensions.at(0) == ".file-extension");
+            REQUIRE(actualInstaller.Dependencies.HasExactDependency(DependencyType::WindowsFeature, "feature1"));
+            REQUIRE(actualInstaller.Dependencies.HasExactDependency(DependencyType::WindowsLibrary, "library1"));
+            REQUIRE(actualInstaller.Dependencies.HasExactDependency(DependencyType::Package, "Foo.Baz", "2.0.0"));
+            REQUIRE(actualInstaller.Dependencies.HasExactDependency(DependencyType::External, "FooBarBaz"));
+            REQUIRE(actualInstaller.PackageFamilyName == "");
+            REQUIRE(actualInstaller.ProductCode == "5b6e0f8a-3bbf-4a17-aefd-024c2b3e075d");
+            REQUIRE(actualInstaller.ReleaseDate == "2021-01-01");
+            REQUIRE(actualInstaller.InstallerAbortsTerminal);
+            REQUIRE(actualInstaller.InstallLocationRequired);
+            REQUIRE(actualInstaller.RequireExplicitUpgrade);
+            REQUIRE(actualInstaller.ElevationRequirement == ElevationRequirementEnum::ElevatesSelf);
+            REQUIRE(actualInstaller.UnsupportedOSArchitectures.size() == 1);
+            REQUIRE(actualInstaller.UnsupportedOSArchitectures.at(0) == Architecture::Arm);
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.size() == 1);
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).DisplayName == "DisplayName");
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).DisplayVersion == "DisplayVersion");
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).Publisher == "Publisher");
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).ProductCode == "ProductCode");
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).UpgradeCode == "UpgradeCode");
+            REQUIRE(actualInstaller.AppsAndFeaturesEntries.at(0).InstallerType == InstallerTypeEnum::Exe);
+            REQUIRE(actualInstaller.Markets.AllowedMarkets.size() == 1);
+            REQUIRE(actualInstaller.Markets.AllowedMarkets.at(0) == "US");
+            REQUIRE(actualInstaller.ExpectedReturnCodes.at(3).ReturnResponseEnum == ExpectedReturnCodeEnum::Custom);
+            REQUIRE(actualInstaller.ExpectedReturnCodes.at(3).ReturnResponseUrl == "http://returnResponseUrl.net");
+            REQUIRE(actualInstaller.NestedInstallerType == InstallerTypeEnum::Portable);
+            REQUIRE(actualInstaller.DisplayInstallWarnings);
+            REQUIRE(actualInstaller.UnsupportedArguments.size() == 1);
+            REQUIRE(actualInstaller.UnsupportedArguments.at(0) == UnsupportedArgumentEnum::Log);
+            REQUIRE(actualInstaller.NestedInstallerFiles.size() == 1);
+            REQUIRE(actualInstaller.NestedInstallerFiles.at(0).RelativeFilePath == "test\\app.exe");
+            REQUIRE(actualInstaller.NestedInstallerFiles.at(0).PortableCommandAlias == "test.exe");
+            REQUIRE(actualInstaller.InstallationMetadata.DefaultInstallLocation == "%TEMP%\\DefaultInstallLocation");
+            REQUIRE(actualInstaller.InstallationMetadata.Files.size() == 1);
+            REQUIRE(actualInstaller.InstallationMetadata.Files.at(0).RelativeFilePath == "test\\app.exe");
+            REQUIRE(actualInstaller.InstallationMetadata.Files.at(0).FileType == InstalledFileTypeEnum::Launch);
+            REQUIRE(actualInstaller.InstallationMetadata.Files.at(0).FileSha256 == AppInstaller::Utility::SHA256::ConvertToBytes("011048877dfaef109801b3f3ab2b60afc74f3fc4f7b3430e0c897f5da1df84b6"));
+            REQUIRE(actualInstaller.InstallationMetadata.Files.at(0).InvocationParameter == "/parameter");
+            REQUIRE(actualInstaller.InstallationMetadata.Files.at(0).DisplayName == "test");
+            REQUIRE(actualInstaller.DownloadCommandProhibited);
+            REQUIRE(actualInstaller.RepairBehavior == RepairBehaviorEnum::Uninstaller);
+            REQUIRE(actualInstaller.ArchiveBinariesDependOnPath);
+            REQUIRE(actualInstaller.AuthInfo.Type == AppInstaller::Authentication::AuthenticationType::MicrosoftEntraId);
+            REQUIRE(actualInstaller.AuthInfo.MicrosoftEntraIdInfo.has_value());
+            REQUIRE(actualInstaller.AuthInfo.MicrosoftEntraIdInfo->Resource == "TestResource");
+            REQUIRE(actualInstaller.AuthInfo.MicrosoftEntraIdInfo->Scope == "TestScope");
+        }
+    };
+}
+
+TEST_CASE("GetManifests_GoodResponse_V1_12", "[RestSource][Interface_1_12]")
+{
+    GoodManifest_AllFields sampleManifest;
+    utility::string_t sample = sampleManifest.GetSampleManifest_AllFields();
+    HttpClientHelper helper{ GetTestRestRequestHandler(web::http::status_codes::OK, std::move(sample)) };
+    Interface v1_12{ TestRestUriString, std::move(helper), {} };
+    std::vector<Manifest> manifests = v1_12.GetManifests("Foo.Bar");
+    REQUIRE(manifests.size() == 1);
+
+    // Verify manifest is populated
+    Manifest& manifest = manifests[0];
+    REQUIRE(manifest.Id == "Foo.Bar");
+    REQUIRE(manifest.Version == "3.0.0abc");
+    REQUIRE(manifest.Moniker == "FooBarMoniker");
+    REQUIRE(manifest.Channel == "");
+    REQUIRE(manifest.ManifestVersion == AppInstaller::Manifest::ManifestVer{ "1.12.0" });
+    sampleManifest.VerifyLocalizations_AllFields(manifest);
+    sampleManifest.VerifyInstallers_AllFields(manifest);
+}

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -383,6 +383,8 @@
     <ClInclude Include="Rest\Schema\1_0\Json\SearchResponseDeserializer.h" />
     <ClInclude Include="Rest\Schema\1_10\Interface.h" />
     <ClInclude Include="Rest\Schema\1_10\Json\ManifestDeserializer.h" />
+    <ClInclude Include="Rest\Schema\1_12\Interface.h" />
+    <ClInclude Include="Rest\Schema\1_12\Json\ManifestDeserializer.h" />
     <ClInclude Include="Rest\Schema\1_1\Interface.h" />
     <ClInclude Include="Rest\Schema\1_1\Json\ManifestDeserializer.h" />
     <ClInclude Include="Rest\Schema\1_1\Json\SearchRequestSerializer.h" />
@@ -480,6 +482,8 @@
     <ClCompile Include="Rest\Schema\1_0\Json\SearchResponseDeserializer_1_0.cpp" />
     <ClCompile Include="Rest\Schema\1_10\Json\ManifestDeserializer_1_10.cpp" />
     <ClCompile Include="Rest\Schema\1_10\RestInterface_1_10.cpp" />
+    <ClCompile Include="Rest\Schema\1_12\Json\ManifestDeserializer_1_12.cpp" />
+    <ClCompile Include="Rest\Schema\1_12\RestInterface_1_12.cpp" />
     <ClCompile Include="Rest\Schema\1_1\Json\ManifestDeserializer_1_1.cpp" />
     <ClCompile Include="Rest\Schema\1_1\Json\SearchRequestSerializer_1_1.cpp" />
     <ClCompile Include="Rest\Schema\1_1\RestInterface_1_1.cpp" />

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -115,6 +115,12 @@
     <Filter Include="Rest\Schema\1_10\Json">
       <UniqueIdentifier>{1a1efb9f-7332-4094-bb98-a4c51ea68b24}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Rest\Schema\1_12">
+      <UniqueIdentifier>{c29ae113-5eb6-41af-b64d-fac925dcf2c2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Rest\Schema\1_12\Json">
+      <UniqueIdentifier>{2075b51e-aa11-473a-bae0-e0d4366f926b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -486,6 +492,12 @@
     <ClInclude Include="Rest\Schema\1_10\Json\ManifestDeserializer.h">
       <Filter>Rest\Schema\1_10\Json</Filter>
     </ClInclude>
+      <ClInclude Include="Rest\Schema\1_12\Interface.h">
+      <Filter>Rest\Schema\1_12</Filter>
+    </ClInclude>
+    <ClInclude Include="Rest\Schema\1_12\Json\ManifestDeserializer.h">
+      <Filter>Rest\Schema\1_12\Json</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -757,6 +769,12 @@
     </ClCompile>
     <ClCompile Include="Rest\Schema\1_10\Json\ManifestDeserializer_1_10.cpp">
       <Filter>Rest\Schema\1_10\Json</Filter>
+    </ClCompile>
+    <ClCompile Include="Rest\Schema\1_12\RestInterface_1_12.cpp">
+      <Filter>Rest\Schema\1_12</Filter>
+    </ClCompile>
+    <ClCompile Include="Rest\Schema\1_12\Json\ManifestDeserializer_1_12.cpp">
+      <Filter>Rest\Schema\1_12\Json</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerRepositoryCore/ManifestJSONParser.cpp
+++ b/src/AppInstallerRepositoryCore/ManifestJSONParser.cpp
@@ -10,6 +10,7 @@
 #include "Rest/Schema/1_7/Json/ManifestDeserializer.h"
 #include "Rest/Schema/1_9/Json/ManifestDeserializer.h"
 #include "Rest/Schema/1_10/Json/ManifestDeserializer.h"
+#include "Rest/Schema/1_12/Json/ManifestDeserializer.h"
 
 namespace AppInstaller::Repository::JSON
 {
@@ -56,9 +57,13 @@ namespace AppInstaller::Repository::JSON
             {
                 m_pImpl->m_deserializer = std::make_unique<Rest::Schema::V1_9::Json::ManifestDeserializer>();
             }
-            else
+            else if (parts.size() > 1 && parts[1].Integer < 12)
             {
                 m_pImpl->m_deserializer = std::make_unique<Rest::Schema::V1_10::Json::ManifestDeserializer>();
+            }
+            else
+            {
+                m_pImpl->m_deserializer = std::make_unique<Rest::Schema::V1_12::Json::ManifestDeserializer>();
             }
         }
         else

--- a/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
@@ -10,6 +10,7 @@
 #include "Rest/Schema/1_7/Interface.h"
 #include "Rest/Schema/1_9/Interface.h"
 #include "Rest/Schema/1_10/Interface.h"
+#include "Rest/Schema/1_12/Interface.h"
 #include "Rest/Schema/InformationResponseDeserializer.h"
 #include "Rest/Schema/CommonRestConstants.h"
 #include <winget/HttpClientHelper.h>
@@ -24,7 +25,17 @@ using namespace AppInstaller::Http;
 namespace AppInstaller::Repository::Rest
 {
     // Supported versions
-    std::set<Version> WingetSupportedContracts = { Version_1_0_0, Version_1_1_0, Version_1_4_0, Version_1_5_0, Version_1_6_0, Version_1_7_0, Version_1_9_0, Version_1_10_0 };
+    std::set<Version> WingetSupportedContracts = {
+        Version_1_0_0,
+        Version_1_1_0,
+        Version_1_4_0,
+        Version_1_5_0,
+        Version_1_6_0,
+        Version_1_7_0,
+        Version_1_9_0,
+        Version_1_10_0,
+        Version_1_12_0,
+    };
 
     constexpr std::string_view WindowsPackageManagerHeader = "Windows-Package-Manager"sv;
     constexpr size_t WindowsPackageManagerHeaderMaxLength = 1024;
@@ -185,6 +196,10 @@ namespace AppInstaller::Repository::Rest
         else if (version == Version_1_10_0)
         {
             return std::make_unique<Schema::V1_10::Interface>(api, helper, information, additionalHeaders, authArgs);
+        }
+        else if (version == Version_1_12_0)
+        {
+            return std::make_unique<Schema::V1_12::Interface>(api, helper, information, additionalHeaders, authArgs);
         }
 
         THROW_HR(APPINSTALLER_CLI_ERROR_RESTSOURCE_INVALID_VERSION);

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Interface.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Interface.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Rest/Schema/1_10/Interface.h"
+
+namespace AppInstaller::Repository::Rest::Schema::V1_12
+{
+    // Interface to this schema version exposed through IRestClient.
+    struct Interface : public V1_10::Interface
+    {
+        Interface(const std::string& restApi, const Http::HttpClientHelper& helper, IRestClient::Information information, const Http::HttpClientHelper::HttpRequestHeaders& additionalHeaders = {}, Authentication::AuthenticationArguments authArgs = {});
+
+        Interface(const Interface&) = delete;
+        Interface& operator=(const Interface&) = delete;
+
+        Interface(Interface&&) = default;
+        Interface& operator=(Interface&&) = default;
+
+        Utility::Version GetVersion() const override;
+    };
+}

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer.h
@@ -10,8 +10,6 @@ namespace AppInstaller::Repository::Rest::Schema::V1_12::Json
     {
     protected:
 
-        std::optional<Manifest::ManifestInstaller> DeserializeInstaller(const web::json::value& installerJsonObject) const override;
-
         Manifest::InstallerTypeEnum ConvertToInstallerType(std::string_view in) const override;
 
         Manifest::ManifestVer GetManifestVersion() const override;

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Rest/Schema/1_10/Json/ManifestDeserializer.h"
+
+namespace AppInstaller::Repository::Rest::Schema::V1_12::Json
+{
+    // Manifest Deserializer.
+    struct ManifestDeserializer : public V1_10::Json::ManifestDeserializer
+    {
+    protected:
+
+        std::optional<Manifest::ManifestInstaller> DeserializeInstaller(const web::json::value& installerJsonObject) const override;
+
+        Manifest::InstallerTypeEnum ConvertToInstallerType(std::string_view in) const override;
+
+        Manifest::ManifestVer GetManifestVersion() const override;
+    };
+}

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer_1_12.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer_1_12.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "ManifestDeserializer.h"
+#include "Rest/Schema/AuthenticationInfoParser.h"
+#include <winget/JsonUtil.h>
+
+using namespace AppInstaller::Manifest;
+
+namespace AppInstaller::Repository::Rest::Schema::V1_12::Json
+{
+    std::optional<Manifest::ManifestInstaller> ManifestDeserializer::DeserializeInstaller(const web::json::value& installerJsonObject) const
+    {
+        auto result = V1_10::Json::ManifestDeserializer::DeserializeInstaller(installerJsonObject);
+
+        if (result)
+        {
+            auto& installer = result.value();
+
+            installer.AuthInfo = ParseAuthenticationInfo(installerJsonObject, ParseAuthenticationInfoType::Installer, GetManifestVersion());
+        }
+
+        return result;
+    }
+
+    Manifest::InstallerTypeEnum ManifestDeserializer::ConvertToInstallerType(std::string_view in) const
+    {
+        std::string inStrLower = Utility::ToLower(in);
+
+        if (inStrLower == "font")
+        {
+            return InstallerTypeEnum::Font;
+        }
+
+        return V1_10::Json::ManifestDeserializer::ConvertToInstallerType(inStrLower);
+    }
+
+    Manifest::ManifestVer ManifestDeserializer::GetManifestVersion() const
+    {
+        return Manifest::s_ManifestVersionV1_12;
+    }
+}

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer_1_12.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/Json/ManifestDeserializer_1_12.cpp
@@ -9,20 +9,6 @@ using namespace AppInstaller::Manifest;
 
 namespace AppInstaller::Repository::Rest::Schema::V1_12::Json
 {
-    std::optional<Manifest::ManifestInstaller> ManifestDeserializer::DeserializeInstaller(const web::json::value& installerJsonObject) const
-    {
-        auto result = V1_10::Json::ManifestDeserializer::DeserializeInstaller(installerJsonObject);
-
-        if (result)
-        {
-            auto& installer = result.value();
-
-            installer.AuthInfo = ParseAuthenticationInfo(installerJsonObject, ParseAuthenticationInfoType::Installer, GetManifestVersion());
-        }
-
-        return result;
-    }
-
     Manifest::InstallerTypeEnum ManifestDeserializer::ConvertToInstallerType(std::string_view in) const
     {
         std::string inStrLower = Utility::ToLower(in);

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_12/RestInterface_1_12.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_12/RestInterface_1_12.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "Rest/Schema/1_12/Interface.h"
+#include "Rest/Schema/CommonRestConstants.h"
+#include "Rest/Schema/IRestClient.h"
+#include <winget/HttpClientHelper.h>
+#include <winget/JsonUtil.h>
+
+namespace AppInstaller::Repository::Rest::Schema::V1_12
+{
+    Interface::Interface(
+        const std::string& restApi,
+        const Http::HttpClientHelper& httpClientHelper,
+        IRestClient::Information information,
+        const Http::HttpClientHelper::HttpRequestHeaders& additionalHeaders,
+        Authentication::AuthenticationArguments authArgs) : V1_10::Interface(restApi, httpClientHelper, std::move(information), additionalHeaders, std::move(authArgs))
+    {
+        m_requiredRestApiHeaders[JSON::GetUtilityString(ContractVersion)] = JSON::GetUtilityString(Version_1_12_0.ToString());
+    }
+
+    Utility::Version Interface::GetVersion() const
+    {
+        return Version_1_12_0;
+    }
+}

--- a/src/AppInstallerRepositoryCore/Rest/Schema/CommonRestConstants.h
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/CommonRestConstants.h
@@ -14,6 +14,7 @@ namespace AppInstaller::Repository::Rest::Schema
     const Utility::Version Version_1_7_0{ "1.7.0" };
     const Utility::Version Version_1_9_0{ "1.9.0" };
     const Utility::Version Version_1_10_0{ "1.10.0" };
+    const Utility::Version Version_1_12_0{ "1.12.0" };
 
     // General API response constants
     constexpr std::string_view Data = "Data"sv;

--- a/src/WinGetUtilInterop.UnitTests/ManifestUnitTest/V1ManifestReadTest.cs
+++ b/src/WinGetUtilInterop.UnitTests/ManifestUnitTest/V1ManifestReadTest.cs
@@ -37,6 +37,7 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
             V1_7_0,
             V1_9_0,
             V1_10_0,
+            V1_12_0,
         }
 
         /// <summary>
@@ -75,6 +76,11 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
                 Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestCollateral", ManifestStrings.V1_10_0ManifestMerged));
 
             this.ValidateManifestFields(v1_10_0manifest, TestManifestVersion.V1_10_0);
+
+            Manifest v1_12_0manifest = Manifest.CreateManifestFromPath(
+                Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestCollateral", ManifestStrings.V1_12_0ManifestMerged));
+
+            this.ValidateManifestFields(v1_12_0manifest, TestManifestVersion.V1_12_0);
         }
 
         /// <summary>
@@ -293,7 +299,15 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
             }
 
             // Individual installers
-            Assert.Equal(2, manifest.Installers.Count);
+            if (manifestVersion >= TestManifestVersion.V1_12_0)
+            {
+                Assert.Equal(4, manifest.Installers.Count);
+            }
+            else
+            {
+                Assert.Equal(2, manifest.Installers.Count);
+            }
+
             ManifestInstaller installer1 = manifest.Installers[0];
             Assert.Equal("x86", installer1.Arch);
             Assert.Equal("en-GB", installer1.InstallerLocale);
@@ -462,6 +476,30 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
                 Assert.Equal("32x32", icon.IconResolution);
                 Assert.Equal("png", icon.IconFileType);
             }
+
+            if (manifestVersion >= TestManifestVersion.V1_12_0)
+            {
+                // Manifest v12 adds support for the Font installer type and NestedInstallerType,
+                // with two additional installers added to the merged manifest to verify these.
+                ManifestInstaller installer3 = manifest.Installers[2];
+                Assert.Equal("neutral", installer3.Arch);
+                Assert.Equal("zip", installer3.InstallerType);
+                Assert.Equal("https://www.microsoft.com/msixsdk/msixsdkx64.exe", installer3.Url);
+                Assert.Equal("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82", installer3.Sha256);
+                Assert.Equal("font", installer3.NestedInstallerType);
+                Assert.Equal(5, installer3.NestedInstallerFiles.Count);
+                Assert.Equal("relativeFilePath1.otf", installer3.NestedInstallerFiles[0].RelativeFilePath);
+                Assert.Equal("relativeFilePath2.ttf", installer3.NestedInstallerFiles[1].RelativeFilePath);
+                Assert.Equal("relativeFilePath3.fnt", installer3.NestedInstallerFiles[2].RelativeFilePath);
+                Assert.Equal("relativeFilePath4.ttc", installer3.NestedInstallerFiles[3].RelativeFilePath);
+                Assert.Equal("relativeFilePath5.otc", installer3.NestedInstallerFiles[4].RelativeFilePath);
+
+                ManifestInstaller installer4 = manifest.Installers[3];
+                Assert.Equal("neutral", installer4.Arch);
+                Assert.Equal("font", installer4.InstallerType);
+                Assert.Equal("https://www.microsoft.com/msixsdk/msixsdkx64.exe", installer4.Url);
+                Assert.Equal("69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82", installer4.Sha256);
+            }
         }
 
         /// <summary>
@@ -499,6 +537,11 @@ namespace WinGetUtilInterop.UnitTests.ManifestUnitTest
             /// Merged v1.10 manifest.
             /// </summary>
             public const string V1_10_0ManifestMerged = "V1_10ManifestMerged.yaml";
+
+            /// <summary>
+            /// Merged v1.12 manifest.
+            /// </summary>
+            public const string V1_12_0ManifestMerged = "V1_12ManifestMerged.yaml";
 #pragma warning restore SA1310 // FieldNamesMustNotContainUnderscore
 
             /// <summary>

--- a/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_12ManifestMerged.yaml
+++ b/src/WinGetUtilInterop.UnitTests/TestCollateral/V1_12ManifestMerged.yaml
@@ -1,0 +1,278 @@
+PackageIdentifier: microsoft.msixsdk
+PackageVersion: 1.7.32
+PackageLocale: en-US
+Publisher: Microsoft
+PublisherUrl: https://www.microsoft.com
+PublisherSupportUrl: https://www.microsoft.com/support
+PrivacyUrl: https://www.microsoft.com/privacy
+Author: Microsoft
+PackageName: MSIX SDK
+PackageUrl: https://www.microsoft.com/msixsdk/home
+License: MIT License
+LicenseUrl: https://www.microsoft.com/msixsdk/license
+Copyright: Copyright Microsoft Corporation
+CopyrightUrl: https://www.microsoft.com/msixsdk/copyright
+ShortDescription: This is MSIX SDK
+Description: The MSIX SDK project is an effort to enable developers
+Moniker: msixsdk
+Tags:
+  - "appxsdk"
+  - "msixsdk"
+ReleaseNotes: Default release notes
+ReleaseNotesUrl: https://DefaultReleaseNotes.net
+PurchaseUrl: https://DefaultPurchaseUrl.com
+InstallationNotes: Default installation notes
+Documentations:
+  - DocumentLabel: Default document label
+    DocumentUrl: https://DefaultDocumentUrl.com
+Icons:
+  - IconUrl: https://testIcon
+    IconFileType: ico
+    IconResolution: custom
+    IconTheme: default
+    IconSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8123
+Agreements:
+  - AgreementLabel: DefaultLabel
+    Agreement: DefaultText
+    AgreementUrl: https://DefaultAgreementUrl.net
+InstallerLocale: en-US
+Platform:
+  - Windows.Desktop
+  - Windows.Universal
+MinimumOSVersion: 10.0.0.0
+InstallerType: zip
+Scope: machine
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+InstallerSwitches:
+  Custom: /custom
+  SilentWithProgress: /silentwithprogress
+  Silent: /silence
+  Interactive: /interactive
+  Log: /log=<LOGPATH>
+  InstallLocation: /dir=<INSTALLPATH>
+  Upgrade: /upgrade
+  Repair: /repair
+InstallerSuccessCodes:
+  - 1
+  - 0x80070005
+UpgradeBehavior: uninstallPrevious
+Commands:
+  - makemsix
+  - makeappx
+Protocols:
+  - protocol1
+  - protocol2
+FileExtensions:
+  - appx
+  - msix
+  - appxbundle
+  - msixbundle
+Dependencies:
+  WindowsFeatures:
+    - IIS
+  WindowsLibraries:
+    - VC Runtime
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.MsixSdkDep
+      MinimumVersion: 1.0.0
+  ExternalDependencies:
+    - Outside dependencies
+Capabilities:
+  - internetClient
+RestrictedCapabilities:
+  - runFullTrust
+PackageFamilyName: Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
+ProductCode: "{Foo}"
+ReleaseDate: 2021-01-01
+InstallerAbortsTerminal: true
+InstallLocationRequired: true
+RequireExplicitUpgrade: true
+DisplayInstallWarnings: true
+ElevationRequirement: elevatesSelf
+UnsupportedOSArchitectures:
+  - arm
+AppsAndFeaturesEntries:
+  - DisplayName: DisplayName
+    DisplayVersion: DisplayVersion
+    Publisher: Publisher
+    ProductCode: ProductCode
+    UpgradeCode: UpgradeCode
+    InstallerType: exe
+Markets:
+  AllowedMarkets:
+    - US
+ExpectedReturnCodes:
+    - InstallerReturnCode: 2
+      ReturnResponse: contactSupport
+      ReturnResponseUrl: https://defaultReturnResponseUrl.com
+    - InstallerReturnCode: 3
+      ReturnResponse: custom
+UnsupportedArguments:
+  - log
+NestedInstallerType: msi
+NestedInstallerFiles:
+  - RelativeFilePath: RelativeFilePath
+    PortableCommandAlias: PortableCommandAlias
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+  Files:
+    - RelativeFilePath: "main.exe"
+      FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+      FileType: launch
+      InvocationParameter: "/arg"
+      DisplayName: "DisplayName"
+DownloadCommandProhibited: true
+ArchiveBinariesDependOnPath: true
+RepairBehavior: uninstaller
+Authentication:
+  AuthenticationType: microsoftEntraId
+  MicrosoftEntraIdAuthenticationInfo:
+    Resource: DefaultResource
+    Scope: DefaultScope
+Localization:
+- Agreements:
+  - Agreement: Text
+    AgreementLabel: Label
+    AgreementUrl: https://AgreementUrl.net
+  Author: Microsoft UK
+  Copyright: Copyright Microsoft Corporation UK
+  CopyrightUrl: https://www.microsoft.com/msixsdk/copyright/UK
+  Description: The MSIX SDK project is an effort to enable developers UK
+  License: MIT License UK
+  LicenseUrl: https://www.microsoft.com/msixsdk/license/UK
+  PackageLocale: en-GB
+  PackageName: MSIX SDK UK
+  PackageUrl: https://www.microsoft.com/msixsdk/home/UK
+  PrivacyUrl: https://www.microsoft.com/privacy/UK
+  Publisher: Microsoft UK
+  PublisherSupportUrl: https://www.microsoft.com/support/UK
+  PublisherUrl: https://www.microsoft.com/UK
+  ReleaseNotes: Release notes
+  ReleaseNotesUrl: https://ReleaseNotes.net
+  ShortDescription: This is MSIX SDK UK
+  Tags:
+  - appxsdkUK
+  - msixsdkUK
+  PurchaseUrl: https://PurchaseUrl.com
+  InstallationNotes: Installation notes
+  Documentations:
+  - DocumentLabel: Document label
+    DocumentUrl: https://DocumentUrl.com
+  Icons:
+  - IconUrl: https://testIcon2
+    IconFileType: png
+    IconResolution: 32x32
+    IconTheme: dark
+    IconSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8321
+Installers:
+  - Architecture: x86
+    InstallerLocale: en-GB
+    Platform:
+      - Windows.Desktop
+    MinimumOSVersion: 10.0.1.0
+    InstallerType: msix
+    InstallerUrl: https://www.microsoft.com/msixsdk/msixsdkx86.msix
+    InstallerSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+    SignatureSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+    Scope: user
+    InstallModes:
+      - interactive
+    InstallerSwitches:
+      Custom: /c
+      SilentWithProgress: /sp
+      Silent: /s
+      Interactive: /i
+      Log: /l=<LOGPATH>
+      InstallLocation: /d=<INSTALLPATH>
+      Upgrade: /u
+      Repair: /r
+    UpgradeBehavior: install
+    Commands:
+      - makemsixPreview
+      - makeappxPreview
+    Protocols:
+      - protocol1preview
+      - protocol2preview
+    FileExtensions:
+      - appxbundle
+      - msixbundle
+      - appx
+      - msix
+    Dependencies:
+      WindowsFeatures:
+        - PreviewIIS
+      WindowsLibraries:
+        - Preview VC Runtime
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.MsixSdkDepPreview
+          MinimumVersion: 1.0.0
+      ExternalDependencies:
+        - Preview Outside dependencies
+    PackageFamilyName: Microsoft.DesktopAppInstallerPreview_8wekyb3d8bbwe
+    Capabilities:
+      - internetClientPreview
+    RestrictedCapabilities:
+      - runFullTrustPreview
+    ReleaseDate: 2021-02-02
+    InstallerAbortsTerminal: false
+    InstallLocationRequired: false
+    NestedInstallerFiles:
+      - RelativeFilePath: RelativeFilePath2
+        PortableCommandAlias: PortableCommandAlias2
+    RequireExplicitUpgrade: false
+    DisplayInstallWarnings: true
+    ElevationRequirement: elevationRequired
+    NestedInstallerType: msi
+    UnsupportedArguments:
+      - location
+    UnsupportedOSArchitectures:
+      - arm64
+    Markets:
+      ExcludedMarkets:
+        - "US"
+    ExpectedReturnCodes:
+      - InstallerReturnCode: 2
+        ReturnResponse: contactSupport
+        ReturnResponseUrl: https://returnResponseUrl.com
+    DownloadCommandProhibited: true
+    ArchiveBinariesDependOnPath: false
+    RepairBehavior: modify
+    InstallationMetadata:
+      DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+      Files:
+        - RelativeFilePath: "main2.exe"
+          FileSha256: 79D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+          FileType: launch2
+          InvocationParameter: "/arg2"
+          DisplayName: "DisplayName2"
+    Authentication:
+      AuthenticationType: microsoftEntraId
+      MicrosoftEntraIdAuthenticationInfo:
+        Resource: Resource
+        Scope: Scope
+  - Architecture: x64
+    InstallerSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+    InstallerUrl: https://www.microsoft.com/msixsdk/msixsdkx64.exe
+    InstallerType: exe
+    ProductCode: '{Bar}'
+    MSStoreProductIdentifier: fakeIdentifier
+  - Architecture: neutral
+    InstallerType: zip
+    InstallerUrl: https://www.microsoft.com/msixsdk/msixsdkx64.exe
+    InstallerSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+    NestedInstallerType: font
+    NestedInstallerFiles:
+      - RelativeFilePath: relativeFilePath1.otf
+      - RelativeFilePath: relativeFilePath2.ttf
+      - RelativeFilePath: relativeFilePath3.fnt
+      - RelativeFilePath: relativeFilePath4.ttc
+      - RelativeFilePath: relativeFilePath5.otc
+  - Architecture: neutral
+    InstallerType: font
+    InstallerUrl: https://www.microsoft.com/msixsdk/msixsdkx64.exe
+    InstallerSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+ManifestType: merged
+ManifestVersion: 1.12.0

--- a/src/WinGetUtilInterop.UnitTests/WinGetUtilInterop.UnitTests.csproj
+++ b/src/WinGetUtilInterop.UnitTests/WinGetUtilInterop.UnitTests.csproj
@@ -102,6 +102,9 @@
     <None Update="TestCollateral\V1_10ManifestMerged.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestCollateral\V1_12ManifestMerged.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Closes #5694 

Updates the RestSource and interface to support v1.12 Manifest schema.

* Added Manifest 1.12 Schema to the Rest source and support for the new installer type.
* Added tests for v1.12 rest source.
* Added unit tests for WinGetUtilInterop for the v1.12 merged manifest and validating the new installertype.

Tested:
* WinGetUtilInterop Unit tests passed, verified in debugger that the new v1.12 manifest and manifest properties were being tested and validated.
* AppInstallerCLITests for [RestSource] and the new [Interface_1_12] both pass.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
(This is part of schema update for 1.12 so nothing new to add to release notes.)

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----
