### PR TITLE
Add sleep to allow background threads to quiesce

### DIFF
--- a/src/AppInstallerCLIE2ETests/InprocTestbedTests.cs
+++ b/src/AppInstallerCLIE2ETests/InprocTestbedTests.cs
@@ -98,12 +98,13 @@ namespace AppInstallerCLIE2ETests
         /// </summary>
         /// <param name="leakCOM">Control whether COM should be uninitialized at the end of the process.</param>
         /// <param name="unloadBehavior">Set the unload behavior for the test.</param>
+        /// <param name="workTestSleep">Sets the number of milliseconds to sleep between each work/test iteration.</param>
         [Test]
         [TestCase(false, UnloadBehavior.AtUninitialize)]
         [TestCase(false, UnloadBehavior.Never)]
-        [TestCase(true, UnloadBehavior.Allow)]
+        [TestCase(true, UnloadBehavior.Allow, 1000)]
         [TestCase(true, UnloadBehavior.Never)]
-        public void CLSID_Tests(bool leakCOM, UnloadBehavior unloadBehavior)
+        public void CLSID_Tests(bool leakCOM, UnloadBehavior unloadBehavior, int? workTestSleep = null)
         {
             this.RunInprocTestbed(new TestbedParameters()
             {
@@ -111,6 +112,7 @@ namespace AppInstallerCLIE2ETests
                 LeakCOM = leakCOM,
                 UnloadBehavior = unloadBehavior,
                 Iterations = 10,
+                WorkTestSleepInterval = workTestSleep,
             });
         }
 
@@ -175,6 +177,11 @@ namespace AppInstallerCLIE2ETests
                 builtParameters += $"-itr {parameters.Iterations} ";
             }
 
+            if (parameters.WorkTestSleepInterval != null)
+            {
+                builtParameters += $"-work-test-sleep {parameters.WorkTestSleepInterval} ";
+            }
+
             var result = TestCommon.RunProcess(this.InprocTestbedPath, this.TargetPackageInformation, builtParameters, null, timeout, true);
             Assert.AreEqual(0, result.ExitCode);
         }
@@ -195,6 +202,8 @@ namespace AppInstallerCLIE2ETests
             internal string Test { get; init; } = "unload_check";
 
             internal int? Iterations { get; init; } = null;
+
+            internal int? WorkTestSleepInterval { get; init; } = null;
         }
     }
 }

--- a/src/ComInprocTestbed/Tests.cpp
+++ b/src/ComInprocTestbed/Tests.cpp
@@ -246,6 +246,11 @@ TestParameters::TestParameters(int argc, const char** argv)
         {
             SkipClearFactories = true;
         }
+        else if ("-work-test-sleep"sv == argv[i])
+        {
+            ADVANCE_ARG_PARAMETER
+            WorkTestSleepInterval = atoi(argv[i]);
+        }
     }
 }
 
@@ -259,6 +264,7 @@ void TestParameters::OutputDetails() const
         "  Unload   : " << UnloadBehavior << "\n"
         "    Expect : " << std::boolalpha << UnloadExpected() << "\n"
         "  Test     : " << TestToRun << "\n"
+        "    Sleep  : " << WorkTestSleepInterval << "\n"
         "  Package  : " << PackageName << "\n"
         "  Source   : " << SourceName << "\n"
         "    URL    : " << SourceURL << "\n"

--- a/src/ComInprocTestbed/Tests.h
+++ b/src/ComInprocTestbed/Tests.h
@@ -74,6 +74,7 @@ struct TestParameters
     UnloadBehavior UnloadBehavior = UnloadBehavior::Allow;
     ActivationType ActivationType = ActivationType::ClassName;
     bool SkipClearFactories = false;
+    DWORD WorkTestSleepInterval = 0;
 };
 
 // Captures a snapshot of current resource usage.

--- a/src/ComInprocTestbed/main.cpp
+++ b/src/ComInprocTestbed/main.cpp
@@ -31,6 +31,11 @@ int main(int argc, const char** argv) try
             winrt::clear_factory_cache();
         }
 
+        if (testParameters.WorkTestSleepInterval)
+        {
+            Sleep(testParameters.WorkTestSleepInterval);
+        }
+
         if (test && !test->RunIterationTest())
         {
             return 4;


### PR DESCRIPTION
## Issue
One of the inproc tests is failing because the module is not unloaded (nor are any of the statics destroyed) after the attempt to unload it through `CoFreeUnusedLibrariesEx`.  This suggests that objects are still active and the unload is doing the correct thing.

While this could be a leak, the initial thinking is that this test fails due to the background threads racing to finish up their work as the main thread continues on after the completion is signaled.  The name-based tests that expect the module to unload also need to free the activation factories that C++/WinRT caches before calling into the test method, which appears to be giving them enough time to complete successfully.

## Change
Add a sleep option to the tests and use it for the failing one.  A more invasive solution would be to use the shutdown monitoring the forcibly close out and wait for the background threads, but test only exports are a pain to manage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5933)