### PR TITLE
Make Repair-WGPM a COM-aware cmdlet and rework version retrieval

### DIFF
--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Commands/WinGetPackageManagerCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
     /// <summary>
     /// Used by Repair-WinGetPackageManager and Assert-WinGetPackageManager.
     /// </summary>
-    public sealed class WinGetPackageManagerCommand : BaseCommand
+    public sealed class WinGetPackageManagerCommand : ManagementDeploymentCommand
     {
         private const string EnvPath = "env:PATH";
 
@@ -132,7 +132,7 @@ namespace Microsoft.WinGet.Client.Engine.Commands
                     switch (currentCategory)
                     {
                         case IntegrityCategory.UnexpectedVersion:
-                            await this.InstallDifferentVersionAsync(new WinGetVersion(expectedVersion), allUsers, force);
+                            await this.InstallDifferentVersionAsync(new WinGetVersion(expectedVersion), e.InstalledVersion, allUsers, force);
                             break;
                         case IntegrityCategory.NotInPath:
                             this.RepairEnvPath();
@@ -167,9 +167,13 @@ namespace Microsoft.WinGet.Client.Engine.Commands
             }
         }
 
-        private async Task InstallDifferentVersionAsync(WinGetVersion toInstallVersion, bool allUsers, bool force)
+        private async Task InstallDifferentVersionAsync(WinGetVersion toInstallVersion, WinGetVersion? installedVersion, bool allUsers, bool force)
         {
-            var installedVersion = WinGetVersion.InstalledWinGetVersion(this);
+            if (installedVersion == null)
+            {
+                installedVersion = WinGetVersion.InstalledWinGetVersion(this);
+            }
+
             bool isDowngrade = installedVersion.CompareAsDeployment(toInstallVersion) > 0;
 
             string message = $"Installed WinGet version '{installedVersion.TagVersion}' " +

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Common/WinGetIntegrity.cs
@@ -39,13 +39,14 @@ namespace Microsoft.WinGet.Client.Engine.Common
                 return;
             }
 
+            WinGetCLICommandResult? versionResult = null;
+
             try
             {
                 // Start by calling winget without its WindowsApp PFN path.
                 // If it succeeds and the exit code is 0 then we are good.
-                var wingetCliWrapper = new WingetCLIWrapper(false);
-                var result = wingetCliWrapper.RunCommand(pwshCmdlet, "--version");
-                result.VerifyExitCode();
+                versionResult = WinGetVersion.RunWinGetVersionFromCLI(pwshCmdlet, false);
+                versionResult.VerifyExitCode();
             }
             catch (Win32Exception e)
             {
@@ -68,7 +69,7 @@ namespace Microsoft.WinGet.Client.Engine.Common
             {
                 // This assumes caller knows that the version exist.
                 WinGetVersion expectedWinGetVersion = new WinGetVersion(expectedVersion);
-                var installedVersion = WinGetVersion.InstalledWinGetVersion(pwshCmdlet);
+                var installedVersion = WinGetVersion.InstalledWinGetVersion(pwshCmdlet, versionResult);
                 if (expectedWinGetVersion.CompareTo(installedVersion) != 0)
                 {
                     throw new WinGetIntegrityException(
@@ -76,7 +77,8 @@ namespace Microsoft.WinGet.Client.Engine.Common
                         string.Format(
                             Resources.IntegrityUnexpectedVersionMessage,
                             installedVersion.TagVersion,
-                            expectedVersion));
+                            expectedVersion))
+                    { InstalledVersion = installedVersion };
                 }
             }
         }

--- a/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/WinGetIntegrityException.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Engine/Exceptions/WinGetIntegrityException.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetIntegrityException.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -9,6 +9,7 @@ namespace Microsoft.WinGet.Client.Engine.Exceptions
     using System;
     using System.Management.Automation;
     using Microsoft.WinGet.Client.Engine.Common;
+    using Microsoft.WinGet.Client.Engine.Helpers;
     using Microsoft.WinGet.Resources;
 
     /// <summary>
@@ -52,6 +53,11 @@ namespace Microsoft.WinGet.Client.Engine.Exceptions
         /// Gets the category of the integrity failure.
         /// </summary>
         public IntegrityCategory Category { get; }
+
+        /// <summary>
+        /// Gets or sets the installed version.
+        /// </summary>
+        internal WinGetVersion? InstalledVersion { get; set; }
 
         private static string GetMessage(IntegrityCategory category) => category switch
         {


### PR DESCRIPTION
Fixes #5826 and #5827

## Issue
A previous change introduced a COM API to retrieve the WinGet version.  The PowerShell methods to get the version were updated to try using it before invoking the existing method (run `winget --version`).

This caused Repair-WGPM to use COM for the first time (IFF a version specifier was provided [which includes `-Latest`]).  This caused the two linked issues:
1. #5826 :: In .NET Framework (Windows PowerShell), the .winmd file must be found in order to generate the COM type information at runtime.  This is required when jit'ing the new version API, used only when a version specifier is provided.  This doesn't affect .NET Core (PowerShell 7) because exceptions are swallowed to support backward compat and the types are all pre-generated by CsWinRT.  Only commands deriving from a specific type were doing the initialization required.
2. #5827 :: Calling a COM API means that the server is active, making attempts to install the package fail due to an in-use error.  This required `-Force` to be provided, again only if a version specifier was provided.

## Change
The larger part of this change reworks the existing assert and repair state machine to better re-use the call to `winget --version` that is actually attempting to probe for WinGet CLI functionality.  We keep that result around and use it when comparing to the supplied target version rather than attempting to retrieve the version again.  If the version is not correct, we attach it to the exception that is thrown so that we can re-use it once again during the attempt to install the different version.

Since the first attempt to call `winget --version` has to succeed in order to get to the code that would check the current version, we can successfully avoid the COM call in this path every time.  Ultimately this means that if WinGet is already installed properly, attempting to change the version with Repair only gets the version once instead of the previous 3 times.

The final portion of the change updates the base command for Repair and Assert to the one that provides the COM initialization.  While this shouldn't be necessary with the other portion, it is preferable to supply `-Force` as a workaround than to simply wait for a resolution if the type cannot be loaded.

## Validation
Manually confirmed flow of saved version information with debugger and the lack of COM server running.
Additional tests are planned for the internal build to better test the real flow due to the complexity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5842)