### PR TITLE
Change how Truncation works

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -561,6 +561,7 @@ swgus
 SYD
 SYG
 systemnotsupported
+tableoutput
 Tagit
 TARG
 taskhostw

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -47,6 +47,11 @@ The WinGet MCP server's existing tools have been extended with new parameters to
 
 The PowerShell module now automatically uses `GH_TOKEN` or `GITHUB_TOKEN` environment variables to authenticate GitHub API requests. This significantly increases the GitHub API rate limit, preventing failures in CI/CD pipelines. Use `-Verbose` to see which token is being used.
 
+### Improved `list` output when redirected
+
+- `winget list` (and similar table commands) no longer truncates output when stdout is redirected to a file or variable — column widths are now computed from the full result set.
+- Spinner and progress bar output are suppressed when no console is attached, keeping redirected output clean.
+
 ## Bug Fixes
 
 * Fixed the `useLatest` property in the DSC v3 `Microsoft.WinGet/Package` resource schema to emit a boolean default (`false`) instead of the incorrect string `"false"`.

--- a/src/AppInstallerCLICore/ChannelStreams.cpp
+++ b/src/AppInstallerCLICore/ChannelStreams.cpp
@@ -8,7 +8,7 @@ namespace AppInstaller::CLI::Execution
 {
     using namespace VirtualTerminal;
 
-    size_t GetConsoleWidth()
+    std::optional<size_t> GetConsoleWidth()
     {
         CONSOLE_SCREEN_BUFFER_INFO consoleInfo{};
         if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo))
@@ -17,7 +17,7 @@ namespace AppInstaller::CLI::Execution
         }
         else
         {
-            return 120;
+            return std::nullopt;
         }
     }
 

--- a/src/AppInstallerCLICore/ChannelStreams.cpp
+++ b/src/AppInstallerCLICore/ChannelStreams.cpp
@@ -8,8 +8,23 @@ namespace AppInstaller::CLI::Execution
 {
     using namespace VirtualTerminal;
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    static std::optional<size_t>* s_consoleWidthOverride = nullptr;
+
+    void TestHook_SetConsoleWidth_Override(std::optional<size_t>* value)
+    {
+        s_consoleWidthOverride = value;
+    }
+#endif
+
     std::optional<size_t> GetConsoleWidth()
     {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (s_consoleWidthOverride)
+        {
+            return *s_consoleWidthOverride;
+        }
+#endif
         CONSOLE_SCREEN_BUFFER_INFO consoleInfo{};
         if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo))
         {

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -5,14 +5,16 @@
 #include "VTSupport.h"
 #include <winget/LocIndependent.h>
 
+#include <optional>
 #include <ostream>
 #include <string>
 
 
 namespace AppInstaller::CLI::Execution
 {
-    // Gets the current console width.
-    size_t GetConsoleWidth();
+    // Gets the current console width, or std::nullopt if stdout is not attached to a console
+    // (e.g. redirected to a file or pipe). Callers that receive nullopt should not truncate output.
+    std::optional<size_t> GetConsoleWidth();
 
     // The base stream for all channels.
     struct BaseStream

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -16,13 +16,6 @@ namespace AppInstaller::CLI::Execution
     // (e.g. redirected to a file or pipe). Callers that receive nullopt should not truncate output.
     std::optional<size_t> GetConsoleWidth();
 
-#ifndef AICLI_DISABLE_TEST_HOOKS
-    // Overrides the value returned by GetConsoleWidth(). Pass nullptr to remove the override.
-    // Pass a pointer to std::nullopt to simulate no console; pass a pointer to a value to
-    // simulate a console of that width.
-    void TestHook_SetConsoleWidth_Override(std::optional<size_t>* value);
-#endif
-
     // The base stream for all channels.
     struct BaseStream
     {

--- a/src/AppInstallerCLICore/ChannelStreams.h
+++ b/src/AppInstallerCLICore/ChannelStreams.h
@@ -16,6 +16,13 @@ namespace AppInstaller::CLI::Execution
     // (e.g. redirected to a file or pipe). Callers that receive nullopt should not truncate output.
     std::optional<size_t> GetConsoleWidth();
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    // Overrides the value returned by GetConsoleWidth(). Pass nullptr to remove the override.
+    // Pass a pointer to std::nullopt to simulate no console; pass a pointer to a value to
+    // simulate a console of that width.
+    void TestHook_SetConsoleWidth_Override(std::optional<size_t>* value);
+#endif
+
     // The base stream for all channels.
     struct BaseStream
     {

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -161,7 +161,7 @@ namespace AppInstaller::CLI::Execution
             }
             else
             {
-                m_out << '\r' << std::string(GetConsoleWidth().value_or(0), ' ') << '\r';
+                m_out << '\n';
             }
         }
 

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -161,7 +161,15 @@ namespace AppInstaller::CLI::Execution
             }
             else
             {
-                m_out << '\r' << std::string(GetConsoleWidth().value_or(0), ' ') << '\r';
+                auto consoleWidth = GetConsoleWidth();
+                if (consoleWidth.has_value())
+                {
+                    m_out << '\r' << std::string(*consoleWidth, ' ') << '\r';
+                }
+                else
+                {
+                    m_out << '\n';
+                }
             }
         }
 

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -161,7 +161,7 @@ namespace AppInstaller::CLI::Execution
             }
             else
             {
-                m_out << '\n';
+                m_out << '\r' << std::string(GetConsoleWidth().value_or(0), ' ') << '\r';
             }
         }
 

