### PR TITLE
Cache information responses from REST sources

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -53,6 +53,7 @@ createpintable
 createportabletable
 createtables
 CRTDECL
+CRYPTPROTECT
 CTLs
 curated
 CURSORPOSITON

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,7 +332,7 @@ jobs:
   - powershell: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers -Latest -Verbose
+      try { Repair-WingetPackageManager -AllUsers -Latest -Verbose } catch { $_.Exception }
       Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,7 +332,7 @@ jobs:
   - powershell: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers -Latest
+      Repair-WingetPackageManager -AllUsers -Latest -ErrorAction Continue
       Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -332,7 +332,7 @@ jobs:
   - powershell: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
       Install-Module Microsoft.WinGet.Client -Repository PSGallery -Force
-      Repair-WingetPackageManager -AllUsers -Latest -ErrorAction Continue
+      Repair-WingetPackageManager -AllUsers -Latest -Verbose
       Install-WinGetPackage -Id Microsoft.Sysinternals.PsTools -Source winget
     displayName: Install Sysinternals PsTools Using Winget
     condition: succeededOrFailed()

--- a/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureCommand.cs
@@ -364,7 +364,7 @@ namespace AppInstallerCLIE2ETests
         public void ConfigureFindUnitProcessors()
         {
             // Find all unit processors.
-            var result = TestCommon.RunAICLICommand("test config-find-unit-processors", string.Empty);
+            var result = TestCommon.RunAICLICommand("test config-find-unit-processors", string.Empty, timeOut: 120000);
             Assert.AreEqual(0, result.ExitCode);
             Assert.True(result.StdOut.Contains("Microsoft/OSInfo"));
 

--- a/src/AppInstallerCLITests/Settings.cpp
+++ b/src/AppInstallerCLITests/Settings.cpp
@@ -281,3 +281,29 @@ TEST_CASE("AttemptSetOnNewValue", "[settings]")
     settingValue = ReadEntireStream(*result);
     REQUIRE(value2 == settingValue);
 }
+
+TEST_CASE("SetAndReadSettingEncrypted", "[settings]")
+{
+    StreamDefinition name{ Type::Encrypted, "encrypted_test_setting" };
+    std::string value = "This is the test setting value";
+
+    Stream stream{ name };
+    REQUIRE(stream.Set(value));
+
+    auto result = stream.Get();
+    REQUIRE(static_cast<bool>(result));
+
+    std::string settingValue = ReadEntireStream(*result);
+    REQUIRE(value == settingValue);
+
+    // Ensure that the data is encrypted
+    name.Type = Type::Standard;
+
+    Stream streamDirect{ name };
+
+    auto resultDirect = streamDirect.Get();
+    REQUIRE(static_cast<bool>(resultDirect));
+
+    std::string settingValueDirect = ReadEntireStream(*resultDirect);
+    REQUIRE(value != settingValueDirect);
+}

--- a/src/AppInstallerCLITests/Settings.cpp
+++ b/src/AppInstallerCLITests/Settings.cpp
@@ -297,7 +297,7 @@ TEST_CASE("SetAndReadSettingEncrypted", "[settings]")
     REQUIRE(value == settingValue);
 
     // Ensure that the data is encrypted
-    name.Type = Type::Standard;
+    name.Type = Type::StandardFile;
 
     Stream streamDirect{ name };
 

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -306,6 +306,14 @@ TEST_CASE("SplitWithSeparator", "[strings]")
     REQUIRE(test5[0] == L"trim");
     REQUIRE(test5[1] == L"spaces");
     REQUIRE(test5[2] == L"");
+
+    std::vector<std::wstring_view> test6 = Split(L" ", '/', true);
+    REQUIRE(test6.size() == 1);
+    REQUIRE(test6[0] == L"");
+
+    std::vector<std::string> test7 = Split("", ';');
+    REQUIRE(test7.size() == 1);
+    REQUIRE(test7[0] == "");
 }
 
 TEST_CASE("ConvertGuid", "[strings]")

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -117,6 +117,9 @@ TEST_CASE("Trim", "[strings]")
     REQUIRE(Trim(str.assign("Multiple words")) == "Multiple words");
     REQUIRE(Trim(str.assign("         Multiple words")) == "Multiple words");
     REQUIRE(Trim(str.assign("Much after is taken \f\n\r\t\v\v\t\r\n\f ")) == "Much after is taken");
+
+    REQUIRE(Trim(L" Test") == L"Test");
+    REQUIRE(Trim(L"   ") == L"");
 }
 
 TEST_CASE("CaseInsensitiveStartsWith", "[strings]")
@@ -297,6 +300,12 @@ TEST_CASE("SplitWithSeparator", "[strings]")
     REQUIRE(test4.size() == 2);
     REQUIRE(test4[0] == "trim");
     REQUIRE(test4[1] == "spaces");
+
+    std::vector<std::wstring_view> test5 = Split(L" trim /spaces /  ", '/', true);
+    REQUIRE(test5.size() == 3);
+    REQUIRE(test5[0] == L"trim");
+    REQUIRE(test5[1] == L"spaces");
+    REQUIRE(test5[2] == L"");
 }
 
 TEST_CASE("ConvertGuid", "[strings]")

--- a/src/AppInstallerCLITests/TestRestRequestHandler.cpp
+++ b/src/AppInstallerCLITests/TestRestRequestHandler.cpp
@@ -23,6 +23,7 @@ std::shared_ptr<TestRestRequestHandler> GetTestRestRequestHandler(
             }
 
             response.headers().set_content_type(mimeType);
+            response.headers().set_cache_control(L"no-store");
             response.set_status_code(statusCode);
             return pplx::task_from_result(response);
         });
