### PR TITLE
Improve MOTW error handling in download flow

### DIFF
--- a/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp
@@ -338,8 +338,8 @@ namespace AppInstaller::CLI::Workflow
 
         context <<
             VerifyInstallerHash <<
-            UpdateInstallerFileMotwIfApplicable <<
-            RenameDownloadedInstaller;
+            RenameDownloadedInstaller <<
+            UpdateInstallerFileMotwIfApplicable;
 
         if (installerDownloadOnly)
         {

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -495,19 +495,8 @@ namespace AppInstaller::Utility
 
         THROW_IF_FAILED(hr);
 
-        auto hrRemove = zoneIdentifier->Remove();
-        if (FAILED(hrRemove))
-        {
-            AICLI_LOG(Core, Error, << "IZoneIdentifier::Remove failed. Result: " << hrRemove);
-            THROW_IF_FAILED(hrRemove);
-        }
-
-        auto hrSave = persistFile->Save(NULL, TRUE);
-        if (FAILED(hrSave))
-        {
-            AICLI_LOG(Core, Error, << "IPersistFile::Save failed after removing motw. Result: " << hrSave);
-            THROW_IF_FAILED(hrSave);
-        }
+        THROW_IF_FAILED(zoneIdentifier->Remove());
+        THROW_IF_FAILED(persistFile->Save(NULL, TRUE));
 
         AICLI_LOG(Core, Info, << "Finished removing motw");
     }
@@ -527,26 +516,9 @@ namespace AppInstaller::Utility
         auto updateMotw = [&]() -> HRESULT
         {
             Microsoft::WRL::ComPtr<IAttachmentExecute> attachmentExecute;
-            auto hrCreate = CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute));
-            if (FAILED(hrCreate))
-            {
-                AICLI_LOG(Core, Error, << "CoCreateInstance(CLSID_AttachmentServices) failed. Result: " << hrCreate);
-                return hrCreate;
-            }
-
-            auto hrSetLocalPath = attachmentExecute->SetLocalPath(filePath.c_str());
-            if (FAILED(hrSetLocalPath))
-            {
-                AICLI_LOG(Core, Error, << "IAttachmentExecute::SetLocalPath failed for path: " << filePath << " Result: " << hrSetLocalPath);
-                return hrSetLocalPath;
-            }
-
-            auto hrSetSource = attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str());
-            if (FAILED(hrSetSource))
-            {
-                AICLI_LOG(Core, Error, << "IAttachmentExecute::SetSource failed for source: " << source << " Result: " << hrSetSource);
-                return hrSetSource;
-            }
+            RETURN_IF_FAILED(CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute)));
+            RETURN_IF_FAILED(attachmentExecute->SetLocalPath(filePath.c_str()));
+            RETURN_IF_FAILED(attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str()));
 
             // IAttachmentExecute::Save() expects the local file to be clean (i.e. it won't clear existing motw if it thinks the source url is trusted).
             // If removal fails for any reason, log a warning and proceed — a removal failure should not abort the security check.
@@ -579,10 +551,9 @@ namespace AppInstaller::Utility
             {
                 try
                 {
-                    hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+                    hr = LOG_IF_FAILED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED));
                     if (FAILED(hr))
                     {
-                        AICLI_LOG(Core, Error, << "CoInitializeEx failed in IAttachmentExecute thread. Result: " << hr);
                         return;
                     }
 

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -131,8 +131,8 @@ namespace AppInstaller::Utility
         std::optional<DownloadInfo> info)
     {
         // For AICLI_LOG usages with string literals.
-#pragma warning(push)
-#pragma warning(disable:26449)
+        #pragma warning(push)
+        #pragma warning(disable:26449)
 
         AICLI_LOG(Core, Info, << "WinINet downloading from url: " << url);
 
@@ -277,7 +277,7 @@ namespace AppInstaller::Utility
 
         AICLI_LOG(Core, Info, << "Download completed.");
 
-#pragma warning(pop)
+        #pragma warning(pop)
 
         return result;
     }
@@ -437,7 +437,7 @@ namespace AppInstaller::Utility
 
         return false;
     }
