### PR TITLE
Move to IReference rather than custom enum for optional bool

### DIFF
--- a/src/AppInstallerCLIE2ETests/Interop/PackageCatalogInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/PackageCatalogInterop.cs
@@ -291,13 +291,14 @@ namespace AppInstallerCLIE2ETests.Interop
             options.SourceUri = Constants.TestSourceUrl;
             options.Name = Constants.TestSourceName;
             options.TrustLevel = PackageCatalogTrustLevel.Trusted;
+            options.Explicit = true;
 
             await this.AddAndValidatePackageCatalogAsync(options, AddPackageCatalogStatus.Ok);
 
             // Edit
             EditPackageCatalogOptions editOptions = this.TestFactory.CreateEditPackageCatalogOptions();
             editOptions.Name = Constants.TestSourceName;
-            editOptions.Explicit = OptionalBoolean.False;
+            editOptions.Explicit = false;
             this.EditAndValidatePackageCatalog(editOptions, EditPackageCatalogStatus.Ok);
 
             // Remove
@@ -340,6 +341,7 @@ namespace AppInstallerCLIE2ETests.Interop
             Assert.IsNotNull(packageCatalog);
             Assert.AreEqual(addPackageCatalogOptions.Name, packageCatalog.Info.Name);
             Assert.AreEqual(addPackageCatalogOptions.SourceUri, packageCatalog.Info.Argument);
+            Assert.AreEqual(addPackageCatalogOptions.Explicit, packageCatalog.Info.Explicit);
 
             return packageCatalog;
         }
@@ -396,9 +398,9 @@ namespace AppInstallerCLIE2ETests.Interop
 
             // Verify edits are correct.
             var packageCatalog = this.packageManager.GetPackageCatalogByName(editPackageCatalogOptions.Name);
-            if (editPackageCatalogOptions.Explicit != OptionalBoolean.Unspecified)
+            if (editPackageCatalogOptions.Explicit != null)
             {
-                Assert.AreEqual(packageCatalog.Info.Explicit, editPackageCatalogOptions.Explicit == OptionalBoolean.True);
+                Assert.AreEqual(packageCatalog.Info.Explicit, editPackageCatalogOptions.Explicit);
             }
         }
     }

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -201,9 +201,9 @@ namespace AppInstaller::Repository
     // Contains information about edits to a source.
     struct SourceEdit
     {
-        SourceEdit(std::optional<bool> isExplicit);
+        SourceEdit() = default;
 
-        // The explicit property of a source.
+        // The Explicit property of a source.
         std::optional<bool> Explicit;
     };
 

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -432,8 +432,6 @@ namespace AppInstaller::Repository
         return CheckForWellKnownSourceMatch(sourceDetails.Name, sourceDetails.Arg, sourceDetails.Type);
     }
 
-    SourceEdit::SourceEdit(std::optional<bool> isExplicit) : Explicit(isExplicit) {}
-
     Source::Source() {}
 
     Source::Source(std::string_view name)

--- a/src/Microsoft.Management.Deployment/Converters.cpp
+++ b/src/Microsoft.Management.Deployment/Converters.cpp
@@ -556,37 +556,4 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         default: return AppInstaller::Manifest::PlatformEnum::Unknown;
         }
     }
-
-    std::optional<bool> GetOptionalBoolean(winrt::Microsoft::Management::Deployment::OptionalBoolean optionalBoolean)
-    {
-        switch (optionalBoolean)
-        {
-        case OptionalBoolean::True:
-            return std::optional<bool> { true };
-        case OptionalBoolean::False:
-            return std::optional<bool> { false };
-        default:
-            return std::nullopt;
-        }
-    }
-
-    winrt::Microsoft::Management::Deployment::OptionalBoolean GetOptionalBoolean(std::optional<bool> optionalBoolean)
-    {
-        if (optionalBoolean.has_value())
-        {
-            if (optionalBoolean.value())
-            {
-                return OptionalBoolean::True;
-            }
-            else
-            {
-                return OptionalBoolean::False;
-            }
-        }
-        else
-        {
-            return OptionalBoolean::Unspecified;
-        }
-    }
-
 }

--- a/src/Microsoft.Management.Deployment/Converters.h
+++ b/src/Microsoft.Management.Deployment/Converters.h
@@ -35,8 +35,6 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     winrt::Microsoft::Management::Deployment::RemovePackageCatalogStatus GetRemovePackageCatalogOperationStatus(winrt::hresult hresult);
     winrt::Microsoft::Management::Deployment::EditPackageCatalogStatus GetEditPackageCatalogOperationStatus(winrt::hresult hresult);
     ::AppInstaller::Manifest::PlatformEnum GetPlatformEnum(winrt::Microsoft::Management::Deployment::WindowsPlatform value);
