### PR TITLE
i18n(adm): localize AppInstaller ADMX resource file to Chinese

### DIFF
--- a/doc/admx/zh-CN/DesktopAppInstaller.adml
+++ b/doc/admx/zh-CN/DesktopAppInstaller.adml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>应用安装程序</displayName>
+  <description>应用安装程序</description>
+  <resources>
+    <stringTable>
+      <string id="AppInstaller">桌面应用安装程序</string>
+      <string id="EnableAppInstaller">启用 Windows 程序包管理器</string>
+      <string id="EnableAppInstallerExplanation">此策略控制用户是否可以使用 Windows 程序包管理器。
+
+如果启用或未配置此设置，用户将能够使用 Windows 程序包管理器。
+
+如果禁用此设置，用户将无法使用 Windows 程序包管理器。</string>
+      <string id="EnableSettings">启用 Windows 程序包管理器设置</string>
+      <string id="EnableSettingsExplanation">此策略控制用户是否可以更改其设置。
+
+如果启用或未配置此设置，用户将能够更改 Windows 程序包管理器的设置。
+
+如果禁用此设置，用户将无法更改 Windows 程序包管理器的设置。</string>
+      <string id="EnableExperimentalFeatures">启用 Windows 程序包管理器实验性功能</string>
+      <string id="EnableExperimentalFeaturesExplanation">此策略控制用户是否可以在 Windows 程序包管理器中启用实验性功能。
+
+如果启用或未配置此设置，用户将能够为 Windows 程序包管理器启用实验性功能。
+
+如果禁用此设置，用户将无法为 Windows 程序包管理器启用实验性功能。</string>
+      <string id="EnableLocalManifestFiles">启用 Windows 程序包管理器本地清单文件</string>
+      <string id="EnableLocalManifestFilesExplanation">此策略控制用户是否可以使用本地清单文件安装程序包。
+
+如果启用或未配置此设置，用户将能够使用 Windows 程序包管理器安装带有本地清单的程序包。
+
+如果禁用此设置，用户将无法使用 Windows 程序包管理器安装带有本地清单的程序包。</string>
+      <string id="EnableBypassCertificatePinningForMicrosoftStore">启用 Windows 程序包管理器 Microsoft 商店源证书验证绕过</string>
+      <string id="EnableBypassCertificatePinningForMicrosoftStoreExplanation">此策略控制当启动与 Microsoft 商店源的连接时，Windows 程序包管理器是否将 Microsoft 商店证书哈希与已知的 Microsoft 商店证书进行匹配验证。
+如果启用此策略，Windows 程序包管理器将绕过 Microsoft 商店证书验证。
+
+如果禁用此策略，Windows 程序包管理器将在与 Microsoft 商店源通信之前，验证所使用的 Microsoft 商店证书是否有效且属于 Microsoft 商店。
+
+如果未配置此策略，则将遵循 Windows 程序包管理器管理员设置。</string>
+      <string id="EnableHashOverride">启用 Windows 程序包管理器哈希值覆盖</string>
+      <string id="EnableHashOverrideExplanation">此策略控制是否可以将 Windows 程序包管理器配置为允许在设置中覆盖 SHA256 安全验证。
+
+如果启用或未配置此策略，用户将能够在 Windows 程序包管理器设置中启用覆盖 SHA256 安全验证的功能。
+
+如果禁用此策略，用户将无法在 Windows 程序包管理器设置中启用覆盖 SHA256 安全验证的功能。</string>
+      <string id="EnableLocalArchiveMalwareScanOverride">启用 Windows 程序包管理器本地存档恶意软件扫描覆盖</string>
+      <string id="EnableLocalArchiveMalwareScanOverrideExplanation">此策略控制在使用命令行参数通过本地清单安装存档文件时，是否允许覆盖恶意软件漏洞扫描。
+如果启用此策略，用户在执行本地清单安装存档文件时可以覆盖恶意软件扫描。
+
+如果禁用此策略，用户在使用本地清单安装存档文件时将无法覆盖恶意软件扫描。
+
+如果未配置此策略，则将遵循 Windows 程序包管理器管理员设置。</string>
+      <string id="EnableDefaultSource">启用 Windows 程序包管理器默认源</string>
+      <string id="EnableDefaultSourceExplanation">此策略控制 Windows 程序包管理器附带的默认源。
+
+如果未配置此设置，Windows 程序包管理器的默认源将可用且可以被移除。
+
+如果启用此设置，Windows 程序包管理器的默认源将可用且无法被移除。
+
+如果禁用此设置，Windows 程序包管理器的默认源将不可用。</string>
+      <string id="EnableMicrosoftStoreSource">启用 Windows 程序包管理器 Microsoft 商店源</string>
+      <string id="EnableMicrosoftStoreSourceExplanation">此策略控制 Windows 程序包管理器附带的 Microsoft 商店源。
+
+如果未配置此设置，Windows 程序包管理器的 Microsoft 商店源将可用且可以被移除。
+
+如果启用此设置，Windows 程序包管理器的 Microsoft 商店源将可用且无法被移除。
+
+如果禁用此设置，Windows 程序包管理器的 Microsoft 商店源将不可用。</string>
+      <string id="EnableFontSource">启用 Windows 程序包管理器字体源</string>
+      <string id="EnableFontSourceExplanation">
+        此策略控制 Windows 程序包管理器附带的字体源。
+
+        如果未配置此设置，Windows 程序包管理器的字体源将可用且可以被移除。
+
+        如果启用此设置，Windows 程序包管理器的字体源将可用且无法被移除。
+
+        如果禁用此设置，Windows 程序包管理器的字体源将不可用。
+      </string>
+      <string id="SourceAutoUpdateInterval">设置 Windows 程序包管理器源自动更新间隔（分钟）</string>
+      <string id="SourceAutoUpdateIntervalExplanation">此策略控制基于包的源的自动更新间隔。Windows 程序包管理器的默认源配置为在本地计算机上缓存包的索引。当用户调用命令且间隔时间已过时，将下载该索引。
+
+如果禁用或未配置此设置，将使用默认间隔或 Windows 程序包管理器设置中指定的值。
+
+如果启用此设置，Windows 程序包管理器将使用指定的分钟数。</string>
+      <string id="EnableAdditionalSources">启用 Windows 程序包管理器附加源</string>
+      <string id="EnableAdditionalSourcesExplanation">此策略控制由企业 IT 管理员提供的附加源。
+
+如果未配置此策略，将不会为 Windows 程序包管理器配置任何附加源。
+
+如果启用此策略，附加源将被添加到 Windows 程序包管理器中且无法被移除。每个附加源的表示形式可以使用“winget source export”从已安装的源中获取。
+
+如果禁用此策略，则无法为 Windows 程序包管理器配置任何附加源。</string>
+      <string id="EnableAllowedSources">启用 Windows 程序包管理器允许的源</string>
+      <string id="EnableAllowedSourcesExplanation">此策略控制企业 IT 管理员允许的附加源。
+
+如果未配置此策略，除了策略配置的源之外，用户将能够添加或移除其他附加源。
+
+如果启用此策略，则只能从 Windows 程序包管理器中添加或移除指定的源。每个允许的源的表示形式可以使用“winget source export”从已安装的源中获取。
+
+如果禁用此策略，则无法为 Windows 程序包管理器配置任何附加源。</string>
+      <string id="EnableMSAppInstallerProtocol">启用应用安装程序 ms-appinstaller 协议</string>
+      <string id="EnableMSAppInstallerProtocolExplanation">此策略控制用户是否可以从使用 ms-appinstaller 协议的网站安装程序包。
+
+如果启用此设置，用户将能够从使用此协议的网站安装程序包。
+
+如果禁用或未配置此设置，用户将无法从使用此协议的网站安装程序包。</string>
+      <string id="EnableWindowsPackageManagerCommandLineInterfaces">启用 Windows 程序包管理器命令行界面</string>
+      <string id="EnableWindowsPackageManagerCommandLineInterfacesExplanation">此策略确定用户是否可以通过命令行界面（WinGet CLI 或 WinGet PowerShell）使用 Windows 程序包管理器执行操作。
+
+        如果禁用此策略，用户将无法执行 Windows 程序包管理器 CLI 命令和 PowerShell cmdlet。
+
+        如果启用或未配置此策略，用户将能够执行 Windows 程序包管理器 CLI 命令和 PowerShell cmdlet。（前提是未禁用“启用应用安装程序”策略）。
+
+        此策略不会覆盖“启用应用安装程序”策略。</string>
+      <string id="EnableWindowsPackageManagerConfiguration">启用 Windows 程序包管理器配置</string>
+      <string id="EnableWindowsPackageManagerConfigurationExplanation">此策略控制用户是否可以使用 Windows 程序包管理器配置功能。
+
+如果启用或未配置此设置，用户将能够使用 Windows 程序包管理器配置功能。
+
+如果禁用此设置，用户将无法使用 Windows 程序包管理器配置功能。</string>
+      <string id="EnableWindowsPackageManagerProxyCommandLineOptions">启用 Windows 程序包管理器代理命令行选项</string>
+      <string id="EnableWindowsPackageManagerProxyCommandLineOptionsExplanation">
+        此策略控制用户是否可以通过命令行配置 Windows 程序包管理器的代理使用情况。
+
+        如果启用此设置，用户将能够通过命令行配置 Windows 程序包管理器的代理使用情况。
+
+        如果禁用或未配置此设置，用户将无法通过命令行配置 Windows 程序包管理器的代理使用情况。</string>
+      <string id="EnableWindowsPackageManagerMcpServer">启用 Windows 程序包管理器的 MCP 服务器</string>
+      <string id="EnableWindowsPackageManagerMcpServerExplanation">
+        此策略控制是否可以使用 Windows 程序包管理器模型上下文协议 (MCP) 服务器。
+
+        如果启用或未配置此设置，用户将能够使用 Windows 程序包管理器的 MCP 服务器。
+
+        如果禁用此设置，用户将无法使用 Windows 程序包管理器的 MCP 服务器。</string>
+      <string id="WindowsPackageManagerDefaultProxy">设置 Windows 程序包管理器默认代理</string>
+      <string id="WindowsPackageManagerDefaultProxyExplanation">此策略控制 Windows 程序包管理器使用的默认代理。
+
+如果禁用或未配置此设置，默认情况下将不使用代理。
+
+如果启用此设置，默认情况下将使用指定的代理。</string>
+      <string id="EnableMsixAllowedZones">启用应用安装程序允许的 MSIX 包区域</string>
+      <string id="EnableMsixAllowedZonesExplanation">此策略控制应用安装程序是否允许安装源自特定 URL 区域的包。包的源区域由其 URI 以及是否存在“来自网络的文件”(MotW) 决定。如果涉及多个 URI，则所有这些 URI 都会被考虑；例如，当使用涉及重定向的 .appinstaller 文件时。
+
+如果启用此策略，用户将能够根据每个区域的配置安装 MSIX 包。
+
+如果禁用或未配置此策略，用户将能够从除“不受信任”区域之外的任何区域安装 MSIX 包。</string>
+      <string id="ZoneAllowed">允许</string>
+      <string id="ZoneBlocked">阻止</string>
+      <string id="EnableMsixSmartScreenCheck">启用针对 MSIX 包的 Microsoft SmartScreen 检查</string>
+      <string id="EnableMsixSmartScreenCheckExplanation">此策略控制在安装 MSIX 包时，应用安装程序是否执行 Microsoft SmartScreen 检查。
+
+如果启用或未配置此策略，将在安装前使用 Microsoft SmartScreen 评估包的 URI。此检查仅针对来自互联网的包执行。
+
+如果禁用，则在安装包之前将不会咨询 Microsoft SmartScreen。</string>
+    </stringTable>
+    <presentationTable>
+      <presentation id="SourceAutoUpdateInterval">
+        <decimalTextBox refId="SourceAutoUpdateInterval" defaultValue="5">源自动更新间隔（分钟）</decimalTextBox>
+      </presentation>
+      <presentation id="AdditionalSources">
+        <listBox refId="AdditionalSources" required="false">附加源：</listBox>
+      </presentation>
+      <presentation id="AllowedSources">
+        <listBox refId="AllowedSources" required="false">允许的源：</listBox>
+      </presentation>
+      <presentation id="WindowsPackageManagerDefaultProxy">
+        <textBox refId="WindowsPackageManagerDefaultProxy">
+          <label>默认代理</label>
+        </textBox>
+      </presentation>
+      <presentation id="MsixAllowedZones">
+        <dropdownList refId="LocalMachine" noSort="true" defaultItem="1">本地计算机</dropdownList>
+        <dropdownList refId="Intranet" noSort="true" defaultItem="1">Intranet</dropdownList>
+        <dropdownList refId="TrustedSites" noSort="true" defaultItem="1">受信任的站点</dropdownList>
+        <dropdownList refId="Internet" noSort="true" defaultItem="1">Internet</dropdownList>
+        <dropdownList refId="UntrustedSites" noSort="true" defaultItem="0">不受信任的站点</dropdownList>
+      </presentation>
+    </presentationTable>
+  </resources>
+</policyDefinitionResources>


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----

## Changes
- Translated all English strings in `DesktopAppInstaller.adml` to Chinese

## Localization Notes
- Followed Microsoft official terminology database (e.g., "Windows Package Manager" → "Windows 程序包管理器")
- "SmartScreen" kept in English (not translated)
- All numbers and default values unchanged
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6070)