### PR TITLE
Enable source reference to get thread globals for off-thread logging

### DIFF
--- a/src/AppInstallerCLICore/ExecutionContext.cpp
+++ b/src/AppInstallerCLICore/ExecutionContext.cpp
@@ -59,7 +59,7 @@ namespace AppInstaller::CLI::Execution
 
     std::unique_ptr<Context> Context::CreateSubContext()
     {
-        auto clone = std::make_unique<Context>(Reporter, m_threadGlobals);
+        auto clone = std::make_unique<Context>(Reporter, *m_threadGlobals);
         clone->m_flags = m_flags;
         clone->m_executingCommand = m_executingCommand;
         // If the parent is hooked up to the CTRL signal, have the clone be as well
@@ -211,12 +211,17 @@ namespace AppInstaller::CLI::Execution
 
     AppInstaller::ThreadLocalStorage::WingetThreadGlobals& Context::GetThreadGlobals()
     {
+        return *m_threadGlobals;
+    }
+
+    std::shared_ptr<ThreadLocalStorage::WingetThreadGlobals> Context::GetSharedThreadGlobals()
+    {
         return m_threadGlobals;
     }
 
     std::unique_ptr<AppInstaller::ThreadLocalStorage::PreviousThreadGlobals> Context::SetForCurrentThread()
     {
-        return m_threadGlobals.SetForCurrentThread();
+        return m_threadGlobals->SetForCurrentThread();
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -100,7 +100,7 @@ namespace AppInstaller::CLI::Execution
         // Constructor for creating a sub-context.
         Context(Execution::Reporter& reporter, ThreadLocalStorage::WingetThreadGlobals& threadGlobals) :
             Reporter(reporter, Execution::Reporter::clone_t{}),
-            m_threadGlobals(threadGlobals, ThreadLocalStorage::WingetThreadGlobals::create_sub_thread_globals_t{}) {}
+            m_threadGlobals(std::make_shared<ThreadLocalStorage::WingetThreadGlobals>(threadGlobals, ThreadLocalStorage::WingetThreadGlobals::create_sub_thread_globals_t{})) {}
 
         virtual ~Context();
 
@@ -163,7 +163,8 @@ namespace AppInstaller::CLI::Execution
         virtual void SetExecutionStage(Workflow::ExecutionStage stage);
 
         // Get Globals for Current Context
-        AppInstaller::ThreadLocalStorage::WingetThreadGlobals& GetThreadGlobals();
+        ThreadLocalStorage::WingetThreadGlobals& GetThreadGlobals();
+        std::shared_ptr<ThreadLocalStorage::WingetThreadGlobals> GetSharedThreadGlobals();
 
         std::unique_ptr<AppInstaller::ThreadLocalStorage::PreviousThreadGlobals> SetForCurrentThread();
 
@@ -209,7 +210,7 @@ namespace AppInstaller::CLI::Execution
         size_t m_CtrlSignalCount = 0;
         ContextFlag m_flags = ContextFlag::None;
         Workflow::ExecutionStage m_executionStage = Workflow::ExecutionStage::Initial;
-        AppInstaller::ThreadLocalStorage::WingetThreadGlobals m_threadGlobals;
+        std::shared_ptr<ThreadLocalStorage::WingetThreadGlobals> m_threadGlobals = std::make_shared<ThreadLocalStorage::WingetThreadGlobals>();
         AppInstaller::CLI::Command* m_executingCommand = nullptr;
         std::unique_ptr<AppInstaller::Checkpoints::CheckpointManager> m_checkpointManager;
     };

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -185,6 +185,7 @@ namespace AppInstaller::CLI::Workflow
                 {
                     source.SetCaller("winget-cli");
                     source.SetAuthenticationArguments(GetAuthenticationArguments(context));
+                    source.SetThreadGlobals(context.GetSharedThreadGlobals());
                     return source.Open(progress);
                 };
                 auto updateFailures = context.Reporter.ExecuteWithProgress(openFunction, true);

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 #pragma once
 #include <winget/Certificates.h>
+#include <winget/SharedThreadGlobals.h>
 #include <cpprest/http_client.h>
 #include <cpprest/json.h>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -34,7 +36,7 @@ namespace AppInstaller::Http
 
         std::optional<web::json::value> HandleGet(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}, const HttpResponseHandler& customHandler = {}) const;
 
