### PR TITLE
Improved manifest validations for MSI and Windows Feature names

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -7,6 +7,7 @@ ACCESSDENIED
 ACCESSTOKEN
 ACL'd
 adjacents
+adminproperties
 adml
 admx
 AFAIK
@@ -98,6 +99,7 @@ COMGLB
 commandline
 compressapi
 concurrencysal
+Consolas
 constexpr
 contactsupport
 contentfiles
@@ -281,6 +283,7 @@ Kaido
 KNOWNFOLDERID
 kool
 ktf
+LASTEXITCODE
 LCID
 learnxinyminutes
 LEBOM
@@ -349,6 +352,7 @@ msdownload
 msft
 msftrubengu
 MSIHASH
+msinewinstance
 MSIXHASH
 MSIXSTRM
 msstore
@@ -513,6 +517,7 @@ sddl
 secureobject
 securestring
 seekp
+Segoe
 seof
 servercert
 servercertificate

--- a/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/DependenciesFlow.cpp
@@ -175,6 +175,12 @@ namespace AppInstaller::CLI::Workflow
                 {
                     AICLI_LOG(Core, Info, << "Successfully enabled [" << featureName << "]");
                 }
+                else if (result == E_INVALIDARG)
+                {
+                    AICLI_LOG(Core, Warning, << "Invalid Windows Feature name [" << featureName << "]");
+                    enableFeaturesFailed = true;
+                    featureContext.Reporter.Warn() << Resource::String::WindowsFeatureNotFound(locIndFeatureName) << std::endl;
+                }
                 else if (result == 0x800f080c) // DISMAPI_E_UNKNOWN_FEATURE
                 {
                     AICLI_LOG(Core, Warning, << "Windows Feature [" << featureName << "] does not exist");

--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -61,14 +61,8 @@ namespace AppInstaller::CLI::Workflow
 
         bool ShouldUseDirectMSIInstall(InstallerTypeEnum type, bool isSilentInstall)
         {
-            switch (type)
-            {
-            case InstallerTypeEnum::Msi:
-            case InstallerTypeEnum::Wix:
-                return isSilentInstall || ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::DirectMSI);
-            default:
-                return false;
-            }
+            return DoesInstallerTypeUseMsiProperties(type) &&
+                (isSilentInstall || ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::DirectMSI));
         }
 
         bool ShouldErrorForUnsupportedArgument(UnsupportedArgumentEnum arg)

--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -509,6 +509,12 @@ namespace AppInstaller::CLI::Workflow
 
     void ShellExecuteEnableWindowsFeature::operator()(Execution::Context& context) const
     {
+        if (!Utility::IsValidWindowsFeaturePattern(m_featureName))
+        {
+            context.Add<Execution::Data::OperationReturnCode>(static_cast<DWORD>(E_INVALIDARG));
+            return;
+        }
+
         Utility::LocIndView locIndFeatureName{ m_featureName };
 
         std::optional<DWORD> doesFeatureExistResult = DoesWindowsFeatureExist(context, m_featureName);

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -1081,6 +1081,18 @@
     <CopyFileToFolders Include="TestData\ManifestV1_28-PowerShellDSC.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-InvalidWindowsFeatureName.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-BlockedMsiProperty.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-InvalidMsiSwitches.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NetworkAddressInSwitches.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AppInstallerCLICore\AppInstallerCLICore.vcxproj">

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -1152,5 +1152,17 @@
     <CopyFileToFolders Include="TestData\ManifestV1_28-Singleton.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-InvalidWindowsFeatureName.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-BlockedMsiProperty.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-InvalidMsiSwitches.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\Manifest-Bad-NetworkAddressInSwitches.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/src/AppInstallerCLITests/InstallDependenciesFlow.cpp
+++ b/src/AppInstallerCLITests/InstallDependenciesFlow.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "WorkflowCommon.h"
 #include "DependenciesTestSource.h"
+#include <AppInstallerRuntime.h>
 #include <Commands/InstallCommand.h>
 #include <Commands/COMCommand.h>
 #include <Workflows/DependenciesFlow.h>
@@ -326,6 +327,42 @@ TEST_CASE("InstallFlow_Dependencies_COM", "[InstallFlow][workflow][dependencies]
     REQUIRE(installationOrder.at(0) == "Dependency1");
     REQUIRE(installationOrder.at(1) == "Dependency2");
     REQUIRE(installationOrder.at(2) == "AppInstallerCliTest.TestExeInstaller.MultipleDependencies");
+}
+
+void InstallFlow_Dependencies_WindowsFeaturesArgument_Generic(std::string_view featureName)
+{
+    std::ostringstream installOutput;
+    TestContext context{ installOutput, std::cin };
+
+    context << ShellExecuteEnableWindowsFeature(featureName);
+
+    INFO(installOutput.str());
+
+    REQUIRE(context.Contains(Execution::Data::OperationReturnCode));
+    REQUIRE(context.Get<Execution::Data::OperationReturnCode>() == E_INVALIDARG);
+}
+
+TEST_CASE("InstallFlow_Dependencies_WindowsFeaturesArgument_Extras", "[InstallFlow][workflow][dependencies][111981]")
+{
+    TempFile potentialLogFile("dism-log", ".log");
+    std::string featureName = "MediaPlayback /LogPath:";
+    featureName.append(potentialLogFile.GetPath().u8string());
+
+    InstallFlow_Dependencies_WindowsFeaturesArgument_Generic(featureName);
+
+    REQUIRE(!std::filesystem::exists(potentialLogFile));
+}
+
+TEST_CASE("InstallFlow_Dependencies_WindowsFeaturesArgument_Quoted", "[InstallFlow][workflow][dependencies][111981]")
+{
+    TempFile potentialLogFile("dism-log", ".log");
+    std::string featureName = "\"MediaPlayback /LogPath:";
+    featureName.append(potentialLogFile.GetPath().u8string());
+    featureName.append("\"");
+
+    InstallFlow_Dependencies_WindowsFeaturesArgument_Generic(featureName);
+
+    REQUIRE(!std::filesystem::exists(potentialLogFile));
 }
 
 // TODO:

--- a/src/AppInstallerCLITests/Strings.cpp
+++ b/src/AppInstallerCLITests/Strings.cpp
@@ -354,3 +354,28 @@ TEST_CASE("ConvertControlCodesToPictures", "[strings]")
 
     REQUIRE(ConvertControlCodesToPictures(allCodes) == ConvertToUTF8(allPictures));
 }
