### PR TITLE
Admin setting and group policy for configuration processor path argument

### DIFF
--- a/doc/admx/DesktopAppInstaller.admx
+++ b/doc/admx/DesktopAppInstaller.admx
@@ -196,6 +196,16 @@
         <decimal value="0" />
       </disabledValue>
     </policy>
+    <policy name="EnableWindowsPackageManagerConfigurationProcessorPath" class="Machine" displayName="$(string.EnableWindowsPackageManagerConfigurationProcessorPath)" explainText="$(string.EnableWindowsPackageManagerConfigurationProcessorPathExplanation)" key="Software\Policies\Microsoft\Windows\AppInstaller" valueName="EnableWindowsPackageManagerConfigurationProcessorPath">
+      <parentCategory ref="AppInstaller" />
+      <supportedOn ref="windows:SUPPORTED_Windows_10_0_RS5" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
     <policy name="WindowsPackageManagerDefaultProxy" class="Machine" displayName="$(string.WindowsPackageManagerDefaultProxy)" explainText="$(string.WindowsPackageManagerDefaultProxyExplanation)" presentation="$(presentation.WindowsPackageManagerDefaultProxy)" key="Software\Policies\Microsoft\Windows\AppInstaller">
       <parentCategory ref="AppInstaller" />
       <supportedOn ref="windows:SUPPORTED_Windows_10_0_RS5" />

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -133,6 +133,13 @@ If you disable this setting, users will not be able to use the Windows Package M
         If you enable or do not configure this setting, users will be able to use the Windows Package Manager's MCP server.
 
         If you disable this setting, users will not be able to to use the Windows Package Manager's MCP server.</string>
+      <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration processor path</string>
+      <string id="EnableWindowsPackageManagerConfigurationProcessorPathExplanation">
+        This policy controls whether users can specify a custom DSC processor path via the --processor-path argument in Windows Package Manager configuration commands. This option is intended for testing purposes.
+
+        If you enable or do not configure this setting, users will be able to specify a custom DSC processor path in configuration commands.
+
+        If you disable this setting, users will not be able to specify a custom DSC processor path in configuration commands.</string>
       <string id="WindowsPackageManagerDefaultProxy">Set Windows Package Manager Default Proxy</string>
       <string id="WindowsPackageManagerDefaultProxyExplanation">This policy controls the default proxy used by the Windows Package Manager.
 

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -133,7 +133,7 @@ If you disable this setting, users will not be able to use the Windows Package M
         If you enable or do not configure this setting, users will be able to use the Windows Package Manager's MCP server.
 
         If you disable this setting, users will not be able to to use the Windows Package Manager's MCP server.</string>
-      <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration processor path</string>
+      <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration Processor Path</string>
       <string id="EnableWindowsPackageManagerConfigurationProcessorPathExplanation">
         This policy controls whether users can specify a custom DSC processor path via the --processor-path argument in Windows Package Manager configuration commands.
 

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -135,9 +135,11 @@ If you disable this setting, users will not be able to use the Windows Package M
         If you disable this setting, users will not be able to to use the Windows Package Manager's MCP server.</string>
       <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration processor path</string>
       <string id="EnableWindowsPackageManagerConfigurationProcessorPathExplanation">
-        This policy controls whether users can specify a custom DSC processor path via the --processor-path argument in Windows Package Manager configuration commands. This option is intended for testing purposes.
+        This policy controls whether users can specify a custom DSC processor path via the --processor-path argument in Windows Package Manager configuration commands.
 
-        If you enable or do not configure this setting, users will be able to specify a custom DSC processor path in configuration commands.
+        If you enable this setting, users will be able to specify a custom DSC processor path in configuration commands.
+
+        If you do not configure this setting, users will be able to specify a custom DSC processor path in configuration commands after enabling the related administrator setting.
 
         If you disable this setting, users will not be able to specify a custom DSC processor path in configuration commands.</string>
       <string id="WindowsPackageManagerDefaultProxy">Set Windows Package Manager Default Proxy</string>

--- a/doc/admx/en-US/DesktopAppInstaller.adml
+++ b/doc/admx/en-US/DesktopAppInstaller.adml
@@ -133,7 +133,7 @@ If you disable this setting, users will not be able to use the Windows Package M
         If you enable or do not configure this setting, users will be able to use the Windows Package Manager's MCP server.
 
         If you disable this setting, users will not be able to to use the Windows Package Manager's MCP server.</string>