--- a/src/AppInstallerCLICore/ExecutionProgress.cpp
+++ b/src/AppInstallerCLICore/ExecutionProgress.cpp
@@ -161,7 +161,7 @@ namespace AppInstaller::CLI::Execution
             }
             else
             {
-                m_out << '\r' << std::string(GetConsoleWidth(), ' ') << '\r';
+                m_out << '\r' << std::string(GetConsoleWidth().value_or(0), ' ') << '\r';
             }
         }
 

--- a/src/AppInstallerCLICore/ExecutionReporter.cpp
+++ b/src/AppInstallerCLICore/ExecutionReporter.cpp
@@ -56,9 +56,15 @@ namespace AppInstaller::CLI::Execution
         m_out(outStream),
         m_in(inStream)
     {
-        auto sixelSupported = [&]() { return SixelsSupported(); };
-        m_spinner = IIndefiniteSpinner::CreateForStyle(*m_out, ConsoleModeRestore::Instance().IsVTEnabled(), VisualStyle::Accent, sixelSupported);
-        m_progressBar = IProgressBar::CreateForStyle(*m_out, ConsoleModeRestore::Instance().IsVTEnabled(), VisualStyle::Accent, sixelSupported);
+        // Only create spinner and progress bar when stdout is attached to a console.
+        // When output is redirected to a file or pipe, suppress all progress output
+        // so it does not appear in the redirected stream.
+        if (GetConsoleWidth().has_value())
+        {
+            auto sixelSupported = [&]() { return SixelsSupported(); };
+            m_spinner = IIndefiniteSpinner::CreateForStyle(*m_out, ConsoleModeRestore::Instance().IsVTEnabled(), VisualStyle::Accent, sixelSupported);
+            m_progressBar = IProgressBar::CreateForStyle(*m_out, ConsoleModeRestore::Instance().IsVTEnabled(), VisualStyle::Accent, sixelSupported);
+        }
 
         SetProgressSink(this);
     }
