### PR TITLE
Improve slow searches involving installed items

### DIFF
--- a/src/AppInstallerCLITests/CompositeSource.cpp
+++ b/src/AppInstallerCLITests/CompositeSource.cpp
@@ -166,6 +166,16 @@ struct CompositeTestSetup
         Composite.AddAvailableSource(Source{ Available });
     }
 
+    ~CompositeTestSetup()
+    {
+        if (Available->CountOfCallsRequiringVersionData || Available->CountOfCallsRequiringManifestData)
+        {
+            std::ostringstream stream;
+            stream << "Version data calls [" << Available->CountOfCallsRequiringVersionData << "] : Manifest data calls [" << Available->CountOfCallsRequiringManifestData << "]";
+            FAIL_CHECK(stream.str());
+        }
+    }
+
     SearchResult Search()
     {
         SearchRequest request;

--- a/src/AppInstallerCLITests/CompositeSource.cpp
+++ b/src/AppInstallerCLITests/CompositeSource.cpp
@@ -166,21 +166,26 @@ struct CompositeTestSetup
         Composite.AddAvailableSource(Source{ Available });
     }
 
-    ~CompositeTestSetup()
+    SearchResult Search(bool disableDataChecks = false)
     {
-        if (Available->CountOfCallsRequiringVersionData || Available->CountOfCallsRequiringManifestData)
-        {
-            std::ostringstream stream;
-            stream << "Version data calls [" << Available->CountOfCallsRequiringVersionData << "] : Manifest data calls [" << Available->CountOfCallsRequiringManifestData << "]";
-            FAIL_CHECK(stream.str());
-        }
-    }
+        size_t initialCountOfCallsRequiringVersionData = Available->CountOfCallsRequiringVersionData;
+        size_t initialCountOfCallsRequiringManifestData = Available->CountOfCallsRequiringManifestData;
 
-    SearchResult Search()
-    {
         SearchRequest request;
         request.Query = RequestMatch(MatchType::Exact, s_Everything_Query);
-        return Composite.Search(request);
+        auto result = Composite.Search(request);
+
+        // We want to prevent calls to these functions for Search as they can require network or I/O activity.
+        size_t countOfCallsRequiringVersionData = Available->CountOfCallsRequiringVersionData - initialCountOfCallsRequiringVersionData;
+        size_t countOfCallsRequiringManifestData = Available->CountOfCallsRequiringManifestData - initialCountOfCallsRequiringManifestData;
+        if (!disableDataChecks && (countOfCallsRequiringVersionData || countOfCallsRequiringManifestData))
+        {
+            std::ostringstream stream;
+            stream << "Version data calls [" << countOfCallsRequiringVersionData << "] : Manifest data calls [" << countOfCallsRequiringManifestData << "]";
+            FAIL(stream.str());
+        }
+
+        return result;
     }
 
     TestPackageHelper MakeInstalled(std::shared_ptr<ISource> source)
@@ -582,7 +587,8 @@ TEST_CASE("CompositePackage_AvailableVersions_ChannelFilteredOut", "[CompositeSo
         return result;
     };
 
-    SearchResult result = setup.Search();
+    // Disable data checks as we call one of the data methods as validation in the search
+    SearchResult result = setup.Search(true);
 
     REQUIRE(result.Matches.size() == 1);
     REQUIRE(result.Matches[0].Package->GetAvailable().size() == 1);
@@ -624,7 +630,8 @@ TEST_CASE("CompositePackage_AvailableVersions_NoChannelFilteredOut", "[Composite
         return result;
     };
 
-    SearchResult result = setup.Search();
+    // Disable data checks as we call one of the data methods as validation in the search
+    SearchResult result = setup.Search(true);
 
     REQUIRE(result.Matches.size() == 1);
     REQUIRE(result.Matches[0].Package->GetAvailable().size() == 1);

--- a/src/AppInstallerCLITests/SQLiteIndexSource.cpp
+++ b/src/AppInstallerCLITests/SQLiteIndexSource.cpp
@@ -233,3 +233,29 @@ TEST_CASE("SQLiteIndexSource_IsSame", "[sqliteindexsource]")
 
     REQUIRE(result1.Matches[0].Package->GetAvailable()[0]->IsSame(result2.Matches[0].Package->GetAvailable()[0].get()));
 }