-      <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration Processor Path</string>
+      <string id="EnableWindowsPackageManagerConfigurationProcessorPath">Enable Windows Package Manager Configuration Processor Override</string>
       <string id="EnableWindowsPackageManagerConfigurationProcessorPathExplanation">
         This policy controls whether users can specify a custom DSC processor path via the --processor-path argument in Windows Package Manager configuration commands.
 

--- a/schemas/JSON/settings/settings.export.schema.0.1.json
+++ b/schemas/JSON/settings/settings.export.schema.0.1.json
@@ -32,6 +32,11 @@
           "type": "boolean",
           "default": false
         },
+        "ConfigurationProcessorPath": {
+          "description": "Enable specifying a custom DSC processor path in configuration commands.",
+          "type": "boolean",
+          "default": false
+        },
         "DefaultProxy": {
           "description": "Default proxy.",
           "type": "string"

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -490,6 +490,8 @@ namespace AppInstaller::CLI
             return Argument{ type, Resource::String::ProxyArgumentDescription, ArgumentType::Standard, TogglePolicy::Policy::ProxyCommandLineOptions, BoolAdminSetting::ProxyCommandLineOptions };
         case Args::Type::NoProxy:
             return Argument{ type, Resource::String::NoProxyArgumentDescription, ArgumentType::Flag, TogglePolicy::Policy::ProxyCommandLineOptions, BoolAdminSetting::ProxyCommandLineOptions };
+        case Args::Type::ConfigurationProcessorPath:
+            return Argument{ type, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help, TogglePolicy::Policy::ConfigurationProcessorPath, BoolAdminSetting::ConfigurationProcessorPath };
         case Args::Type::Family:
             return Argument{ type, Resource::String::FontFamilyNameArgumentDescription, ArgumentType::Positional, false };
         case Args::Type::Details:

--- a/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureCommand.cpp
@@ -37,7 +37,7 @@ namespace AppInstaller::CLI
         return {
             Argument{ Execution::Args::Type::ConfigurationFile, Resource::String::ConfigurationFileArgumentDescription, ArgumentType::Positional },
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath, ArgumentType::Positional },
-            Argument{ Execution::Args::Type::ConfigurationProcessorPath, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help },
+            Argument::ForType(Execution::Args::Type::ConfigurationProcessorPath),
             Argument{ Execution::Args::Type::ConfigurationHistoryItem, Resource::String::ConfigurationHistoryItemArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationAcceptWarning, Resource::String::ConfigurationAcceptWarningArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::ConfigurationSuppressPrologue, Resource::String::ConfigurationSuppressPrologueArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },

--- a/src/AppInstallerCLICore/Commands/ConfigureShowCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureShowCommand.cpp
@@ -16,7 +16,7 @@ namespace AppInstaller::CLI
             // Required for now, make exclusive when history implemented
             Argument{ Execution::Args::Type::ConfigurationFile, Resource::String::ConfigurationFileArgumentDescription, ArgumentType::Positional },
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath, ArgumentType::Positional },
-            Argument{ Execution::Args::Type::ConfigurationProcessorPath, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help },
+            Argument::ForType(Execution::Args::Type::ConfigurationProcessorPath),
             Argument{ Execution::Args::Type::ConfigurationHistoryItem, Resource::String::ConfigurationHistoryItemArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
         };
     }

--- a/src/AppInstallerCLICore/Commands/ConfigureTestCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureTestCommand.cpp
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         return {
             Argument{ Execution::Args::Type::ConfigurationFile, Resource::String::ConfigurationFileArgumentDescription, ArgumentType::Positional },
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath, ArgumentType::Positional },
-            Argument{ Execution::Args::Type::ConfigurationProcessorPath, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help },
+            Argument::ForType(Execution::Args::Type::ConfigurationProcessorPath),
             Argument{ Execution::Args::Type::ConfigurationHistoryItem, Resource::String::ConfigurationHistoryItemArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationSuppressPrologue, Resource::String::ConfigurationSuppressPrologueArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help },
             Argument{ Execution::Args::Type::ConfigurationAcceptWarning, Resource::String::ConfigurationAcceptWarningArgumentDescription, ArgumentType::Flag },

