### PR TITLE
Fix two unrelated version issues

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.h
+++ b/src/AppInstallerRepositoryCore/Microsoft/SQLiteIndexSourceV2.h
@@ -45,7 +45,7 @@ namespace AppInstaller::Repository::Microsoft::details::V2
         // Contains the information needed to map a version key to it's rows.
         struct MapKey
         {
-            Utility::NormalizedString Version;
+            Utility::Version Version;
             Utility::NormalizedString Channel;
 
             bool operator<(const MapKey& other) const;

--- a/src/AppInstallerRepositoryCore/Microsoft/Schema/2_0/PackagesTable.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/Schema/2_0/PackagesTable.cpp
@@ -29,7 +29,7 @@ namespace AppInstaller::Repository::Microsoft::Schema::V2_0
 
             for (const ColumnInfo& value : values)
             {
-                ColumnBuilder columnBuilder(value.Name, Type::Int64);
+                ColumnBuilder columnBuilder(value.Name, value.Type);
 
                 if (!value.AllowNull)
                 {

--- a/src/AppInstallerRepositoryCore/RepositorySearch.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySearch.cpp
@@ -96,7 +96,7 @@ namespace AppInstaller::Repository
     {
         return
             ((other.SourceId.empty() || other.SourceId == SourceId) &&
-             (other.Version.empty() || Utility::ICUCaseInsensitiveEquals(other.Version, Version)) &&
+             (other.Version.empty() || Utility::Version{ other.Version } == Utility::Version{ Version }) &&
              (other.Channel.empty() || Utility::ICUCaseInsensitiveEquals(other.Channel, Channel)));
     }
 


### PR DESCRIPTION
Fixes #4928
Fixes providing "1" for the version when the version is actually "1.0" and the like (there is probably an issue filed but I didn't find it after a quick search).

## Issues
Due to SQLite helpfully not being picky about data types, the packages table in the v2 index was using INT64 for every column, when in reality they should mostly by strings (TEXT).  When the version was parsable as a number, it would drop unnecessary portions (trailing 0s).

New code in the v2 index and the composite package changes were using string comparison instead of `Version`, requiring an exact string match rather than `Version` equality.

## Changes
Use the data type that we already had set up rather than always INT64.  This will require a service update to actually fix anything (but doesn't require a client update).

Use `Version` comparisons rather than string in the v2 index and composite package version selection.

## Validation
Added new tests and confirmed via manual usage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5719)