-
+    
     static inline bool FileSupportsMotw(const std::filesystem::path& path)
     {
         return SupportsNamedStreams(path);
@@ -481,9 +481,11 @@ namespace AppInstaller::Utility
         THROW_IF_FAILED(zoneIdentifier.As(&persistFile));
 
         auto hr = persistFile->Load(filePath.c_str(), STGM_READ);
-        if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) ||
+            hr == HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
         {
-            // IPersistFile::Load returns same error for "file not found" and "motw not found".
+            // IPersistFile::Load can return ERROR_FILE_NOT_FOUND or ERROR_PATH_NOT_FOUND for
+            // both "file not found" and "motw not found" depending on the Windows build.
             // Check if the file exists to be sure we are on the "motw not found" case.
             THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), !std::filesystem::exists(filePath));
 
@@ -491,8 +493,21 @@ namespace AppInstaller::Utility
             return;
         }
 
-        THROW_IF_FAILED(zoneIdentifier->Remove());
-        THROW_IF_FAILED(persistFile->Save(NULL, TRUE));
+        THROW_IF_FAILED(hr);
+
+        auto hrRemove = zoneIdentifier->Remove();
+        if (FAILED(hrRemove))
+        {
+            AICLI_LOG(Core, Error, << "IZoneIdentifier::Remove failed. Result: " << hrRemove);
+            THROW_IF_FAILED(hrRemove);
+        }
+
+        auto hrSave = persistFile->Save(NULL, TRUE);
+        if (FAILED(hrSave))
+        {
+            AICLI_LOG(Core, Error, << "IPersistFile::Save failed after removing motw. Result: " << hrSave);
+            THROW_IF_FAILED(hrSave);
+        }
 
         AICLI_LOG(Core, Info, << "Finished removing motw");
     }
@@ -510,27 +525,53 @@ namespace AppInstaller::Utility
         // Attachment execution service needs STA to succeed, so we'll create a new thread and CoInitialize with STA.
         HRESULT aesSaveResult = S_OK;
         auto updateMotw = [&]() -> HRESULT
+        {
+            Microsoft::WRL::ComPtr<IAttachmentExecute> attachmentExecute;
+            auto hrCreate = CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute));
+            if (FAILED(hrCreate))
             {
-                Microsoft::WRL::ComPtr<IAttachmentExecute> attachmentExecute;
-                RETURN_IF_FAILED(CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute)));
-                RETURN_IF_FAILED(attachmentExecute->SetLocalPath(filePath.c_str()));
-                RETURN_IF_FAILED(attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str()));
+                AICLI_LOG(Core, Error, << "CoCreateInstance(CLSID_AttachmentServices) failed. Result: " << hrCreate);
+                return hrCreate;
+            }
 
-                // IAttachmentExecute::Save() expects the local file to be clean(i.e. it won't clear existing motw if it thinks the source url is trusted)
+            auto hrSetLocalPath = attachmentExecute->SetLocalPath(filePath.c_str());
+            if (FAILED(hrSetLocalPath))
+            {
+                AICLI_LOG(Core, Error, << "IAttachmentExecute::SetLocalPath failed for path: " << filePath << " Result: " << hrSetLocalPath);
+                return hrSetLocalPath;
+            }
+
+            auto hrSetSource = attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str());
+            if (FAILED(hrSetSource))
+            {
+                AICLI_LOG(Core, Error, << "IAttachmentExecute::SetSource failed for source: " << source << " Result: " << hrSetSource);
+                return hrSetSource;
+            }
+
+            // IAttachmentExecute::Save() expects the local file to be clean (i.e. it won't clear existing motw if it thinks the source url is trusted).
+            // If removal fails for any reason, log a warning and proceed — a removal failure should not abort the security check.
+            try
+            {
                 RemoveMotwIfApplicable(filePath);
+            }
+            catch (...)
+            {
+                HRESULT hrRemoveMotw = wil::ResultFromCaughtException();
+                AICLI_LOG(Core, Warning, << "RemoveMotwIfApplicable failed before IAttachmentExecute::Save(). Result: " << hrRemoveMotw << ". Proceeding with Save()");
+            }
 
