### PR TITLE
fix(install): defer success message until post-install checks

### DIFF
--- a/src/AppInstallerCLICore/ExecutionContext.h
+++ b/src/AppInstallerCLICore/ExecutionContext.h
@@ -76,6 +76,12 @@ namespace AppInstaller::CLI::Execution
         RebootRequired = 0x400,
         RegisterResume = 0x800,
         InstallerExecutionUseRepair = 0x1000,
+        // InstallPackageInstaller: suppress immediate success until post-install checks complete.
+        DeferInstallSuccessMessage = 0x2000,
+        // MSIX registration deferred: do not emit generic success after checks (warning already shown).
+        SuppressDeferredInstallSuccess = 0x4000,
+        // Set when an install would have reported success but output was deferred.
+        PendingDeferredInstallSuccess = 0x8000,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(ContextFlag);

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -255,6 +255,14 @@ namespace AppInstaller::CLI::Workflow
             if (registrationDeferred)
             {
                 context.Reporter.Warn() << Resource::String::InstallFlowRegistrationDeferred << std::endl;
+                if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+                {
+                    context.SetFlags(Execution::ContextFlag::SuppressDeferredInstallSuccess);
+                }
+            }
+            else if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+            {
+                context.SetFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
             }
             else
             {
@@ -575,7 +583,11 @@ namespace AppInstaller::CLI::Workflow
         }
         else
         {
-            if (isRepair)
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+            {
+                context.SetFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            }
+            else if (isRepair)
             {
                 context.Reporter.Info() << Resource::String::RepairFlowRepairSuccess << std::endl;
             }
@@ -583,6 +595,40 @@ namespace AppInstaller::CLI::Workflow
             {
                 context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
             }
+        }
+    }
+
+    void ReportDeferredInstallSuccess(Execution::Context& context)
+    {
+        if (!WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+        {
+            return;
+        }
+        context.ClearFlags(Execution::ContextFlag::DeferInstallSuccessMessage);
+        if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::SuppressDeferredInstallSuccess))
+        {
+            context.ClearFlags(Execution::ContextFlag::SuppressDeferredInstallSuccess);
+            context.ClearFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            return;
+        }
+        if (context.IsTerminated())
+        {
+            context.ClearFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            return;
+        }
+        if (!WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::PendingDeferredInstallSuccess))
+        {
+            return;
+        }
+        context.ClearFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+        const bool isRepair = WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::InstallerExecutionUseRepair);
+        if (isRepair)
+        {
+            context.Reporter.Info() << Resource::String::RepairFlowRepairSuccess << std::endl;
+        }
+        else
+        {
+            context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
         }
     }
 
@@ -595,6 +641,9 @@ namespace AppInstaller::CLI::Workflow
 
     void InstallPackageInstaller(Execution::Context& context)
     {
+        context.ClearFlags(
+            Execution::ContextFlag::PendingDeferredInstallSuccess | Execution::ContextFlag::SuppressDeferredInstallSuccess);
+        context.SetFlags(Execution::ContextFlag::DeferInstallSuccessMessage);
         context <<
             Workflow::ReportExecutionStage(ExecutionStage::PreExecution) <<
             Workflow::SnapshotARPEntries <<
@@ -606,6 +655,7 @@ namespace AppInstaller::CLI::Workflow
             Workflow::ForceInstalledCacheUpdate <<
             Workflow::RemoveInstaller <<
             Workflow::DisplayInstallationNotes;
+        ReportDeferredInstallSuccess(context);
     }
 
     void InstallDependencies(Execution::Context& context)

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.h
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.h
@@ -147,6 +147,9 @@ namespace AppInstaller::CLI::Workflow
     // Inputs: InstallerPath, Manifest, Installer, PackageVersion, InstalledPackageVersion?
     // Outputs: None
     void InstallPackageInstaller(Execution::Context& context);
+
+    // Emits deferred install/repair success after post-install steps (ARP verification, etc.).
+    void ReportDeferredInstallSuccess(Execution::Context& context);
     
     // Installs the dependencies for a specific package. CreateDependencySubContexts should have been called before this task.
     // Required Args: None

--- a/src/AppInstallerCLICore/Workflows/MSStoreInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/MSStoreInstallerHandler.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "MSStoreInstallerHandler.h"
 #include "WorkflowBase.h"
+#include "ExecutionContext.h"
 #include <AppInstallerSHA256.h>
 #include <AppInstallerDownloader.h>
 #include <AppInstallerRuntime.h>
@@ -159,7 +160,14 @@ namespace AppInstaller::CLI::Workflow
 
         if (SUCCEEDED(hr))
         {
-            context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+            {
+                context.SetFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            }
+            else
+            {
+                context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+            }
         }
         else
         {
@@ -200,7 +208,14 @@ namespace AppInstaller::CLI::Workflow
 
         if (SUCCEEDED(hr))
         {
-            context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+            {
+                context.SetFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            }
+            else
+            {
+                context.Reporter.Info() << Resource::String::InstallFlowInstallSuccess << std::endl;
+            }
         }
         else
         {
@@ -241,7 +256,14 @@ namespace AppInstaller::CLI::Workflow
 
         if (SUCCEEDED(hr))
         {
-            context.Reporter.Info() << Resource::String::RepairFlowRepairSuccess << std::endl;
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DeferInstallSuccessMessage))
+            {
+                context.SetFlags(Execution::ContextFlag::PendingDeferredInstallSuccess);
+            }
+            else
+            {
+                context.Reporter.Info() << Resource::String::RepairFlowRepairSuccess << std::endl;
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Delays the **Successfully installed** / repair success line until after post-install work runs (ARP snapshot correlation, upgrade version verification, record install, installation notes).

## Details

- New context flags: `DeferInstallSuccessMessage`, `PendingDeferredInstallSuccess`, `SuppressDeferredInstallSuccess`.
- `InstallPackageInstaller` sets defer, runs the existing pipeline, then `ReportDeferredInstallSuccess`.
- `ReportInstallerResult`, `MsixInstall`, and Microsoft Store install/update/repair paths respect defer; MSIX registration-deferred suppresses generic success (warning already shown).
- `PendingDeferredInstallSuccess` avoids printing success when the installer never completed (for example install lock cancelled before a success path).

## Related

Complements accurate reporting after install (for example ARP / version checks); avoids claiming success before those steps finish.

## Testing

CI build; manual install scenarios recommended.

Made with [Cursor](https://cursor.com)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6098)
