### PR TITLE
Add admin check to uninstall of machine font

### DIFF
--- a/src/AppInstallerCLICore/Workflows/FontFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/FontFlow.cpp
@@ -315,6 +315,12 @@ namespace AppInstaller::CLI::Workflow
                 fontContext.Scope = scope;
             }
 
+            if (fontContext.Scope == Manifest::ScopeEnum::Machine && !Runtime::IsRunningAsAdmin())
+            {
+                context.Reporter.Error() << Resource::String::CommandRequiresAdmin << std::endl;
+                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_COMMAND_REQUIRES_ADMIN);
+            }
+
             auto uninstallResult = Fonts::UninstallFontPackage(fontContext);
             if (uninstallResult.Result() != FontResult::Success)
             {


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
Fixes #5774 

Adds an admin check to the font uninstall flow.

Non-elevated uninstall of machine font
<img width="585" height="63" alt="image" src="https://github.com/user-attachments/assets/e02bea39-8e88-42fc-9355-7b90b875e44a" />

Elevated uninstall of machine font
<img width="517" height="53" alt="image" src="https://github.com/user-attachments/assets/d22d502f-64d2-4f4e-8bed-6a8f8ada9071" />


Tested:
* Uninstall of machine installed font succeeds from elevated command prompt.
* Uninstall of machine font from non-elevated command prompt fails.

No release note update required for this, fixes a bug in unreleased code.

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5779)