### PR TITLE
Update Moq, curl, and c-ares

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.1742" />
     <PackageVersion Include="ModelContextProtocol" Version="0.3.0-preview.3" />
-    <PackageVersion Include="Moq" Version="4.18.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="nunit" Version="3.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -29,7 +29,7 @@
   "overrides": [
     {
       "name": "c-ares",
-      "version": "1.19.1"
+      "version": "1.34.6"
     },
     {
       "name": "correlation-vector-cpp",
@@ -41,7 +41,7 @@
     },
     {
       "name": "curl",
-      "version": "8.12.1"
+      "version": "8.19.0"
     },
     {
       "name": "nlohmann-json",


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
  - Dependency updates, don't believe these need to be tracked in release notes
- [ ] This pull request is related to an issue.

# Update security-sensitive dependencies: c-ares, curl, Moq

## Summary

Updates three dependencies to address security vulnerabilities and remove a supply-chain trust concern. A fourth intended update (zlib 1.3.1 → 1.3.2) is **blocked** pending a vcpkg registry baseline bump — zlib 1.3.2 is not yet available in the current baseline.

| Dependency | Type | Old Version | New Version | CVEs Fixed |
|------------|------|-------------|-------------|------------|
| `c-ares` | vcpkg (C++) | 1.19.1 | 1.34.6 | 3 CVEs + hardening |
| `curl` | vcpkg (C++) | 8.12.1 | 8.19.0 | 16 CVEs |
| `Moq` | NuGet (.NET) | 4.18.2 | 4.20.72 | SponsorLink removal |

## Files Changed

- `src/vcpkg.json` — updated `overrides` for `c-ares` and `curl`
- `src/Directory.Packages.props` — updated `Moq` version

---

## Security Details

<details>
<summary><strong>c-ares 1.19.1 → 1.34.6 — 3 CVEs fixed + memory-safety hardening</strong></summary>

### CVE-2024-25629 — Out-of-Bounds Read in Configuration File Parser
**Fixed in:** 1.27.0 (Feb 23, 2024) · **Severity:** Moderate · **CWE-125/CWE-127**

`ares__read_line()` parses local config files (`/etc/resolv.conf`, `/etc/nsswitch.conf`, `HOSTALIASES`). If any of these files has a null byte (`\0`) as the **first character of a new line**, the parser attempts to **read memory prior to the start of the buffer** (buffer under-read), causing a crash. Reported by Vojtěch Vobr.

---

### CVE-2025-31498 — Use-After-Free in `read_answers()` · GHSA-6hxc-62jh-p29v
**Fixed in:** 1.34.5 (Apr 8, 2025) · **Severity:** High (CVSS 4.0: AV:N/AC:H, VA:High) · **CWE-416**

Introduced by v1.32.3's UDP write failure detection. When `process_answer()` re-enqueues a DNS query (triggered by a DNS Cookie failure, an upstream server not supporting EDNS, or a TCP server closing the connection immediately after a response), the connection handle is freed — but `read_answers()` continues holding and using that freed handle. A remote attacker controlling the upstream nameserver could trigger this path; a local attacker could force `send()`/`write()` to return failure. Result: crash / denial of service. Reported by Erik Lax.

---

### CVE-2025-62408 — Use-After-Free in `read_answers()` (missed case) · GHSA-jq53-42q6-pqr5
**Fixed in:** 1.34.6 (Dec 8, 2025) · **Severity:** Medium (NVD pending) · **CWE-416**

An incomplete fix from CVE-2025-31498 in the same `read_answers()` function. This second UAF fires when `process_answer()` **terminates a query after maximum retry attempts** — a different trigger path than 31498. The connection may be closed, but `read_answers()` still iterates and accesses the freed handle.

---

### Non-CVE Security Hardening (selected highlights)

| Version | Change | Security Relevance |
|---------|--------|--------------------|
| 1.20.0 | Replace `sprintf` → `snprintf` throughout | Eliminates buffer overflow vectors |
| 1.20.0 | Add `getrandom()` syscall for entropy | Stronger CSPRNG for DNS query ID / port randomization |
| 1.20.0 | `ARES_OPT_UDP_MAX_QUERIES` limit per ephemeral port | Reduces cache poisoning attack window |
| 1.20.1 | Fix UAF when TCP connection closes before response | Memory safety (no CVE assigned) |
| 1.21.0 | Replace all hand-written DNS parsers with unified memory-safe parser | Eliminates entire class of OOB reads/writes in DNS response processing |
| 1.24.0 | Memory-safe nameserver + sortlist config parsers | Hardens the class exploited by CVE-2024-25629 |
| 1.25.0 | Rewrite `ares_strsplit()` on safe buffer abstraction | Memory safety |
| 1.28.0 | Replace all config file parsers with memory-safe implementation | Direct follow-up to CVE-2024-25629 |
| 1.30.0 | DNS strings must be printable ASCII; reject others | Prevents control-character injection via DNS responses |
| 1.32.0 | DNS 0x20 bit randomization (`ARES_FLAG_DNS0x20`) | Anti-cache-poisoning mitigation |
| 1.33.0 | DNS Cookie support (RFC 7873 + RFC 9018) | Cryptographic query/response authentication; prevents off-path cache poisoning |

</details>

---

<details>
<summary><strong>curl 8.12.1 → 8.19.0 — 16 CVEs fixed across 7 releases</strong></summary>

> The curl project does not publish CVSSv3 scores — they use qualitative severity ratings (Low / Medium / High) plus CWE identifiers.

<details>
<summary>8.14.0 — April 2, 2025 — 2 CVEs</summary>

### CVE-2025-4947 — QUIC Certificate Check Skip with wolfSSL
**Severity:** Medium · **CWE-295: Improper Certificate Validation** · Bug bounty: $2,540

When connecting to a host specified as an **IP address** (not a hostname) over QUIC/HTTP3 with wolfSSL as the TLS backend, libcurl **skipped certificate verification entirely**, allowing undetected MITM attacks. Only affects QUIC+wolfSSL; TCP TLS is unaffected. Reported by Hiroki Kurosawa.

---

### CVE-2025-5025 — No QUIC Certificate Pinning with wolfSSL
**Severity:** Medium · **CWE-295: Improper Certificate Validation**

`CURLOPT_PINNEDPUBLICKEY` / `--pinnedpubkey` pinning was **silently not performed** for QUIC/HTTP3 connections with the wolfSSL backend. Applications expecting to pin a server's public key would unknowingly connect to an impostor without any error. Reported by Hiroki Kurosawa.

</details>

<details>
<summary>8.14.1 — June 4, 2025 — 1 CVE</summary>

### CVE-2025-5399 — WebSocket Endless Loop
**Severity:** Low · **CWE-835: Loop with Unreachable Exit Condition**

A malicious server can send a crafted packet causing libcurl's WebSocket auto-pong handler to enter an **infinite busy-loop**, DoS-ing the consuming application. Introduced in 8.13.0. Does not affect the curl command-line tool. Reported by z2\_ on HackerOne.

</details>

<details>
<summary>8.15.0 — July 16, 2025 — 0 CVEs (hardening only)</summary>

No CVEs. Notable security changes:
- Removed Secure Transport and BearSSL TLS backends (both unmaintained)
- Fixed NULL dereference with bad password when no user is provided
- Fixed reuse of unclean connections

</details>

<details>
<summary>8.16.0 — September 10, 2025 — 2 CVEs</summary>

### CVE-2025-9086 — Out-of-Bounds Read for Cookie Path
**Severity:** Low · **CWE-125: Out-of-bounds Read** · C mistake (memory-safe language would have prevented this)

A sequence involving a `secure` cookie over HTTPS, a redirect to HTTP, and the HTTP server setting the same cookie with a single-slash path triggers a **heap out-of-bounds read by one byte** in curl's path comparison logic. Can crash or cause the insecure site to incorrectly override the secure cookie. Introduced in 8.13.0. Discovered by Google Big Sleep (AI-based vulnerability research).

---

### CVE-2025-10148 — Predictable WebSocket Mask
**Severity:** Low · **CWE-340: Generation of Predictable Numbers or Identifiers**

curl's WebSocket framing used a **fixed 32-bit mask for the entire connection** instead of updating it per-frame as required by RFC 6455. A predictable mask enables a malicious server to craft traffic that tricks an intermediate proxy into treating WebSocket data as HTTP — a cache-poisoning vector. Affects `ws://` (unencrypted) connections through defective proxies. Reported by Calvin Ruocco (Vector Informatik GmbH).

Also in this release: **default minimum TLS version raised from TLS 1.0/1.1 to TLS 1.2**.

</details>

<details>
<summary>8.17.0 — November 5, 2025 — 1 CVE</summary>

### CVE-2025-10966 — Missing SFTP Host Verification with wolfSSH
**Severity:** Low · **CWE-322: Key Exchange without Entity Authentication**

The wolfSSH SFTP backend had **no host verification implemented at all** — no known-host checking, no host key verification. Any MITM could intercept SFTP connections transparently. The fix was to **remove wolfSSH support entirely** from curl (7.69.0–8.16.0 affected). Reported by Stanislav Fort (Aisle Research).

Also in this release: OpenSSL minimum version raised to 3.0.0; GnuTLS < 3.6.5 dropped; FTP Kerberos support removed.

</details>

<details>
<summary>8.18.0 — January 7, 2026 — 6 CVEs</summary>

### CVE-2025-13034 — No QUIC Certificate Pinning with GnuTLS
**Severity:** Medium · **CWE-295: Improper Certificate Validation** · Bug bounty: $2,540

Same class as CVE-2025-5025 but for the **ngtcp2+GnuTLS** QUIC backend: `CURLOPT_PINNEDPUBLICKEY` was not enforced for QUIC when standard cert verification was explicitly disabled by the caller. Connection to impostors goes undetected. Reported by Stanislav Fort (Aisle Research).

---

### CVE-2025-14017 — Broken TLS Options for Threaded LDAPS
**Severity:** Medium · **CWE-567: Unsynchronized Access to Shared Data in a Multi-threaded Context**

In multi-threaded applications using LDAP over TLS, **setting a TLS option (e.g., disabling cert verification) on one connection could globally affect other concurrent LDAP connections** due to unsynchronized access to shared state. Only affects legacy non-OpenLDAP, non-WinLDAP builds. Has existed since 7.17.0. Reported by Stanislav Fort (Aisle Research).

---

### CVE-2025-14524 — Bearer Token Leak on Cross-Protocol Redirect
**Severity:** Low · **CWE-522: Insufficiently Protected Credentials**

When an OAuth2 bearer token is in use and curl follows a redirect to a non-HTTP protocol (IMAP, LDAP, POP3, SMTP) — which requires explicitly enabling non-HTTP redirects — the bearer token could be **forwarded to the new host**. Reported anonymously on HackerOne.

---

### CVE-2025-14819 — OpenSSL Partial Chain Store Policy Bypass
**Severity:** Low · **CWE-295: Improper Certificate Validation** · Bug bounty: $505

Due to CA store caching, toggling `CURLSSLOPT_NO_PARTIALCHAIN` between transfers on a reused handle could cause curl to **accept a partial certificate trust chain it should have rejected** (using the cached store from a previous setting). Only affects OpenSSL backend; only impacts applications toggling this option between transfers. Reported by Stanislav Fort (Aisle Research).

---

### CVE-2025-15079 — libssh Global known_hosts Override
**Severity:** Low · **CWE-297: Improper Validation of Certificate with Host Mismatch** · Bug bounty: $505

When `CURLOPT_SSH_KNOWNHOSTS` is specified for SCP/SFTP via the libssh backend, libssh's automatic fallback to its compile-time **global known_hosts file** meant curl could **accept connections to hosts not present in the user's specified file**. Fix: both user and global known_hosts paths are set to the user-provided path. Reported by Harry Sintonen.

---

### CVE-2025-15224 — libssh Key Passphrase Bypass Without Agent Set
**Severity:** Low · **CWE-287: Improper Authentication** · Bug bounty: $505

When using public key authentication with the libssh backend, curl **silently also attempted SSH agent authentication** even when no agent was configured, due to libssh's automatic fallback behavior. Violates the caller's explicit authentication intent. Reported by Harry Sintonen.

</details>

<details>
<summary>8.19.0 — March 11, 2026 — 4 CVEs</summary>

### CVE-2026-1965 — Bad Reuse of HTTP Negotiate Connection
**Severity:** Medium · **CWE-305: Authentication Bypass by Primary Weakness**

When using HTTP Negotiate (Kerberos/GSSAPI) authentication, curl could **reuse an existing connection authenticated under a different user** for a new request with different credentials, because Negotiate authenticates connections (not individual requests). A request intended for `user2` could be sent over `user1`'s authenticated connection. Present since 7.10.6. Mitigatable by disabling connection reuse. Reported by Zhicheng Chen.

---

### CVE-2026-3783 — Token Leak with Redirect and netrc
**Severity:** Medium · **CWE-522: Insufficiently Protected Credentials**

When an OAuth2 bearer token is in use and curl follows an HTTP redirect, if the redirect target hostname appears in the user's `.netrc` file, curl **forwards the bearer token to the redirect target host**. Reported on HackerOne #3583983.

---

### CVE-2026-3784 — Wrong Proxy Connection Reuse with Credentials
**Severity:** Low · **CWE-305: Authentication Bypass by Primary Weakness**

curl wrongly **reuses an existing HTTP proxy CONNECT tunnel** even when the new request uses **different proxy credentials**, potentially bypassing per-request proxy authorization. Present since curl 7.7. Reported by Muhamad Arga Reksapati on HackerOne.

---

### CVE-2026-3805 — Use After Free in SMB Connection Reuse
**Severity:** Medium · **CWE-416: Use After Free** · C mistake

On a **second SMB request to the same host** (reused connection), curl reads from an **already-freed memory pointer**, potentially leaking data from that memory address into the outgoing SMB packet. Introduced in 8.13.0. Reported by Daniel Wade on HackerOne.

</details>

---

### curl CVE Summary

| # | CVE | Severity | Fixed In | Component | Type |
|---|-----|----------|----------|-----------|------|
| 1 | CVE-2025-4947 | **Medium** | 8.14.0 | QUIC cert verify / wolfSSL | Cert verification skip (IP) |
| 2 | CVE-2025-5025 | **Medium** | 8.14.0 | QUIC pinning / wolfSSL | Missing pinned key check |
| 3 | CVE-2025-5399 | Low | 8.14.1 | WebSocket auto-pong | Infinite loop / DoS |
| 4 | CVE-2025-9086 | Low | 8.16.0 | Cookie path | Heap out-of-bounds read |
| 5 | CVE-2025-10148 | Low | 8.16.0 | WebSocket masking | Predictable mask / cache poisoning |
| 6 | CVE-2025-10966 | Low | 8.17.0 | SFTP / wolfSSH | No host verification (backend removed) |
| 7 | CVE-2025-13034 | **Medium** | 8.18.0 | QUIC pinning / GnuTLS | Missing pinned key check |
| 8 | CVE-2025-14017 | **Medium** | 8.18.0 | LDAPS / threaded | TLS global state race |
| 9 | CVE-2025-14524 | Low | 8.18.0 | Bearer / redirect | Cross-protocol credential leak |
| 10 | CVE-2025-14819 | Low | 8.18.0 | OpenSSL CA cache | Partial chain bypass |
| 11 | CVE-2025-15079 | Low | 8.18.0 | SSH / libssh | known_hosts bypass |
| 12 | CVE-2025-15224 | Low | 8.18.0 | SSH / libssh pubkey auth | SSH agent auth bypass |
| 13 | CVE-2026-1965 | **Medium** | 8.19.0 | HTTP Negotiate conn pool | Wrong connection reuse |
| 14 | CVE-2026-3783 | **Medium** | 8.19.0 | Bearer / netrc redirect | OAuth2 token leak |
| 15 | CVE-2026-3784 | Low | 8.19.0 | HTTP proxy CONNECT | Wrong proxy conn reuse |
| 16 | CVE-2026-3805 | **Medium** | 8.19.0 | SMB connection reuse | Use-after-free |

</details>

---

<details>
<summary><strong>Moq 4.18.2 → 4.20.72 — SponsorLink supply-chain incident - Ensure no affected version</strong></summary>

> No CVE was formally issued. This is a supply-chain trust and privacy incident.

### What Happened

Moq 4.20.0 and 4.20.1 (released Aug 4–9, 2023) introduced a dependency on `Devlooped.SponsorLink` — a closed-source, obfuscated Roslyn analyzer that ran at IDE build time (Visual Studio / Rider; **not** CI or `dotnet build`). It was removed in **4.20.2** (Aug 9, 2023) and has not returned.

> **Note:** The project is currently on 4.18.2, which predates SponsorLink. No 4.19.x series was ever published. The upgrade to 4.20.72 permanently skips the two affected releases (4.20.0 and 4.20.1) and lands on a clean, SponsorLink-free version.

### What SponsorLink Did at Build Time

1. Ran `git config --get user.email` to retrieve the developer's configured git email
2. SHA256-hashed + Base62-encoded the address
3. Sent two HTTP HEAD requests to Azure Blob Storage:
   - Checked whether the developer had installed the **SponsorLink GitHub App**
   - Checked whether the developer was **sponsoring the `devlooped` account**
4. Emitted Roslyn diagnostics (warnings SL02/SL03) in the IDE
5. Injected a **random build delay of 0–4,000 ms** for non-sponsors
6. The SponsorLink DLL was **closed-source and obfuscated** — impossible to audit

### Why It Was Removed

- **SHA256 is not anonymization** — email addresses have low entropy and are trivially reversible via brute force or rainbow tables. The author acknowledged this.
- **No disclosure or opt-out** — the behavior was undocumented in changelog, README, or package description. No disabling property was provided.
- **Closed-source binary in a widely-trusted OSS package** — at the time, Moq had hundreds of millions of NuGet downloads.
- **Build-time outbound network calls** — breaks offline, air-gapped, and enterprise proxy environments.
- **Deliberate build degradation** — intentionally slowing non-sponsor builds is coercive; `TreatWarningsAsErrors` projects had builds broken entirely.
- **Broke macOS/Linux restore** — the immediate technical trigger for removal; `dotnet restore` failed on non-Windows platforms.

The author open-sourced the SponsorLink codebase the following day and stated SponsorLink would not return to Moq until the privacy concerns were properly addressed. As of 4.20.72, it has not returned.

### Other Security-Relevant Changes in This Range

- **4.18.2** (current): `Castle.Core` (DynamicProxy) upgraded from 5.0.0 → 5.1.0; `System.Threading.Tasks.Extensions` dependency removed for netstandard2.1 and net6.0 targets
- **4.18.4**: `Castle.Core` upgraded to 5.1.1
- **4.20.72** (target): Full backward API compatibility with 4.18.x mock setups; `Castle.Core` 5.1.1 retained; no SponsorLink

</details>

---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6112)