-    std::optional<bool> GetOptionalBoolean(winrt::Microsoft::Management::Deployment::OptionalBoolean optionalBoolean);
-    winrt::Microsoft::Management::Deployment::OptionalBoolean GetOptionalBoolean(std::optional<bool> optionalBoolean);
 
 #define WINGET_GET_OPERATION_RESULT_STATUS(_installResultStatus_, _uninstallResultStatus_, _downloadResultStatus_, _repairResultStatus_) \
     if constexpr (std::is_same_v<TStatus, winrt::Microsoft::Management::Deployment::InstallResultStatus>) \

--- a/src/Microsoft.Management.Deployment/EditPackageCatalogOptions.cpp
+++ b/src/Microsoft.Management.Deployment/EditPackageCatalogOptions.cpp
@@ -18,15 +18,18 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     {
         return hstring(m_name);
     }
+
     void EditPackageCatalogOptions::Name(hstring const& value)
     {
         m_name = value;
     }
-    OptionalBoolean EditPackageCatalogOptions::Explicit()
+
+    Windows::Foundation::IReference<bool> EditPackageCatalogOptions::Explicit()
     {
         return m_explicit;
     }
-    void EditPackageCatalogOptions::Explicit(OptionalBoolean const& value)
+
+    void EditPackageCatalogOptions::Explicit(Windows::Foundation::IReference<bool> value)
     {
         m_explicit = value;
     }

--- a/src/Microsoft.Management.Deployment/EditPackageCatalogOptions.h
+++ b/src/Microsoft.Management.Deployment/EditPackageCatalogOptions.h
@@ -4,6 +4,7 @@
 #include "EditPackageCatalogOptions.g.h"
 #include "public/ComClsids.h"
 #include <winget/ModuleCountBase.h>
+#include <optional>
 
 namespace winrt::Microsoft::Management::Deployment::implementation
 {
@@ -15,13 +16,13 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         hstring Name();
         void Name(hstring const& value);
 
-        OptionalBoolean Explicit();
-        void Explicit(OptionalBoolean const& value);
+        Windows::Foundation::IReference<bool> Explicit();
+        void Explicit(Windows::Foundation::IReference<bool> value);
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
         hstring m_name = L"";
-        OptionalBoolean m_explicit = OptionalBoolean::Unspecified;
+        std::optional<bool> m_explicit;
 #endif
     };
 }

--- a/src/Microsoft.Management.Deployment/PackageManager.cpp
+++ b/src/Microsoft.Management.Deployment/PackageManager.cpp
@@ -1467,7 +1467,8 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             THROW_HR_IF(APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST, !matchingSource.has_value());
             ::AppInstaller::Repository::Source sourceToEdit = ::AppInstaller::Repository::Source{ matchingSource.value().Name };
 
-            ::AppInstaller::Repository::SourceEdit edits{ GetOptionalBoolean(options.Explicit())};
+            ::AppInstaller::Repository::SourceEdit edits;
+            edits.Explicit = options.Explicit();
             if (sourceToEdit.RequiresChanges(edits))
             {
                 sourceToEdit.Edit(edits);

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -1541,15 +1541,6 @@ namespace Microsoft.Management.Deployment
         HRESULT ExtendedErrorCode { get; };
     };
 
-    /// IMPLEMENTATION NOTE: OptionalBoolean
-    [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 28)]
-    enum OptionalBoolean
-    {
-        Unspecified,
-        False,
-        True,
-    };
-
     /// IMPLEMENTATION NOTE: EditPackageCatalogOptions
     [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 28)]
     runtimeclass EditPackageCatalogOptions
@@ -1562,7 +1553,7 @@ namespace Microsoft.Management.Deployment
         String Name;
 
         /// Editing the Explicit property has three states: true, false, and not specified (no changes).
-        OptionalBoolean Explicit;
+        Windows.Foundation.IReference<Boolean> Explicit;
     };
 
     /// IMPLEMENTATION NOTE: RemovePackageCatalogStatus
@@ -1620,12 +1611,6 @@ namespace Microsoft.Management.Deployment
             Windows.Foundation.IAsyncOperationWithProgress<RemovePackageCatalogResult, Double> RemovePackageCatalogAsync(RemovePackageCatalogOptions options);
         }
 
-        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 28)]
-        {
-            /// Edit an existing Windows Package Catalog.
-            EditPackageCatalogResult EditPackageCatalog(EditPackageCatalogOptions options);
-        }
-
         /// Install the specified package
         Windows.Foundation.IAsyncOperationWithProgress<InstallResult, InstallProgress> InstallPackageAsync(CatalogPackage package, InstallOptions options);
 
@@ -1666,6 +1651,12 @@ namespace Microsoft.Management.Deployment
         {
             // The version of the Windows Package Manager that is running.
             String Version{ get; };
+        }
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 28)]
+        {
+            /// Edit an existing Windows Package Catalog.
+            EditPackageCatalogResult EditPackageCatalog(EditPackageCatalogOptions options);
         }
     }
 


### PR DESCRIPTION
## Change
Use an `IReference<Boolean>` rather than a custom enum to represent an optional bool value.  The projection is much cleaner and scales better to other value types.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6022)