### PR TITLE
[ListCommand] Fix --source filter not restricting list output to specified source

### DIFF
--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1102,6 +1102,7 @@ namespace AppInstaller::CLI::Workflow
 
         auto &source = context.Get<Execution::Data::Source>();
         bool shouldShowSource = source.IsComposite() && source.GetAvailableSources().size() > 1;
+        bool sourceFilterProvided = context.Args.Contains(Execution::Args::Type::Source);
 
         PinBehavior pinBehavior;
         if (m_onlyShowUpgrades && !context.Args.Contains(Execution::Args::Type::Force))
@@ -1175,7 +1176,13 @@ namespace AppInstaller::CLI::Workflow
                     }
                 }
 
-                // The only time we don't want to output a line is when filtering and no update is available.
+                // When --source is given, only show packages that have a correlation (available version)
+                // in the specified source. Packages with no available match are not from that source.
+                if (sourceFilterProvided && !latestVersion)
+                {
+                    continue;
+                }
+
                 if (updateAvailable || !m_onlyShowUpgrades)
                 {
                     Utility::LocIndString availableVersion, sourceName;


### PR DESCRIPTION
Fixes #4236

## Summary

`winget list --source <name>` displayed ALL installed packages instead of only those correlated with the specified source. The root cause was that `ReportListResult` had no source-filtering logic -- the only row-skipping guard (`m_onlyShowUpgrades`) is always false for the `list` command, so every installed package was unconditionally displayed. This PR adds a source-correlation check that skips packages with no available match in the specified source.

## Root Cause

When `--source` is provided, `OpenCompositeSource(Installed)` creates a composite of installed (ARP) packages correlated against the specified source. Correlated packages get a non-null `latestVersion`; uncorrelated ones get null. However, `ReportListResult` never used this signal for filtering. The only skip logic at line 1186 (`if (updateAvailable || !m_onlyShowUpgrades)`) is **always true** for `list` because `m_onlyShowUpgrades=false`. `latestVersion` was only checked for display formatting, never for row filtering.

## What Changed

- **Source-correlation filter**: Added a `sourceFilterProvided` flag that checks `context.Args.Contains(Execution::Args::Type::Source)`. When the flag is set and `latestVersion` is null (meaning the installed package has no correlation with the specified source's available packages), the package is skipped with `continue`.
- **Placement**: The check is inserted at line 1179, before the existing `updateAvailable || !m_onlyShowUpgrades` guard. This ensures non-correlated packages are filtered out early, regardless of the `m_onlyShowUpgrades` state.

## Design Notes

- The fix is confined to the display layer (`ReportListResult`), leveraging the existing CompositeSource correlation mechanism without modifying search semantics.
- The fix is also defense-in-depth for `--upgrade-available` -- non-correlated packages were already excluded by `updateAvailable=false`, but the new check adds an explicit early exit.
- `--source` filters by **correlation** (does the source's index contain this package ID?), not by install origin. A package in multiple sources correctly appears in results for either source.

## Impact

- `winget list --source <name>` now returns only packages correlated with the specified source
- `winget list` (no source filter) is unchanged -- all installed packages still appear
- `winget list --upgrade-available --source <name>` correctly intersects both filters (source correlation AND upgrade availability)
- `winget list --upgrade-available` (no source filter) is unchanged -- all upgradable packages still appear
- No feature flags; the fix is unconditional

## How Validated

- [x] **Manual E2E testing** with `wingetdev` deployed with fix, using custom dev source (`devsource`):
  - `wingetdev list` - all installed packages shown (no regression)
  - `wingetdev list --source winget` - only winget-correlated packages shown
  - `wingetdev list --source devsource` - only devsource-correlated packages shown (was showing all before fix)
  - `wingetdev list --upgrade-available` - all upgradable packages shown (no regression)
  - `wingetdev list --upgrade-available --source devsource` - only upgradable packages from devsource shown
- [x] **Unit Tests**: Pending PR pipeline. Existing `CompositeSource` tests validate correlation; no direct `ReportListResult` source filter tests exist.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6159)