+
+TEST_CASE("IsValidWindowsFeaturePattern_AllFound_True", "[strings][111981]")
+{
+    for (const auto& name : {
+            "IIS-ODBCLogging",
+            "NetFx3",
+            "SMB1Protocol",
+        })
+    {
+        INFO(name);
+        REQUIRE(IsValidWindowsFeaturePattern(name));
+    }
+}
+
+TEST_CASE("IsValidWindowsFeaturePattern_Bad_False", "[strings][111981]")
+{
+    for (const auto& name : {
+            "MediaPlayback /LogPath:C:\\file.txt",
+            "\"MediaPlayback /LogPath:C:\\file.txt\"",
+        })
+    {
+        INFO(name);
+        REQUIRE(!IsValidWindowsFeaturePattern(name));
+    }
+}

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-BlockedMsiProperty.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-BlockedMsiProperty.yaml
@@ -1,0 +1,19 @@
+# Installer with a blocked MSI property in a switch value
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
+PackageIdentifier: AppInstallerCliTest.TestMsiInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test MSI Installer
+ShortDescription: AppInstaller Test MSI Installer
+Publisher: Microsoft Corporation
+License: Test
+InstallerType: msi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://ThisIsNotUsed
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    InstallerSwitches:
+      Silent: TRANSFORMS=evil.mst
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-InvalidMsiSwitches.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-InvalidMsiSwitches.yaml
@@ -1,0 +1,19 @@
+# Installer with unparseable MSI switch arguments
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
+PackageIdentifier: AppInstallerCliTest.TestMsiInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test MSI Installer
+ShortDescription: AppInstaller Test MSI Installer
+Publisher: Microsoft Corporation
+License: Test
+InstallerType: msi
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://ThisIsNotUsed
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    InstallerSwitches:
+      Silent: '@INVALID'
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-InvalidWindowsFeatureName.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-InvalidWindowsFeatureName.yaml
@@ -1,0 +1,22 @@
+# Installer with an invalid Windows Feature name in dependencies
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
+PackageIdentifier: AppInstallerCliTest.TestMsixInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test MSIX Installer
+ShortDescription: AppInstaller Test MSIX Installer
+Publisher: Microsoft Corporation
+Moniker: AICLITestMsix
+License: Test
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/microsoft/msix-packaging/blob/master/src/test/testData/unpack/TestAppxPackage_x64.appx?raw=true
+    InstallerType: msix
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    PackageFamilyName: 20477fca-282d-49fb-b03e-371dca074f0f_8wekyb3d8bbwe
+    Dependencies:
+      WindowsFeatures:
+        - Invalid@Feature
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Bad-NetworkAddressInSwitches.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Bad-NetworkAddressInSwitches.yaml
@@ -1,0 +1,20 @@
+# Installer with a network address in a switch value
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.0.0.schema.json
+
+PackageIdentifier: AppInstallerCliTest.TestExeInstaller
+PackageVersion: 1.0.0.0
+PackageLocale: en-US
+PackageName: AppInstaller Test Exe Installer
+ShortDescription: AppInstaller Test Exe Installer
+Publisher: Microsoft Corporation
+License: Test
+InstallerType: exe
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://ThisIsNotUsed
+    InstallerSha256: 6a2d3683fa19bf00e58e07d1313d20a5f5735ebbd6a999d33381d28740ee07ea
+    InstallerSwitches:
+      Silent: http://evil.example.com
+      SilentWithProgress: /normal
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/AppInstallerCLITests/TestData/Manifest-Good-Switches.yaml
+++ b/src/AppInstallerCLITests/TestData/Manifest-Good-Switches.yaml
@@ -6,11 +6,11 @@ Publisher: Microsoft
 InstallerType: Msi
 License: Test
 Switches:
-  SilentWithProgress: /sp
+  SilentWithProgress: /passive
 Installers:
   - Arch: x86
     Url: https://ThisIsNotUsed
     Sha256: 98B67758CEAFFCBB3FE47838FD0A8D7BD581C2650842D6B2B0E0D49A23270CCD
     Switches:
-      Silent: /s
+      Silent: /quiet
 ManifestVersion: 0.1.0

--- a/src/AppInstallerCLITests/YamlManifest.cpp
+++ b/src/AppInstallerCLITests/YamlManifest.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "TestCommon.h"
+#include "TestSettings.h"
 #include <AppInstallerSHA256.h>
 #include <AppInstallerLanguageUtilities.h>
 #include <winget/ManifestYamlParser.h>
@@ -52,6 +53,11 @@ namespace
     void ValidateError(const ValidationError& error, ValidationError::Level level, AppInstaller::StringResource::StringId message)
     {
         ValidateError(error, level, message, std::string(), std::string());
+    }
+
+    std::vector<ValidationError> ValidateManifest(const Manifest& manifest, bool fullValidation)
+    {
+        return ValidateManifest(manifest, ManifestValidateOption{ fullValidation });
     }
 
     struct ManifestExceptionMatcher : public Catch::Matchers::MatcherBase<ManifestException>
@@ -1358,6 +1364,67 @@ TEST_CASE("PortableFileTypeValidation", "[ManifestValidation]")
 
     errors = ValidateManifest(rootManifest, false);
     REQUIRE(errors.size() == 0);
+}
+
+TEST_CASE("WindowsFeatureNameValidation", "[ManifestValidation][111981]")
+{
+    // An invalid Windows Feature name should produce an error regardless of the fullValidation flag
+    Manifest invalidManifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Bad-InvalidWindowsFeatureName.yaml"));
+
+    auto errors = ValidateManifest(invalidManifest, true);
+    REQUIRE(errors.size() == 1);
+    ValidateError(errors[0], ValidationError::Level::Error, ManifestError::InvalidWindowsFeatureName, "Invalid@Feature", "");
+
+    errors = ValidateManifest(invalidManifest, false);
+    REQUIRE(errors.size() == 1);
+    ValidateError(errors[0], ValidationError::Level::Error, ManifestError::InvalidWindowsFeatureName, "Invalid@Feature", "");
+}
+
+TEST_CASE("NetworkAddressInSwitchesValidation", "[ManifestValidation][111981]")
+{
+    Manifest manifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Bad-NetworkAddressInSwitches.yaml"));
+
+    auto errors = ValidateManifest(manifest, true);
+    REQUIRE(errors.size() == 1);
+    ValidateError(errors[0], ValidationError::Level::Warning, ManifestError::ContainsNetworkAddress, "http://evil.example.com", "");
+
+    ManifestValidateOption options{ true };
+    options.ErrorOnNetworkAddressInSwitches = true;
+    errors = ValidateManifest(manifest, options);
+    REQUIRE(errors.size() == 1);
+    ValidateError(errors[0], ValidationError::Level::Error, ManifestError::ContainsNetworkAddress, "http://evil.example.com", "");
+
+    errors = ValidateManifest(manifest, false);
+    REQUIRE(errors.size() == 0);
+}
+
+TEST_CASE("BlockedMsiPropertyValidation", "[ManifestValidation][111981]")
+{
+    SECTION("Blocked property is detected under full validation")
+    {
+        Manifest manifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Bad-BlockedMsiProperty.yaml"));
+
+        auto errors = ValidateManifest(manifest, true);
+        REQUIRE(errors.size() == 1);
+        ValidateError(errors[0], ValidationError::Level::Error, ManifestError::BlockedMsiProperty, "TRANSFORMS", "");
+
+        // Not checked when fullValidation is false
+        errors = ValidateManifest(manifest, false);
+        REQUIRE(errors.size() == 0);
+    }
+
+    SECTION("Invalid MSI switches are detected under full validation")
+    {
+        Manifest manifest = YamlParser::CreateFromPath(TestDataFile("Manifest-Bad-InvalidMsiSwitches.yaml"));
+
+        auto errors = ValidateManifest(manifest, true);
+        REQUIRE(errors.size() == 1);
+        ValidateError(errors[0], ValidationError::Level::Error, ManifestError::InvalidMsiSwitches);
+
+        // Not checked when fullValidation is false
+        errors = ValidateManifest(manifest, false);
+        REQUIRE(errors.size() == 0);
+    }
 }
 
 TEST_CASE("ReadManifestAndValidateMsixInstallers_Success", "[ManifestValidation]")

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -964,6 +964,13 @@ namespace AppInstaller::Manifest
             installerType == InstallerTypeEnum::Exe;
     }
 