@@ -38,6 +39,7 @@ std::shared_ptr<TestRestRequestHandler> GetTestRestRequestHandler(
             response.set_body(utf16string{});
 
             response.headers().set_content_type(web::http::details::mime_types::application_json);
+            response.headers().set_cache_control(L"no-store");
             response.set_status_code(handler(request));
             return pplx::task_from_result(response);
         });
@@ -65,6 +67,7 @@ std::shared_ptr<TestRestRequestHandler> GetHeaderVerificationHandler(
             }
 
             response.headers().set_content_type(web::http::details::mime_types::application_json);
+            response.headers().set_cache_control(L"no-store");
             response.set_status_code(statusCode);
             return pplx::task_from_result(response);
         });

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -616,6 +616,8 @@ namespace AppInstaller::Utility
 
     CacheControlPolicy::CacheControlPolicy(std::wstring_view header)
     {
+        static constexpr std::wstring_view s_MaxAge = L"max-age"sv;
+
         if (header.empty())
         {
             return;
@@ -625,7 +627,38 @@ namespace AppInstaller::Utility
 
         for (std::wstring_view directive : directives)
         {
+            if (!directive.empty())
+            {
+                // Even if we don't understand the directive, the value was not empty
+                Present = true;
+            }
 
+            std::wstring lowerDirective = ToLower(directive);
+
+            if (lowerDirective == L"public"sv)
+            {
+                Public = true;
+            }
+            else if (lowerDirective == L"no-cache"sv)
+            {
+                NoCache = true;
+            }
+            else if (lowerDirective == L"no-store"sv)
+            {
+                NoStore = true;
+            }
+            else if (StartsWith(lowerDirective, s_MaxAge))
+            {
+                std::vector<std::wstring_view> parts = Utility::Split(lowerDirective, L'=', true);
+                if (parts.size() == 2)
+                {
+                    try
+                    {
+                        MaxAge = std::min(std::stoull(std::wstring{ parts[1] }), MaximumMaxAge);
+                    }
+                    CATCH_LOG();
+                }
+            }
         }
     }
 }

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -613,4 +613,19 @@ namespace AppInstaller::Utility
     {
         return GetRetryAfter(response.Headers().RetryAfter());
     }
+
+    CacheControlPolicy::CacheControlPolicy(std::wstring_view header)
+    {
+        if (header.empty())
+        {
+            return;
+        }
+
+        std::vector<std::wstring_view> directives = Utility::Split(header, L',', true);
+
+        for (std::wstring_view directive : directives)
+        {
+
+        }
+    }
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -117,4 +117,26 @@ namespace AppInstaller::Utility
 
     // Gets the retry after value in terms of a delay in seconds.
     std::chrono::seconds GetRetryAfter(const winrt::Windows::Web::Http::HttpResponseMessage& response);
+
+    // Data about the cache-control header.
+    struct CacheControlPolicy
+    {
+        CacheControlPolicy() = default;
+        CacheControlPolicy(std::wstring_view header);
+
+        // True only if the cache-control header was present and contained at least one directive.
+        bool Present = false;
+
+        // The max-age directive; in seconds.
+        size_t MaxAge = 0;
+
+        // The no-cache directive; indicates that the cache should always revalidate.
+        bool NoCache = false;
+
+        // The no-store directive; indicates that the data should not be cached.
+        bool NoStore = false;
+
+        // The public directive; indicates that the data is not user specific.
+        bool Public = false;
+    };
 }

--- a/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerDownloader.h
@@ -121,6 +121,9 @@ namespace AppInstaller::Utility
     // Data about the cache-control header.
     struct CacheControlPolicy
     {
+        // Limit max age to a year
+        static constexpr unsigned long long MaximumMaxAge = 60 * 60 * 24 * 365;
+
         CacheControlPolicy() = default;
         CacheControlPolicy(std::wstring_view header);
 
@@ -128,7 +131,7 @@ namespace AppInstaller::Utility
         bool Present = false;
 
         // The max-age directive; in seconds.
-        size_t MaxAge = 0;
+        unsigned long long MaxAge = 0;
 
         // The no-cache directive; indicates that the cache should always revalidate.
         bool NoCache = false;

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -64,8 +64,8 @@ namespace AppInstaller::Runtime
         FontsUserInstallLocation,
         // The location where fonts are installed with machine scope.
         FontsMachineInstallLocation,
-        // The temporary file location; only valid when running packaged.
-        PackagedTemp,
+        // The location that standard type settings are stored in files.
+        StandardFileSettings,
         // Always one more than the last path; for being able to iterate paths in tests.
         Max
     };

--- a/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerRuntime.h
@@ -64,6 +64,8 @@ namespace AppInstaller::Runtime
         FontsUserInstallLocation,
         // The location where fonts are installed with machine scope.
         FontsMachineInstallLocation,
+        // The temporary file location; only valid when running packaged.
+        PackagedTemp,
         // Always one more than the last path; for being able to iterate paths in tests.
         Max
     };

--- a/src/AppInstallerCommonCore/Public/winget/Settings.h
+++ b/src/AppInstallerCommonCore/Public/winget/Settings.h
@@ -42,6 +42,8 @@ namespace AppInstaller::Settings
         UserFile,
         // A settings stream that should not be modified except by admin privileges.
         Secure,
+        // A settings stream that is encrypted. It does not require admin privileges to write to.
+        Encrypted,
     };
 
     // Converts the Type enum to a string.
@@ -76,6 +78,8 @@ namespace AppInstaller::Settings
         constexpr static StreamDefinition BackupUserSettings{ Type::UserFile, "settings.json.backup"sv };
         // The admin settings.
         constexpr static StreamDefinition AdminSettings{ Type::Secure, "admin_settings"sv };
