### PR TITLE
Add manifest version to WinGetUtilInterop

### DIFF
--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -53,6 +53,8 @@ namespace AppInstaller::Manifest
     // V1.12 manifest version
     constexpr std::string_view s_ManifestVersionV1_12 = "1.12.0"sv;
 
+    // Any new manifest version must also be added to src\WinGetUtilInterop\Manifest\ManifestVersion.cs.
+
     // The manifest extension for the MS Store
     constexpr std::string_view s_MSStoreExtension = "msstore"sv;
 

--- a/src/WinGetUtilInterop/Manifest/ManifestVersion.cs
+++ b/src/WinGetUtilInterop/Manifest/ManifestVersion.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------
+// <copyright file="ManifestVersion.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGetUtil.Manifest
+{
+    /// <summary>
+    /// Supported manifest version values.
+    /// </summary>
+    public static class ManifestVersion
+    {
+#pragma warning disable SA1310 // Field names should not contain underscore
+
+        /// <summary>
+        /// V1 manifest version for GA.
+        /// </summary>
+        public const string ManifestVersionV1 = "1.0.0";
+
+        /// <summary>
+        /// V1.1 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_1 = "1.1.0";
+
+        /// <summary>
+        /// V1.2 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_2 = "1.2.0";
+
+        /// <summary>
+        /// V1.4 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_4 = "1.4.0";
+
+        /// <summary>
+        /// V1.5 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_5 = "1.5.0";
+
+        /// <summary>
+        /// V1.6 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_6 = "1.6.0";
+
+        /// <summary>
+        /// V1.7 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_7 = "1.7.0";
+
+        /// <summary>
+        /// V1.9 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_9 = "1.9.0";
+
+        /// <summary>
+        /// V1.10 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_10 = "1.10.0";
+
+        /// <summary>
+        /// V1.12 manifest version.
+        /// </summary>
+        public const string ManifestVersionV1_12 = "1.12.0";
+
+#pragma warning restore SA1310 // Field names should not contain underscore
+    }
+}


### PR DESCRIPTION
Adds all current V1 manfiest versions to WinGetUtilInterop.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5964)