-        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration);
+        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {});
 
     protected:
         std::optional<web::json::value> ValidateAndExtractResponse(const web::http::http_response& response) const;

--- a/src/AppInstallerRepositoryCore/ISource.h
+++ b/src/AppInstallerRepositoryCore/ISource.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "Public/winget/RepositorySource.h"
+#include <winget/SharedThreadGlobals.h>
 #include <memory>
 
 namespace AppInstaller::Repository
@@ -96,6 +97,9 @@ namespace AppInstaller::Repository
 
         // Opens the source. This function should throw upon open failure rather than returning an empty pointer.
         virtual std::shared_ptr<ISource> Open(IProgressCallback& progress) = 0;
+
+        // Sets thread globals for the source. This allows the option for sources that operate on other threads to log properly.
+        virtual void SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>&) {}
     };
 
     // Internal interface extension to ISource for databases that can be updated after creation, like InstallingPackages

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -6,6 +6,7 @@
 #include <AppInstallerProgress.h>
 #include <winget/Certificates.h>
 #include <winget/Authentication.h>
+#include <winget/SharedThreadGlobals.h>
 
 #include <chrono>
 #include <filesystem>
@@ -273,6 +274,9 @@ namespace AppInstaller::Repository
 
         // Set authentication arguments. Must be set before Open to have effect.
         void SetAuthenticationArguments(Authentication::AuthenticationArguments args);
+
+        // Set thread globals. Must be set before Open to have effect.
+        void SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>& threadGlobals);
 
         // Set background update check interval.
         void SetBackgroundUpdateInterval(TimeSpan interval);

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -677,6 +677,14 @@ namespace AppInstaller::Repository
         }
     }
 
+    void Source::SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>& threadGlobals)
+    {
+        for (auto& sourceReference : m_sourceReferences)
+        {
+            sourceReference->SetThreadGlobals(threadGlobals);
+        }
+    }
+
     void Source::SetBackgroundUpdateInterval(TimeSpan interval)
     {
         m_backgroundUpdateInterval = interval;

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -54,13 +54,18 @@ namespace AppInstaller::Repository::Rest
                 return std::make_shared<RestSource>(m_details, m_information, std::move(restClient));
             }
 
+            void SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>& threadGlobals) override
+            {
+                m_threadGlobals = threadGlobals;
+            }
+
         private:
             void Initialize()
             {
                 std::call_once(m_initializeFlag,
                     [&]()
                     {
-                        m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration);
+                        m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration, m_threadGlobals);
                         m_restClientInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
 
                         m_details.Identifier = m_restClientInformation.SourceIdentifier;
@@ -88,6 +93,7 @@ namespace AppInstaller::Repository::Rest
             std::string m_caller;
             Authentication::AuthenticationArguments m_authArgs;
             std::once_flag m_initializeFlag;
+            std::shared_ptr<ThreadLocalStorage::ThreadGlobals> m_threadGlobals;
         };
 
         // The base class for data that comes from a rest based source.

--- a/src/AppInstallerSharedLib/Certificates.cpp
+++ b/src/AppInstallerSharedLib/Certificates.cpp
@@ -650,6 +650,7 @@ namespace AppInstaller::Certificates
         {
             if (chain.Validate(chainContext.get()))
             {
+                AICLI_LOG(Core, Verbose, << "Certificate `" << GetSimpleDisplayName(certContext) << "` accepted by pinning configuration:\n" << chain.GetDescription());
                 result = true;
                 break;
             }


### PR DESCRIPTION
## Change
Allow `ISourceReference` and `Source` to have `ThreadGlobals` provided so that they can use them for other-thread logging.  Enable this for the thread async REST source so that our certificate pinning callback can log results.

## Validation
Manual confirmation of new log line appearing after update.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5780)