### PR TITLE
Add a recurring schedule to the localization pipeline

### DIFF
--- a/azure-pipelines.loc.yml
+++ b/azure-pipelines.loc.yml
@@ -7,10 +7,18 @@
 
 # Expects a variable called LocServiceKey to contain the OAuth client secret for Touchdown.
 
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+
 trigger: none
 pr: none
 
-name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+- cron: "0 0 * * Sun"
+  displayName: Scheduled build
+  branches:
+    include:
+    - master
 
 jobs:
 - job: Localize


### PR DESCRIPTION
This PR configures the localization pipeline to run automatically every week. This only automates sending the strings to the localization service, and we will still have to manually apply the patch here. The intention is to not have to wait for localized strings at the end of the release cycle when we want to make a stable build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5786)