### PR TITLE
Encapsulate argument with quotes in German translation for clarity

### DIFF
--- a/Localization/Resources/de-DE/winget.resw
+++ b/Localization/Resources/de-DE/winget.resw
@@ -1730,7 +1730,7 @@ Geben Sie eine Option für --source an, um den Vorgang fortzusetzen.</value>
     <comment>{Locked="winget pin","--include-pinned"} Error shown when we block an upgrade due to the package being pinned</comment>
   </data>
   <data name="UpgradePinnedByUserCount" xml:space="preserve">
-    <value>{0} Pakete verfügen über Pins, die ein Upgrade verhindern. Verwenden Sie den Befehl "winget pin", um Pins anzuzeigen und zu bearbeiten. Wenn Sie das --include-pinned-Argument verwenden, werden möglicherweise weitere Ergebnisse angezeigt.</value>
+    <value>{0} Pakete verfügen über Pins, die ein Upgrade verhindern. Verwenden Sie den Befehl "winget pin", um Pins anzuzeigen und zu bearbeiten. Wenn Sie das "--include-pinned"-Argument verwenden, werden möglicherweise weitere Ergebnisse angezeigt.</value>
     <comment>{Locked="winget pin","--include-pinned"} {0} is a placeholder replaced by an integer number of packages</comment>
   </data>
   <data name="ConfigureCommandLongDescription" xml:space="preserve">


### PR DESCRIPTION
While the actual example command "winget pin" is already quoted, the "--include-pinned" argument was not. Due to German use of hyphens, this was less than optimal for readability.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [X] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] ~~I have updated the [Release Notes](../doc/ReleaseNotes.md).~~ => change too little to be relevant
- [ ] ~~This pull request is related to an issue.~~ => If a trivial change like this really needs to be related to an issue, someone please create one yourself. 🤦‍♂️ 

-----