--- a/src/AppInstallerCLICore/Commands/ConfigureValidateCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ConfigureValidateCommand.cpp
@@ -15,7 +15,7 @@ namespace AppInstaller::CLI
         return {
             Argument{ Execution::Args::Type::ConfigurationFile, Resource::String::ConfigurationFileArgumentDescription, ArgumentType::Positional, true },
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath, ArgumentType::Positional },
-            Argument{ Execution::Args::Type::ConfigurationProcessorPath, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help },
+            Argument::ForType(Execution::Args::Type::ConfigurationProcessorPath),
         };
     }
 

--- a/src/AppInstallerCLICore/ConfigureExportCommand.cpp
+++ b/src/AppInstallerCLICore/ConfigureExportCommand.cpp
@@ -18,7 +18,7 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::ConfigurationExportModule, Resource::String::ConfigureExportModule },
             Argument{ Execution::Args::Type::ConfigurationExportResource, Resource::String::ConfigureExportResource },
             Argument{ Execution::Args::Type::ConfigurationModulePath, Resource::String::ConfigurationModulePath },
-            Argument{ Execution::Args::Type::ConfigurationProcessorPath, Resource::String::ConfigurationProcessorPath, ArgumentType::Standard, Argument::Visibility::Help },
+            Argument::ForType(Execution::Args::Type::ConfigurationProcessorPath),
             Argument{ Execution::Args::Type::Source, Resource::String::ExportSourceArgumentDescription, ArgumentType::Standard },
             Argument{ Execution::Args::Type::IncludeVersions, Resource::String::ExportIncludeVersionsArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::ConfigurationExportAll, Resource::String::ConfigureExportAll, ArgumentType::Flag },

--- a/src/AppInstallerCLIE2ETests/GroupPolicy.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicy.cs
@@ -278,5 +278,32 @@ namespace AppInstallerCLIE2ETests
             result = TestCommon.RunAICLICommand("configure show", TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml"));
             Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
         }
+
+        /// <summary>
+        /// Test that using a custom configuration processor path is disabled by policy.
+        /// </summary>
+        [Test]
+        public void EnableConfigurationProcessorPath()
+        {
+            GroupPolicyHelper.EnableConfigurationProcessorPath.Disable();
+
+            // --processor-path is rejected by policy at argument validation time across all configure subcommands.
+            var result = TestCommon.RunAICLICommand("configure", $"--processor-path C:\\dsc.exe {TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml")}");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            result = TestCommon.RunAICLICommand("configure show", $"--processor-path C:\\dsc.exe {TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml")}");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            result = TestCommon.RunAICLICommand("configure test", $"--processor-path C:\\dsc.exe {TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml")}");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            result = TestCommon.RunAICLICommand("configure validate", $"--processor-path C:\\dsc.exe {TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml")}");
+            Assert.AreEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+
+            // When not configured, the argument is allowed by policy (admin setting governs).
+            GroupPolicyHelper.EnableConfigurationProcessorPath.SetNotConfigured();
+            result = TestCommon.RunAICLICommand("configure show", $"--processor-path C:\\dsc.exe {TestCommon.GetTestDataFile("Configuration\\ShowDetails_TestRepo.yml")}");
+            Assert.AreNotEqual(Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY, result.ExitCode);
+        }
     }
 }

--- a/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
@@ -129,6 +129,11 @@ namespace AppInstallerCLIE2ETests
         public static GroupPolicyHelper EnableProxyCommandLineOptions { get; private set; } = new GroupPolicyHelper("EnableWindowsPackageManagerProxyCommandLineOptions");
 
         /// <summary>
+        /// Gets the Enable Windows Package Manager Configuration processor path policy.
+        /// </summary>
+        public static GroupPolicyHelper EnableConfigurationProcessorPath { get; private set; } = new GroupPolicyHelper("EnableWindowsPackageManagerConfigurationProcessorPath");
+
+        /// <summary>
         /// Gets the Enable auto update interval policy.
         /// </summary>
         public static GroupPolicyHelper SourceAutoUpdateInterval { get; private set; } = new GroupPolicyHelper("SourceAutoUpdateInterval", "SourceAutoUpdateInterval");
@@ -150,6 +155,7 @@ namespace AppInstallerCLIE2ETests
             EnableWinGetCommandLineInterfaces,
             EnableConfiguration,
             EnableProxyCommandLineOptions,
