### PR TITLE
Added more info for "Installer Types" values in Settings.md.

### DIFF
--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -182,7 +182,7 @@ The `architectures` behavior affects what architectures will be selected when in
 
 ### Installer Types
 
-The `installerTypes` behavior affects what installer types will be selected when installing a package. It can also determine which type to install by default if a manifest has multiple types: The first (leftmost) ones are looked for first, which can be convenient for users who for instance prefer portable packages or MSIX/AppX installations. The matching parameter is `--installer-type`.
+The `installerTypes` behavior affects what installer types will be selected when installing a package. It can also determine which type to install by default if a manifest has multiple types: The list is in priority order, with the first listed type being preferred over the others, and so on.  This is convenient for users who for instance prefer portable packages or MSIX/AppX installations. The matching parameter is `--installer-type`, which will override the settings.
 
 Allowed values as of version 1.12.470 include: `appx`, `burn`, `exe`, `font`, `inno`, `msi`, `msix`, `msstore`, `nullsoft`, `portable`, `wix`, `zip`
 


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----
Strongly inspired by:
* https://github.com/microsoft/winget-pkgs/issues/342123
* And secondarily by how I've wondered how I could get packages to default to MSIX on my end by default.

The current documentation on the priority orders of installer types when using `winget install` without having specified `--installer-type`, was unfortunately pretty scarce. So I've filled in most of the gaps now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6067)