### PR TITLE
Improve translation of 'explicit' in Japanese

### DIFF
--- a/Localization/Resources/ja-JP/winget.resw
+++ b/Localization/Resources/ja-JP/winget.resw
@@ -2891,7 +2891,7 @@
     <value>指定しない限り、ソースを検出から除外します</value>
   </data>
   <data name="SourceListExplicit" xml:space="preserve">
-    <value>成人指定</value>
+    <value>明示的ソース</value>
   </data>
   <data name="SourceTrustLevelArgumentDescription" xml:space="preserve">
     <value>ソースの信頼レベル (なしまたは信頼済み)</value>


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----

SourceListExplicit was previously translated as「成人指定」, which incorrectly implies NSFW content. In this context, explicit means "explicitly specified" or "directly designated," referring to sources that the user has explicitly specified.

I have updated the translation to 「明示的ソース」, which accurately reflects the intended meaning and avoids confusion.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5895)