@@ -146,7 +152,7 @@ namespace AppInstaller::CLI::Execution
     {
         m_style = style;
 
-        if (m_channel == Channel::Output)
+        if (m_channel == Channel::Output && GetConsoleWidth().has_value())
         {
             auto sixelSupported = [&]() { return SixelsSupported(); };
             m_spinner = IIndefiniteSpinner::CreateForStyle(*m_out, ConsoleModeRestore::Instance().IsVTEnabled(), style, sixelSupported);

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -20,8 +20,8 @@ namespace AppInstaller::CLI::Execution
         using header_t = std::array<Resource::LocString, FieldCount>;
         using line_t = std::array<std::string, FieldCount>;
 
-        TableOutput(Reporter& reporter, header_t&& header, size_t sizingBuffer = 50) :
-            m_reporter(reporter), m_sizingBuffer(sizingBuffer),
+        TableOutput(Reporter& reporter, header_t&& header) :
+            m_reporter(reporter),
             m_hasConsole(GetConsoleWidth().has_value())
         {
             for (size_t i = 0; i < FieldCount; ++i)
@@ -36,19 +36,11 @@ namespace AppInstaller::CLI::Execution
         {
             m_empty = false;
 
-            // When a console is present, stream rows beyond the sizing buffer directly to avoid
-            // holding all data in memory. When there is no console (redirected output), buffer
-            // every row so that column widths are computed from the full dataset before any
-            // output is written, guaranteeing perfect alignment with no truncation.
-            if (m_hasConsole && m_buffer.size() >= m_sizingBuffer)
-            {
-                EvaluateAndFlushBuffer();
-                OutputLineToStream(line);
-            }
-            else
-            {
-                m_buffer.emplace_back(std::move(line));
-            }
+            // Always buffer every row so that column widths are computed from the full dataset
+            // before any output is written. This guarantees that the widest value in any column
+            // is always fully visible and columns are perfectly aligned, whether output goes to
+            // a console or is redirected. Complete() triggers the actual output.
+            m_buffer.emplace_back(std::move(line));
         }
 
         void Complete()
@@ -76,7 +68,6 @@ namespace AppInstaller::CLI::Execution
 
         Reporter& m_reporter;
         std::array<Column, FieldCount> m_columns;
-        size_t m_sizingBuffer;
         std::vector<line_t> m_buffer;
         bool m_bufferEvaluated = false;
         bool m_empty = true;

--- a/src/AppInstallerCLICore/TableOutput.h
+++ b/src/AppInstallerCLICore/TableOutput.h
@@ -21,7 +21,8 @@ namespace AppInstaller::CLI::Execution
         using line_t = std::array<std::string, FieldCount>;
 
         TableOutput(Reporter& reporter, header_t&& header, size_t sizingBuffer = 50) :
-            m_reporter(reporter), m_sizingBuffer(sizingBuffer)
+            m_reporter(reporter), m_sizingBuffer(sizingBuffer),
+            m_hasConsole(GetConsoleWidth().has_value())
         {
             for (size_t i = 0; i < FieldCount; ++i)
             {
@@ -35,14 +36,18 @@ namespace AppInstaller::CLI::Execution
         {
             m_empty = false;
 
-            if (m_buffer.size() < m_sizingBuffer)
-            {
-                m_buffer.emplace_back(std::move(line));
-            }
-            else
+            // When a console is present, stream rows beyond the sizing buffer directly to avoid
+            // holding all data in memory. When there is no console (redirected output), buffer
+            // every row so that column widths are computed from the full dataset before any
+            // output is written, guaranteeing perfect alignment with no truncation.
+            if (m_hasConsole && m_buffer.size() >= m_sizingBuffer)
             {
                 EvaluateAndFlushBuffer();
                 OutputLineToStream(line);
+            }
+            else
+            {
+                m_buffer.emplace_back(std::move(line));
             }
         }
 
@@ -75,6 +80,7 @@ namespace AppInstaller::CLI::Execution
         std::vector<line_t> m_buffer;
         bool m_bufferEvaluated = false;
         bool m_empty = true;
+        bool m_hasConsole = false;
 
         void EvaluateAndFlushBuffer()
         {
@@ -127,13 +133,14 @@ namespace AppInstaller::CLI::Execution
                 totalRequired += m_columns[i].MaxLength + (m_columns[i].SpaceAfter ? 1 : 0);
             }
 
-            size_t consoleWidth = GetConsoleWidth();
+            auto consoleWidthOpt = GetConsoleWidth();
 
-            // If the total space would be too big, shrink them.
-            // We don't want to use the last column, lest we auto-wrap
-            if (totalRequired >= consoleWidth)
+            // If there is a console and the total space would be too big, shrink columns.
+            // We don't want to use the last column, lest we auto-wrap.
+            // When there is no console (e.g. output redirected to a file), skip truncation entirely.
+            if (consoleWidthOpt && totalRequired >= *consoleWidthOpt)
             {
-                size_t extra = (totalRequired - consoleWidth) + 1;
+                size_t extra = (totalRequired - *consoleWidthOpt) + 1;
 
                 while (extra)
                 {
@@ -151,7 +158,7 @@ namespace AppInstaller::CLI::Execution
                     extra -= 1;
                 }
 
-                totalRequired = consoleWidth - 1;
+                totalRequired = *consoleWidthOpt - 1;
             }
 
             // Header line

--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
@@ -19,6 +19,7 @@
 #include <winget/SelfManagement.h>
 #include <winget/PathTree.h>
 #include <winrt/Microsoft.Management.Configuration.h>
+#include <limits>
 
 using namespace AppInstaller::CLI::Execution;
 using namespace winrt::Microsoft::Management::Configuration;
@@ -356,7 +357,7 @@ namespace AppInstaller::CLI::Workflow
                     truncated = true;
                 }
 
-                if (Utility::LimitOutputLines(lines, GetConsoleWidth(), maxLines))
+                if (Utility::LimitOutputLines(lines, GetConsoleWidth().value_or(std::numeric_limits<size_t>::max()), maxLines))
                 {
                     truncated = true;
                 }
@@ -767,7 +768,7 @@ namespace AppInstaller::CLI::Workflow
             if (messageData.ShowDescription && !description.empty())
             {
                 constexpr size_t maximumDescriptionLines = 3;
-                size_t consoleWidth = GetConsoleWidth();
+                size_t consoleWidth = GetConsoleWidth().value_or(std::numeric_limits<size_t>::max());
                 std::vector<std::string> lines = Utility::SplitIntoLines(description, maximumDescriptionLines + 1);
                 bool wasLimited = Utility::LimitOutputLines(lines, consoleWidth, maximumDescriptionLines);
 

--- a/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ConfigurationFlow.cpp
@@ -19,7 +19,6 @@
 #include <winget/SelfManagement.h>
 #include <winget/PathTree.h>
 #include <winrt/Microsoft.Management.Configuration.h>
-#include <limits>
 
 using namespace AppInstaller::CLI::Execution;
 using namespace winrt::Microsoft::Management::Configuration;
@@ -357,7 +356,7 @@ namespace AppInstaller::CLI::Workflow
                     truncated = true;
                 }
 
-                if (Utility::LimitOutputLines(lines, GetConsoleWidth().value_or(std::numeric_limits<size_t>::max()), maxLines))
+                if (Utility::LimitOutputLines(lines, GetConsoleWidth().value_or(120), maxLines))
                 {
                     truncated = true;
                 }
@@ -768,7 +767,7 @@ namespace AppInstaller::CLI::Workflow
             if (messageData.ShowDescription && !description.empty())
             {
                 constexpr size_t maximumDescriptionLines = 3;
-                size_t consoleWidth = GetConsoleWidth().value_or(std::numeric_limits<size_t>::max());
+                size_t consoleWidth = GetConsoleWidth().value_or(120);
                 std::vector<std::string> lines = Utility::SplitIntoLines(description, maximumDescriptionLines + 1);
                 bool wasLimited = Utility::LimitOutputLines(lines, consoleWidth, maximumDescriptionLines);
 

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -113,7 +113,7 @@ namespace AppInstaller::CLI::Workflow
         {
             // Using a height of 4 arbitrarily; allow width up to the entire console.
             UINT imageHeightCells = 4;
-            UINT imageWidthCells = static_cast<UINT>(Execution::GetConsoleWidth());
+            UINT imageWidthCells = static_cast<UINT>(Execution::GetConsoleWidth().value_or(120));
 
             icon.RenderSizeInCells(imageWidthCells, imageHeightCells);
             icon.RenderTo(outputStream);

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -326,6 +326,7 @@
     <ClCompile Include="SQLiteIndex.cpp" />
     <ClCompile Include="SQLiteWrapper.cpp" />
     <ClCompile Include="Synchronization.cpp" />
+    <ClCompile Include="TableOutput.cpp" />
     <ClCompile Include="TestCommon.cpp" />
     <ClCompile Include="WorkflowCommon.cpp" />
     <ClCompile Include="WorkflowGroupPolicy.cpp" />

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -230,6 +230,9 @@
     <ClCompile Include="Synchronization.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
+    <ClCompile Include="TableOutput.cpp">
+      <Filter>Source Files\Common</Filter>
+    </ClCompile>
     <ClCompile Include="TestRestRequestHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/AppInstallerCLITests/TableOutput.cpp
+++ b/src/AppInstallerCLITests/TableOutput.cpp
@@ -165,3 +165,47 @@ TEST_CASE("TableOutput_NoConsoleOverride_NeverTruncates", "[tableoutput]")
     REQUIRE(result.find(longValue) != std::string::npos);
     REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
 }
+
+// Test that a large number of rows can be buffered and output in a single table without
+// any truncation or missing rows.
+TEST_CASE("TableOutput_ManyRowsBuffered", "[tableoutput]")
+{
+    // At the time of creating this test, there were ~12k unique package IDs in the community repository
+    constexpr size_t RowCount = 25000;
+    std::ostringstream output;
+    std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::nullopt }; // no console: no truncation
+
+    Reporter reporter(output, input);
+
+    TableOutput<3> table(reporter, { MakeHeader("Name"), MakeHeader("Id"), MakeHeader("Version") });
+
+    for (size_t i = 0; i < RowCount; ++i)
+    {
+        table.OutputLine({
+            "Package.Name." + std::to_string(i),
+            "pkg.id." + std::to_string(i),
+            "1.0." + std::to_string(i)
+        });
+    }
+
+    table.Complete();
+
+    REQUIRE_FALSE(table.IsEmpty());
+
+    std::string result = output.str();
+
+    // Spot-check first, middle, and last rows
+    REQUIRE_FALSE(result.empty());
+    REQUIRE(result.find("pkg.id.0") != std::string::npos);
+    REQUIRE(result.find("pkg.id." + std::to_string(RowCount / 2)) != std::string::npos);
+    REQUIRE(result.find("pkg.id." + std::to_string(RowCount - 1)) != std::string::npos);
+
+    // Count newlines to verify all rows were written (header + separator + RowCount data rows)
+    size_t lineCount = std::count(result.begin(), result.end(), '\n');
+    REQUIRE(lineCount == RowCount + 2); // +2 for header and separator lines
+
+    // No truncation ellipsis anywhere
+    REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
+}

--- a/src/AppInstallerCLITests/TableOutput.cpp
+++ b/src/AppInstallerCLITests/TableOutput.cpp
@@ -218,3 +218,35 @@ TEST_CASE("TableOutput_ManyRowsBuffered", "[tableoutput]")
     // No truncation ellipsis anywhere
     REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
 }
+
+// Test that when output is redirected (no console), triggering progress/spinner produces no
+// spinner characters in the output stream — only the table content is present.
+TEST_CASE("TableOutput_Redirected_NoSpinnerOutput", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::nullopt }; // simulate redirected output
+
+    Reporter reporter(output, input);
+
+    // Simulate a spinner lifecycle that would emit characters if a spinner were active.
+    reporter.BeginProgress();
+    reporter.SetProgressMessage("Searching...");
+    reporter.EndProgress(true);
+
+    // Now output a table with known content.
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+    table.OutputLine({ "TestPackage", "test.pkg" });
+    table.Complete();
+
+    std::string result = output.str();
+
+    // The table data must be present.
+    REQUIRE(result.find("TestPackage") != std::string::npos);
+    REQUIRE(result.find("test.pkg") != std::string::npos);
+
+    // Spinner frames written with \r must not appear.
+    // The character spinner uses '-', '\', '|', '/' preceded by '\r'.
+    REQUIRE(result.find('\r') == std::string::npos);
+}

--- a/src/AppInstallerCLITests/TableOutput.cpp
+++ b/src/AppInstallerCLITests/TableOutput.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "TestCommon.h"
+#include <ChannelStreams.h>
+#include <ExecutionReporter.h>
+#include <TableOutput.h>
+
+using namespace AppInstaller::CLI;
+using namespace AppInstaller::CLI::Execution;
+using namespace AppInstaller::Utility;
+
+namespace
+{
+    Resource::LocString MakeHeader(std::string text)
+    {
+        return Resource::LocString{ LocIndString{ std::move(text) } };
+    }
+}
+
+// Test that all rows are buffered and column widths account for values beyond the first 50 rows.
+// In the old sizing-buffer design, a row at position 55 with a longer value than any of the
+// first 50 rows would be truncated. The new design buffers every row so no value is clipped.
+TEST_CASE("TableOutput_AllRowsBuffered_NoTruncation", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+
+    // 54 rows with a short first-column value
+    for (int i = 0; i < 54; ++i)
+    {
+        table.OutputLine({ "ShortValue", "id" + std::to_string(i) });
+    }
+
+    // Row 55: first column is much longer than any previous row
+    std::string longValue(50, 'A');
+    table.OutputLine({ longValue, "id54" });
+
+    table.Complete();
+
+    std::string result = output.str();
+
+    // The full long value must appear; the ellipsis character (U+2026, UTF-8: E2 80 A6)
+    // must not appear anywhere, confirming no truncation occurred.
+    REQUIRE(result.find(longValue) != std::string::npos);
+    REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
+}
+
+// Test that every data row has its second column starting at the same horizontal position,
+// i.e., column 1 is consistently padded regardless of the individual value lengths.
+TEST_CASE("TableOutput_ColumnsAligned", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+
+    table.OutputLine({ "Short",          "id.short" });
+    table.OutputLine({ "MediumValue",    "id.medium" });
+    table.OutputLine({ "LongerValueHere","id.longer" });
+
+    table.Complete();
+
+    std::string result = output.str();
+    std::istringstream ss(result);
+    std::vector<std::string> lines;
+    std::string line;
+    while (std::getline(ss, line))
+    {
+        if (!line.empty()) lines.push_back(line);
+    }
+
+    // Expect: header, separator, 3 data rows = 5 lines minimum
+    REQUIRE(lines.size() >= 5);
+
+    // The "id." prefix of the second-column value should start at the same position in every data row.
+    size_t pos0 = lines[2].find("id.");
+    size_t pos1 = lines[3].find("id.");
+    size_t pos2 = lines[4].find("id.");
+
+    REQUIRE(pos0 != std::string::npos);
+    REQUIRE(pos0 == pos1);
+    REQUIRE(pos0 == pos2);
+}
+
+// Test that calling Complete() on an empty table produces no output.
+TEST_CASE("TableOutput_Empty_ProducesNoOutput", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+
+    REQUIRE(table.IsEmpty());
+    table.Complete();
+    REQUIRE(output.str().empty());
+}
+
+// Test that GetConsoleWidth does not throw and returns a sensible result.
+// In test runner contexts (CI, test explorer) stdout is typically redirected,
+// so nullopt is the expected value; when run interactively nullopt or a positive
+// width are both valid.
+TEST_CASE("GetConsoleWidth_DoesNotCrash", "[channelstreams]")
+{
+    auto width = GetConsoleWidth();
+    if (width.has_value())
+    {
+        REQUIRE(*width > 0);
+    }
+    // nullopt is also valid when stdout is not attached to a console
+}

--- a/src/AppInstallerCLITests/TableOutput.cpp
+++ b/src/AppInstallerCLITests/TableOutput.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "TestCommon.h"
+#include "TestHooks.h"
 #include <ChannelStreams.h>
 #include <ExecutionReporter.h>
 #include <TableOutput.h>
@@ -101,16 +102,66 @@ TEST_CASE("TableOutput_Empty_ProducesNoOutput", "[tableoutput]")
     REQUIRE(output.str().empty());
 }
 
-// Test that GetConsoleWidth does not throw and returns a sensible result.
-// In test runner contexts (CI, test explorer) stdout is typically redirected,
-// so nullopt is the expected value; when run interactively nullopt or a positive
-// width are both valid.
-TEST_CASE("GetConsoleWidth_DoesNotCrash", "[channelstreams]")
+// Test that the console width override works and that TableOutput truncates the widest column
+// (with ellipsis) when the console is too narrow to fit all columns.
+TEST_CASE("TableOutput_ConsoleWidth_TruncatesWhenNarrow", "[tableoutput]")
 {
-    auto width = GetConsoleWidth();
-    if (width.has_value())
-    {
-        REQUIRE(*width > 0);
-    }
-    // nullopt is also valid when stdout is not attached to a console
+    std::ostringstream output;
+    std::istringstream input;
+
+    // Simulate a console that is too narrow for the content.
+    // Column 0 max = 20 ("VeryLongPackageName0"), column 1 max = 6 ("pkg.id").
+    // SpaceAfter on col 0 = true -> totalRequired = 20 + 1 + 6 = 27.
+    // With width = 20, extra = (27 - 20) + 1 = 8, so col 0 shrinks to 12.
+    // "VeryLongPackageName0" (20 chars) > 12 -> ellipsis in output.
+    TestHook::SetConsoleWidth_Override widthOverride{ std::optional<size_t>{20} };
+
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+    table.OutputLine({ "VeryLongPackageName0", "pkg.id" });
+    table.Complete();
+
+    std::string result = output.str();
+    REQUIRE(result.find("\xE2\x80\xA6") != std::string::npos); // ellipsis present = truncation occurred
+}
+
+// Test that with a wide enough console, values are output in full (no ellipsis).
+TEST_CASE("TableOutput_ConsoleWidth_NoTruncationWhenWide", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::optional<size_t>{200} };
+
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+    std::string longValue(50, 'A');
+    table.OutputLine({ longValue, "pkg.id" });
+    table.Complete();
+
+    std::string result = output.str();
+    REQUIRE(result.find(longValue) != std::string::npos);
+    REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
+}
+
+// Test that with no-console override (nullopt), content is never truncated regardless of length.
+TEST_CASE("TableOutput_NoConsoleOverride_NeverTruncates", "[tableoutput]")
+{
+    std::ostringstream output;
+    std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::nullopt }; // simulate redirected output
+
+    Reporter reporter(output, input);
+
+    TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
+    std::string longValue(200, 'B');
+    table.OutputLine({ longValue, "pkg.id" });
+    table.Complete();
+
+    std::string result = output.str();
+    REQUIRE(result.find(longValue) != std::string::npos);
+    REQUIRE(result.find("\xE2\x80\xA6") == std::string::npos);
 }