-                aesSaveResult = attachmentExecute->Save();
+            aesSaveResult = attachmentExecute->Save();
 
-                // Reapply desired zone upon scan failure.
-                // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
-                if (aesSaveResult != S_OK && std::filesystem::exists(filePath))
-                {
-                    ApplyMotwIfApplicable(filePath, zoneIfScanFailure);
-                }
+            // Reapply desired zone upon scan failure.
+            // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
+            if (aesSaveResult != S_OK && std::filesystem::exists(filePath))
+            {
+                ApplyMotwIfApplicable(filePath, zoneIfScanFailure);
+            }
 
-                RETURN_IF_FAILED(aesSaveResult);
-                return S_OK;
-            };
+            RETURN_IF_FAILED(aesSaveResult);
+            return S_OK;
+        };
 
         HRESULT hr = S_OK;
 

--- a/src/AppInstallerCommonCore/Downloader.cpp
+++ b/src/AppInstallerCommonCore/Downloader.cpp
@@ -131,8 +131,8 @@ namespace AppInstaller::Utility
         std::optional<DownloadInfo> info)
     {
         // For AICLI_LOG usages with string literals.
-        #pragma warning(push)
-        #pragma warning(disable:26449)
+#pragma warning(push)
+#pragma warning(disable:26449)
 
         AICLI_LOG(Core, Info, << "WinINet downloading from url: " << url);
 
@@ -277,7 +277,7 @@ namespace AppInstaller::Utility
 
         AICLI_LOG(Core, Info, << "Download completed.");
 
-        #pragma warning(pop)
+#pragma warning(pop)
 
         return result;
     }
@@ -437,7 +437,7 @@ namespace AppInstaller::Utility
 
         return false;
     }
-    
+
     static inline bool FileSupportsMotw(const std::filesystem::path& path)
     {
         return SupportsNamedStreams(path);
@@ -510,47 +510,58 @@ namespace AppInstaller::Utility
         // Attachment execution service needs STA to succeed, so we'll create a new thread and CoInitialize with STA.
         HRESULT aesSaveResult = S_OK;
         auto updateMotw = [&]() -> HRESULT
-        {
-            Microsoft::WRL::ComPtr<IAttachmentExecute> attachmentExecute;
-            RETURN_IF_FAILED(CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute)));
-            RETURN_IF_FAILED(attachmentExecute->SetLocalPath(filePath.c_str()));
-            RETURN_IF_FAILED(attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str()));
-
-            // IAttachmentExecute::Save() expects the local file to be clean(i.e. it won't clear existing motw if it thinks the source url is trusted)
-            RemoveMotwIfApplicable(filePath);
-
-            aesSaveResult = attachmentExecute->Save();
-
-            // Reapply desired zone upon scan failure.
-            // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
-            if (aesSaveResult != S_OK && std::filesystem::exists(filePath))
             {
-                ApplyMotwIfApplicable(filePath, zoneIfScanFailure);
-            }
+                Microsoft::WRL::ComPtr<IAttachmentExecute> attachmentExecute;
+                RETURN_IF_FAILED(CoCreateInstance(CLSID_AttachmentServices, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&attachmentExecute)));
+                RETURN_IF_FAILED(attachmentExecute->SetLocalPath(filePath.c_str()));
+                RETURN_IF_FAILED(attachmentExecute->SetSource(Utility::ConvertToUTF16(source).c_str()));
 
