### PR TITLE
Remove openssl from sfsclient cgmanifest

### DIFF
--- a/src/SfsClient/sfs-client/cgmanifest.json
+++ b/src/SfsClient/sfs-client/cgmanifest.json
@@ -65,25 +65,6 @@
       "component": {
         "type": "git",
         "git": {
-          "repositoryUrl": "https://github.com/openssl/openssl",
-          "commitHash": "01d5e2318405362b4de5e670c90d9b40a351d053"
-        }
-      },
-      "developmentDependency": false,
-      "dependencyRoots": [
-        {
-          "type": "git",
-          "git": {
-            "repositoryUrl": "https://github.com/curl/curl",
-            "commitHash": "83bedbd730d62b83744cc26fa0433d3f6e2e4cd6"
-          }
-        }
-      ]
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
           "repositoryUrl": "https://github.com/microsoft/do-client",
           "commitHash": "d71ade6f692dd8bc319ec3228c956517e9b29292"
         }


### PR DESCRIPTION
Component Governance is reporting issues from openssl. The alert is caused by it being in the `cgmanifest.json` of `sfs-client` even though [they don't use it on Windows](https://github.com/microsoft/sfs-client/blob/63aab71b46d92977a60b231849bebcf6cbd37715/vcpkg.json#L21). Since it is not actually used, we can't do something like overriding the version (and even if we did, CG would also pick the version in the json).

Removing it from their cgmanifest should get rid of the alert, although it will cause issues the next time we update the subtree.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5775)