### PR TITLE
Ignore ReleaseStatic outputs and clean intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ settings.json
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
+[Rr]elease[Ss]tatic/
 [Rr]eleases/
 x64/
 x86/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,8 @@ jobs:
                     /p:AppxBundlePlatforms="$(buildPlatform)"
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
-                    /p:UapAppxPackageBuildMode=SideloadOnly'
+                    /p:UapAppxPackageBuildMode=SideloadOnly
+                    /p:WingetCleanIntermediateFiles=true'
       maximumCpuCount: true
 
   - task: MSBuild@1

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,4 +27,9 @@
   <PropertyGroup Condition="'$(WinGetMacros)' != ''">
     <DefineConstants>$(WinGetMacros)$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
+  <!-- To prevent build agents from running out of disk space, clean as we go. -->
+  <Target Name="CleanIntermediateFiles" AfterTargets="Build" Condition="'$(WingetCleanIntermediateFiles)'=='true'">
+    <RemoveDir Directories="$(IntDir)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Change
Copy the C++/WinRT method for keeping the build servers with plenty of space by cleaning the intermediates after building each project.  The precompiled headers alone are several GBs.

Also adds `ReleaseStatic` outputs to the .gitignore.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5848)