### PR TITLE
Allow unsigned source for development testing

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -59,6 +59,7 @@ curated
 CURSORPOSITON
 CUSTOMHEADER
 cvd
+DAICLI
 datatelemetry
 datetime
 dbconn

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -20,7 +20,7 @@ namespace AppInstaller::Repository::Microsoft
 {
     namespace
     {
-        // To use an unsigned source, set AICLI_ALLOW_UNSTIGNED_SOURCE and use a debug build.
+        // To use an unsigned source, set AICLI_ALLOW_UNSIGNED_SOURCE and use a debug build.
         // Ex: set CL=/DAICLI_ALLOW_UNSIGNED_SOURCE
 #if ! defined( AICLI_DISABLE_TEST_HOOKS ) && defined( AICLI_ALLOW_UNSIGNED_SOURCE )
         static bool s_AllowUnsignedSource = true;


### PR DESCRIPTION

This formalizes a workaround I have been using for testing an unsigned Pre-Indexed Package Source. It would be convenient to have this in the code so I don't have to constantly stash/unstash the changes when moving around branches.

This works only when test hooks are enabled (i.e. a debug build) AND you set the preprocessor directive "AICLI_ALLOW_UNSIGNED_SOURCE"

The easy way to set this up is to add CL=/DAICLI_ALLOW_UNSIGNED_SOURCE to your Environment variables and restart visual studio.

I've noticed Visual Studio will not recognize the directive is set, but the compiler will set it when it builds and it will work. I did not make these const due to a web of compiler warnings and errors when a const value is specified first in an if statement.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5790)