### PR TITLE
Mitigate packaged preindexed source open lock convoy

### DIFF
--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -412,6 +412,35 @@ namespace AppInstaller::Repository::Microsoft
             return IsAfterUpdateCheckTime(details.Name, timeToCheck, requestedUpdateInterval);
         }
 
+        SQLiteIndex OpenPackagedContextIndex(const SourceDetails& details, IProgressCallback& progress, long long& extensionLookupMs, long long& verifyContentIntegrityMs, long long& sqliteOpenMs)
+        {
+            const auto extensionLookupStart = std::chrono::steady_clock::now();
+            auto extension = GetExtensionFromDetails(details);
+            extensionLookupMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - extensionLookupStart).count();
+            if (!extension)
+            {
+                AICLI_LOG(Repo, Info, << "Package not found " << details.Data);
+                THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_MISSING);
+            }
+
+            const auto verifyStart = std::chrono::steady_clock::now();
+            THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NEEDS_REMEDIATION), !extension->VerifyContentIntegrity(progress));
+            verifyContentIntegrityMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - verifyStart).count();
+
+            // To work around an issue with accessing the public folder, we are temporarily
+            // constructing the location ourself.  This was already the case for the non-packaged
+            // runtime, and we can fix both in the future.  The only problem with this is that
+            // the directory in the extension *must* be Public, rather than one set by the creator.
+            std::filesystem::path indexLocation = extension->GetPackagePath();
+            indexLocation /= s_PreIndexedPackageSourceFactory_IndexFilePath;
+
+            const auto sqliteOpenStart = std::chrono::steady_clock::now();
+            auto index = SQLiteIndex::Open(indexLocation.u8string(), SQLiteIndex::OpenDisposition::Immutable);
+            sqliteOpenMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - sqliteOpenStart).count();
+
+            return index;
+        }
+
         struct PackagedContextSourceReference : public ISourceReference
         {
             PackagedContextSourceReference(const SourceDetails& details) : m_details(details)
@@ -433,34 +462,55 @@ namespace AppInstaller::Repository::Microsoft
 
             std::shared_ptr<ISource> Open(IProgressCallback& progress) override
             {
-                Synchronization::CrossProcessLock lock(CreateNameForCPL(m_details));
-                if (!lock.Acquire(progress))
+                const auto openStart = std::chrono::steady_clock::now();
+                bool succeeded = false;
+                bool usedLockFallback = false;
+                long long extensionLookupMs = 0;
+                long long verifyContentIntegrityMs = 0;
+                long long sqliteOpenMs = 0;
+                auto logOpenTiming = wil::scope_exit([&]()
+                    {
+                        const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - openStart).count();
+                        AICLI_LOG(Repo, Info, << "Packaged source open for '" << m_details.Name << "' " << (succeeded ? "succeeded" : "failed") <<
+                            " in " << totalMs << " ms [extensionLookup=" << extensionLookupMs <<
+                            " ms, verifyContentIntegrity=" << verifyContentIntegrityMs <<
+                            " ms, sqliteOpen=" << sqliteOpenMs << " ms, mode=" << (usedLockFallback ? "fallbackLocked" : "optimistic") << "]");
+                    });
+
+                try
                 {
-                    return {};
-                }
+                    auto index = OpenPackagedContextIndex(m_details, progress, extensionLookupMs, verifyContentIntegrityMs, sqliteOpenMs);
 
-                auto extension = GetExtensionFromDetails(m_details);
-                if (!extension)
+                    // We didn't use to store the source identifier, so we compute it here in case it's
+                    // missing from the details.
+                    m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
+                    succeeded = true;
+                    return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
+                }
+                catch (...)
                 {
-                    AICLI_LOG(Repo, Info, << "Package not found " << m_details.Data);
-                    THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_MISSING);
+                    if (progress.IsCancelledBy(CancelReason::Any))
+                    {
+                        throw;
+                    }
+
+                    LOG_CAUGHT_EXCEPTION_MSG("Optimistic packaged source open failed, retrying under lock for source: %hs", m_details.Name.c_str());
+
+                    Synchronization::CrossProcessLock lock(CreateNameForCPL(m_details));
+                    usedLockFallback = true;
+                    if (!lock.Acquire(progress))
+                    {
+                        return {};
+                    }
+
+                    auto index = OpenPackagedContextIndex(m_details, progress, extensionLookupMs, verifyContentIntegrityMs, sqliteOpenMs);
+
+                    // We didn't use to store the source identifier, so we compute it here in case it's
+                    // missing from the details.
+                    m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
+                    succeeded = true;
+                    return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
                 }