+    bool DoesInstallerTypeUseMsiProperties(InstallerTypeEnum installerType)
+    {
+        return
+            installerType == InstallerTypeEnum::Msi ||
+            installerType == InstallerTypeEnum::Wix;
+    }
+
     bool IsArchiveType(InstallerTypeEnum installerType)
     {
         return (installerType == InstallerTypeEnum::Zip);

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -8,6 +8,7 @@
 #include "winget/MsixManifestValidation.h"
 #include "winget/Locale.h"
 #include "winget/Filesystem.h"
+#include "winget/MsiExecArguments.h"
 
 namespace AppInstaller::Manifest
 {
@@ -85,13 +86,29 @@ namespace AppInstaller::Manifest
                 { AppInstaller::Manifest::ManifestError::SchemaHeaderUrlPatternMismatch, "The schema header URL does not match the expected pattern."sv },
                 { AppInstaller::Manifest::ManifestError::InvalidPortableFiletype, "The file type of the referenced file is not allowed."sv },
                 { AppInstaller::Manifest::ManifestError::InvalidFontFiletype, "The file type of the referenced file is not a supported font file type."sv },
+                { AppInstaller::Manifest::ManifestError::InvalidWindowsFeatureName, "The provided value is not a valid Windows feature name."sv },
+                { AppInstaller::Manifest::ManifestError::BlockedMsiProperty, "Contains a blocked MSI property."sv },
+                { AppInstaller::Manifest::ManifestError::InvalidMsiSwitches, "Contains invalid MSI switches."sv },
+                { AppInstaller::Manifest::ManifestError::ContainsNetworkAddress, "Installer switch contains network address."sv },
             };
 
             return ErrorIdToMessageMap;
         }
+
+        bool ContainsSharePathSignifier(std::string_view input)
+        {
+            return Utility::CaseInsensitiveContainsSubstring(input, "\\\\");
+        }
+
+        bool ContainsNetworkAddressSignifier(std::string_view input)
+        {
+            return Utility::CaseInsensitiveContainsSubstring(input, "http://") ||
+                Utility::CaseInsensitiveContainsSubstring(input, "https://") ||
+                Utility::CaseInsensitiveContainsSubstring(input, "ftp://");
+        }
     }
 
-    std::vector<ValidationError> ValidateManifest(const Manifest& manifest, bool fullValidation)
+    std::vector<ValidationError> ValidateManifest(const Manifest& manifest, const ManifestValidateOption& options)
     {
         std::vector<ValidationError> resultErrors;
 
@@ -115,7 +132,7 @@ namespace AppInstaller::Manifest
             resultErrors.emplace_back(ManifestError::InvalidFieldValue, "PackageVersion", manifest.Version);
         }
 
-        auto defaultLocErrors = ValidateManifestLocalization(manifest.DefaultLocalization, !fullValidation);
+        auto defaultLocErrors = ValidateManifestLocalization(manifest.DefaultLocalization, !options.FullValidation);
         std::move(defaultLocErrors.begin(), defaultLocErrors.end(), std::inserter(resultErrors, resultErrors.end()));
 
         // Comparison function to check duplicate installer entry. {installerType, arch, language and scope} combination is the key.
@@ -166,7 +183,7 @@ namespace AppInstaller::Manifest
         for (auto const& installer : manifest.Installers)
         {
             // If not full validation, for future compatibility, skip validating unknown installers.
-            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Unknown && !fullValidation)
+            if (installer.EffectiveInstallerType() == InstallerTypeEnum::Unknown && !options.FullValidation)
             {
                 continue;
             }
