### PR TITLE
Add issue types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,5 +1,6 @@
 name: '🐛 Bug Report'
 description: Report errors or unexpected behavior.
+type: Bug
 labels:
 - Issue-Bug
 - Needs-Triage

--- a/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Documentation_Issue.yml
@@ -1,5 +1,6 @@
 name: '📚 Documentation Issue'
 description: Report issues in our documentation.
+type: Task
 labels:
 - Issue-Docs
 - Needs-Triage

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -1,5 +1,6 @@
 name: '🚀 Feature Request / Idea'
 description: Suggest a new feature or improvement (this does not mean you have to implement it).
+type: Feature
 labels:
 - Issue-Feature
 - Needs-Triage


### PR DESCRIPTION
Adds the `type` field to each issue template so newly created issues are automatically assigned the correct issue type.

| Template | Issue Type |
|---|---|
| Bug_Report.yml | Bug |
| Documentation_Issue.yml | Task |
| Feature_Request.yml | Feature |
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6139)