+        // The REST information cache.
+        constexpr static StreamDefinition RestInformationCache{ Type::Encrypted, "rest_information"sv };
 
         // Gets a Stream for the StreamDefinition.
         // If the stream is synchronized, attempts to Set the value can fail due to another writer

--- a/src/AppInstallerCommonCore/Public/winget/Settings.h
+++ b/src/AppInstallerCommonCore/Public/winget/Settings.h
@@ -36,7 +36,7 @@ namespace AppInstaller::Settings
     // Names should still be unique, as there is no guarantee made about types mapping to unique roots.
     enum class Type
     {
-        // A Standard setting stream has no special requirements.
+        // A Standard setting stream has no special requirements (limited to 8K contents and no embedded null characters).
         Standard,
         // A UserFile setting stream should be located in a file that is easily editable by the user.
         UserFile,
@@ -44,6 +44,8 @@ namespace AppInstaller::Settings
         Secure,
         // A settings stream that is encrypted. It does not require admin privileges to write to.
         Encrypted,
+        // A setting stream has should be stored in a file, removing the limitations of the Standard type.
+        StandardFile,
     };
 
     // Converts the Type enum to a string.

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -288,6 +288,11 @@ namespace AppInstaller::Runtime
             result.Path.assign(appStorage.LocalFolder().Path().c_str());
             mayBeInProfilePath = true;
             break;
+        case PathName::PackagedTemp:
+            result.Path.assign(appStorage.TemporaryFolder().Path().c_str());
+            result.Path /= s_DefaultTempDirectory;
+            mayBeInProfilePath = true;
+            break;
         case PathName::DefaultLogLocation:
             // To enable UIF collection through Feedback hub, we must put our logs here.
             result.Path.assign(appStorage.LocalFolder().Path().c_str());