@@ -215,7 +232,7 @@ namespace AppInstaller::Manifest
 
             if (installer.EffectiveInstallerType() == InstallerTypeEnum::MSStore)
             {
-                if (fullValidation)
+                if (options.FullValidation)
                 {
                     // MSStore type is not supported in community repo
                     resultErrors.emplace_back(
@@ -247,7 +264,7 @@ namespace AppInstaller::Manifest
 
                 // Ensure that each URL has a one to one mapping with a Sha256 and
                 // warn if a Sha256 has a one to many mapping with a URL
-                if (fullValidation && !installer.Url.empty() && !installer.Sha256.empty())
+                if (options.FullValidation && !installer.Url.empty() && !installer.Sha256.empty())
                 {
                     std::string checksum = Utility::SHA256::ConvertToString(installer.Sha256);
                     std::string url = installer.Url;
@@ -351,7 +368,7 @@ namespace AppInstaller::Manifest
                     }
 
                     // If running full validation, check filetype
-                    if (fullValidation)
+                    if (options.FullValidation)
                     {
                         if (isPortable)
                         {
@@ -425,7 +442,7 @@ namespace AppInstaller::Manifest
             // Check AuthInfo validity. For full validation (community repo), authentication type must be none.
             if (installer.AuthInfo.Type != Authentication::AuthenticationType::None)
             {
-                if (fullValidation)
+                if (options.FullValidation)
                 {
                     // Authentication is not supported (must be none) in community repo.
                     resultErrors.emplace_back(ManifestError::FieldNotSupported, "Authentication");
@@ -437,7 +454,15 @@ namespace AppInstaller::Manifest
                 }
             }
 
-            if (fullValidation)
+            installer.Dependencies.ApplyToType(DependencyType::WindowsFeature, [&](const Dependency& dependency)
+                {
+                    if (!IsValidWindowsFeaturePattern(dependency.Id()))
+                    {
+                        resultErrors.emplace_back(ManifestError::InvalidWindowsFeatureName, dependency.Id());
+                    }
+                });
+
+            if (options.FullValidation)
             {
                 for (const auto& container : installer.DesiredStateConfiguration)
                 {
@@ -448,13 +473,50 @@ namespace AppInstaller::Manifest
                         break;
                     }
                 }
+
+                if (DoesInstallerTypeUseMsiProperties(installer.EffectiveInstallerType()))
+                {
+                    try
+                    {
+                        for (const auto& item : installer.Switches)
+                        {
+                            if (!item.second.empty())
+                            {
+                                auto blocked = Msi::ParseMSIArguments(item.second).GetFirstBlockedProperty();
+                                if (blocked)
+                                {
+                                    resultErrors.emplace_back(ManifestError::BlockedMsiProperty, blocked.value());
+                                }
+                            }
+                        }
+                    }
+                    catch (...)
+                    {
+                        resultErrors.emplace_back(ManifestError::InvalidMsiSwitches);
+                    }
+                }
+
+                for (const auto& item : installer.Switches)
+                {
+                    if (!item.second.empty())
+                    {
+                        if (ContainsSharePathSignifier(item.second))
+                        {
+                            resultErrors.emplace_back(ManifestError::ContainsNetworkAddress, item.second);
+                        }
+                        else if (ContainsNetworkAddressSignifier(item.second))
+                        {
+                            resultErrors.emplace_back(ManifestError::ContainsNetworkAddress, item.second, options.ErrorOnNetworkAddressInSwitches ? ValidationError::Level::Error : ValidationError::Level::Warning);
+                        }
+                    }
+                }
             }
         }
 
         // Validate localizations
         for (auto const& localization : manifest.Localizations)
         {
-            auto locErrors = ValidateManifestLocalization(localization, !fullValidation);
+            auto locErrors = ValidateManifestLocalization(localization, !options.FullValidation);
             std::move(locErrors.begin(), locErrors.end(), std::inserter(resultErrors, resultErrors.end()));
         }
 

--- a/src/AppInstallerCommonCore/Manifest/YamlParser.cpp
+++ b/src/AppInstallerCommonCore/Manifest/YamlParser.cpp
@@ -477,7 +477,7 @@ namespace AppInstaller::Manifest::YamlParser
             // Extra semantic validations after basic validation and field population
             if (validateOption.FullValidation)
             {
-                errors = ValidateManifest(manifest);
+                errors = ValidateManifest(manifest, validateOption);
                 std::move(errors.begin(), errors.end(), std::inserter(resultErrors, resultErrors.end()));
 
                 // Validate the schema header for manifest version 1.7 and above

--- a/src/AppInstallerCommonCore/MsiExecArguments.cpp
+++ b/src/AppInstallerCommonCore/MsiExecArguments.cpp
@@ -355,14 +355,14 @@ namespace AppInstaller::Msi
         // Validates that a token represents a property.
         // This checks that the property has the form PropertyName=Value,
         // with the value optionally quoted.
-        bool IsValidPropertyToken(std::string_view token)
+        std::optional<MsiParsedArguments::ParsedProperty> ParsePropertyToken(std::string_view token)
         {
             THROW_HR_IF(APPINSTALLER_CLI_ERROR_INTERNAL_ERROR, token.empty());
 
             if (token[0] != '%' && !IsCharAlphaNumericA(token[0]))
             {
                 AICLI_LOG(Core, Error, << "Bad property for msiexec: " << token);
-                return false;
+                return std::nullopt;
             }
 
             // Find the = separator at the end of the property name
@@ -375,8 +375,10 @@ namespace AppInstaller::Msi
             if (pos == token.size() || token[pos] != '=')
             {
                 AICLI_LOG(Core, Error, << "Expected property for call to msiexec, but couldn't find separator: " << token);
-                return false;
+                return std::nullopt;
             }
+
+            size_t nameLength = pos;
 
             // Validate the property value.
             // It should be completely enclosed in quotes, or not contain white space.
@@ -386,7 +388,7 @@ namespace AppInstaller::Msi
             if (pos == token.size())
             {
                 // Empty value
-                return true;
+                return MsiParsedArguments::ParsedProperty{ std::string{ token.substr(0, nameLength) }, {} };
             }
 
             // If quoted, we will only inspect the values between the quotes.
@@ -438,7 +440,7 @@ namespace AppInstaller::Msi
                 ++pos;
             }
 
-            return true;
+            return MsiParsedArguments::ParsedProperty{ std::string{ token.substr(0, nameLength) }, std::string{ token.substr(nameLength + 1) } };
         }
 
         // Replaces long options in the arguments (e.g. /quiet), by their short equivalents
@@ -502,9 +504,11 @@ namespace AppInstaller::Msi
             tokens.pop_front();
             if (!IsSwitch(token))
             {
+                auto propertyToken = ParsePropertyToken(token);
                 // Token is a property, i.e. NAME=value. Add it to the parsed args.
-                THROW_HR_IF(APPINSTALLER_CLI_ERROR_INVALID_MSIEXEC_ARGUMENT, !IsValidPropertyToken(token));
+                THROW_HR_IF(APPINSTALLER_CLI_ERROR_INVALID_MSIEXEC_ARGUMENT, !propertyToken);
                 parsedArgs.Properties += L" " + Utility::ConvertToUTF16(token);
+                parsedArgs.ParsedProperties.emplace_back(std::move(propertyToken).value());
                 return;
             }
 
@@ -548,6 +552,30 @@ namespace AppInstaller::Msi
             }
             }
         }
+    }
+
+    std::optional<std::string> MsiParsedArguments::GetFirstBlockedProperty() const
+    {
+        for (const auto& property : ParsedProperties)
+        {
+            auto lowerName = Utility::ToLower(property.first);
+
+            for (const auto& blockedName : {
+                    "transforms",
+                    "patch",
+                    "msinewinstance",
+                    "adminproperties",
+                })
+            {
+                if (blockedName == lowerName)
+                {
+                    AICLI_LOG(Core, Warning, << "MSI arguments contain blocked property: " << lowerName);
+                    return property.first;
+                }
+            }
+        }
+
+        return std::nullopt;
     }
 
     MsiParsedArguments ParseMSIArguments(std::string_view arguments)

--- a/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestCommon.h
@@ -64,9 +64,13 @@ namespace AppInstaller::Manifest
 
     struct ManifestValidateOption
     {
+        ManifestValidateOption() = default;
+        explicit ManifestValidateOption(bool fullValidation) : FullValidation(fullValidation) {}
+
         bool SchemaValidationOnly = false;
         bool ErrorOnVerifiedPublisherFields = false;
         bool InstallerValidation = false;
+        bool ErrorOnNetworkAddressInSwitches = false;
 
         // Options not exposed in winget util
         bool FullValidation = false;
@@ -495,6 +499,9 @@ namespace AppInstaller::Manifest
 
     // Gets a value indicating whether the given installer requires RepairBehavior for repair.
     bool DoesInstallerTypeRequireRepairBehaviorForRepair(InstallerTypeEnum installerType);
+
+    // Gets a value indicating whether the given installer type uses MSI properties in its command line.
+    bool DoesInstallerTypeUseMsiProperties(InstallerTypeEnum installerType);
 
     // Gets a value indicating whether the given installer type is an archive.
     bool IsArchiveType(InstallerTypeEnum installerType);

--- a/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
@@ -23,7 +23,9 @@ namespace AppInstaller::Manifest
         WINGET_DEFINE_RESOURCE_STRINGID(ArpValidationError);
         WINGET_DEFINE_RESOURCE_STRINGID(ArpVersionOverlapWithIndex);
         WINGET_DEFINE_RESOURCE_STRINGID(ArpVersionValidationInternalError);
+        WINGET_DEFINE_RESOURCE_STRINGID(BlockedMsiProperty);
         WINGET_DEFINE_RESOURCE_STRINGID(BothAllowedAndExcludedMarketsDefined);
+        WINGET_DEFINE_RESOURCE_STRINGID(ContainsNetworkAddress);
         WINGET_DEFINE_RESOURCE_STRINGID(DuplicatePortableCommandAlias);
         WINGET_DEFINE_RESOURCE_STRINGID(DuplicateRelativeFilePath);
         WINGET_DEFINE_RESOURCE_STRINGID(DuplicateMultiFileManifestLocale);
@@ -54,7 +56,9 @@ namespace AppInstaller::Manifest
         WINGET_DEFINE_RESOURCE_STRINGID(InstallerTypeDoesNotWriteAppsAndFeaturesEntry);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidBcp47Value);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidFieldValue);
