### PR TITLE
Unregister signal handler (CP to 1.12)

### DIFF
--- a/src/AppInstallerCLICore/ShutdownMonitoring.cpp
+++ b/src/AppInstallerCLICore/ShutdownMonitoring.cpp
@@ -101,6 +101,8 @@ namespace AppInstaller::ShutdownMonitoring
 
     TerminationSignalHandler::~TerminationSignalHandler()
     {
+        SetConsoleCtrlHandler(StaticCtrlHandlerFunction, FALSE);
+
         // std::thread requires that any managed thread (joinable) be joined or detached before destructing
         if (m_windowThread.joinable())
         {


### PR DESCRIPTION
## Change
Remove the CTRL handler when we destruct.

CP of #5861 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5862)