-
-                THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NEEDS_REMEDIATION), !extension->VerifyContentIntegrity(progress));
-
-                // To work around an issue with accessing the public folder, we are temporarily
-                // constructing the location ourself.  This was already the case for the non-packaged
-                // runtime, and we can fix both in the future.  The only problem with this is that
-                // the directory in the extension *must* be Public, rather than one set by the creator.
-                std::filesystem::path indexLocation = extension->GetPackagePath();
-                indexLocation /= s_PreIndexedPackageSourceFactory_IndexFilePath;
-
-                SQLiteIndex index = SQLiteIndex::Open(indexLocation.u8string(), SQLiteIndex::OpenDisposition::Immutable);
-
-                // We didn't use to store the source identifier, so we compute it here in case it's
-                // missing from the details.
-                m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
-                return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
             }
 
         private:

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -329,7 +329,7 @@ namespace AppInstaller::Repository::Microsoft
             }
         };
 
-        // *Should only be called when under a CrossProcessReaderWriteLock*
+        // Optimistic packaged source open may call this without the cross process lock and retry under the lock on failure.
         std::optional<Deployment::Extension> GetExtensionFromDetails(const SourceDetails& details)
         {
             Deployment::ExtensionCatalog catalog(Deployment::SourceExtensionName);
@@ -412,20 +412,75 @@ namespace AppInstaller::Repository::Microsoft
             return IsAfterUpdateCheckTime(details.Name, timeToCheck, requestedUpdateInterval);
         }
 
-        SQLiteIndex OpenPackagedContextIndex(const SourceDetails& details, IProgressCallback& progress, long long& extensionLookupMs, long long& verifyContentIntegrityMs, long long& sqliteOpenMs)
+        struct PackagedSourceOpenTimer
         {
-            const auto extensionLookupStart = std::chrono::steady_clock::now();
+            using clock = std::chrono::steady_clock;
+
+            struct SingleTimer
+            {
+                SingleTimer(long long& durationMs) : m_durationMs(durationMs), m_start(clock::now()) {}
+
+                ~SingleTimer()
+                {
+                    Stop();
+                }
+
+                void Stop()
+                {
+                    if (!m_stopped)
+                    {
+                        m_durationMs += std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - m_start).count();
+                        m_stopped = true;
+                    }
+                }
+
+            private:
+                long long& m_durationMs;
+                clock::time_point m_start;
+                bool m_stopped = false;
+            };
+
+            PackagedSourceOpenTimer(const std::string& sourceName) : m_sourceName(sourceName), m_start(clock::now()) {}
+
+            ~PackagedSourceOpenTimer()
+            {
+                const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - m_start).count();
+                AICLI_LOG(Repo, Info, << "Packaged source open for '" << m_sourceName << "' " << (m_succeeded ? "succeeded" : "failed") <<
+                    " in " << totalMs << " ms [extensionLookup=" << m_extensionLookupMs <<
+                    " ms, verifyContentIntegrity=" << m_verifyContentIntegrityMs <<
+                    " ms, sqliteOpen=" << m_sqliteOpenMs << " ms, mode=" << (m_usedLockFallback ? "fallbackLocked" : "optimistic") << "]");
+            }
+
+            SingleTimer MeasureExtensionLookup() { return SingleTimer{ m_extensionLookupMs }; }
+            SingleTimer MeasureVerifyContentIntegrity() { return SingleTimer{ m_verifyContentIntegrityMs }; }
+            SingleTimer MeasureSQLiteOpen() { return SingleTimer{ m_sqliteOpenMs }; }
+            void MarkFallbackLocked() { m_usedLockFallback = true; }
+            void MarkSucceeded() { m_succeeded = true; }
+
+        private:
+            const std::string& m_sourceName;
+            clock::time_point m_start;
+            bool m_succeeded = false;
+            bool m_usedLockFallback = false;
+            long long m_extensionLookupMs = 0;
+            long long m_verifyContentIntegrityMs = 0;
+            long long m_sqliteOpenMs = 0;
+        };
+
+        SQLiteIndex OpenPackagedContextIndex(const SourceDetails& details, IProgressCallback& progress, PackagedSourceOpenTimer& openTimer)
+        {
+            auto extensionLookupTimer = openTimer.MeasureExtensionLookup();
             auto extension = GetExtensionFromDetails(details);
-            extensionLookupMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - extensionLookupStart).count();
+            extensionLookupTimer.Stop();
             if (!extension)
             {
                 AICLI_LOG(Repo, Info, << "Package not found " << details.Data);
                 THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_DATA_MISSING);
             }
 
-            const auto verifyStart = std::chrono::steady_clock::now();
+            auto verifyTimer = openTimer.MeasureVerifyContentIntegrity();
             THROW_HR_IF(HRESULT_FROM_WIN32(ERROR_NEEDS_REMEDIATION), !extension->VerifyContentIntegrity(progress));
-            verifyContentIntegrityMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - verifyStart).count();
+            verifyTimer.Stop();
 
             // To work around an issue with accessing the public folder, we are temporarily
             // constructing the location ourself.  This was already the case for the non-packaged