+        WINGET_DEFINE_RESOURCE_STRINGID(InvalidMsiSwitches);
         WINGET_DEFINE_RESOURCE_STRINGID(InvalidRootNode);
+        WINGET_DEFINE_RESOURCE_STRINGID(InvalidWindowsFeatureName);
         WINGET_DEFINE_RESOURCE_STRINGID(MissingManifestDependenciesNode);
         WINGET_DEFINE_RESOURCE_STRINGID(MsixSignatureHashFailed);
         WINGET_DEFINE_RESOURCE_STRINGID(MultiManifestPackageHasDependencies);
@@ -253,7 +257,7 @@ namespace AppInstaller::Manifest
     };
 
     // fullValidation: bool to set if manifest validation should perform extra validation that is not required for reading a manifest.
-    std::vector<ValidationError> ValidateManifest(const Manifest& manifest, bool fullValidation = true);
+    std::vector<ValidationError> ValidateManifest(const Manifest& manifest, const ManifestValidateOption& options);
     std::vector<ValidationError> ValidateManifestLocalization(const ManifestLocalization& localization, bool treatErrorAsWarning = false);
     std::vector<ValidationError> ValidateManifestInstallers(const Manifest& manifest, bool treatErrorAsWarning = false);
 }

--- a/src/AppInstallerCommonCore/Public/winget/MsiExecArguments.h
+++ b/src/AppInstallerCommonCore/Public/winget/MsiExecArguments.h
@@ -51,6 +51,14 @@ namespace AppInstaller::Msi
 
         // Properties string
         std::wstring Properties;
+
+        using ParsedProperty = std::pair<std::string, std::string>;
+
+        // Contains the properties as split into name and value portions.
+        std::vector<ParsedProperty> ParsedProperties;
+
+        // Checks for properties that are blocked in some cases.
+        std::optional<std::string> GetFirstBlockedProperty() const;
     };
 
     // Parses a command line string for msiexec.

--- a/src/AppInstallerRepositoryCore/Rest/Schema/1_0/RestInterface_1_0.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/Schema/1_0/RestInterface_1_0.cpp
@@ -256,7 +256,7 @@ namespace AppInstaller::Repository::Rest::Schema::V1_0
         for (auto& manifestItem : manifests)
         {
             std::vector<AppInstaller::Manifest::ValidationError> validationErrors =
-                AppInstaller::Manifest::ValidateManifest(manifestItem, false);
+                AppInstaller::Manifest::ValidateManifest(manifestItem, AppInstaller::Manifest::ManifestValidateOption{ false });
 
             int errors = 0;
             for (auto& error : validationErrors)

--- a/src/AppInstallerSharedLib/AppInstallerStrings.cpp
+++ b/src/AppInstallerSharedLib/AppInstallerStrings.cpp
@@ -1141,4 +1141,22 @@ namespace AppInstaller::Utility
 
         return result;
     }
+
+    bool IsValidWindowsFeaturePattern(std::string_view value)
+    {
+        if (value.empty())
+        {
+            return false;
+        }
+
+        for (char c : value)
+        {
+            if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerStrings.h
@@ -326,4 +326,7 @@ namespace AppInstaller::Utility
 
     // Generates a random alpha numeric string.
     std::string GetRandomString(size_t size = 8);
+
+    // Checks whether a given string is a valid potential Windows feature name.
+    bool IsValidWindowsFeaturePattern(std::string_view value);
 }

--- a/src/WinGetUtil/Exports.cpp
+++ b/src/WinGetUtil/Exports.cpp
@@ -303,6 +303,7 @@ extern "C"
             validateOption.SchemaValidationOnly = WI_IsFlagSet(option, WinGetValidateManifestOption::SchemaValidationOnly);
             validateOption.ErrorOnVerifiedPublisherFields = WI_IsFlagSet(option, WinGetValidateManifestOption::ErrorOnVerifiedPublisherFields);
             validateOption.InstallerValidation = WI_IsFlagSet(option, WinGetValidateManifestOption::InstallerValidations);
+            validateOption.ErrorOnNetworkAddressInSwitches = WI_IsFlagSet(option, WinGetValidateManifestOption::ErrorOnNetworkAddressInSwitches);
 
             (void)YamlParser::CreateFromPath(inputPath, validateOption, mergedManifestPath ? mergedManifestPath : L"");
 
@@ -348,6 +349,7 @@ extern "C"
                 validateOption.ThrowOnWarning = true;
                 validateOption.SchemaValidationOnly = WI_IsFlagClear(option, WinGetCreateManifestOption::SchemaAndSemanticValidation);
                 validateOption.ErrorOnVerifiedPublisherFields = WI_IsFlagSet(option, WinGetCreateManifestOption::ReturnErrorOnVerifiedPublisherFields);
+                validateOption.ErrorOnNetworkAddressInSwitches = WI_IsFlagSet(option, WinGetCreateManifestOption::ReturnErrorOnNetworkAddressInSwitches);
             }
 
             if (WI_IsFlagSet(option, WinGetCreateManifestOption::AllowShadowManifest))

--- a/src/WinGetUtil/WinGetUtil.h
+++ b/src/WinGetUtil/WinGetUtil.h
@@ -26,6 +26,7 @@ extern "C"
         SchemaValidationOnly = 0x1,
         ErrorOnVerifiedPublisherFields = 0x2,
         InstallerValidations = 0x4,
+        ErrorOnNetworkAddressInSwitches = 0x8,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(WinGetValidateManifestOption);
@@ -45,6 +46,9 @@ extern "C"
 
         // Return error on manifest fields that require verified publishers, used during semantic validation
         ReturnErrorOnVerifiedPublisherFields = 0x1000,
+
+        // Return error if a network address is present in installer switches.
+        ReturnErrorOnNetworkAddressInSwitches = 0x2000,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(WinGetCreateManifestOption);

