### PR TITLE
Don't require --source when partial source failure leaves a single result

### DIFF
--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -610,6 +610,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(SearchFailureError);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchFailureErrorListMatches);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchFailureErrorNoMatches);
+        WINGET_DEFINE_RESOURCE_STRINGID(SearchFailureSingleResultPrompt);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchFailureWarning);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchId);
         WINGET_DEFINE_RESOURCE_STRINGID(SearchMatch);

--- a/src/AppInstallerCLICore/Workflows/PromptFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/PromptFlow.cpp
@@ -11,35 +11,36 @@ using namespace AppInstaller::Utility::literals;
 
 namespace AppInstaller::CLI::Workflow
 {
+    bool IsInteractivityAllowed(Execution::Context& context)
+    {
+        // Interactivity can be disabled for several reasons:
+        //   * We are running in a non-interactive context (e.g., COM call)
+        //   * It is disabled in the settings
+        //   * It was disabled from the command line
+
+        if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DisableInteractivity))
+        {
+            AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled due to non-interactive context.");
+            return false;
+        }
+
+        if (context.Args.Contains(Execution::Args::Type::DisableInteractivity))
+        {
+            AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled by command line argument.");
+            return false;
+        }
+
+        if (Settings::User().Get<Settings::Setting::InteractivityDisable>())
+        {
+            AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled in settings.");
+            return false;
+        }
+
+        return true;
+    }
+
     namespace
     {
-        bool IsInteractivityAllowed(Execution::Context& context)
-        {
-            // Interactivity can be disabled for several reasons:
-            //   * We are running in a non-interactive context (e.g., COM call)
-            //   * It is disabled in the settings
-            //   * It was disabled from the command line
-
-            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::DisableInteractivity))
-            {
-                AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled due to non-interactive context.");
-                return false;
-            }
-
-            if (context.Args.Contains(Execution::Args::Type::DisableInteractivity))
-            {
-                AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled by command line argument.");
-                return false;
-            }
-
-            if (Settings::User().Get<Settings::Setting::InteractivityDisable>())
-            {
-                AICLI_LOG(CLI, Verbose, << "Skipping prompt. Interactivity is disabled in settings.");
-                return false;
-            }
-
-            return true;
-        }
 
         bool HandleSourceAgreementsForOneSource(Execution::Context& context, const Repository::Source& source)
         {

--- a/src/AppInstallerCLICore/Workflows/PromptFlow.h
+++ b/src/AppInstallerCLICore/Workflows/PromptFlow.h
@@ -5,6 +5,10 @@
 
 namespace AppInstaller::CLI::Workflow
 {
+    // Returns true if interactivity is currently allowed in the given context.
+    bool IsInteractivityAllowed(Execution::Context& context);
+
+
     // Handles all opened source(s) agreements if needed.
     // Required Args: The source to be checked for agreements
     // Inputs: None

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -973,19 +973,45 @@ namespace AppInstaller::CLI::Workflow
 
         if (!searchResult.Failures.empty())
         {
-            // When the install command finds exactly one result from working sources, auto-proceed
-            // instead of requiring the user to specify --source.
-            bool singleResultOnPartialFailure =
-                WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::ShowSearchResultsOnPartialFailure) &&
-                searchResult.Matches.size() == 1;
-
-            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::TreatSourceFailuresAsWarning) || singleResultOnPartialFailure)
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::TreatSourceFailuresAsWarning))
             {
                 auto warn = context.Reporter.Warn();
                 for (const auto& failure : searchResult.Failures)
                 {
                     warn << Resource::String::SearchFailureWarning(Utility::LocIndView{ failure.SourceName }) << std::endl;
                 }
+            }
+            // When ShowSearchResultsOnPartialFailure is set (e.g. install) and exactly one match
+            // was found, prompt the user interactively rather than failing outright.
+            // Falls back to the hard error path if interactivity is disabled.
+            else if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::ShowSearchResultsOnPartialFailure) &&
+                     searchResult.Matches.size() == 1 &&
+                     IsInteractivityAllowed(context))
+            {
+                {
+                    auto warn = context.Reporter.Warn();
+                    for (const auto& failure : searchResult.Failures)
+                    {
+                        warn << Resource::String::SearchFailureWarning(Utility::LocIndView{ failure.SourceName }) << std::endl;
+                    }
+                }
+
+                if (context.Reporter.PromptForBoolResponse(Resource::String::SearchFailureSingleResultPrompt, Reporter::Level::Warning, false))
+                {
+                    return;
+                }
+
+                // User declined; terminate with the source failure HRESULT without re-showing errors
+                HRESULT overallHR = S_OK;
+                for (const auto& failure : searchResult.Failures)
+                {
+                    HRESULT failureHR = HandleException(nullptr, failure.Exception);
+                    if (overallHR == S_OK)
+                    {
+                        overallHR = failureHR;
+                    }
+                }
+                context.SetTerminationHR(overallHR);
             }
             else
             {

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -973,7 +973,13 @@ namespace AppInstaller::CLI::Workflow
 
         if (!searchResult.Failures.empty())
         {
-            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::TreatSourceFailuresAsWarning))
+            // When the install command finds exactly one result from working sources, auto-proceed
+            // instead of requiring the user to specify --source.
+            bool singleResultOnPartialFailure =
+                WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::ShowSearchResultsOnPartialFailure) &&
+                searchResult.Matches.size() == 1;
+
+            if (WI_IsFlagSet(context.GetFlags(), Execution::ContextFlag::TreatSourceFailuresAsWarning) || singleResultOnPartialFailure)
             {
                 auto warn = context.Reporter.Warn();
                 for (const auto& failure : searchResult.Failures)

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -1332,6 +1332,10 @@ Do you agree to the terms?</value>
 Please specify one of them using the --source option to proceed.</value>
     <comment>{Locked="--source"} "working sources" as in "sources that are working correctly"</comment>
   </data>
+  <data name="SearchFailureSingleResultPrompt" xml:space="preserve">
+    <value>A package was found among the working sources. Would you like to proceed?</value>
+    <comment>"working sources" as in "sources that are working correctly"</comment>
+  </data>
   <data name="SearchFailureErrorNoMatches" xml:space="preserve">
     <value>No packages were found among the working sources.</value>
     <comment>"working sources" as in "sources that are working correctly"</comment>

--- a/src/AppInstallerCLITests/WorkFlow.cpp
+++ b/src/AppInstallerCLITests/WorkFlow.cpp
@@ -6,6 +6,7 @@
 #include <AppInstallerDownloader.h>
 #include <winget/Settings.h>
 #include <Workflows/DownloadFlow.h>
+#include <Workflows/WorkflowBase.h>
 #include <Commands/InstallCommand.h>
 #include <Commands/SettingsCommand.h>
 #include <Commands/ValidateCommand.h>
@@ -185,5 +186,66 @@ TEST_CASE("Export_Settings", "[Settings][workflow]")
 
         auto userSettingsFileValue = std::string(json["userSettingsFile"].asCString());
         REQUIRE(userSettingsFileValue.find("settings.json") != std::string::npos);
+    }
+}
+
+TEST_CASE("HandleSearchResultFailures_SingleMatchWithPartialFailure", "[HandleSearchResultFailures][workflow]")
+{
+    auto makeSearchResult = []()
+    {
+        SearchResult result;
+        result.Matches.push_back(ResultMatch{
+            TestCompositePackage::Make(std::vector<Manifest>{ Manifest{} }),
+            PackageMatchFilter{ PackageMatchField::Id, MatchType::Exact }
+        });
+        result.Failures.push_back({ "FailedSource", std::make_exception_ptr(std::runtime_error("source error")) });
+        return result;
+    };
+
+    SECTION("Interactive_Accept")
+    {
+        std::istringstream input{ "y\n" };
+        std::ostringstream output;
+        TestContext context{ output, input };
+        auto previousThreadGlobals = context.SetForCurrentThread();
+        context.SetFlags(ContextFlag::ShowSearchResultsOnPartialFailure);
+        context.Add<Data::SearchResult>(makeSearchResult());
+
+        context << HandleSearchResultFailures;
+
+        INFO(output.str());
+        REQUIRE_FALSE(context.IsTerminated());
+        REQUIRE(output.str().find("FailedSource") != std::string::npos);
+    }
+
+    SECTION("Interactive_Decline")
+    {
+        std::istringstream input{ "n\n" };
+        std::ostringstream output;
+        TestContext context{ output, input };
+        auto previousThreadGlobals = context.SetForCurrentThread();
+        context.SetFlags(ContextFlag::ShowSearchResultsOnPartialFailure);
+        context.Add<Data::SearchResult>(makeSearchResult());
+
+        context << HandleSearchResultFailures;
+
+        INFO(output.str());
+        REQUIRE(context.IsTerminated());
+    }
+
+    SECTION("NonInteractive_HardError")
+    {
+        std::ostringstream output;
+        TestContext context{ output, std::cin };
+        auto previousThreadGlobals = context.SetForCurrentThread();
+        context.SetFlags(ContextFlag::ShowSearchResultsOnPartialFailure);
+        context.Args.AddArg(Args::Type::DisableInteractivity);
+        context.Add<Data::SearchResult>(makeSearchResult());
+
+        context << HandleSearchResultFailures;
+
+        INFO(output.str());
+        REQUIRE(context.IsTerminated());
+        REQUIRE(output.str().find("FailedSource") != std::string::npos);
     }
 }


### PR DESCRIPTION
Fixes #6164

Right now, when one or more sources fail during an install search, winget shows the results from the sources that did respond and asks you to pick one via `--source` even if there's only one result. This happens in `HandleSearchResultFailures` via the `ShowSearchResultsOnPartialFailure` flag, which is set exclusively by the install command.

The fix is small: before routing into the "error and stop" path, check whether we're in install mode with exactly one match. If so, fall into the same "warn and continue" path that `TreatSourceFailuresAsWarning` already uses, the failed sources still get surfaced as warnings, but the install proceeds.

Existing behavior is preserved for:
- Zero results from working sources -> still a hard error
- Two or more results -> still shows the ambiguous list and requires `--source`
- All other commands (search, upgrade, etc.) -> unaffected, they don't set `ShowSearchResultsOnPartialFailure`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6165)