### PR TITLE
Shorter default installer log filename

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -173,11 +173,9 @@ namespace AppInstaller::CLI::Workflow
                 const auto& manifest = context.Get<Execution::Data::Manifest>();
 
                 auto path = Runtime::GetPathTo(Runtime::PathName::DefaultLogLocation);
-                path /= Logging::FileLogger::DefaultPrefix();
+                path /= Utility::ConvertToUTF16(manifest.Id + '.' + manifest.Version);
                 path += '-';
-                path += Utility::ConvertToUTF16(manifest.Id + '.' + manifest.Version);
-                path += '-';
-                path += Utility::GetCurrentTimeForFilename();
+                path += Utility::GetCurrentTimeForFilename(true);
                 path += Logging::FileLogger::DefaultExt();
 
                 logPath = path.u8string();

--- a/src/AppInstallerCLITests/DateTime.cpp
+++ b/src/AppInstallerCLITests/DateTime.cpp
@@ -82,3 +82,12 @@ TEST_CASE("GetTimePointFromVersion", "[datetime]")
     system_clock::time_point now = system_clock::now();
     REQUIRE(GetTimePointFromVersion(UInt64Version{ StringFromTimePoint(now) }) == time_point_cast<minutes>(now));
 }
+
+TEST_CASE("ShortFileTime", "[datetime]")
+{
+    auto shortTime = GetCurrentTimeForFilename(true);
+    auto longTime = GetCurrentTimeForFilename(false);
+    INFO(shortTime);
+    INFO(longTime);
+    REQUIRE(shortTime.length() < longTime.length());
+}

--- a/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
@@ -7,16 +7,43 @@
 
 namespace AppInstaller::Utility
 {
+    // The individual aspects of a time point.
+    enum class TimeFacet
+    {
+        None        = 0x000,
+        Millisecond = 0x001,
+        Second      = 0x002,
+        Minute      = 0x004,
+        Hour        = 0x008,
+        Day         = 0x010,
+        Month       = 0x020,
+        Year        = 0x040,
+        // `Year - 2000` [2 digits for 75 more years]
+        ShortYear   = 0x080,
+        // Includes unspecified time zone
+        RFC3339     = 0x100,
+        // Limits special character use
+        Filename    = 0x200,
+
+        Default = Year | Month | Day | Hour | Minute | Second | Millisecond,
+        ShortYearSecondPrecision = ShortYear | Month | Day | Hour | Minute | Second,
+    };
+
+    DEFINE_ENUM_FLAG_OPERATORS(TimeFacet);
+
     // Writes the given time to the given stream.
     // Assumes that system_clock uses Linux epoch (as required by C++20 standard).
     // Time is also assumed to be after the epoch.
     void OutputTimePoint(std::ostream& stream, const std::chrono::system_clock::time_point& time, bool useRFC3339 = false);
+    void OutputTimePoint(std::ostream& stream, const std::chrono::system_clock::time_point& time, TimeFacet facet);
 
     // Converts the time point to a string using OutputTimePoint.
     std::string TimePointToString(const std::chrono::system_clock::time_point& time, bool useRFC3339 = false);
+    std::string TimePointToString(const std::chrono::system_clock::time_point& time, TimeFacet facet);
 
     // Gets the current time as a string. Can be used as a file name.
-    std::string GetCurrentTimeForFilename();
+    // Tries to make things a little bit shorter when shortTime == true.
+    std::string GetCurrentTimeForFilename(bool shortTime = false);
 
     // Gets the current date as a string to be used in the ARP registry.
     std::string GetCurrentDateForARP();

--- a/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
+++ b/src/WindowsPackageManager/ConfigurationStaticFunctions.cpp
@@ -90,7 +90,7 @@ namespace ConfigurationShim
             auto& diagnosticsLogger = m_threadGlobals.GetDiagnosticLogger();
             diagnosticsLogger.SetEnabledChannels(AppInstaller::Logging::Channel::All);
             diagnosticsLogger.SetLevel(AppInstaller::Logging::Level::Verbose);
-            diagnosticsLogger.AddLogger(std::make_unique<AppInstaller::Logging::FileLogger>("ConfigStatics"sv));
+            diagnosticsLogger.AddLogger(std::make_unique<AppInstaller::Logging::FileLogger>("WinGetCFG"sv));
 
             if (IsConfigurationAvailable())
             {


### PR DESCRIPTION
## Change
Make `OutputTimePoint` more flexible by allowing arbitrary fields and behaviors to be requested via flags.

Shorten the default installer log filename by removing the leading `WinGet-` and dropping the milliseconds.  Some installers use the log file path as a base with no error handling to ensure a valid path is produced.  Anything we can remove means more likely success.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5705)