--- a/src/WinGetUtilInterop/Common/Enums.cs
+++ b/src/WinGetUtilInterop/Common/Enums.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="Enums.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -42,6 +42,11 @@ namespace Microsoft.WinGetUtil.Common
         /// Return error on manifest fields that require verified publishers, used during semantic validation
         /// </summary>
         ReturnErrorOnVerifiedPublisherFields = 0x1000,
+
+        /// <summary>
+        /// Return error if a network address is present in installer switches.
+        /// </summary>
+        ReturnErrorOnNetworkAddressInSwitches = 0x2000,
     }
 
     /// <summary>

--- a/tools/ManifestValidation/Invoke-ManifestValidation.ps1
+++ b/tools/ManifestValidation/Invoke-ManifestValidation.ps1
@@ -1,0 +1,434 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Runs manifest validation on every manifest under a given path and produces an HTML report.
+
+.DESCRIPTION
+    Discovers all manifest directories under the specified path (the leaf directories
+    containing YAML files, as found in a winget-pkgs clone), runs 'wingetdev validate'
+    on each, shows progress, and writes a self-contained HTML report with no external
+    script or style references.
+
+    wingetdev is resolved from PATH. An explicit path may be provided via -WingetDevPath
+    if wingetdev is not on PATH.
+
+.PARAMETER ManifestsPath
+    Path to search for manifests. May be the root of a winget-pkgs clone (the script will
+    descend into its 'manifests' subdirectory if present) or a manifests directory directly.
+
+.PARAMETER WingetDevPath
+    Optional explicit path to wingetdev.exe. If not provided, wingetdev is resolved from PATH.
+
+.PARAMETER OutputPath
+    Optional path for the HTML report file. Defaults to 'manifest-validation-report.html'
+    in the current working directory.
+
+.EXAMPLE
+    .\Invoke-ManifestValidation.ps1 -ManifestsPath C:\repos\winget-pkgs
+
+.EXAMPLE
+    .\Invoke-ManifestValidation.ps1 -ManifestsPath C:\repos\winget-pkgs\manifests `
+        -WingetDevPath C:\tools\wingetdev.exe -OutputPath C:\reports\results.html
+#>
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $true, Position = 0, HelpMessage = "Path to search for manifests (winget-pkgs root or manifests directory).")]
+    [string] $ManifestsPath,
+
+    [Parameter(HelpMessage = "Path to wingetdev.exe. Resolved from PATH if not provided.")]
+    [string] $WingetDevPath,
+
+    [Parameter(HelpMessage = "Output path for the HTML report.")]
+    [string] $OutputPath = (Join-Path (Get-Location) "manifest-validation-report.html"),
+
+    [Parameter(HelpMessage = "Launch the HTML report in the default browser when complete.")]
+    [switch] $Launch,
+
+    [Parameter(HelpMessage = "Exclude warnings from the report results table.")]
+    [switch] $SuppressWarnings,
+
+    [Parameter(HelpMessage = "Resume from an existing report file, skipping already-completed top-level directories.")]
+    [switch] $Resume
+)
+
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# HTML encoding helper (avoids requiring System.Web)
+# ---------------------------------------------------------------------------
+function ConvertTo-HtmlEncoded([string] $text)
+{
+    $text.Replace('&', '&amp;').Replace('<', '&lt;').Replace('>', '&gt;').Replace('"', '&quot;')
+}
+
+# ---------------------------------------------------------------------------
+# Resolve wingetdev
+# ---------------------------------------------------------------------------
+if ($WingetDevPath)
+{
+    if (-not (Test-Path $WingetDevPath -PathType Leaf))
+    {
+        Write-Error -Category InvalidArgument -Message "wingetdev.exe not found at: $WingetDevPath"
+    }
+    $wingetDev = $WingetDevPath
+}
+else
+{
+    $wingetDevCmd = Get-Command "wingetdev" -ErrorAction SilentlyContinue
+    if (-not $wingetDevCmd)
+    {
+        Write-Error -Category ObjectNotFound -Message @"
+wingetdev was not found on PATH.
+Either add wingetdev to your PATH, or provide its location with -WingetDevPath.
+"@
+    }
+    $wingetDev = $wingetDevCmd.Source
+}
+
+Write-Host "Using wingetdev: $wingetDev"
+
+$wingetDevVersion = (& $wingetDev --version 2>&1 | Out-String).Trim()
+
+# ---------------------------------------------------------------------------
+# Resolve manifests search root
+# ---------------------------------------------------------------------------
+$ManifestsPath = [System.IO.Path]::GetFullPath($ManifestsPath)
+if (-not (Test-Path $ManifestsPath -PathType Container))
+{
+    Write-Error -Category InvalidArgument -Message "ManifestsPath does not exist or is not a directory: $ManifestsPath"
+}
+
+# Support passing either the repo root (which contains a 'manifests' subdirectory)
+# or the manifests directory itself.
+$manifestsSubdir = Join-Path $ManifestsPath "manifests"
+$searchRoot = if (Test-Path $manifestsSubdir -PathType Container) { $manifestsSubdir } else { $ManifestsPath }
+
+Write-Host "Discovering top-level directories under: $searchRoot"
+
+$tier1Dirs = Get-ChildItem $searchRoot -Directory -ErrorAction SilentlyContinue | Sort-Object Name
+if (-not $tier1Dirs)
+{
+    Write-Error -Category ObjectNotFound -Message "No subdirectories found under: $searchRoot"
+}
+$tier1Total   = $tier1Dirs.Count
+$tier1Current = 0
+
+Write-Host "Found $tier1Total top-level directories."
+
+# ---------------------------------------------------------------------------
+# Initialize script-level state (shared with Write-ValidationReport)
+# ---------------------------------------------------------------------------
+$script:existingRowsHtml   = ''
+$script:completedTier1Dirs = [System.Collections.Generic.List[string]]::new()
+
+$passed   = 0
+$warnings = 0
+$failed   = 0
+$errors   = 0
+$total    = 0
+
+if ($Resume)
+{
+    if (-not (Test-Path $OutputPath -PathType Leaf))
+    {
+        Write-Error -Category ObjectNotFound -Message "Resume requested but no report file found at: $OutputPath"
+    }
+
+    Write-Host "Reading resume state from: $OutputPath"
+    $content = Get-Content $OutputPath -Raw -Encoding utf8
+
+    if ($content -notmatch '(?s)<script type="application/json" id="validation-state">(.*?)</script>')
+    {
+        Write-Error -Category InvalidData -Message "Could not find embedded resume state in: $OutputPath"
+    }
+    $state = $Matches[1].Trim() | ConvertFrom-Json
+
+    foreach ($d in $state.completedTier1Dirs) { $script:completedTier1Dirs.Add($d) }
+    $passed   = [int]$state.passed
+    $warnings = [int]$state.warnings
+    $failed   = [int]$state.failed
+    $errors   = [int]$state.errors
+    $total    = [int]$state.total
+
+    if ($content -match '(?s)<tbody id="tb">(.*?)</tbody>')
+    {
+        $script:existingRowsHtml = $Matches[1].Trim()
+    }
+
+    Write-Host ("Resuming: {0} top-level directories already complete, {1} manifests already processed." -f $script:completedTier1Dirs.Count, $total)
+}
+
+# ---------------------------------------------------------------------------
+# Report writing helper
+# ---------------------------------------------------------------------------
+function Write-ValidationReport
+{
+    param(
+        [System.Collections.Generic.List[PSCustomObject]] $Results,
+        [int] $Total,
+        [int] $Passed,
+        [int] $Warnings,
+        [int] $Failed,
+        [int] $Errors
+    )
+
+    # Always back up the existing report before overwriting - guards against data loss
+    # during a long-running write. State is already in memory at this point.
+    if (Test-Path $OutputPath -PathType Leaf)
+    {
+        $dir    = [System.IO.Path]::GetDirectoryName($OutputPath)
+        $base   = [System.IO.Path]::GetFileNameWithoutExtension($OutputPath)
+        $ext    = [System.IO.Path]::GetExtension($OutputPath)
+        $backup = Join-Path $dir "$base.backup$ext"
+        Move-Item $OutputPath $backup -Force
+    }
+
+    $timestamp        = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+    $escapedRoot      = ConvertTo-HtmlEncoded $searchRoot
+    $escapedWingetVer = ConvertTo-HtmlEncoded $wingetDevVersion
+
+    # Rows from the previous (resumed) run come first; new rows from this run follow.
+    $newRowsHtml = ($Results | ForEach-Object {
+        $statusClass   = $_.Status.ToLower()
+        $escapedPath   = ConvertTo-HtmlEncoded $_.RelativePath
+        $escapedOutput = (ConvertTo-HtmlEncoded $_.Output) -replace "`r?`n", '<br>'
+        "      <tr class='$statusClass'><td>$escapedPath</td><td class='sc'>$($_.Status)</td><td class='oc'>$escapedOutput</td></tr>"
+    }) -join "`n"
+
+    $rowsHtml = if ($script:existingRowsHtml -and $newRowsHtml) { "$($script:existingRowsHtml)`n$newRowsHtml" }
+                elseif ($script:existingRowsHtml)                { $script:existingRowsHtml }
+                else                                              { $newRowsHtml }
+
+    # Embed progress state so the run can be resumed later.
+    $stateJson = [PSCustomObject]@{
+        completedTier1Dirs = @($script:completedTier1Dirs)
+        tier1Total = $tier1Total
+        total    = $Total
+        passed   = $Passed
+        warnings = $Warnings
+        failed   = $Failed
+        errors   = $Errors
+    } | ConvertTo-Json -Compress
+
+    $completed = $script:completedTier1Dirs.Count
+    $bannerHtml = if ($completed -lt $tier1Total) {
+        "  <div class=`"banner`"><svg width=`"22`" height=`"22`" viewBox=`"0 0 24 24`" fill=`"none`" stroke=`"#e65100`" stroke-width=`"2`" stroke-linecap=`"round`" stroke-linejoin=`"round`"><path d=`"M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z`"/><line x1=`"12`" y1=`"9`" x2=`"12`" y2=`"13`"/><line x1=`"12`" y1=`"17`" x2=`"12.01`" y2=`"17`"/></svg><div class=`"banner-text`"><strong>Validation in progress &mdash; results are partial</strong><span>$completed of $tier1Total top-level directories complete.</span></div></div>"
+    } else { '' }
+
+    $html = @"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Manifest Validation Report</title>
+  <style>
+    *,*::before,*::after{box-sizing:border-box}
+    body{font-family:"Segoe UI",Arial,sans-serif;margin:0;padding:20px;background:#f4f4f4;color:#222}
+    h1{margin-bottom:4px}
+    .meta{color:#666;font-size:.875em;margin-bottom:18px}
+    .summary{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:18px}
+    .card{background:#fff;border-radius:6px;padding:12px 22px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.12);min-width:100px}
+    .card .n{font-size:2em;font-weight:700;line-height:1.1}
+    .card .l{font-size:.78em;color:#666;margin-top:3px;text-transform:uppercase;letter-spacing:.04em}
+    .ct .n{color:#333}
+    .cp .n{color:#2e7d32}
+    .cw .n{color:#e65100}
+    .cf .n{color:#c62828}
+    .ce .n{color:#6a1b9a}
+    .controls{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:10px}
+    .fi{padding:6px 11px;font-size:.9em;border:1px solid #ccc;border-radius:4px;width:340px}
+    .fi:focus{outline:none;border-color:#0078d4;box-shadow:0 0 0 2px rgba(0,120,212,.18)}
+    select{padding:6px 10px;font-size:.9em;border:1px solid #ccc;border-radius:4px}
+    .cl{color:#666;font-size:.85em}
+    table{width:100%;border-collapse:collapse;background:#fff;border-radius:6px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.12)}
+    thead th{background:#0078d4;color:#fff;padding:9px 13px;text-align:left;cursor:pointer;user-select:none;white-space:nowrap}
+    thead th:hover{background:#006cbd}
+    thead th.sa::after{content:" \u25b2"}
+    thead th.sd::after{content:" \u25bc"}
+    tbody tr{border-bottom:1px solid #f0f0f0}
+    tbody tr:last-child{border-bottom:none}
+    tbody tr:hover td{background:#fafafa}
+    tbody tr.pass{border-left:4px solid #2e7d32}
+    tbody tr.warning{border-left:4px solid #e65100}
+    tbody tr.fail{border-left:4px solid #c62828}
+    tbody tr.error{border-left:4px solid #6a1b9a}
+    td{padding:8px 13px;vertical-align:top;font-size:.875em}
+    .sc{font-weight:600;white-space:nowrap}
+    tr.pass    .sc{color:#2e7d32}
+    tr.warning .sc{color:#e65100}
+    tr.fail    .sc{color:#c62828}
+    tr.error   .sc{color:#6a1b9a}
+    .oc{font-family:Consolas,"Courier New",monospace;font-size:.82em;color:#555;max-width:560px;word-break:break-word}
+    .hidden{display:none!important}
+    .banner{display:flex;align-items:center;gap:12px;background:#fff8e1;border:1px solid #ffc107;border-left:5px solid #e65100;border-radius:6px;padding:12px 16px;margin-bottom:18px}
+    .banner svg{flex-shrink:0;animation:pulse 1.6s ease-in-out infinite}
+    .banner-text strong{display:block;color:#bf360c}
+    .banner-text span{font-size:.85em;color:#555}
+    @keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
+  </style>
+</head>
+<body>
+  <h1>Manifest Validation Report</h1>
+$bannerHtml
+  <div class="meta">
+    Generated: $timestamp &nbsp;&bull;&nbsp;
+    wingetdev: $escapedWingetVer &nbsp;&bull;&nbsp;
+    Path: $escapedRoot
+  </div>
+
+  <div class="summary">
+    <div class="card ct"><div class="n">$Total</div><div class="l">Total</div></div>
+    <div class="card cp"><div class="n">$Passed</div><div class="l">Pass</div></div>
+    <div class="card cw"><div class="n">$Warnings</div><div class="l">Warning</div></div>
+    <div class="card cf"><div class="n">$Failed</div><div class="l">Fail</div></div>
+    <div class="card ce"><div class="n">$Errors</div><div class="l">Error</div></div>
+  </div>
+
+  <div class="controls">
+    <input type="text" class="fi" id="fi" placeholder="Filter by path or output&hellip;" oninput="applyFilters()">
+    <select id="sf" onchange="applyFilters()">
+      <option value="">All statuses</option>
+      <option value="pass">Pass</option>
+      <option value="warning">Warning</option>
+      <option value="fail">Fail</option>
+      <option value="error">Error</option>
+    </select>
+    <span class="cl" id="cl"></span>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th onclick="sortTable(0)">Path</th>
+        <th onclick="sortTable(1)">Status</th>
+        <th onclick="sortTable(2)">Output</th>
+      </tr>
+    </thead>
+    <tbody id="tb">
+$rowsHtml
+    </tbody>
+  </table>
+
+  <script>
+    var sc=-1,sa=true;
+    function applyFilters(){
+      var txt=document.getElementById('fi').value.toLowerCase();
+      var st=document.getElementById('sf').value;
+      var rows=document.querySelectorAll('#tb tr');
+      var vis=0;
+      rows.forEach(function(r){
+        var ok=(!txt||r.textContent.toLowerCase().indexOf(txt)!==-1)&&(!st||r.classList.contains(st));
+        r.classList.toggle('hidden',!ok);
+        if(ok)vis++;
+      });
+      document.getElementById('cl').textContent='Showing '+vis+' of '+rows.length;
+    }
+    function sortTable(col){
+      var tb=document.getElementById('tb');
+      var rows=Array.from(tb.querySelectorAll('tr'));
+      if(sc===col){sa=!sa;}else{sc=col;sa=true;}
+      rows.sort(function(a,b){
+        var at=a.cells[col]?a.cells[col].textContent.trim():'';
+        var bt=b.cells[col]?b.cells[col].textContent.trim():'';
+        return sa?at.localeCompare(bt):bt.localeCompare(at);
+      });
+      rows.forEach(function(r){tb.appendChild(r);});
+      document.querySelectorAll('thead th').forEach(function(th){th.classList.remove('sa','sd');});
+      document.querySelectorAll('thead th')[col].classList.add(sa?'sa':'sd');
+    }
+    applyFilters();
+  </script>
+  <script type="application/json" id="validation-state">$stateJson</script>
+</body>
+</html>
+"@
+
+    $html | Out-File -FilePath $OutputPath -Encoding utf8 -Force
+}
+
+# ---------------------------------------------------------------------------
+# Validate manifests with two-tier progress
+# ---------------------------------------------------------------------------
+$results = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($tier1 in $tier1Dirs)
+{
+    $tier1Current++
+    Write-Progress -Id 1 -Activity "Processing top-level directories" `
+                   -Status "($tier1Current / $tier1Total) $($tier1.Name)" `
+                   -PercentComplete (($tier1Current / $tier1Total) * 100)
+
+    if ($script:completedTier1Dirs.Contains($tier1.Name))
+    {
+        Write-Host "Skipping (already complete): $($tier1.Name)"
+        continue
+    }
+
+    # Discover manifest directories (leaf dirs with .yaml files) under this tier-1 dir.
+    $yamlFiles    = Get-ChildItem $tier1.FullName -Recurse -File -Filter "*.yaml" -ErrorAction SilentlyContinue
+    $manifestDirs = if ($yamlFiles) { $yamlFiles | Select-Object -ExpandProperty DirectoryName | Sort-Object -Unique } else { @() }
+    $tier2Total   = $manifestDirs.Count
+    $tier2Current = 0
+    $total       += $tier2Total
+
+    foreach ($dir in $manifestDirs)
+    {
+        $tier2Current++
+        $relativePath = $dir.Substring($searchRoot.Length).TrimStart([char]'\', [char]'/')
+
+        Write-Progress -Id 2 -ParentId 1 -Activity "Validating manifests" `
+                       -Status "($tier2Current / $tier2Total) $relativePath" `
+                       -PercentComplete (($tier2Current / $tier2Total) * 100)
+
+        $output   = & $wingetDev validate $dir 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+
+        $status = if     ($output -match 'Manifest validation succeeded with warnings') { 'Warning' }
+                  elseif ($output -match 'Manifest validation succeeded')                { 'Pass'    }
+                  elseif ($output -match 'Manifest validation failed')                   { 'Fail'    }
+                  else                                                                   { 'Error'   }
+
+        switch ($status)
+        {
+            'Pass'    { $passed++;   break }
+            'Warning' { $warnings++; break }
+            'Fail'    { $failed++;   break }
+            'Error'   { $errors++;   break }
+        }
+
+        $keepInReport = $status -ne 'Pass' -and (-not $SuppressWarnings -or $status -ne 'Warning')
+        if ($keepInReport)
+        {
+            $results.Add([PSCustomObject]@{
+                RelativePath = $relativePath
+                AbsolutePath = $dir
+                Status       = $status
+                ExitCode     = $exitCode
+                Output       = $output.Trim()
+            })
+        }
+    }
+
+    Write-Progress -Id 2 -Completed
+
+    $script:completedTier1Dirs.Add($tier1.Name)
+    Write-ValidationReport -Results $results -Total $total -Passed $passed `
+                           -Warnings $warnings -Failed $failed -Errors $errors
+}
+
+Write-Progress -Id 1 -Completed
+
+Write-Host ""
+Write-Host ("Results: Total={0}  Pass={1}  Warning={2}  Fail={3}  Error={4}" -f $total, $passed, $warnings, $failed, $errors)
+
+if ($Launch)
+{
+    Start-Process $OutputPath
+}
+else
+{
+    Write-Host "Report created at $OutputPath"
+}


### PR DESCRIPTION
CP of #6169 onto main branch.

## Change
Adds some additional validation for MSI switches and Windows Feature names:

1. MSI switches are checked during full manifest validation in the same way that they are checked when we attempt to use the MSI APIs rather than msiexec. The API is used for fully all silent installs of MSIs, so we now ensure that those will work (6 total manifests in winget-pkgs were found that needed fixes).
2. Windows Feature names in dependencies are validated to be { alphanumeric, `-`, `_` }. This is done both during full manifest validation and at runtime.

A PowerShell script
(tools/ManifestValidation/Invoke-ManifestValidation.ps1) is added that will run `wingetdev validate` against a directory recursively and generate a report. There is support for resuming in the middle of the run. This would probably perform much better if it were updated to use the WinGetUtil API, but that can be a future project.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6170)