### PR TITLE
Add the ARP correlation entry to the context for portable installs

### DIFF
--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -281,7 +281,7 @@ namespace AppInstaller::CLI::Portable
         return true;
     }
 
-    void PortableInstaller::Install( Workflow::OperationType operation = Workflow::OperationType::Install)
+    void PortableInstaller::Install(Workflow::OperationType operation)
     {
         // If the operation is an install, the ARP entry should be created first so that a catastrophic failure
         // leaves the system in a state where an uninstall may be possible
@@ -418,6 +418,19 @@ namespace AppInstaller::CLI::Portable
         InstallDate = Utility::GetCurrentDateForARP();
         URLInfoAbout = manifest.CurrentLocalization.Get<Manifest::Localization::PackageUrl>();
         HelpLink = manifest.CurrentLocalization.Get<Manifest::Localization::PublisherSupportUrl>();
+    }
+
+    AppInstaller::Manifest::AppsAndFeaturesEntry PortableInstaller::GetAppsAndFeaturesEntry()
+    {
+        Manifest::AppsAndFeaturesEntry entry;
+
+        entry.DisplayName = DisplayName;
+        entry.Publisher = Publisher;
+        entry.DisplayVersion = DisplayVersion;
+        entry.InstallerType = Manifest::InstallerTypeEnum::Portable;
+        entry.ProductCode = GetProductCode();
+
+        return entry;
     }
 
     void PortableInstaller::SetExpectedState()

--- a/src/AppInstallerCLICore/PortableInstaller.h
+++ b/src/AppInstallerCLICore/PortableInstaller.h
@@ -59,7 +59,7 @@ namespace AppInstaller::CLI::Portable
             m_desiredEntries = {};
         }
 
-        void Install( AppInstaller::CLI::Workflow::OperationType operation );
+        void Install(AppInstaller::CLI::Workflow::OperationType operation = Workflow::OperationType::Install);
 
         void Uninstall();
 
@@ -90,6 +90,8 @@ namespace AppInstaller::CLI::Portable
         void SetAppsAndFeaturesMetadata(
             const Manifest::Manifest& manifest,
             const std::vector<AppInstaller::Manifest::AppsAndFeaturesEntry>& entries);
+
+        AppInstaller::Manifest::AppsAndFeaturesEntry GetAppsAndFeaturesEntry();
 
     private:
         PortableARPEntry m_portableARPEntry;

--- a/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PortableFlow.cpp
@@ -167,7 +167,7 @@ namespace AppInstaller::CLI::Workflow
         }
 
         portableInstaller.TargetInstallLocation = targetInstallDirectory;
-        portableInstaller.SetAppsAndFeaturesMetadata(context.Get<Execution::Data::Manifest>(), context.Get<Execution::Data::Installer>()->AppsAndFeaturesEntries);
+        portableInstaller.SetAppsAndFeaturesMetadata(context.Get<Execution::Data::Manifest>(), installer.AppsAndFeaturesEntries);
         context.Add<Execution::Data::PortableInstaller>(std::move(portableInstaller));
     }
 
@@ -274,6 +274,7 @@ namespace AppInstaller::CLI::Workflow
             }
 
             portableInstaller.Install(installType);
+            context.Add<Execution::Data::CorrelatedAppsAndFeaturesEntries>({ portableInstaller.GetAppsAndFeaturesEntry() });
             context.Add<Execution::Data::OperationReturnCode>(ERROR_SUCCESS);
             context.Reporter.Warn() << portableInstaller.GetOutputMessage();
         }

--- a/src/AppInstallerCLITests/PortableInstaller.cpp
+++ b/src/AppInstallerCLITests/PortableInstaller.cpp
@@ -47,6 +47,9 @@ TEST_CASE("PortableInstaller_InstallToRegistry", "[PortableInstaller]")
 
     portableInstaller.Install(AppInstaller::CLI::Workflow::OperationType::Install);
 
+    auto entry = portableInstaller.GetAppsAndFeaturesEntry();
+    REQUIRE(entry.ProductCode == portableInstaller.GetProductCode());
+
     PortableInstaller portableInstaller2 = PortableInstaller(ScopeEnum::User, Architecture::X64, "testProductCode");
     REQUIRE(portableInstaller2.ARPEntryExists());
     REQUIRE(std::filesystem::exists(portableInstaller2.PortableTargetFullPath));


### PR DESCRIPTION
Fixes #5688

## Issue
We were not recording ARP changes for portable installs, which prevented the product code from being in the tracking database, which led to inconclusive correlation results for packages with shared normalized name+publisher.

## Change
Portable install flow extracts the `AppsAndFeaturesEntry` for the install and puts it into the `CorrelatedAppsAndFeaturesEntries` context item.

## Validation
Manually confirmed fix, updated test to ensure product code extraction.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5707)