--- a/src/AppInstallerCLITests/TableOutput.cpp
+++ b/src/AppInstallerCLITests/TableOutput.cpp
@@ -26,6 +26,9 @@ TEST_CASE("TableOutput_AllRowsBuffered_NoTruncation", "[tableoutput]")
 {
     std::ostringstream output;
     std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::optional<size_t>{120} };
+
     Reporter reporter(output, input);
 
     TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
@@ -56,6 +59,9 @@ TEST_CASE("TableOutput_ColumnsAligned", "[tableoutput]")
 {
     std::ostringstream output;
     std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::optional<size_t>{120} };
+
     Reporter reporter(output, input);
 
     TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });
@@ -93,6 +99,9 @@ TEST_CASE("TableOutput_Empty_ProducesNoOutput", "[tableoutput]")
 {
     std::ostringstream output;
     std::istringstream input;
+
+    TestHook::SetConsoleWidth_Override widthOverride{ std::optional<size_t>{120} };
+
     Reporter reporter(output, input);
 
     TableOutput<2> table(reporter, { MakeHeader("Name"), MakeHeader("Id") });

--- a/src/AppInstallerCLITests/TestHooks.h
+++ b/src/AppInstallerCLITests/TestHooks.h
@@ -75,6 +75,11 @@ namespace AppInstaller
         void TestHook_SetScanArchiveResult_Override(bool* status);
     }
 
