### PR TITLE
Improve translation of 'FontFamily' and 'FontFace' in Chinese(zh-CN and zh-TW)

### DIFF
--- a/Localization/Resources/zh-CN/winget.resw
+++ b/Localization/Resources/zh-CN/winget.resw
@@ -3166,17 +3166,19 @@
     <value>使用子命令管理字体。可以安装、升级或卸载与 package 类似的字体。 </value>
   </data>
   <data name="FontFamily" xml:space="preserve">
-    <value>家庭</value>
+    <value>字体族</value>
+    <comment>"Family" represents the font family such as 'Arial' or 'Times New Roman'</comment>
   </data>
   <data name="FontFaces" xml:space="preserve">
-    <value>脸</value>
+    <value>字体样式</value>
     <comment>"Faces" represents the typeface of the font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFamilyNameArgumentDescription" xml:space="preserve">
-    <value>按家庭名称筛选结果</value>
+    <value>按字体族名称筛选结果</value>
+    <comment>"Family" represents the font family such as 'Arial' or 'Times New Roman'</comment>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>脸</value>
+    <value>字体样式</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">

--- a/Localization/Resources/zh-TW/winget.resw
+++ b/Localization/Resources/zh-TW/winget.resw
@@ -3166,17 +3166,18 @@
     <value>使用子命令管理字型。可以安裝、升級或卸載類似封裝的字型。 </value>
   </data>
   <data name="FontFamily" xml:space="preserve">
-    <value>家庭</value>
+    <value>字型族</value>
+    <comment>"Family" represents the font family such as 'Arial' or 'Times New Roman'</comment>
   </data>
   <data name="FontFaces" xml:space="preserve">
-    <value>表情</value>
+    <value>字型樣式</value>
     <comment>"Faces" represents the typeface of the font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFamilyNameArgumentDescription" xml:space="preserve">
-    <value>依家庭名稱篩選結果</value>
+    <value>依字型族名稱篩選結果</value>
   </data>
   <data name="FontFace" xml:space="preserve">
-    <value>臉</value>
+    <value>字型樣式</value>
     <comment>"Face" represents the typeface of a font family such as 'Bold' or 'Italic'</comment>
   </data>
   <data name="FontFilePaths" xml:space="preserve">


### PR DESCRIPTION

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----

## Description
This PR improves the Chinese translation of technical terms 'FontFamily' and 'FontFace' to be more accurate and context-appropriate.

## Changes Made
* FontFamily: Updated translation from "家族" to "字体族"(zh-CN) and "字型族"(zh-TW). Related comments are appended.

  * "家族" literally means "family" in the sense of parents and children, which is not appropriate for typography context.

* FontFace: Updated translation from "脸" to "字体样式"(zh-CN) and "字型樣式"(zh-TW).

  * "脸" literally means the physical face of people, which is completely unrelated.
  * "字体样式" is the usual translation of font typeface.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5943)