@@ -394,6 +399,7 @@ namespace AppInstaller::Runtime
         switch (path)
         {
         case PathName::Temp:
+        case PathName::PackagedTemp:
         case PathName::DefaultLogLocation:
         {
             result.Path = GetPathToUserTemp(forDisplay);

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -22,6 +22,7 @@ namespace AppInstaller::Runtime
     {
         using namespace std::string_view_literals;
         constexpr std::string_view s_DefaultTempDirectory = "WinGet"sv;
+        constexpr std::string_view s_SettingsFile_Relative = "Settings"sv;
         constexpr std::string_view s_SecureSettings_Base = "Microsoft\\WinGet"sv;
         constexpr std::string_view s_SecureSettings_UserRelative = "settings"sv;
         constexpr std::string_view s_SecureSettings_Relative_Unpackaged = "win"sv;
@@ -288,9 +289,9 @@ namespace AppInstaller::Runtime
             result.Path.assign(appStorage.LocalFolder().Path().c_str());
             mayBeInProfilePath = true;
             break;
-        case PathName::PackagedTemp:
-            result.Path.assign(appStorage.TemporaryFolder().Path().c_str());
-            result.Path /= s_DefaultTempDirectory;
+        case PathName::StandardFileSettings:
+            result.Path.assign(appStorage.LocalFolder().Path().c_str());
+            result.Path /= s_SettingsFile_Relative;
             mayBeInProfilePath = true;
             break;
         case PathName::DefaultLogLocation:
@@ -399,7 +400,6 @@ namespace AppInstaller::Runtime
         switch (path)
         {
         case PathName::Temp:
-        case PathName::PackagedTemp:
         case PathName::DefaultLogLocation:
         {
             result.Path = GetPathToUserTemp(forDisplay);
@@ -419,6 +419,7 @@ namespace AppInstaller::Runtime
             result.Path /= GetRuntimePathStateName();
             break;
         case PathName::StandardSettings:
+        case PathName::StandardFileSettings:
         case PathName::UserFileSettings:
             result = Filesystem::GetPathDetailsFor(Filesystem::PathName::UnpackagedSettingsRoot, anonymize);
             result.Create = !forDisplay;

--- a/src/AppInstallerCommonCore/Settings.cpp
+++ b/src/AppInstallerCommonCore/Settings.cpp
@@ -420,8 +420,8 @@ namespace AppInstaller::Settings
                         ApplicationDataSettingsContainer::GetRelativeContainer(
                             winrt::Windows::Storage::ApplicationData::Current().LocalSettings(), GetPathTo(PathName::StandardSettings)),
                         name);
-                case Type::Encrypted:
-                    return std::make_unique<FileSettingsContainer>(GetPathTo(PathName::PackagedTemp), name);
+                case Type::StandardFile:
+                    return std::make_unique<FileSettingsContainer>(GetPathTo(PathName::StandardFileSettings), name);
                 default:
                     THROW_HR(E_UNEXPECTED);
                 }
@@ -432,7 +432,7 @@ namespace AppInstaller::Settings
                 switch (type)
                 {
                 case Type::Standard:
-                case Type::Encrypted:
+                case Type::StandardFile:
                     return std::make_unique<FileSettingsContainer>(GetPathTo(PathName::StandardSettings), name);
                 default:
                     THROW_HR(E_UNEXPECTED);
@@ -459,7 +459,11 @@ namespace AppInstaller::Settings
 
             case Type::Encrypted:
                 // Encrypted settings add encryption on top of exchange semantics
-                return std::make_unique<EncryptedSettingsContainer>(GetRawSettingsContainer(Type::Encrypted, name), name);
+                return std::make_unique<EncryptedSettingsContainer>(GetRawSettingsContainer(Type::StandardFile, name), name);
+
+            case Type::StandardFile:
+                // Standard settings should use exchange semantics to prevent overwrites
+                return std::make_unique<ExchangeSettingsContainer>(GetRawSettingsContainer(type, name), name);
 
             default:
                 THROW_HR(E_UNEXPECTED);
@@ -484,6 +488,8 @@ namespace AppInstaller::Settings
             return "Secure"sv;
         case Type::Encrypted:
             return "Encrypted"sv;
+        case Type::StandardFile:
+            return "StandardFile"sv;
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCommonCore/Settings.cpp
+++ b/src/AppInstallerCommonCore/Settings.cpp
@@ -101,7 +101,7 @@ namespace AppInstaller::Settings
             {
                 if (std::filesystem::exists(m_settingFile))
                 {
-                    auto result = std::make_unique<std::ifstream>(m_settingFile);
+                    auto result = std::make_unique<std::ifstream>(m_settingFile, std::ios_base::in | std::ios_base::binary);
                     THROW_LAST_ERROR_IF(result->fail());
                     return result;
                 }
@@ -420,6 +420,8 @@ namespace AppInstaller::Settings
                         ApplicationDataSettingsContainer::GetRelativeContainer(
                             winrt::Windows::Storage::ApplicationData::Current().LocalSettings(), GetPathTo(PathName::StandardSettings)),
                         name);
+                case Type::Encrypted:
+                    return std::make_unique<FileSettingsContainer>(GetPathTo(PathName::PackagedTemp), name);
                 default:
                     THROW_HR(E_UNEXPECTED);
                 }
@@ -430,6 +432,7 @@ namespace AppInstaller::Settings
                 switch (type)
                 {
                 case Type::Standard:
+                case Type::Encrypted:
                     return std::make_unique<FileSettingsContainer>(GetPathTo(PathName::StandardSettings), name);
                 default:
                     THROW_HR(E_UNEXPECTED);
@@ -456,7 +459,7 @@ namespace AppInstaller::Settings
 
             case Type::Encrypted:
                 // Encrypted settings add encryption on top of exchange semantics
-                return std::make_unique<EncryptedSettingsContainer>(GetRawSettingsContainer(Type::Standard, name), name);
+                return std::make_unique<EncryptedSettingsContainer>(GetRawSettingsContainer(Type::Encrypted, name), name);
 
             default:
                 THROW_HR(E_UNEXPECTED);

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj
@@ -375,6 +375,7 @@
     <ClInclude Include="Public\winget\RepositorySearch.h" />
     <ClInclude Include="Public\winget\RepositorySource.h" />
     <ClInclude Include="Rest\RestClient.h" />
+    <ClInclude Include="Rest\RestInformationCache.h" />
     <ClInclude Include="Rest\RestSource.h" />
     <ClInclude Include="Rest\RestSourceFactory.h" />
     <ClInclude Include="Rest\Schema\1_0\Interface.h" />
@@ -474,6 +475,7 @@
     <ClCompile Include="RepositorySearch.cpp" />
     <ClCompile Include="RepositorySource.cpp" />
     <ClCompile Include="Rest\RestClient.cpp" />
+    <ClCompile Include="Rest\RestInformationCache.cpp" />
     <ClCompile Include="Rest\RestSource.cpp" />
     <ClCompile Include="Rest\RestSourceFactory.cpp" />
     <ClCompile Include="Rest\Schema\1_0\RestInterface_1_0.cpp" />

--- a/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
+++ b/src/AppInstallerRepositoryCore/AppInstallerRepositoryCore.vcxproj.filters
@@ -492,11 +492,14 @@
     <ClInclude Include="Rest\Schema\1_10\Json\ManifestDeserializer.h">
       <Filter>Rest\Schema\1_10\Json</Filter>
     </ClInclude>
-      <ClInclude Include="Rest\Schema\1_12\Interface.h">
+    <ClInclude Include="Rest\Schema\1_12\Interface.h">
       <Filter>Rest\Schema\1_12</Filter>
     </ClInclude>
     <ClInclude Include="Rest\Schema\1_12\Json\ManifestDeserializer.h">
       <Filter>Rest\Schema\1_12\Json</Filter>
+    </ClInclude>
+    <ClInclude Include="Rest\RestInformationCache.h">
+      <Filter>Rest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -775,6 +778,9 @@
     </ClCompile>
     <ClCompile Include="Rest\Schema\1_12\Json\ManifestDeserializer_1_12.cpp">
       <Filter>Rest\Schema\1_12\Json</Filter>
+    </ClCompile>
+    <ClCompile Include="Rest\RestInformationCache.cpp">
+      <Filter>Rest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/AppInstallerRepositoryCore/Rest/RestInformationCache.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestInformationCache.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "RestInformationCache.h"
+#include "Rest/Schema/InformationResponseDeserializer.h"
+#include <winget/JsonUtil.h>
+
+namespace AppInstaller::Repository::Rest
+{
+    namespace
+    {
+        constexpr std::wstring_view s_EndpointName = L"endpoint"sv;
+        constexpr std::wstring_view s_HashName = L"hash"sv;
+        constexpr std::wstring_view s_ExpirationName = L"expiration"sv;
+        constexpr std::wstring_view s_DataName = L"data"sv;
+
+        // Calculates the hash of values that might change per-call.
+        Utility::SHA256::HashBuffer GetHash(const std::optional<std::string>& customHeader, std::string_view caller)
+        {
+            std::stringstream stream;
+            if (customHeader)
+            {
+                stream << customHeader.value();
+            }
+            stream << '|' << caller;
+
+            return Utility::SHA256::ComputeHash(stream);
+        }
+
+        uint64_t CalculateExpiration(std::chrono::seconds duration)
+        {
+            // If no expiration information is provided, use 1 minute
+            if (!duration.count())
+            {
+                duration = 60s;
+            }
+
+            return Utility::ConvertSystemClockToUnixEpoch(std::chrono::system_clock::now() + duration);
+        }
+    }
+
+    std::optional<Schema::IRestClient::Information> RestInformationCache::Get(const std::wstring& endpoint, const std::optional<std::string>& customHeader, std::string_view caller)
+#ifdef AICLI_DISABLE_TEST_HOOKS
+        try
+#endif
+    {
+        LoadCacheView();
+
+        Utility::SHA256::HashBuffer hashValue = GetHash(customHeader, caller);
+        CacheItem* item = FindCacheItem(endpoint, hashValue);
+
+        // If we don't find a private match, see if there is a public one.
+        if (!item)
+        {
+            item = FindCacheItem(endpoint, {});
+        }
+
+        if (!item)
+        {
+            return std::nullopt;
+        }
+
+        Schema::InformationResponseDeserializer responseDeserializer;
+        return responseDeserializer.Deserialize(item->Data);
+    }
+#ifdef AICLI_DISABLE_TEST_HOOKS
+    catch (...)
+    {
+        LOG_CAUGHT_EXCEPTION_MSG("RestInformationCache::Get exception");
+        return std::nullopt;
+    }
+#endif
+
+    void RestInformationCache::Cache(const std::wstring& endpoint, const std::optional<std::string>& customHeader, std::string_view caller, const Utility::CacheControlPolicy& cacheControl, web::json::value response)
+#ifdef AICLI_DISABLE_TEST_HOOKS
+        try
+#endif
+    {
+        // If requested, do not cache this response.
+        // Since this data is small, treat no-cache as no-store.
+        if (cacheControl.NoStore || cacheControl.NoCache)
+        {
+            return;
+        }
+
+        // If not public, we use the header values to differentiate the cache items.
+        Utility::SHA256::HashBuffer hashValue;
+        if (!cacheControl.Public)
+        {
+            hashValue = GetHash(customHeader, caller);
+        }
+
+        uint64_t expirationEpoch = CalculateExpiration(std::chrono::seconds{ cacheControl.MaxAge });
+
+        // Due to the exchange semantics on the setting stream, we may have to retry storing the value.
+        for (int i = 0; i < 10; ++i)
+        {
+            CacheItem* item = FindCacheItem(endpoint, hashValue);
+
+            if (!item)
+            {
+                item = &m_cacheView.emplace_back();
+
+                item->Endpoint = endpoint;
+                item->Hash = hashValue;
+            }
+
+            item->UnixEpochExpiration = expirationEpoch;
+            item->Data = std::move(response);
+
+            if (StoreCacheView())
+            {
+                AICLI_LOG(Repo, Verbose, << "RestInformationCache stored information for: " << Utility::ConvertToUTF8(endpoint));
+                return;
+            }
+            else
+            {
+                // Extract the response back from the item for the next iteration
+                response = std::move(item->Data);
+
+                // Failed to store due to the cache changing, reload and try again.
+                LoadCacheView();
+            }
+        }
+
+        AICLI_LOG(Repo, Warning, << "RestInformationCache failed to store information cache after 10 attempts.");
+    }
+#ifdef AICLI_DISABLE_TEST_HOOKS
+    CATCH_LOG();
+#endif
+
+    void RestInformationCache::LoadCacheView()
+    {
+        using namespace web::json;
+
+        std::unique_ptr<std::istream> stream = m_settingsStream.Get();
+        m_cacheView.clear();
+
+        if (!stream)
+        {
+            return;
+        }
+
+        value cacheValue = value::parse(*stream);
+
+        if (!cacheValue.is_array())
+        {
+            AICLI_LOG(Repo, Warning, << "RestInformationCache value was not an array.");
+            return;
+        }
+
+        array& cacheArray = cacheValue.as_array();
+
+        for (const value& cacheItemValue : cacheArray)
+        {
+            if (!cacheItemValue.is_object())
+            {
+                AICLI_LOG(Repo, Warning, << "RestInformationCache cache item was not an object.");
+                continue;
+            }
+
+            std::optional<uint64_t> expiration = JSON::GetRawUInt64ValueFromJsonNode(cacheItemValue, std::wstring{ s_ExpirationName });
+            if (!expiration)
+            {
+                AICLI_LOG(Repo, Warning, << "RestInformationCache cache item missing expiration.");
+                continue;
+            }
+
+            if (std::chrono::system_clock::now() > Utility::ConvertUnixEpochToSystemClock(expiration.value()))
+            {
+                AICLI_LOG(Repo, Verbose, << "RestInformationCache cache item has expired.");
+                continue;
+            }
+
+            std::optional<std::wstring> endpoint = JSON::GetWideStringValueFromJsonNode(cacheItemValue, std::wstring{ s_EndpointName });
+            if (!JSON::IsValidNonEmptyStringValue(endpoint))
+            {
+                AICLI_LOG(Repo, Warning, << "RestInformationCache cache item missing endpoint.");
+                continue;
+            }
+
+            CacheItem cacheItem;
+            cacheItem.Endpoint = endpoint.value();
+            cacheItem.UnixEpochExpiration = expiration.value();
+
+            std::optional<std::wstring> hash = JSON::GetWideStringValueFromJsonNode(cacheItemValue, std::wstring{ s_HashName });
+            if (JSON::IsValidNonEmptyStringValue(hash))
+            {
+                cacheItem.Hash = Utility::SHA256::ConvertToBytes(hash.value());
+            }
+
+            auto dataValue = JSON::GetJsonValueFromNode(cacheItemValue, std::wstring{ s_DataName });
+            if (!dataValue)
+            {
+                AICLI_LOG(Repo, Warning, << "RestInformationCache cache item missing data.");
+                continue;
+            }
+
+            cacheItem.Data = dataValue.value().get();
+            if (cacheItem.Data.is_null())
+            {
+                AICLI_LOG(Repo, Warning, << "RestInformationCache cache item data value null.");
+                continue;
+            }
+
+            m_cacheView.emplace_back(std::move(cacheItem));
+        }
+    }
+
+    RestInformationCache::CacheItem* RestInformationCache::FindCacheItem(const std::wstring& endpoint, const Utility::SHA256::HashBuffer& hash)
+    {
+        for (CacheItem& item : m_cacheView)
+        {
+            if (item.Endpoint == endpoint &&
+                Utility::SHA256::AreEqual(item.Hash, hash))
+            {
+                return &item;
+            }
+        }
+
+        return nullptr;
+    }
+
+    [[nodiscard]] bool RestInformationCache::StoreCacheView()
+    {
+        using namespace web::json;
+
+        value cacheValue = value::array();
+        array& cacheArray = cacheValue.as_array();
+
+        for (const CacheItem& item : m_cacheView)
+        {
+            value cacheItemValue = value::object();
+            object& cacheItemObject = cacheItemValue.as_object();
+
+            cacheItemObject[std::wstring{ s_EndpointName }] = value::value(item.Endpoint);
+            cacheItemObject[std::wstring{ s_HashName }] = value::value(Utility::ConvertToUTF16(Utility::ConvertToHexString(item.Hash)));
+            cacheItemObject[std::wstring{ s_ExpirationName }] = value::value(item.UnixEpochExpiration);
+            cacheItemObject[std::wstring{ s_DataName }] = item.Data;
+
+            cacheArray[cacheArray.size()] = std::move(cacheItemValue);
+        }
+
+        std::stringstream stream;
+        cacheValue.serialize(stream);
+
+        return m_settingsStream.Set(std::move(stream).str());
+    }
+}

--- a/src/AppInstallerRepositoryCore/Rest/RestInformationCache.h
+++ b/src/AppInstallerRepositoryCore/Rest/RestInformationCache.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "Rest/Schema/IRestClient.h"
+#include <AppInstallerDownloader.h>
+#include <AppInstallerSHA256.h>
+#include <winget/Settings.h>
+#include <cpprest/json.h>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace AppInstaller::Repository::Rest
+{
+    // Provides access to cached responses to the /information request.
+    struct RestInformationCache
+    {
+        // Attempts to get a cached information response for the provided inputs.
+        std::optional<Schema::IRestClient::Information> Get(const std::wstring& endpoint, const std::optional<std::string>& customHeader, std::string_view caller);
+
+        // Stores the information response as appropriate.
+        void Cache(const std::wstring& endpoint, const std::optional<std::string>& customHeader, std::string_view caller, const Utility::CacheControlPolicy& cacheControl, web::json::value response);
+
+    private:
+        struct CacheItem
+        {
+            std::wstring Endpoint;
+            Utility::SHA256::HashBuffer Hash;
+            uint64_t UnixEpochExpiration = 0;
+            web::json::value Data;
+        };
+
+        // Reads from the cache, constructing our view of the items it contains.
+        // Discards any expired items while reading the cache.
+        void LoadCacheView();
+
+        // Finds the cache item for the given inputs, or nullptr if it is not found.
+        CacheItem* FindCacheItem(const std::wstring& endpoint, const Utility::SHA256::HashBuffer& hash);
+
+        // Attempts to store the current cache view back to the cache.
+        // Returns true if successful; false if the cache was updated since our last read and a retry is necessary.
+        [[nodiscard]] bool StoreCacheView();
+
+        Settings::Stream m_settingsStream{ Settings::Stream::RestInformationCache };
+        std::vector<CacheItem> m_cacheView;
+    };
+}

--- a/src/AppInstallerSharedLib/AppInstallerStrings.cpp
+++ b/src/AppInstallerSharedLib/AppInstallerStrings.cpp
@@ -139,6 +139,11 @@ namespace AppInstaller::Utility
         return std::any_of(a.begin(), a.end(), [&](const std::string_view& s) { return ToLower(s) == B; });
     }
 
+    bool StartsWith(std::wstring_view a, std::wstring_view b)
+    {
+        return a.length() >= b.length() && a.substr(0, b.length()) == b;
+    }
+
     bool CaseInsensitiveStartsWith(std::string_view a, std::string_view b)
     {
         return a.length() >= b.length() && CaseInsensitiveEquals(a.substr(0, b.length()), b);
@@ -590,7 +595,7 @@ namespace AppInstaller::Utility
         return str;
     }
 
-    std::wstring_view Trim(std::wstring_view str)
+    std::wstring_view& Trim(std::wstring_view& str)
     {
         if (!str.empty())
         {
@@ -608,6 +613,13 @@ namespace AppInstaller::Utility
         }
 
         return str;
+    }
+
+    std::wstring_view Trim(std::wstring_view&& str)
+    {
+        std::wstring_view result = std::move(str);
+        Utility::Trim(result);
+        return result;
     }
 
     std::string Trim(std::string&& str)

--- a/src/AppInstallerSharedLib/AppInstallerStrings.cpp
+++ b/src/AppInstallerSharedLib/AppInstallerStrings.cpp
@@ -97,6 +97,30 @@ namespace AppInstaller::Utility
             wil::unique_any<UBreakIterator*, decltype(ubrk_close), &ubrk_close> m_brk;
             int32_t m_currentBrk = 0;
         };
+
+        template <typename StringType>
+        std::vector<StringType> SplitTemplate(const StringType& input, typename StringType::value_type separator, bool trim)
+        {
+            std::vector<StringType> result;
+            size_t startIndex = 0;
+            size_t endIndex = 0;
+
+            while ((endIndex = input.find(separator, startIndex)) != StringType::npos)
+            {
+                StringType substring = input.substr(startIndex, endIndex - startIndex);
+
+                if (trim)
+                {
+                    Utility::Trim(substring);
+                }
+
+                result.emplace_back(std::move(substring));
+                startIndex = endIndex + 1;
+            }
+
+            result.emplace_back(trim ? Utility::Trim(input.substr(startIndex)) : input.substr(startIndex));
+            return result;
+        }
     }
 
     bool CaseInsensitiveEquals(std::string_view a, std::string_view b)
@@ -566,6 +590,26 @@ namespace AppInstaller::Utility
         return str;
     }
 
