### PR TITLE
Update CODEOWNERS to include winget-developers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @microsoft/windows-package-manager-admins
+* @microsoft/winget-developers
+


### PR DESCRIPTION
Not sure when we changed the team name, but now I keep missing new PRs because we're no longer getting auto-added as reviewers
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5891)