+    namespace CLI::Execution
+    {
+        void TestHook_SetConsoleWidth_Override(std::optional<size_t>* value);
+    }
+
     namespace CLI::Workflow
     {
         void TestHook_SetEnableWindowsFeatureResult_Override(std::optional<DWORD>&& result);
@@ -344,6 +349,24 @@ namespace TestHook
             AppInstaller::Utility::DownloadType type,
             AppInstaller::IProgressCallback& progress,
             std::optional<AppInstaller::Utility::DownloadInfo> info)> m_downloadFunction;
+    };
+
+    struct SetConsoleWidth_Override
+    {
+        // Pass std::nullopt to simulate no console (redirected output);
+        // pass a size_t value to simulate a console of that width.
+        SetConsoleWidth_Override(std::optional<size_t> width) : m_width(width)
+        {
+            AppInstaller::CLI::Execution::TestHook_SetConsoleWidth_Override(&m_width);
+        }
+
+        ~SetConsoleWidth_Override()
+        {
+            AppInstaller::CLI::Execution::TestHook_SetConsoleWidth_Override(nullptr);
+        }
+
+    private:
+        std::optional<size_t> m_width;
     };
 
     struct SetGetFontRegistryRoot_Override


### PR DESCRIPTION
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [x] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.
  - Several, will link them after review and before merge
  - Resolves #6137
  - Resolves #1653
  - Resolves #3986
  - Resolves #3071
  - Resolves #1300
  - Resolves #2603
  - Resolves #2161
  - Related to #1618

