### PR TITLE
Dont log failures to get font title info

### DIFF
--- a/src/AppInstallerCommonCore/Fonts.cpp
+++ b/src/AppInstallerCommonCore/Fonts.cpp
@@ -34,7 +34,12 @@ namespace AppInstaller::Fonts
             // This code can fail in a number of ways, including if the file isn't actually
             // a font file or does not have a title.
             wil::com_ptr<IPropertyStore> pPropertyStore;
-            THROW_IF_FAILED(SHGetPropertyStoreFromParsingName(fontFilePath.c_str(), nullptr, GPS_DEFAULT, IID_PPV_ARGS(&pPropertyStore)));
+            if (FAILED(SHGetPropertyStoreFromParsingName(fontFilePath.c_str(), nullptr, GPS_DEFAULT, IID_PPV_ARGS(&pPropertyStore))))
+            {
+                // Intentionally not throwing here as this is an expected failure case for non-font files or files without titles.
+                return {};
+            }
+
             PROPVARIANT prop;
             PropVariantInit(&prop);
             THROW_IF_FAILED(pPropertyStore->GetValue(PKEY_Title, &prop));


### PR DESCRIPTION
This is a simple fix to not log failures to get font title info so as not to put a bunch of false-positive error noise in the log file.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [ ] This pull request is related to an issue.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6163)