+    std::wstring_view Trim(std::wstring_view str)
+    {
+        if (!str.empty())
+        {
+            size_t begin = str.find_first_not_of(s_WideSpaceChars);
+            size_t end = str.find_last_not_of(s_WideSpaceChars);
+
+            if (begin == std::string_view::npos || end == std::string_view::npos)
+            {
+                str = {};
+            }
+            else if (begin != 0 || end != str.length() - 1)
+            {
+                str = str.substr(begin, (end - begin) + 1);
+            }
+        }
+
+        return str;
+    }
+
     std::string Trim(std::string&& str)
     {
         std::string result = std::move(str);
@@ -870,25 +914,12 @@ namespace AppInstaller::Utility
 
     std::vector<std::string> Split(const std::string& input, char separator, bool trim)
     {
-        std::vector<std::string> result;
-        size_t startIndex = 0;
-        size_t endIndex = 0;
+        return SplitTemplate(input, separator, trim);
+    }
 
-        while ((endIndex = input.find(separator, startIndex)) != std::string::npos)
-        {
-            std::string substring = input.substr(startIndex, endIndex - startIndex);
-
-            if (trim)
-            {
-                Utility::Trim(substring);
-            }
-
-            result.push_back(substring);
-            startIndex = endIndex + 1;
-        }
-
-        result.push_back(trim ? Utility::Trim(input.substr(startIndex)) : input.substr(startIndex));
-        return result;
+    std::vector<std::wstring_view> Split(std::wstring_view input, wchar_t separator, bool trim)
+    {
+        return SplitTemplate(input, separator, trim);
     }
 
     std::string_view ConvertBoolToString(bool value)

--- a/src/AppInstallerSharedLib/JsonUtil.cpp
+++ b/src/AppInstallerSharedLib/JsonUtil.cpp
@@ -99,6 +99,16 @@ namespace AppInstaller::JSON
         return utility::conversions::to_utf8string(value.as_string());
     }
 