+            EnableConfigurationProcessorPath,
         };
 
         /// <summary>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -2879,6 +2879,10 @@ Please specify one of them using the --source option to proceed.</value>
     <value>Enable Windows Package Manager proxy command line options</value>
     <comment>Describes a Group Policy that can enable the use of the --proxy option to set a proxy</comment>
   </data>
+  <data name="PolicyEnableConfigurationProcessorPath" xml:space="preserve">
+    <value>Enable Windows Package Manager Configuration processor path</value>
+    <comment>Describes a Group Policy that can enable the use of the --processor-path option in configuration commands</comment>
+  </data>
   <data name="ProxyArgumentDescription" xml:space="preserve">
     <value>Set a proxy to use for this execution</value>
   </data>

--- a/src/AppInstallerCLITests/AdminSettings.cpp
+++ b/src/AppInstallerCLITests/AdminSettings.cpp
@@ -85,8 +85,49 @@ TEST_CASE("AdminSetting_AllSettingsAreImplemented", "[adminSettings]")
     }
 }
 
-TEST_CASE("AdminSetting_CorruptedVerificationFile", "[adminSettings]")
+TEST_CASE("AdminSetting_ConfigurationProcessorPath", "[adminSettings]")
 {
+    WHEN("Default state")
+    {
+        GroupPolicyTestOverride policies;
+        policies.SetState(TogglePolicy::Policy::ConfigurationProcessorPath, PolicyState::NotConfigured);
+
+        REQUIRE_FALSE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+    }
+
+    WHEN("Group policy not configured - can enable and disable")
+    {
+        GroupPolicyTestOverride policies;
+        policies.SetState(TogglePolicy::Policy::ConfigurationProcessorPath, PolicyState::NotConfigured);
+
+        REQUIRE(EnableAdminSetting(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE(DisableAdminSetting(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE_FALSE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+    }
+
+    WHEN("Group policy enabled - cannot disable")
+    {
+        GroupPolicyTestOverride policies;
+        policies.SetState(TogglePolicy::Policy::ConfigurationProcessorPath, PolicyState::Enabled);
+
+        REQUIRE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE_FALSE(DisableAdminSetting(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+    }
+
+    WHEN("Group policy disabled - cannot enable")
+    {
+        GroupPolicyTestOverride policies;
+        policies.SetState(TogglePolicy::Policy::ConfigurationProcessorPath, PolicyState::Disabled);
+
+        REQUIRE_FALSE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE_FALSE(EnableAdminSetting(BoolAdminSetting::ConfigurationProcessorPath));
+        REQUIRE_FALSE(IsAdminSettingEnabled(BoolAdminSetting::ConfigurationProcessorPath));
+    }
+}
+
+TEST_CASE("AdminSetting_CorruptedVerificationFile", "[adminSettings]"){
     GroupPolicyTestOverride policies;
     policies.SetState(TogglePolicy::Policy::LocalManifestFiles, PolicyState::NotConfigured);
 

--- a/src/AppInstallerCLITests/GroupPolicy.cpp
+++ b/src/AppInstallerCLITests/GroupPolicy.cpp
@@ -404,6 +404,7 @@ TEST_CASE("GroupPolicy_AllEnabled", "[groupPolicy]")
     SetRegistryValue(policiesKey.get(), ConfigurationPolicyValueName, 1);
     SetRegistryValue(policiesKey.get(), ProxyCommandLineOptionsPolicyValueName, 1);
     SetRegistryValue(policiesKey.get(), McpServerValueName, 1);
+    SetRegistryValue(policiesKey.get(), ConfigurationProcessorPathValueName, 1);
 
     GroupPolicy groupPolicy{ policiesKey.get() };
     for (const auto& policy : TogglePolicy::GetAllPolicies())

--- a/src/AppInstallerCLITests/TestSettings.h
+++ b/src/AppInstallerCLITests/TestSettings.h
@@ -26,6 +26,7 @@ namespace TestCommon
     const std::wstring ConfigurationPolicyValueName = L"EnableWindowsPackageManagerConfiguration";
     const std::wstring ProxyCommandLineOptionsPolicyValueName = L"EnableWindowsPackageManagerProxyCommandLineOptions";
     const std::wstring McpServerValueName = L"EnableWindowsPackageManagerMcpServer";
+    const std::wstring ConfigurationProcessorPathValueName = L"EnableWindowsPackageManagerConfigurationProcessorPath";
 
     const std::wstring SourceUpdateIntervalPolicyValueName = L"SourceAutoUpdateInterval";
     const std::wstring SourceUpdateIntervalPolicyOldValueName = L"SourceAutoUpdateIntervalInMinutes";

--- a/src/AppInstallerCommonCore/AdminSettings.cpp
+++ b/src/AppInstallerCommonCore/AdminSettings.cpp
@@ -20,6 +20,7 @@ namespace AppInstaller::Settings
         constexpr Utility::LocIndView s_AdminSettingsYaml_InstallerHashOverride = "InstallerHashOverride"_liv;
         constexpr Utility::LocIndView s_AdminSettingsYaml_LocalArchiveMalwareScanOverride = "LocalArchiveMalwareScanOverride"_liv;
         constexpr Utility::LocIndView s_AdminSettingsYaml_ProxyCommandLineOptions = "ProxyCommandLineOptions"_liv;
+        constexpr Utility::LocIndView s_AdminSettingsYaml_ConfigurationProcessorPath = "ConfigurationProcessorPath"_liv;
 
         constexpr Utility::LocIndView s_AdminSettingsYaml_DefaultProxy = "DefaultProxy"_liv;
 
@@ -46,6 +47,7 @@ namespace AppInstaller::Settings
             bool InstallerHashOverride = false;
             bool LocalArchiveMalwareScanOverride = false;
             bool ProxyCommandLineOptions = false;
+            bool ConfigurationProcessorPath = false;
 
             std::optional<std::string> DefaultProxy;
         };
@@ -122,6 +124,9 @@ namespace AppInstaller::Settings
                     case BoolAdminSetting::ProxyCommandLineOptions:
                         m_settingValues.ProxyCommandLineOptions = enabled;
                         return true;
+                    case BoolAdminSetting::ConfigurationProcessorPath:
+                        m_settingValues.ConfigurationProcessorPath = enabled;
+                        return true;
                     default:
                         return false;
                     }
@@ -157,6 +162,8 @@ namespace AppInstaller::Settings
                 return m_settingValues.LocalArchiveMalwareScanOverride;
             case BoolAdminSetting::ProxyCommandLineOptions:
                 return m_settingValues.ProxyCommandLineOptions;
+            case BoolAdminSetting::ConfigurationProcessorPath:
+                return m_settingValues.ConfigurationProcessorPath;
             default:
                 return false;
             }
@@ -232,6 +239,7 @@ namespace AppInstaller::Settings
             TryReadScalar<bool>(document, s_AdminSettingsYaml_InstallerHashOverride, m_settingValues.InstallerHashOverride);
             TryReadScalar<bool>(document, s_AdminSettingsYaml_LocalArchiveMalwareScanOverride, m_settingValues.LocalArchiveMalwareScanOverride);
             TryReadScalar<bool>(document, s_AdminSettingsYaml_ProxyCommandLineOptions, m_settingValues.ProxyCommandLineOptions);
+            TryReadScalar<bool>(document, s_AdminSettingsYaml_ConfigurationProcessorPath, m_settingValues.ConfigurationProcessorPath);
 
             std::string defaultProxy;
             if (TryReadScalar<std::string>(document, s_AdminSettingsYaml_DefaultProxy, defaultProxy))
@@ -251,6 +259,7 @@ namespace AppInstaller::Settings
             out << YAML::Key << s_AdminSettingsYaml_InstallerHashOverride << YAML::Value << m_settingValues.InstallerHashOverride;
             out << YAML::Key << s_AdminSettingsYaml_LocalArchiveMalwareScanOverride << YAML::Value << m_settingValues.LocalArchiveMalwareScanOverride;
             out << YAML::Key << s_AdminSettingsYaml_ProxyCommandLineOptions << YAML::Value << m_settingValues.ProxyCommandLineOptions;
+            out << YAML::Key << s_AdminSettingsYaml_ConfigurationProcessorPath << YAML::Value << m_settingValues.ConfigurationProcessorPath;
 
             if (m_settingValues.DefaultProxy)
             {
@@ -304,6 +313,10 @@ namespace AppInstaller::Settings
         {
             result = BoolAdminSetting::ProxyCommandLineOptions;
         }
+        else if (Utility::CaseInsensitiveEquals(s_AdminSettingsYaml_ConfigurationProcessorPath, in))
+        {
+            result = BoolAdminSetting::ConfigurationProcessorPath;
+        }
 
         return result;
     }
@@ -334,6 +347,8 @@ namespace AppInstaller::Settings
             return s_AdminSettingsYaml_LocalArchiveMalwareScanOverride;
         case BoolAdminSetting::ProxyCommandLineOptions:
             return s_AdminSettingsYaml_ProxyCommandLineOptions;
+        case BoolAdminSetting::ConfigurationProcessorPath:
+            return s_AdminSettingsYaml_ConfigurationProcessorPath;
         default:
             return "Unknown"_liv;
         }
@@ -364,6 +379,8 @@ namespace AppInstaller::Settings
             return TogglePolicy::Policy::LocalArchiveMalwareScanOverride;
         case BoolAdminSetting::ProxyCommandLineOptions:
             return TogglePolicy::Policy::ProxyCommandLineOptions;
+        case BoolAdminSetting::ConfigurationProcessorPath:
+            return TogglePolicy::Policy::ConfigurationProcessorPath;
         default:
             return TogglePolicy::Policy::None;
         }

--- a/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/AdminSettings.h
@@ -16,6 +16,7 @@ namespace AppInstaller::Settings
         InstallerHashOverride,
         LocalArchiveMalwareScanOverride,
         ProxyCommandLineOptions,
+        ConfigurationProcessorPath,
         Max,
     };
 

--- a/src/AppInstallerSharedLib/GroupPolicy.cpp
+++ b/src/AppInstallerSharedLib/GroupPolicy.cpp
@@ -336,6 +336,8 @@ namespace AppInstaller::Settings
             return TogglePolicy(policy, "EnableWindowsPackageManagerProxyCommandLineOptions"sv, String::PolicyEnableProxyCommandLineOptions);
         case TogglePolicy::Policy::McpServer:
             return TogglePolicy(policy, "EnableWindowsPackageManagerMcpServer"sv, String::PolicyEnableMcpServer);
+        case TogglePolicy::Policy::ConfigurationProcessorPath:
+            return TogglePolicy(policy, "EnableWindowsPackageManagerConfigurationProcessorPath"sv, String::PolicyEnableConfigurationProcessorPath);
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerSharedLib/Public/winget/GroupPolicy.h
+++ b/src/AppInstallerSharedLib/Public/winget/GroupPolicy.h
@@ -49,6 +49,7 @@ namespace AppInstaller::Settings
             Configuration,
             ProxyCommandLineOptions,
             McpServer,
+            ConfigurationProcessorPath,
             Max,
         };
 

