### PR TITLE
Add Timeserver Support for SourceCreator and support spaces in paths and file names

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -138,6 +138,7 @@ devhome
 DFX
 DHAVE
 dic
+digicert
 diskfull
 DISPLAYCATALOG
 DMC

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -38,4 +38,5 @@ The PowerShell module now automatically uses `GH_TOKEN` or `GITHUB_TOKEN` enviro
 
 ## Bug Fixes
 
-<!-- Nothing yet! -->
+* `SignFile` in `WinGetSourceCreator` now supports an optional RFC 3161 timestamp server via the new `TimestampServer` property on the `Signature` model. When set, `signtool.exe` is called with `/tr <url> /td sha256`, embedding a countersignature timestamp so that signed packages remain valid after the signing certificate expires.
+* File and directory paths passed to `signtool.exe` and `makeappx.exe` are now quoted, fixing failures when paths contain spaces.

--- a/src/WinGetSourceCreator/Helpers.cs
+++ b/src/WinGetSourceCreator/Helpers.cs
@@ -36,12 +36,16 @@ namespace Microsoft.WinGetSourceCreator
 
             string pathToSDK = SDKDetector.Instance.LatestSDKBinPath;
             string signtoolExecutable = Path.Combine(pathToSDK, "signtool.exe");
-            string command = $"sign /a /fd sha256 /f {signature.CertFile} ";
+            string command = $"sign /a /fd sha256 /f \"{signature.CertFile}\" ";
             if (!string.IsNullOrEmpty(signature.Password))
             {
                 command += $"/p {signature.Password} ";
             }
-            command += fileToSign;
+            if (!string.IsNullOrEmpty(signature.TimestampServer))
+            {
+                command += $"/tr {signature.TimestampServer} /td sha256 ";
+            }
+            command += $"\"{fileToSign}\"";
             RunCommand(signtoolExecutable, command);
         }
 
@@ -81,7 +85,7 @@ namespace Microsoft.WinGetSourceCreator
 
             string pathToSDK = SDKDetector.Instance.LatestSDKBinPath;
             string makeappxExecutable = Path.Combine(pathToSDK, "makeappx.exe");
-            string args = $"unpack /nv /p {package} /d {outDir}";
+            string args = $"unpack /nv /p \"{package}\" /d \"{outDir}\"";
             Process p = new Process
             {
                 StartInfo = new ProcessStartInfo(makeappxExecutable, args)
@@ -99,7 +103,7 @@ namespace Microsoft.WinGetSourceCreator
 
             string pathToSDK = SDKDetector.Instance.LatestSDKBinPath;
             string makeappxExecutable = Path.Combine(pathToSDK, "makeappx.exe");
-            string args = $"pack /o /nv /f {mappingFile} /p {outputPackage}";
+            string args = $"pack /o /nv /f \"{mappingFile}\" /p \"{outputPackage}\"";
             RunCommand(makeappxExecutable, args);
         }
 
@@ -117,7 +121,7 @@ namespace Microsoft.WinGetSourceCreator
 
             string pathToSDK = SDKDetector.Instance.LatestSDKBinPath;
             string makeappxExecutable = Path.Combine(pathToSDK, "makeappx.exe");
-            string args = $"pack /o /d {directoryToPack} /p {outputPackage}";
+            string args = $"pack /o /d \"{directoryToPack}\" /p \"{outputPackage}\"";
             RunCommand(makeappxExecutable, args);
         }
 

--- a/src/WinGetSourceCreator/Model/Signature.cs
+++ b/src/WinGetSourceCreator/Model/Signature.cs
@@ -13,6 +13,11 @@ namespace WinGetSourceCreator.Model
         // The publisher for the AppxPackage Identity Name property.
         public string? Publisher { get; set; }
 
+        // RFC 3161 timestamp server URL (e.g. http://timestamp.digicert.com).
+        // When set, a countersignature timestamp is added so the signature remains
+        // valid after the signing certificate expires.
+        public string? TimestampServer { get; set; }
+
         internal void Validate()
         {
             if (string.IsNullOrEmpty(this.CertFile))


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.
  - #5844 
  - #4948 

Implemented as described in the issues, validated by copilot

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6113)