+
+TEST_CASE("SQLiteIndexSource_Package_ProductCodes", "[sqliteindexsource]")
+{
+    TempFile tempFile{ "repolibtest_tempdb"s, ".db"s };
+    INFO("Using temporary file named: " << tempFile.GetPath());
+
+    SourceDetails details;
+    Manifest manifest;
+    std::string relativePath;
+    std::shared_ptr<SQLiteIndexSource> source = SimpleTestSetup(tempFile, details, manifest, relativePath);
+
+    SearchRequest request;
+    request.Query = RequestMatch(MatchType::Exact, manifest.Id);
+
+    auto results = source->Search(request);
+    REQUIRE(results.Matches.size() == 1);
+    REQUIRE(results.Matches[0].Package);
+
+    auto package = results.Matches[0].Package->GetAvailable()[0];
+
+    auto manifestPCs = manifest.GetProductCodes();
+    auto propertyPCs = package->GetMultiProperty(PackageMultiProperty::ProductCode);
+    REQUIRE(manifestPCs.size() == 1);
+    REQUIRE(propertyPCs.size() == 1);
+    REQUIRE(manifestPCs[0] == propertyPCs[0].get());
+}

--- a/src/AppInstallerCLITests/TestSource.cpp
+++ b/src/AppInstallerCLITests/TestSource.cpp
@@ -191,6 +191,27 @@ namespace TestCommon
         }
     }
 
+    std::vector<TestPackage::LocIndString> TestPackage::GetMultiProperty(PackageMultiProperty property) const
+    {
+        std::vector<LocIndString> result;
+        PackageVersionMultiProperty mappedProperty = PackageMultiPropertyToPackageVersionMultiProperty(property);
+
+        for (const auto& version : Versions)
+        {
+            for (auto&& string : version->GetMultiProperty(mappedProperty))
+            {
+                auto itr = std::lower_bound(result.begin(), result.end(), string);
+
+                if (itr == result.end() || *itr != string)
+                {
+                    result.emplace(itr, std::move(string));
+                }
+            }
+        }
+
+        return result;
+    }
+
     std::vector<PackageVersionKey> TestPackage::GetVersionKeys() const
     {
         if (auto source = GetTestSource())

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -10,6 +10,8 @@
 
 namespace TestCommon
 {
+    struct TestSource;
+
     // IPackageVersion for TestSource
     struct TestPackageVersion : public AppInstaller::Repository::IPackageVersion
     {
@@ -40,6 +42,7 @@ namespace TestCommon
 
     protected:
         static void AddIfHasValueAndNotPresent(const AppInstaller::Utility::NormalizedString& value, std::vector<LocIndString>& target, bool folded = false);
+        TestSource* GetTestSource() const;
     };
 
     // IPackage for TestSource
@@ -76,6 +79,9 @@ namespace TestCommon
         std::weak_ptr<const ISource> Source;
         size_t DefaultIsSameIdentity = 0;
         std::function<bool(const IPackage*, const IPackage*)> IsSameOverride;
+
+    protected:
+        TestSource* GetTestSource() const;
     };
 
     // ICompositePackage for TestSource
@@ -127,6 +133,13 @@ namespace TestCommon
 
         TestSource() = default;
         TestSource(const AppInstaller::Repository::SourceDetails& details) : Details(details) {}
+
+        // Tracking for potential network impacts
+        void IncrementCountOfCallsRequiringVersionData();
+        size_t CountOfCallsRequiringVersionData = 0;
+
+        void IncrementCountOfCallsRequiringManifestData();
+        size_t CountOfCallsRequiringManifestData = 0;
     };
 
     struct TestSourceReference : public AppInstaller::Repository::ISourceReference

--- a/src/AppInstallerCLITests/TestSource.h
+++ b/src/AppInstallerCLITests/TestSource.h
@@ -68,6 +68,7 @@ namespace TestCommon
         }
 
         AppInstaller::Utility::LocIndString GetProperty(AppInstaller::Repository::PackageProperty property) const override;