--- a/src/AppInstallerSharedLib/Public/winget/Resources.h
+++ b/src/AppInstallerSharedLib/Public/winget/Resources.h
@@ -62,6 +62,7 @@ namespace AppInstaller
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableWinGetConfiguration);
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableProxyCommandLineOptions);
             WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableMcpServer);
+            WINGET_DEFINE_RESOURCE_STRINGID(PolicyEnableConfigurationProcessorPath);
 
             WINGET_DEFINE_RESOURCE_STRINGID(SettingsWarningInvalidFieldFormat);
             WINGET_DEFINE_RESOURCE_STRINGID(SettingsWarningInvalidFieldValue);

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="DisableSettingCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -30,7 +30,8 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             "BypassCertificatePinningForMicrosoftStore",
             "InstallerHashOverride",
             "LocalArchiveMalwareScanOverride",
-            "ProxyCommandLineOptions")]
+            "ProxyCommandLineOptions",
+            "ConfigurationProcessorPath")]
         public string Name { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
+++ b/src/PowerShell/Microsoft.WinGet.Client.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="EnableSettingCmdlet.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -30,7 +30,8 @@ namespace Microsoft.WinGet.Client.Cmdlets.Cmdlets
             "BypassCertificatePinningForMicrosoftStore",
             "InstallerHashOverride",
             "LocalArchiveMalwareScanOverride",
-            "ProxyCommandLineOptions")]
+            "ProxyCommandLineOptions",
+            "ConfigurationProcessorPath")]
         public string Name { get; set; }
 
         /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
