### PR TITLE
docs: fix multiple documentation issues (#5296, #5921, #5108, #4372, #5867)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ The same Microsoft Store package will be made available via our [Releases](https
 
 Please read our [troubleshooting guide](/doc/troubleshooting/README.md).
 
+## PowerShell Module
+
+The [Microsoft.WinGet.Client](https://www.powershellgallery.com/packages/Microsoft.WinGet.Client/) PowerShell module provides native cmdlets for interacting with the Windows Package Manager. You can install it from the PowerShell Gallery:
+
+```powershell
+Install-Module -Name Microsoft.WinGet.Client
+```
+
+Example usage:
+
+```powershell
+# Search for a package
+Find-WinGetPackage -Query "Visual Studio Code"
+
+# Install a package
+Install-WinGetPackage -Id Microsoft.VisualStudioCode
+
+# List installed packages
+Get-WinGetPackage
+
+# Update a package
+Update-WinGetPackage -Id Microsoft.VisualStudioCode
+
+# Repair the WinGet package manager installation
+Repair-WinGetPackageManager
+```
+
+For more information, see the [Microsoft.WinGet.Client](https://www.powershellgallery.com/packages/Microsoft.WinGet.Client/) page on the PowerShell Gallery.
+
 ## Administrator Considerations
 
 Installer behavior can be different depending on whether you are running **WinGet** with administrator privileges.

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -248,6 +248,22 @@ The `defaultModuleRoot` behavior affects the default root directory where module
     },
 ```
 
+## Download Behavior
+
+The `downloadBehavior` settings affect the default behavior of downloading packages.
+
+### Default Download Directory
+
+The `defaultDownloadDirectory` setting affects the default directory where installers are downloaded to. Defaults to `%USERPROFILE%/Downloads/` if value is not set or is invalid.
+
+> Note: This setting value must be an absolute path.
+
+```json
+    "downloadBehavior": {
+        "defaultDownloadDirectory": "C:/Users/FooBar/Downloads"
+    },
+```
+
 ## Telemetry
 
 The `telemetry` settings control whether winget writes ETW events that may be sent to Microsoft on a default installation of Windows.

--- a/doc/troubleshooting/README.md
+++ b/doc/troubleshooting/README.md
@@ -113,6 +113,9 @@ These errors most commonly occur for one of following reasons. Please try out th
    1. Get the `PackageFullName` of your installed `App Installer` package (PowerShell): `Get-AppxPackage Microsoft.DesktopAppInstaller | Select Name, PackageFullName`.
    2. `Add-AppxPackage -register "C:\Program Files\WindowsApps\{PackageFullName}\appxmanifest.xml" -DisableDevelopmentMode` (where `{PackageFullName}` is the info from the previous point).
    3. Toggle the App Execution Alias for winget, again (see above).
+5. The App Installer package may be in a broken state. You can try resetting it using PowerShell:
+   * On **Windows 11**: `Get-AppxPackage Microsoft.DesktopAppInstaller | Reset-AppxPackage`
+   * On **Windows 10**: `$Manifest = (Get-AppxPackage Microsoft.DesktopAppInstaller).InstallLocation + '\appxmanifest.xml'; Add-AppxPackage -DisableDevelopmentMode -Register $Manifest`
 
 If the above guidelines do not resolve the problem, please open an issue with details of the Windows version and App Installer version you are using.
 

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -329,6 +329,11 @@
           "type": "boolean",
           "default": false
         },
+        "resume": {
+          "description": "Enable support for some commands to resume",
+          "type": "boolean",
+          "default": false
+        },
         "sourcePriority": {
           "description": "Enable source priority feature",
           "type": "boolean",

--- a/src/AppInstallerCLICore/Commands/DscCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/DscCommand.cpp
@@ -64,7 +64,7 @@ namespace AppInstaller::CLI
 
     Utility::LocIndView DscCommand::HelpLink() const
     {
-        return "https://aka.ms/winget-dsc-resources"_liv;
+        return "https://learn.microsoft.com/windows/package-manager/configuration/"_liv;
     }
 
     void DscCommand::ExecuteInternal(Execution::Context& context) const


### PR DESCRIPTION
## Summary

This PR addresses 5 open documentation Task issues:

### Changes

| Issue | Description | File Changed |
|-------|-------------|--------------|
| #5296 | Add missing `downloadBehavior` and `defaultDownloadDirectory` settings to Settings.md | `doc/Settings.md` |
| #5921 | Add PowerShell module (`Microsoft.WinGet.Client`) section with cmdlet examples to README | `README.md` |
| #5108 | Add missing `resume` experimental feature to the settings JSON schema | `schemas/JSON/settings/settings.schema.0.2.json` |
| #4372 | Add AppInstaller reset/repair commands (Win10 & Win11) to troubleshooting guide | `doc/troubleshooting/README.md` |
| #5867 | Fix broken `aka.ms/winget-dsc-resources` help link that redirects to Bing | `src/AppInstallerCLICore/Commands/DscCommand.cpp` |

### Details

- **Settings.md (#5296):** The `downloadBehavior` section with `defaultDownloadDirectory` was already defined in the settings schema (`settings.schema.0.2.json`) but was not documented in `doc/Settings.md`. Added it between Configure Behavior and Telemetry sections.

- **README.md (#5921):** Added a new **PowerShell Module** section showing how to install `Microsoft.WinGet.Client` from the PowerShell Gallery and example cmdlet usage (`Find-WinGetPackage`, `Install-WinGetPackage`, `Get-WinGetPackage`, `Update-WinGetPackage`, `Repair-WinGetPackageManager`).

- **Settings schema (#5108):** The `resume` experimental feature was documented in `Settings.md` but missing from the JSON schema. Added it alongside the existing experimental features. (The other items from the original issue — `archiveExtractionMethod` and `fonts` — have already been fixed.)

- **Troubleshooting (#4372):** Added step 5 with PowerShell commands to reset the App Installer package when it's in a broken state, with separate commands for Windows 10 and Windows 11.

- **DSC help link (#5867):** The `https://aka.ms/winget-dsc-resources` URL in `DscCommand.cpp` redirects to Bing's home page. Updated it to point to the WinGet Configuration documentation on Microsoft Learn.

Fixes #5296, #5921, #5108, #4372, #5867
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6110)