+        std::vector<AppInstaller::Utility::LocIndString> GetMultiProperty(AppInstaller::Repository::PackageMultiProperty property) const override;
         std::vector<AppInstaller::Repository::PackageVersionKey> GetVersionKeys() const override;
         std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetLatestVersion() const override;
         std::shared_ptr<AppInstaller::Repository::IPackageVersion> GetVersion(const AppInstaller::Repository::PackageVersionKey& versionKey) const override;

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV1.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV1.cpp
@@ -115,6 +115,28 @@ namespace AppInstaller::Repository::Microsoft::details::V1
         return result;
     }
 
+    std::vector<Utility::LocIndString> SQLitePackage::GetMultiProperty(PackageMultiProperty property) const
+    {
+        std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();
+        std::vector<Utility::LocIndString> result;
+        PackageVersionMultiProperty mappedProperty = PackageMultiPropertyToPackageVersionMultiProperty(property);
+
+        for (const auto& version : source->GetIndex().GetVersionKeysById(m_idId))
+        {
+            for (auto&& string : source->GetIndex().GetMultiPropertyByPrimaryId(version.ManifestId, mappedProperty))
+            {
+                auto itr = std::lower_bound(result.begin(), result.end(), string);
+
+                if (itr == result.end() || itr->get() != string)
+                {
+                    result.emplace(itr, std::move(string));
+                }
+            }
+        }
+
+        return result;
+    }
+
     std::vector<PackageVersionKey> SQLitePackage::GetVersionKeys() const
     {
         std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV1.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV1.h
@@ -16,6 +16,8 @@ namespace AppInstaller::Repository::Microsoft::details::V1
         // Inherited via IPackage
         Utility::LocIndString GetProperty(PackageProperty property) const;
 
+        std::vector<Utility::LocIndString> GetMultiProperty(PackageMultiProperty property) const override;
+
         std::vector<PackageVersionKey> GetVersionKeys() const override;
 
         std::shared_ptr<IPackageVersion> GetLatestVersion() const override;

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.cpp
@@ -445,6 +445,19 @@ namespace AppInstaller::Repository::Microsoft::details::V2
         return LocIndString{ result ? std::move(result).value() : std::string{} };
     }
 
+    std::vector<Utility::LocIndString> SQLitePackage::GetMultiProperty(PackageMultiProperty property) const
+    {
+        std::vector<LocIndString> result;
+
+        for (auto&& value : GetReferenceSource()->GetIndex().GetMultiPropertyByPrimaryId(m_packageRowId, PackageMultiPropertyToPackageVersionMultiProperty(property)))
+        {
+            // Values coming from the index will always be localized/independent.
+            result.emplace_back(std::move(value));
+        }
+
+        return result;
+    }
+
     std::vector<PackageVersionKey> SQLitePackage::GetVersionKeys() const
     {
         std::shared_ptr<SQLiteIndexSource> source = GetReferenceSource();

--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.h
@@ -22,6 +22,8 @@ namespace AppInstaller::Repository::Microsoft::details::V2
         // Inherited via IPackage
         Utility::LocIndString GetProperty(PackageProperty property) const;
 
+        std::vector<Utility::LocIndString> GetMultiProperty(PackageMultiProperty property) const override;
+
         std::vector<PackageVersionKey> GetVersionKeys() const override;
 
         std::shared_ptr<IPackageVersion> GetLatestVersion() const override;

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySearch.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySearch.h
@@ -281,6 +281,28 @@ namespace AppInstaller::Repository
         Name,
     };
 