@@ -434,9 +489,9 @@ namespace AppInstaller::Repository::Microsoft
             std::filesystem::path indexLocation = extension->GetPackagePath();
             indexLocation /= s_PreIndexedPackageSourceFactory_IndexFilePath;
 
-            const auto sqliteOpenStart = std::chrono::steady_clock::now();
+            auto sqliteOpenTimer = openTimer.MeasureSQLiteOpen();
             auto index = SQLiteIndex::Open(indexLocation.u8string(), SQLiteIndex::OpenDisposition::Immutable);
-            sqliteOpenMs += std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - sqliteOpenStart).count();
+            sqliteOpenTimer.Stop();
 
             return index;
         }
@@ -462,30 +517,22 @@ namespace AppInstaller::Repository::Microsoft
 
             std::shared_ptr<ISource> Open(IProgressCallback& progress) override
             {
-                const auto openStart = std::chrono::steady_clock::now();
-                bool succeeded = false;
-                bool usedLockFallback = false;
-                long long extensionLookupMs = 0;
-                long long verifyContentIntegrityMs = 0;
-                long long sqliteOpenMs = 0;
-                auto logOpenTiming = wil::scope_exit([&]()
+                PackagedSourceOpenTimer openTimer{ m_details.Name };
+                auto completeOpen = [&](SQLiteIndex index)
                     {
-                        const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - openStart).count();
-                        AICLI_LOG(Repo, Info, << "Packaged source open for '" << m_details.Name << "' " << (succeeded ? "succeeded" : "failed") <<
-                            " in " << totalMs << " ms [extensionLookup=" << extensionLookupMs <<
-                            " ms, verifyContentIntegrity=" << verifyContentIntegrityMs <<
-                            " ms, sqliteOpen=" << sqliteOpenMs << " ms, mode=" << (usedLockFallback ? "fallbackLocked" : "optimistic") << "]");
-                    });
+                        // We didn't use to store the source identifier, so we compute it here in case it's
+                        // missing from the details.
+                        m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
+                        openTimer.MarkSucceeded();
+                        return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
+                    };
+
+                std::optional<SQLiteIndex> index;
+                bool retryUnderLock = false;
 
                 try
                 {
-                    auto index = OpenPackagedContextIndex(m_details, progress, extensionLookupMs, verifyContentIntegrityMs, sqliteOpenMs);
-
-                    // We didn't use to store the source identifier, so we compute it here in case it's
-                    // missing from the details.
-                    m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
-                    succeeded = true;
-                    return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
+                    index.emplace(OpenPackagedContextIndex(m_details, progress, openTimer));
                 }
                 catch (...)
                 {
@@ -495,22 +542,22 @@ namespace AppInstaller::Repository::Microsoft
                     }
 
                     LOG_CAUGHT_EXCEPTION_MSG("Optimistic packaged source open failed, retrying under lock for source: %hs", m_details.Name.c_str());
+                    retryUnderLock = true;
+                }
 
+                if (retryUnderLock)
+                {
+                    openTimer.MarkFallbackLocked();
                     Synchronization::CrossProcessLock lock(CreateNameForCPL(m_details));
-                    usedLockFallback = true;
                     if (!lock.Acquire(progress))
                     {
                         return {};
                     }
 
-                    auto index = OpenPackagedContextIndex(m_details, progress, extensionLookupMs, verifyContentIntegrityMs, sqliteOpenMs);
-
-                    // We didn't use to store the source identifier, so we compute it here in case it's
-                    // missing from the details.
-                    m_details.Identifier = GetPackageFamilyNameFromDetails(m_details);
-                    succeeded = true;
-                    return std::make_shared<SQLiteIndexSource>(m_details, std::move(index), false, true);
+                    index.emplace(OpenPackagedContextIndex(m_details, progress, openTimer));
                 }
+
+                return completeOpen(std::move(index.value()));
             }
 
         private:


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
- [ ] I have updated the [Release Notes](../doc/ReleaseNotes.md).
- [x] This pull request is related to an issue.

-----

## Related issue

Closes #6167

## Summary

This change narrows the lock scope for packaged preindexed source opens.

Previously, opening a packaged preindexed source always acquired the named cross-process lock before doing the read-only open work. Under concurrent `winget` usage, that serialized source reads behind unrelated activity and caused large stalls before commands like `show` or `search` could do meaningful work.

This PR changes the packaged-context open path to:

- attempt the packaged source open optimistically first
- reuse a helper for extension lookup, content integrity verification, and immutable SQLite open
- fall back to the existing cross-process lock only if the optimistic open fails
- preserve cancellation behavior
- add timing/logging around the open path to make the mode and cost visible

The change is limited to PreIndexedPackageSourceFactory.cpp.

## Testing

Manual validation against the issue repro:
- compared behavior against concurrent packaged source reads
- verified the fallback path still retries under the existing lock when optimistic open fails

Static validation:
- no diagnostics reported for the touched file
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6172)