### PR TITLE
Add workflow for automatic issue deduplication

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -63,6 +63,7 @@ datetime
 dbconn
 DBId
 debugbreak
+dedup
 defaultlocale
 delstore
 Demitrius
@@ -113,6 +114,7 @@ FLUSHEACHLINE
 fnt
 forcerestart
 gdi
+genai
 HCCE
 hcertstore
 HCRYPTMSG
@@ -228,6 +230,7 @@ Pathto
 PBYTE
 pch
 PCWSTR
+pelikhan
 PEVENT
 pfns
 pfp

--- a/.github/workflows/.github/workflows/automatic-issue-deduplication.yml
+++ b/.github/workflows/.github/workflows/automatic-issue-deduplication.yml
@@ -1,0 +1,19 @@
+name: Automatic New Issue Deduplication
+on:
+  issues:
+    types: [opened, reopened]
+permissions:
+  models: read
+  issues: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+jobs:
+  deduplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Deduplicate Action
+        uses: pelikhan/action-genai-issue-dedup@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label_as_duplicate: true


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----

This adds a bot to automatically detect duplicate issues after an issue is opened or re-opened. It can only apply the "duplicate" label. It will not close the issue and it will leave a comment with the duplicate issue(s).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5738)