## Problem

When winget list output is redirected to a file or variable:

 - Output was truncated at 120 characters (hardcoded fallback width)
 - Rows beyond the first 50 were truncated to widths locked by earlier rows
 - Spinner and progress bar characters appeared in the redirected output

## Changes

### ChannelStreams.h / ChannelStreams.cpp

 - GetConsoleWidth() now returns std::optional<size_t> — nullopt when no console is attached (stdout redirected), actual width otherwise. Eliminates the hardcoded 120-column fallback.

### TableOutput.h

 - All rows are now buffered before any output is written. Column widths are computed from the full dataset in EvaluateAndFlushBuffer(), eliminating truncation and misalignment for both console and 
non-console output.
 - Column shrinking to fit console width is skipped when no console is present.
 - Removed the 50-row "sizing buffer" optimization that was the root cause of truncation even if the console was wide enough for all columns.

> [!NOTE]
> I assumed the 50-row sizing buffer was for performance reasons and to ensure the CLI would not take too much memory. A test on my machine showed a terminal width of 220 and roughly 200 packages. Assuming a terminal width of 500 characters on an ultrawide monitor, UTF-16 encoded, with 10k rows, that would be roughly 10 MB of buffered content. Given that 10k rows and 500 characters would be a statistical anomaly, I assumed that it would be safe to remove this sizing buffer even if it comes at a minor performance cost.

### ExecutionReporter.cpp

 - Spinner and progress bar are only created when a console is present (GetConsoleWidth().has_value()). When stdout is redirected they remain nullptr, suppressing all progress noise from redirected output.

### ExecutionProgress.cpp, WorkflowBase.cpp, ConfigurationFlow.cpp

 - Updated call sites to handle std::optional<size_t> from GetConsoleWidth().

### AppInstallerCLITests

- Added new test cases to ensure console width creates appropriate truncation behavior
- Added new test to ensure that buffering all lines at once does not cause issues

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6142)