### PR TITLE
Use a binary cache for vcpkg in pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ pool:
 variables:
   solution: 'src\AppInstallerCLI.sln'
   EnableDetectorVcpkg: true
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://pkgs.dev.azure.com/shine-oss/winget-cli/_packaging/WinGetDependencies/nuget/v3/index.json,readwrite"
 
 # Do not set the build version for a PR build.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,9 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet Feed'
+
   # Restores all projects, including native (vcxproj) projects
   - task: NuGetCommand@2
     displayName: Restore Solution
@@ -640,6 +643,9 @@ jobs:
   steps:
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate to NuGet Feed'
 
   - task: NuGetCommand@2
     displayName: Restore Solution


### PR DESCRIPTION
This should speed up each pipeline run by a few minutes.

It can also be configured locally by setting the environment variable `VCPKG_BINARY_SOURCES` to `nuget,https://pkgs.dev.azure.com/shine-oss/winget-cli/_packaging/WinGetDependencies/nuget/v3/index.json`

I configured it at the pipeline level instead of adding it to the projects to not interfere with the configuration used in internal builds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5936)