+    // A property of a package that can have multiple values.
+    enum class PackageMultiProperty
+    {
+        // The package family names (PFN) associated with the package.
+        PackageFamilyName,
+        // The product codes associated with the package.
+        ProductCode,
+        // The upgrade codes associated with the package.
+        UpgradeCode,
+        // The normalized names for the package.
+        NormalizedName,
+        // The normalized publisher names for the package.
+        NormalizedPublisher,
+        // The tags associated with the package.
+        Tag,
+        // The commands associated with the package.
+        Command,
+    };
+
+    // Maps the package multi-property value to its package version multi-property value for internal use.
+    PackageVersionMultiProperty PackageMultiPropertyToPackageVersionMultiProperty(PackageMultiProperty property);
+
     // To allow for runtime casting from IPackage to the specific types, this enum contains all of the IPackage implementations.
     enum class IPackageType
     {
@@ -316,6 +338,9 @@ namespace AppInstaller::Repository
 
         // Gets a property of this package.
         virtual Utility::LocIndString GetProperty(PackageProperty property) const = 0;
+
+        // Gets a property of this package that can have multiple values.
+        virtual std::vector<Utility::LocIndString> GetMultiProperty(PackageMultiProperty property) const = 0;
 
         // Gets the source that this package is from.
         virtual Source GetSource() const = 0;

--- a/src/AppInstallerRepositoryCore/RepositorySearch.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySearch.cpp
@@ -117,7 +117,7 @@ namespace AppInstaller::Repository
         case PackageMultiProperty::Tag: return PackageVersionMultiProperty::Tag;
         case PackageMultiProperty::Command: return PackageVersionMultiProperty::Command;
         default:
-            THROW_HR(E_UNEXPECTED);
+            THROW_HR_MSG(E_UNEXPECTED, "PackageMultiProperty must map to a PackageVersionMultiProperty");
         }
     }
 

--- a/src/AppInstallerRepositoryCore/RepositorySearch.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySearch.cpp
@@ -105,6 +105,22 @@ namespace AppInstaller::Repository
         return Version.empty() && Channel.empty();
     }
 