+    std::optional<std::wstring> GetWideStringValueFromJsonValue(const web::json::value& value)
+    {
+        if (value.is_null() || !value.is_string())
+        {
+            return {};
+        }
+
+        return value.as_string();
+    }
+
     std::optional<std::string> GetRawStringValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName)
     {
         std::optional<std::reference_wrapper<const web::json::value>> jsonValue = GetJsonValueFromNode(node, keyName);
@@ -106,6 +116,18 @@ namespace AppInstaller::JSON
         if (jsonValue)
         {
             return GetRawStringValueFromJsonValue(jsonValue.value().get());
+        }
+
+        return {};
+    }
+
+    std::optional<std::wstring> GetWideStringValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName)
+    {
+        std::optional<std::reference_wrapper<const web::json::value>> jsonValue = GetJsonValueFromNode(node, keyName);
+
+        if (jsonValue)
+        {
+            return GetWideStringValueFromJsonValue(jsonValue.value().get());
         }
 
         return {};
@@ -121,6 +143,23 @@ namespace AppInstaller::JSON
         return value.as_integer();
     }
 
+    std::optional<uint64_t> GetRawUInt64ValueFromJsonValue(const web::json::value& value)
+    {
+        if (value.is_null() || !value.is_number())
+        {
+            return {};
+        }
+
+        const web::json::number& valueNumber = value.as_number();
+
+        if (!valueNumber.is_uint64())
+        {
+            return {};
+        }
+
+        return valueNumber.to_uint64();
+    }
+
     std::optional<int> GetRawIntValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName)
     {
         std::optional<std::reference_wrapper<const web::json::value>> jsonValue = GetJsonValueFromNode(node, keyName);
@@ -128,6 +167,18 @@ namespace AppInstaller::JSON
         if (jsonValue)
         {
             return GetRawIntValueFromJsonValue(jsonValue.value().get());
+        }
+
+        return {};
+    }
+
+    std::optional<uint64_t> GetRawUInt64ValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName)
+    {
+        std::optional<std::reference_wrapper<const web::json::value>> jsonValue = GetJsonValueFromNode(node, keyName);
+
+        if (jsonValue)
+        {
+            return GetRawUInt64ValueFromJsonValue(jsonValue.value().get());
         }
 
         return {};
@@ -257,6 +308,16 @@ namespace AppInstaller::JSON
     bool IsValidNonEmptyStringValue(std::optional<std::string>& value)
     {
         if (Utility::IsEmptyOrWhitespace(value.value_or("")))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool IsValidNonEmptyStringValue(std::optional<std::wstring>& value)
+    {
+        if (Utility::IsEmptyOrWhitespace(value.value_or(L"")))
         {
             return false;
         }

--- a/src/AppInstallerSharedLib/Public/AppInstallerSHA256.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerSHA256.h
@@ -73,6 +73,7 @@ namespace AppInstaller::Utility {
         static std::wstring ConvertToWideString(const HashBuffer& hashBuffer);
 
         static HashBuffer ConvertToBytes(const std::string& hashStr);
+        static HashBuffer ConvertToBytes(const std::wstring& hashStr);
 
         // Returns a value indicating whether the two hashes are equal.
         static bool AreEqual(const HashBuffer& first, const HashBuffer& second);

--- a/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
@@ -115,6 +115,9 @@ namespace AppInstaller::Utility
     // Returns if a UTF8 string is contained within a vector in a case-insensitive manner.
     bool CaseInsensitiveContains(const std::vector<std::string_view>& a, std::string_view b);
 
+    // Determines if string a starts with string b. UTF16.
+    bool StartsWith(std::wstring_view a, std::wstring_view b);
+
     // Determines if string a starts with string b. UTF8.
     // Use this if one of the values is a known value, and thus ToLower is sufficient.
     bool CaseInsensitiveStartsWith(std::string_view a, std::string_view b);
@@ -179,7 +182,8 @@ namespace AppInstaller::Utility
     std::wstring& Trim(std::wstring& str);
 
     // Removes whitespace from the beginning and end of the string.
-    std::wstring_view Trim(std::wstring_view str);
+    std::wstring_view& Trim(std::wstring_view& str);
+    std::wstring_view Trim(std::wstring_view&& str);
 
     // Reads the entire stream into a string.
     std::string ReadEntireStream(std::istream& stream);

--- a/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
@@ -178,6 +178,9 @@ namespace AppInstaller::Utility
     // Removes whitespace from the beginning and end of the string.
     std::wstring& Trim(std::wstring& str);
 
+    // Removes whitespace from the beginning and end of the string.
+    std::wstring_view Trim(std::wstring_view str);
+
     // Reads the entire stream into a string.
     std::string ReadEntireStream(std::istream& stream);
 
@@ -266,6 +269,9 @@ namespace AppInstaller::Utility
 
     // Splits the string using the provided separator. Entries can also be trimmed.
     std::vector<std::string> Split(const std::string& input, char separator, bool trim = false);
+
+    // Splits the string using the provided separator. Entries can also be trimmed.
+    std::vector<std::wstring_view> Split(std::wstring_view input, wchar_t separator, bool trim = false);
 
     // Format an input string by replacing placeholders {index} with provided values at corresponding indices.
     // Note: After upgrading to C++20, this function should be deprecated in favor of std::format.

--- a/src/AppInstallerSharedLib/Public/winget/JsonUtil.h
+++ b/src/AppInstallerSharedLib/Public/winget/JsonUtil.h
@@ -39,8 +39,10 @@ namespace AppInstaller::JSON
     std::optional<std::reference_wrapper<const web::json::value>> GetJsonValueFromNode(const web::json::value& node, const utility::string_t& keyName);
 
     std::optional<std::string> GetRawStringValueFromJsonValue(const web::json::value& value);
+    std::optional<std::wstring> GetWideStringValueFromJsonValue(const web::json::value& value);
 
     std::optional<std::string> GetRawStringValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName);
+    std::optional<std::wstring> GetWideStringValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName);
 
     std::optional<bool> GetRawBoolValueFromJsonValue(const web::json::value& value);
 
@@ -53,7 +55,11 @@ namespace AppInstaller::JSON
 
     std::optional<int> GetRawIntValueFromJsonValue(const web::json::value& value);
 
-    std::optional<int> GetRawIntValueFromJsonNode(const web::json::value& value, const utility::string_t& keyName);
+    std::optional<uint64_t> GetRawUInt64ValueFromJsonValue(const web::json::value& value);
+
+    std::optional<int> GetRawIntValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName);
+
+    std::optional<uint64_t> GetRawUInt64ValueFromJsonNode(const web::json::value& node, const utility::string_t& keyName);
 
     utility::string_t GetUtilityString(std::string_view nodeName);
 
@@ -63,8 +69,9 @@ namespace AppInstaller::JSON
     std::string Base64Encode(const std::vector<BYTE>& input);
 
     // Base64 decode
-    std::vector<BYTE>Base64Decode(const std::string& input);
+    std::vector<BYTE> Base64Decode(const std::string& input);
 #endif
 
     bool IsValidNonEmptyStringValue(std::optional<std::string>& value);
+    bool IsValidNonEmptyStringValue(std::optional<std::wstring>& value);
 }

--- a/src/AppInstallerSharedLib/SHA256.cpp
+++ b/src/AppInstallerSharedLib/SHA256.cpp
@@ -102,6 +102,11 @@ namespace AppInstaller::Utility {
         return Utility::ParseFromHexString(hashStr, HashBufferSizeInBytes);
     }
 
+    SHA256::HashBuffer SHA256::ConvertToBytes(const std::wstring& hashStr)
+    {
+        return Utility::ParseFromHexString(Utility::ConvertToUTF8(hashStr), HashBufferSizeInBytes);
+    }
+
     SHA256::HashBuffer SHA256::ComputeHash(const std::uint8_t* buffer, std::uint32_t cbBuffer)
     {
         SHA256 hasher;


### PR DESCRIPTION
## Change
Store and use the `/information` response from REST sources per their `cache-control` header.

At the base of this change is a new type of setting stream: `Encrypted`.  These settings are encrypted to the user and machine that the data is stored on.

Based on the log file from running with and without a cached value, the time between close log lines dropped from 189 ms to 8 ms for the msstore source.  This time saving should be in effect for the large majority of uses of WinGet.

## Validation
Added tests across various levels of the change.
Manually verified functionality of CLI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5726)