### PR TITLE
Escape caller in user agent header

### DIFF
--- a/src/AppInstallerCLITests/HttpClientHelper.cpp
+++ b/src/AppInstallerCLITests/HttpClientHelper.cpp
@@ -9,6 +9,7 @@
 #include <winget/Certificates.h>
 #include <winget/HttpClientHelper.h>
 #include <CertificateResources.h>
+#include <winget/JsonUtil.h>
 
 using namespace AppInstaller::Http;
 using namespace AppInstaller::Runtime;
@@ -78,4 +79,13 @@ TEST_CASE("HttpClientHelper_PinningConfiguration", "[RestSource]")
     helper.SetPinningConfiguration(config);
 
     REQUIRE_THROWS_HR(helper.HandleGet(L"https://github.com"), APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH);
+}
+
+TEST_CASE("HttpClientHelper_CallerCharacters", "[RestSource]")
+{
+    HttpClientHelper::HttpRequestHeaders headers;
+    headers.emplace(web::http::header_names::user_agent, AppInstaller::JSON::GetUtilityString(AppInstaller::Runtime::GetUserAgent("\xe6\xb5\x8b\xe8\xaf\x95")));
+
+    HttpClientHelper helper;
+    REQUIRE_THROWS_HR(helper.HandleGet(L"https://github.com", headers), APPINSTALLER_CLI_ERROR_RESTAPI_UNSUPPORTED_MIME_TYPE);
 }

--- a/src/AppInstallerCommonCore/Runtime.cpp
+++ b/src/AppInstallerCommonCore/Runtime.cpp
@@ -572,9 +572,11 @@ namespace AppInstaller::Runtime
 
     Utility::LocIndString GetUserAgent(std::string_view caller)
     {
+        auto escapedCaller = winrt::Windows::Foundation::Uri::EscapeComponent(Utility::ConvertToUTF16(caller));
+
         std::ostringstream strstr;
         strstr <<
-            caller <<
+            Utility::ConvertToUTF8(escapedCaller) <<
             " WindowsPackageManager/" << GetClientVersion() <<
             " DesktopAppInstaller/" << GetPackageVersion();
         return Utility::LocIndString{ strstr.str() };


### PR DESCRIPTION
## Change
Escape the caller string in the user agent header using UTF-8 `%` encoding.  If we don't, invalid characters lead to failures to set the headers and a broken flow.

## Validation
Added a unit test with the caller `测试` ("test" through machine translation).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/5998)