+    PackageVersionMultiProperty PackageMultiPropertyToPackageVersionMultiProperty(PackageMultiProperty property)
+    {
+        switch (property)
+        {
+        case PackageMultiProperty::PackageFamilyName: return PackageVersionMultiProperty::PackageFamilyName;
+        case PackageMultiProperty::ProductCode: return PackageVersionMultiProperty::ProductCode;
+        case PackageMultiProperty::UpgradeCode: return PackageVersionMultiProperty::UpgradeCode;
+        case PackageMultiProperty::NormalizedName: return PackageVersionMultiProperty::Name;
+        case PackageMultiProperty::NormalizedPublisher: return PackageVersionMultiProperty::Publisher;
+        case PackageMultiProperty::Tag: return PackageVersionMultiProperty::Tag;
+        case PackageMultiProperty::Command: return PackageVersionMultiProperty::Command;
+        default:
+            THROW_HR(E_UNEXPECTED);
+        }
+    }
+
     const char* UnsupportedRequestException::what() const noexcept
     {
         if (m_whatMessage.empty())

--- a/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
@@ -207,19 +207,19 @@ namespace AppInstaller::Repository::Rest
             switch (property)
             {
             case PackageVersionMultiProperty::PackageFamilyName:
-                for (std::string pfn : versionInfo.PackageFamilyNames)
+                for (const std::string& pfn : versionInfo.PackageFamilyNames)
                 {
                     Action(result, Utility::LocIndString{ pfn });
                 }
                 break;
             case PackageVersionMultiProperty::ProductCode:
-                for (std::string productCode : versionInfo.ProductCodes)
+                for (const std::string& productCode : versionInfo.ProductCodes)
                 {
                     Action(result, Utility::LocIndString{ productCode });
                 }
                 break;
             case PackageVersionMultiProperty::UpgradeCode:
-                for (std::string upgradeCode : versionInfo.UpgradeCodes)
+                for (const std::string& upgradeCode : versionInfo.UpgradeCodes)
                 {
                     Action(result, Utility::LocIndString{ upgradeCode });
                 }
@@ -227,7 +227,7 @@ namespace AppInstaller::Repository::Rest
             case PackageVersionMultiProperty::Name:
                 if (versionInfo.Manifest)
                 {
-                    for (auto name : versionInfo.Manifest->GetPackageNames())
+                    for (auto&& name : versionInfo.Manifest->GetPackageNames())
                     {
                         Action(result, Utility::LocIndString{ std::move(name) });
                     }
@@ -240,7 +240,7 @@ namespace AppInstaller::Repository::Rest
             case PackageVersionMultiProperty::Publisher:
                 if (versionInfo.Manifest)
                 {
-                    for (auto publisher : versionInfo.Manifest->GetPublishers())
+                    for (auto&& publisher : versionInfo.Manifest->GetPublishers())
                     {
                         Action(result, Utility::LocIndString{ std::move(publisher) });
                     }

--- a/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSource.cpp
@@ -54,6 +54,8 @@ namespace AppInstaller::Repository::Rest
                 }
             }
 
+            std::vector<Utility::LocIndString> GetMultiProperty(PackageMultiProperty property) const override;
+
             std::vector<PackageVersionKey> GetVersionKeys() const override
             {
                 std::shared_ptr<const RestSource> source = GetReferenceSource();
@@ -195,6 +197,99 @@ namespace AppInstaller::Repository::Rest
             mutable std::mutex m_packageVersionsLock;
         };
 
+        void GetMultiPropertyValues(
+            const RestPackage* package,
+            const IRestClient::VersionInfo& versionInfo,
+            PackageVersionMultiProperty property,
+            std::vector<Utility::LocIndString>& result,
+            void (*Action)(std::vector<Utility::LocIndString>&, Utility::LocIndString&&))
+        {
+            switch (property)
+            {
+            case PackageVersionMultiProperty::PackageFamilyName:
+                for (std::string pfn : versionInfo.PackageFamilyNames)
+                {
+                    Action(result, Utility::LocIndString{ pfn });
+                }
+                break;
+            case PackageVersionMultiProperty::ProductCode:
+                for (std::string productCode : versionInfo.ProductCodes)
+                {
+                    Action(result, Utility::LocIndString{ productCode });
+                }
+                break;
+            case PackageVersionMultiProperty::UpgradeCode:
+                for (std::string upgradeCode : versionInfo.UpgradeCodes)
+                {
+                    Action(result, Utility::LocIndString{ upgradeCode });
+                }
+                break;
+            case PackageVersionMultiProperty::Name:
+                if (versionInfo.Manifest)
+                {
+                    for (auto name : versionInfo.Manifest->GetPackageNames())
+                    {
+                        Action(result, Utility::LocIndString{ std::move(name) });
+                    }
+                }
+                else
+                {
+                    Action(result, Utility::LocIndString{ package->PackageInfo().PackageName });
+                }
+                break;
+            case PackageVersionMultiProperty::Publisher:
+                if (versionInfo.Manifest)
+                {
+                    for (auto publisher : versionInfo.Manifest->GetPublishers())
+                    {
+                        Action(result, Utility::LocIndString{ std::move(publisher) });
+                    }
+                }
+                else
+                {
+                    Action(result, Utility::LocIndString{ package->PackageInfo().Publisher });
+                }
+                break;
+            case PackageVersionMultiProperty::Locale:
+                if (versionInfo.Manifest)
+                {
+                    Action(result, Utility::LocIndString{ versionInfo.Manifest->DefaultLocalization.Locale });
+                    for (const auto& loc : versionInfo.Manifest->Localizations)
+                    {
+                        Action(result, Utility::LocIndString{ loc.Locale });
+                    }
+                }
+                break;
+            }
+        }
+
+        std::vector<Utility::LocIndString> RestPackage::GetMultiProperty(PackageMultiProperty property) const
+        {
+            std::scoped_lock versionsLock{ m_packageVersionsLock };
+            std::vector<Utility::LocIndString> result;
+            PackageVersionMultiProperty mappedProperty = PackageMultiPropertyToPackageVersionMultiProperty(property);
+
+            for (const auto& versionInfo : m_package.Versions)
+            {
+                GetMultiPropertyValues(
+                    this,
+                    versionInfo,
+                    mappedProperty,
+                    result,
+                    [](std::vector<Utility::LocIndString>& result, Utility::LocIndString&& string)
+                    {
+                        auto itr = std::lower_bound(result.begin(), result.end(), string);
+
+                        if (itr == result.end() || *itr != string)
+                        {
+                            result.emplace(itr, std::move(string));
+                        }
+                    });
+            }
+
+            return result;
+        }
+
         // The IPackageVersion impl for RestSource.
         struct PackageVersion : public SourceReference, public IPackageVersion
         {
@@ -257,63 +352,16 @@ namespace AppInstaller::Repository::Rest
             std::vector<Utility::LocIndString> GetMultiProperty(PackageVersionMultiProperty property) const override
             {
                 std::vector<Utility::LocIndString> result;
-                switch (property)
-                {
-                case PackageVersionMultiProperty::PackageFamilyName:
-                    for (std::string pfn : m_versionInfo.PackageFamilyNames)
+
+                GetMultiPropertyValues(
+                    m_package.get(),
+                    m_versionInfo,
+                    property,
+                    result,
+                    [](std::vector<Utility::LocIndString>& result, Utility::LocIndString&& string)
                     {
-                        result.emplace_back(Utility::LocIndString{ pfn });
-                    }
-                    break;
-                case PackageVersionMultiProperty::ProductCode:
-                    for (std::string productCode : m_versionInfo.ProductCodes)
-                    {
-                        result.emplace_back(Utility::LocIndString{ productCode });
-                    }
-                    break;
-                case PackageVersionMultiProperty::UpgradeCode:
-                    for (std::string upgradeCode : m_versionInfo.UpgradeCodes)
-                    {
-                        result.emplace_back(Utility::LocIndString{ upgradeCode });
-                    }
-                    break;
-                case PackageVersionMultiProperty::Name:
-                    if (m_versionInfo.Manifest)
-                    {
-                        for (auto name : m_versionInfo.Manifest->GetPackageNames())
-                        {
-                            result.emplace_back(std::move(name));
-                        }
-                    }
-                    else
-                    {
-                        result.emplace_back(m_package->PackageInfo().PackageName);
-                    }
-                    break;
-                case PackageVersionMultiProperty::Publisher:
-                    if (m_versionInfo.Manifest)
-                    {
-                        for (auto publisher : m_versionInfo.Manifest->GetPublishers())
-                        {
-                            result.emplace_back(std::move(publisher));
-                        }
-                    }
-                    else
-                    {
-                        result.emplace_back(m_package->PackageInfo().Publisher);
-                    }
-                    break;
-                case PackageVersionMultiProperty::Locale:
-                    if (m_versionInfo.Manifest)
-                    {
-                        result.emplace_back(m_versionInfo.Manifest->DefaultLocalization.Locale);
-                        for (const auto& loc : m_versionInfo.Manifest->Localizations)
-                        {
-                            result.emplace_back(loc.Locale);
-                        }
-                    }
-                    break;
-                }
+                        result.emplace_back(std::move(string));
+                    });
 
                 return result;
             }

--- a/src/AppInstallerSharedLib/Public/winget/LocIndependent.h
+++ b/src/AppInstallerSharedLib/Public/winget/LocIndependent.h
@@ -47,6 +47,7 @@ namespace AppInstaller::Utility
         bool operator!=(const LocIndString& other) const { return m_value != other.m_value; }
 
         bool operator<(const LocIndString& other) const { return m_value < other.m_value; }
+        bool operator<(const std::string& other) const { return m_value < other; }
 
         friend std::ostream& operator<<(std::ostream& out, const AppInstaller::Utility::LocIndString& lis)
         {


### PR DESCRIPTION
Fixes #5629 
(and probably quite a few more list/upgrade some-query-provided performance related issues)

While things could still be made better, the good case (where files were already cached locally) of the previous behavior trying to complete `winget list Micro` was taking 51 seconds.  With this change, it takes 6 seconds on the debug build.  Given that there is intentionally little to no I/O and much of the CPU time is likely spent in our code, that should speed up more with the release.

## Issue
The indexed `IPackage` implementation for v2 needed to acquire the intermediate manifest to provide the response for `GetVersionKeys`.  Since this is used extensively to perform correlation between available packages and local items during a search, any available packages found by the query would then result in a download/disk read of the intermediate manifest.

## Change
Introduces `IPackage::GetMultiProperty`, allowing code that just wanted to get all of these values across all versions to do so more efficiently.  For the v2 index, this is how the data is already stored in the database.  For the other `IPackage` implementations, the data was also present and is just aggregated from each version's output.

## Validation
Added test for calling new interface function.
Added validation across `CompositeSource` tests to ensure that the functions known to need non-indexed data are not called.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5701)