-            RETURN_IF_FAILED(aesSaveResult);
-            return S_OK;
-        };
+                // IAttachmentExecute::Save() expects the local file to be clean(i.e. it won't clear existing motw if it thinks the source url is trusted)
+                RemoveMotwIfApplicable(filePath);
+
+                aesSaveResult = attachmentExecute->Save();
+
+                // Reapply desired zone upon scan failure.
+                // Not using SUCCEEDED(hr) to check since there are cases file is missing after a successful scan
+                if (aesSaveResult != S_OK && std::filesystem::exists(filePath))
+                {
+                    ApplyMotwIfApplicable(filePath, zoneIfScanFailure);
+                }
+
+                RETURN_IF_FAILED(aesSaveResult);
+                return S_OK;
+            };
 
         HRESULT hr = S_OK;
 
         std::thread aesThread([&]()
             {
-                hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-                if (FAILED(hr))
+                try
                 {
-                    return;
-                }
+                    hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+                    if (FAILED(hr))
+                    {
+                        AICLI_LOG(Core, Error, << "CoInitializeEx failed in IAttachmentExecute thread. Result: " << hr);
+                        return;
+                    }
 
-                hr = updateMotw();
-                CoUninitialize();
+                    hr = updateMotw();
+                    CoUninitialize();
+                }
+                catch (...)
+                {
+                    hr = wil::ResultFromCaughtException();
+                    AICLI_LOG(Core, Error, << "Exception in IAttachmentExecute thread. Result: " << hr);
+                }
             });
 
         aesThread.join();
 
         AICLI_LOG(Core, Info, << "Finished applying motw using IAttachmentExecute. Result: " << hr << " IAttachmentExecute::Save() result: " << aesSaveResult);
 
-        return aesSaveResult;
+        // Return the thread's hr when aesSaveResult was never updated (e.g. CoInitializeEx failure or exception
+        // before IAttachmentExecute::Save() was called), so the caller sees the real failure instead of S_OK.
+        return (FAILED(hr) && aesSaveResult == S_OK) ? hr : aesSaveResult;
     }
 
     Microsoft::WRL::ComPtr<IStream> GetReadOnlyStreamFromURI(std::string_view uriStr)


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.
  - Resolves #6121 
  - Resolves #6126 

##  Fix MOTW security check failures for downloaded installers

###  Problem

  All installer downloads were failing the security check with 0x80070003 (ERROR_PATH_NOT_FOUND), causing every install to terminate with "Installer failed security check".

  Two root causes were identified:

-  Wrong file scanned by IAttachmentExecute — UpdateInstallerFileMotwIfApplicable ran before RenameDownloadedInstaller in the workflow. This meant the Attachment Execution Service (AES) was scanning the
  temporary pre-hash-validation file (a raw SHA256 hex string with no extension, e.g. aab2dc8e…) rather than the final installer (e.g. BadlionClient.exe).  

> [!IMPORTANT]
> __Shell32's AES relies on file extension for MIME-type detection, scan policy, and zone assignment, so scanning an extensionless file produced unreliable results__

-  RemoveMotwIfApplicable failures aborted the security check — If removing the existing Zone.Identifier ADS failed, the exception propagated through the AES thread, leaving IAttachmentExecute::Save() never
  called and the whole check returning a failure code. Additionally, a missing THROW_IF_FAILED(hr) after IPersistFile::Load meant unexpected load errors were silently ignored, leading to Remove()/Save()
  being called on a non-loaded object.

###  Changes

####  DownloadFlow.cpp

   - Reorder workflow: RenameDownloadedInstaller now runs before UpdateInstallerFileMotwIfApplicable, so AES always scans the properly-named installer file.

####  Downloader.cpp — RemoveMotwIfApplicable

   - Also handle ERROR_PATH_NOT_FOUND (in addition to ERROR_FILE_NOT_FOUND) from IPersistFile::Load — different Windows builds return different codes when no Zone.Identifier ADS is present.
   - Restore missing THROW_IF_FAILED(hr) to correctly surface any other Load failures rather than falling through to Remove()/Save() on an unloaded object.

####  Downloader.cpp — ApplyMotwUsingIAttachmentExecuteIfApplicable

   - Wrap RemoveMotwIfApplicable in a try/catch inside the updateMotw lambda — log a warning but proceed to IAttachmentExecute::Save(). MOTW removal is best-effort; a removal failure should not abort the 
  security scan.
   - Wrap the entire AES thread body in try/catch and log exceptions via AICLI_LOG, so unhandled errors are surfaced rather than silently leaving hr in an indeterminate state. Use LOG_IF_FAILED for 
  CoInitializeEx so failures are captured through WIL.
   - Fix the return value: previously aesSaveResult was always returned, reporting S_OK when Save() was never reached (e.g. after CoInitializeEx failure). Now returns the thread's hr when aesSaveResult was 
  never updated

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6127)