### PR TITLE
Fix line endings and add IncludePrerelease parameter support

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AssertWinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/AssertWinGetPackageManagerCmdlet.cs
@@ -34,7 +34,7 @@ namespace Microsoft.WinGet.Client.Commands
             }
             else
             {
-                command.Assert(this.Version);
+                command.Assert(this.Version, this.IncludePrerelease.ToBool());
             }
         }
     }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/WinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/Common/WinGetPackageManagerCmdlet.cs
@@ -34,7 +34,6 @@ namespace Microsoft.WinGet.Client.Commands.Common
         /// Gets or sets a value indicating whether to include prerelease winget versions.
         /// </summary>
         [Parameter(
-            ParameterSetName = Constants.IntegrityLatestSet,
             ValueFromPipelineByPropertyName = true)]
         public SwitchParameter IncludePrerelease { get; set; }
     }

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RepairWinGetPackageManagerCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/RepairWinGetPackageManagerCmdlet.cs
@@ -49,7 +49,7 @@ namespace Microsoft.WinGet.Client.Commands
             }
             else
             {
-                this.command.Repair(this.Version, this.AllUsers.ToBool(), this.Force.ToBool());
+                this.command.Repair(this.Version, this.AllUsers.ToBool(), this.Force.ToBool(), this.IncludePrerelease.ToBool());
             }
         }
 


### PR DESCRIPTION
- Convert CRLF to LF line endings across PowerShell cmdlets
- Add IncludePrerelease parameter to Assert-WinGetPackageManager and Repair-WinGetPackageManager
- Make IncludePrerelease parameter available across all parameter sets
- Update WinGetPackageManagerCommand to handle prerelease versions in repair operations

See: #5657
