### PR TITLE
Fix portable path removal on upgrade

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,6 +5,7 @@
 
 ## Bug Fixes
 * Manifest validation no longer fails using `UTF-8 BOM` encoding when the schema header is on the first line
+* Upgrading a portable package with dev mode disabled will no longer remove the package from the PATH variable.
 
 ## Experimental Features
 * Experimental support for Fonts

--- a/src/AppInstallerCLICore/PortableInstaller.cpp
+++ b/src/AppInstallerCLICore/PortableInstaller.cpp
@@ -382,6 +382,7 @@ namespace AppInstaller::CLI::Portable
         {
             if (PathVariable(GetScope()).Remove(value))
             {
+                InstallDirectoryAddedToPath = false;
                 AICLI_LOG(CLI, Info, << "Removed target directory from PATH registry: " << value);
             }
             else


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
Closes #4044
Closes #3616 

The path is being lost under the condition of Dev Mode being disabled with a user install, because we only set the PATH if symlinks are not available. In this situation, the portable package is registered with a path set, and that information is added to the ARP entry. When an upgrade occurs, this path being set value is true and when removing the old version we are also removing the path since it was set. Then when we add the new version, the variable that says the path was set is still true, so it does not re-add the path and does not set the path information in the ARP entry.

The fix is to update the variable that indicates the path has been set whenever we remove the path. This causes the install of the new version to recognize that the path has been removed and to re-enable it (and then re-set the variable). This is a targeted fix that only affects the PATH setting

Repro steps for this issue:
1) Disable dev mode (it does not repro with dev mode enabled)
2) Install old version of package
3) Open a new command window and verify path is correctly set and program launches.
4) Upgrade to latest version of package
5) Open a command window and verify that the path is now gone.

With the fix step 5 is the same result as step 3.

Tested:
* Verified with terragrunt and pnpm are confirmed fixed.
* Tested with and without the fix to confirm the fix addresses the issue.
* Verified in debugger the code path expected is hit.

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5756)