+++ b/src/PowerShell/Microsoft.WinGet.Configuration.Engine/Commands/ConfigurationCommand.cs
@@ -23,6 +23,7 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
     using Microsoft.WinGet.Configuration.Engine.Helpers;
     using Microsoft.WinGet.Configuration.Engine.PSObjects;
     using Microsoft.WinGet.Resources;
+    using Microsoft.WinGet.SharedLib.Exceptions;
     using Microsoft.WinGet.SharedLib.PolicySettings;
     using Windows.Storage;
     using Windows.Storage.Streams;
@@ -403,6 +404,11 @@ namespace Microsoft.WinGet.Configuration.Engine.Commands
             var factoryMap = factory.As<IDictionary<string, string>>();
             if (!string.IsNullOrEmpty(openParams.ProcessorPath))
             {
+                if (!GroupPolicy.GetInstance().IsEnabled(Policy.ConfigurationProcessorPath))
+                {
+                    throw new GroupPolicyException(Policy.ConfigurationProcessorPath, GroupPolicyFailureType.BlockedByPolicy);
+                }
+
                 factoryMap.Add(DSCv3FactoryMapKeyDscExecutablePath, openParams.ProcessorPath);
             }
             else

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/PolicySettings/Enums.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/PolicySettings/Enums.cs
@@ -106,6 +106,11 @@ namespace Microsoft.WinGet.SharedLib.PolicySettings
         /// Enabled MCP server.
         /// </summary>
         McpServer,
+
+        /// <summary>
+        /// Enable Configuration Processor Path.
+        /// </summary>
+        ConfigurationProcessorPath,
     }
 
     /// <summary>

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/PolicySettings/TogglePolicy.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/PolicySettings/TogglePolicy.cs
@@ -129,6 +129,8 @@ namespace Microsoft.WinGet.SharedLib.PolicySettings
                     return new TogglePolicy(policy, "EnableWindowsPackageManagerConfiguration", GroupPolicyResource.PolicyEnableWinGetConfiguration);
                 case Policy.McpServer:
                     return new TogglePolicy(policy, "EnableWindowsPackageManagerMcpServer", GroupPolicyResource.PolicyEnableMcpServer);
+                case Policy.ConfigurationProcessorPath:
+                    return new TogglePolicy(policy, "EnableWindowsPackageManagerConfigurationProcessorPath", GroupPolicyResource.PolicyEnableConfigurationProcessorPath);
                 default:
                     throw new ArgumentException(null, nameof(policy));
             }

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/Resources/GroupPolicyResource.Designer.cs
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/Resources/GroupPolicyResource.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.WinGet.SharedLib.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable Windows Package Manager Configuration processor path.
+        /// </summary>
+        internal static string PolicyEnableConfigurationProcessorPath {
+            get {
+                return ResourceManager.GetString("PolicyEnableConfigurationProcessorPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable Windows App Installer Default Source.
         /// </summary>
         internal static string PolicyEnableDefaultSource {

--- a/src/PowerShell/Microsoft.WinGet.SharedLib/Resources/GroupPolicyResource.resx
+++ b/src/PowerShell/Microsoft.WinGet.SharedLib/Resources/GroupPolicyResource.resx
@@ -156,6 +156,9 @@
   <data name="PolicyEnableProxyCommandLineOptions" xml:space="preserve">
     <value>Enable Windows Package Manager proxy command line options</value>
   </data>
+  <data name="PolicyEnableConfigurationProcessorPath" xml:space="preserve">
+    <value>Enable Windows Package Manager Configuration processor path</value>
+  </data>
   <data name="PolicyEnableWindowsPackageManagerCommandLineInterfaces" xml:space="preserve">
     <value>Enable Windows Package Manager command line interfaces</value>
   </data>

--- a/src/WinGetServer/WinGetServerManualActivation_Client.cpp
+++ b/src/WinGetServer/WinGetServerManualActivation_Client.cpp
@@ -71,7 +71,7 @@ struct ServerProcessLauncher
 
 #ifndef USE_PROD_WINGET_SERVER
             // The feature that allows directly launching a packaged process as long as it has a matching alias
-            // requires a failure to trigger, and the dev package is not ACL'd to force this to happen. Attempting
+            // requires a failure to trigger, and the dev package ACL does not force this to happen. Attempting
             // to use the other code path results in an unpackaged server, causing other issues.
             // We run the product code above to ensure that it is functioning properly, but then replace it with
             // the path of the alias.


### PR DESCRIPTION
## Change
Adds an admin setting (`ConfigurationProcessorPath`) and group policy (`EnableWindowsPackageManagerConfigurationProcessorPath`) to gate access to the `--processor-path` argument for configuration commands.

Yes, it sadly does take touching 23 files to implement that.

## Validation
New unit test for gp/setting interaction and e2e test for enforcement.  Manual confirmation of admin setting functionality as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6119)