### PR TITLE
Add telemetry event for index updates

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -9,6 +9,7 @@
 #include "Public/winget/ThreadGlobals.h"
 #include "winget/Filesystem.h"
 #include "winget/UserSettings.h"
+#include <AppInstallerDateTime.h>
 
 #define AICLI_TraceLoggingStringView(_sv_,_name_) TraceLoggingCountedUtf8String(_sv_.data(), static_cast<ULONG>(_sv_.size()), _name_)
 #define AICLI_TraceLoggingWStringView(_sv_,_name_) TraceLoggingCountedWideString(_sv_.data(), static_cast<ULONG>(_sv_.size()), _name_)
@@ -735,6 +736,74 @@ namespace AppInstaller::Logging
                 m_summary.DOHResult = hr;
             }
         }
+    }
+
+    void TelemetryTraceLogger::LogPreindexedPackageUpdate(
+        std::string_view sourceId,
+        std::optional<std::chrono::system_clock::time_point> previousIndexPublishedAt,
+        std::chrono::system_clock::time_point newIndexPublishedAt,
+        bool usedDeltaDownload,
+        std::optional<std::chrono::system_clock::time_point> previousBaselinePublishedAt,
+        std::optional<std::chrono::system_clock::time_point> newBaselinePublishedAt,
+        bool baselineUpdated,
+        uint64_t downloadedBytes,
+        bool isManualUpdate) const noexcept
+    {
+        // Converts a system_clock time_point to FILETIME. An empty optional maps to FILETIME{0,0} (null sentinel).
+        auto toFileTime = [](const std::optional<std::chrono::system_clock::time_point>& tp) -> FILETIME
+        {
+            return tp ? Utility::ConvertSystemClockToFileTime(*tp) : FILETIME{};
+        };
+
+        bool isNewClient = !previousIndexPublishedAt.has_value();
+
+        double indexStalenessDays = -1.0;
+        if (previousIndexPublishedAt)
+        {
+            indexStalenessDays = std::chrono::duration<double, std::ratio<86400>>(
+                newIndexPublishedAt - *previousIndexPublishedAt).count();
+        }
+
+        double baselineStalenessDays = -1.0;
+        if (previousBaselinePublishedAt && newBaselinePublishedAt)
+        {
+            baselineStalenessDays = std::chrono::duration<double, std::ratio<86400>>(
+                *newBaselinePublishedAt - *previousBaselinePublishedAt).count();
+        }
+
+        FILETIME previousIndexFt = toFileTime(previousIndexPublishedAt);
+        FILETIME newIndexFt = toFileTime(newIndexPublishedAt);
+        FILETIME previousBaselineFt = toFileTime(previousBaselinePublishedAt);
+        FILETIME newBaselineFt = toFileTime(newBaselinePublishedAt);
+
+        if (IsTelemetryEnabled())
+        {
+            AICLI_TraceLoggingWriteActivity(
+                "PreindexedPackageUpdate",
+                AICLI_TraceLoggingStringView(sourceId, "SourceId"),
+                TraceLoggingFileTime(previousIndexFt, "PreviousIndexPublishedAt"),
+                TraceLoggingFileTime(newIndexFt, "NewIndexPublishedAt"),
+                TraceLoggingFloat64(indexStalenessDays, "IndexStalenessDays"),
+                TraceLoggingBool(isNewClient, "IsNewClient"),
+                TraceLoggingBool(usedDeltaDownload, "UsedDeltaDownload"),
+                TraceLoggingFileTime(previousBaselineFt, "PreviousBaselinePublishedAt"),
+                TraceLoggingFileTime(newBaselineFt, "NewBaselinePublishedAt"),
+                TraceLoggingFloat64(baselineStalenessDays, "BaselineStalenessDays"),
+                TraceLoggingBool(baselineUpdated, "BaselineUpdated"),
+                TraceLoggingUInt64(downloadedBytes, "DownloadedBytes"),
+                TraceLoggingBool(isManualUpdate, "IsManualUpdate"),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
+        }
+
+        AICLI_LOG(Repo, Verbose, << "PreindexedPackageUpdate: Source [" << sourceId
+            << "] IsNewClient [" << isNewClient
+            << "] IndexStalenessDays [" << indexStalenessDays
+            << "] UsedDeltaDownload [" << usedDeltaDownload
+            << "] BaselineStalenessDays [" << baselineStalenessDays
+            << "] BaselineUpdated [" << baselineUpdated
+            << "] DownloadedBytes [" << downloadedBytes
+            << "] IsManualUpdate [" << isManualUpdate << "]");
     }
 
     void TelemetryTraceLogger::LogRepairFailure(std::string_view id, std::string_view version, std::string_view type, uint32_t errorCode) const noexcept

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -4,6 +4,8 @@
 #include <AppInstallerLanguageUtilities.h>
 #include <wil/result_macros.h>
 
+#include <chrono>
+#include <optional>
 #include <string_view>
 #include <vector>
 #include <cguid.h>
@@ -266,6 +268,19 @@ namespace AppInstaller::Logging
             std::string_view arpLanguage) const noexcept;
 
         void LogNonFatalDOError(std::string_view url, HRESULT hr) const noexcept;
+
+        // Logs details of a preindexed package source update (full or delta).
+        // Nullable datetime fields use a null optional; nullable float fields use -1.0.
+        void LogPreindexedPackageUpdate(
+            std::string_view sourceId,
+            std::optional<std::chrono::system_clock::time_point> previousIndexPublishedAt,
+            std::chrono::system_clock::time_point newIndexPublishedAt,
+            bool usedDeltaDownload,
+            std::optional<std::chrono::system_clock::time_point> previousBaselinePublishedAt,
+            std::optional<std::chrono::system_clock::time_point> newBaselinePublishedAt,
+            bool baselineUpdated,
+            uint64_t downloadedBytes,
+            bool isManualUpdate) const noexcept;
 
     protected:
         bool IsTelemetryEnabled() const noexcept;

--- a/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Microsoft/PreIndexedPackageSourceFactory.cpp
@@ -241,7 +241,32 @@ namespace AppInstaller::Repository::Microsoft
                     return false;
                 }
 
-                return UpdateInternal(packageInfo.PackageLocation(), details, progress);
+                std::optional<uint64_t> downloadedBytes;
+                bool result = UpdateInternal(packageInfo.PackageLocation(), details, progress, downloadedBytes);
+
+                if (downloadedBytes)
+                {
+                    try
+                    {
+                        auto manifests = packageInfo.MsixInfo().GetAppPackageManifests();
+                        if (!manifests.empty())
+                        {
+                            Logging::Telemetry().LogPreindexedPackageUpdate(
+                                details.Identifier,
+                                std::nullopt,
+                                Utility::GetTimePointFromVersion(manifests[0].GetIdentity().GetVersion()),
+                                false,
+                                std::nullopt,
+                                std::nullopt,
+                                false,
+                                downloadedBytes.value(),
+                                true);
+                        }
+                    }
+                    CATCH_LOG();
+                }
+
+                return result;
             }
 
             bool Update(const SourceDetails& details, IProgressCallback& progress) override final
@@ -257,7 +282,7 @@ namespace AppInstaller::Repository::Microsoft
             // Retrieves the currently cached version of the package.
             virtual std::optional<Msix::PackageVersion> GetCurrentVersion(const SourceDetails& details) = 0;
 
-            virtual bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) = 0;
+            virtual bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress, std::optional<uint64_t>& downloadedBytes) = 0;
 
             bool Remove(const SourceDetails& details, IProgressCallback& progress) override final
             {
@@ -325,7 +350,30 @@ namespace AppInstaller::Repository::Microsoft
                     return false;
                 }
 
-                return UpdateInternal(updateCheck.PackageLocation(), details, progress);
+                std::optional<uint64_t> downloadedBytes = 0;
+                bool result = UpdateInternal(updateCheck.PackageLocation(), details, progress, downloadedBytes);
+
+                if (downloadedBytes)
+                {
+                    std::optional<std::chrono::system_clock::time_point> previousIndexPublishedAt;
+                    if (currentVersion)
+                    {
+                        previousIndexPublishedAt = Utility::GetTimePointFromVersion(currentVersion.value());
+                    }
+
+                    Logging::Telemetry().LogPreindexedPackageUpdate(
+                        details.Identifier,
+                        previousIndexPublishedAt,
+                        Utility::GetTimePointFromVersion(updateCheck.AvailableVersion()),
+                        false,
+                        std::nullopt,
+                        std::nullopt,
+                        false,
+                        downloadedBytes.value(),
+                        !isBackground);
+                }
+
+                return result;
             }
         };
 
@@ -577,7 +625,7 @@ namespace AppInstaller::Repository::Microsoft
                 return PackagedContextGetCurrentVersion(details);
             }
 
-            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) override
+            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress, std::optional<uint64_t>& downloadedBytes) override
             {
                 // Due to complications with deployment, download the file and deploy from
                 // a local source while we investigate further.
@@ -589,7 +637,8 @@ namespace AppInstaller::Repository::Microsoft
                     localFile = Runtime::GetPathTo(Runtime::PathName::Temp);
                     localFile /= GetPackageFamilyNameFromDetails(details) + ".msix";
 
-                    Utility::Download(packageLocation, localFile, Utility::DownloadType::Index, progress);
+                    auto downloadResult = Utility::Download(packageLocation, localFile, Utility::DownloadType::Index, progress);
+                    downloadedBytes = downloadResult.SizeInBytes;
                 }
                 else
                 {
@@ -731,7 +780,7 @@ namespace AppInstaller::Repository::Microsoft
                 return DesktopContextGetCurrentVersion(details);
             }
 
-            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress) override
+            bool UpdateInternal(const std::string& packageLocation, const SourceDetails& details, IProgressCallback& progress, std::optional<uint64_t>& downloadedBytes) override
             {
                 // We will extract the manifest and index files directly to this location
                 std::filesystem::path packageState = GetStatePathFromDetails(details);
@@ -754,7 +803,8 @@ namespace AppInstaller::Repository::Microsoft
 
                 if (Utility::IsUrlRemote(packageLocation))
                 {
-                    AppInstaller::Utility::Download(packageLocation, tempPackagePath, AppInstaller::Utility::DownloadType::Index, progress);
+                    auto downloadResult = AppInstaller::Utility::Download(packageLocation, tempPackagePath, AppInstaller::Utility::DownloadType::Index, progress);
+                    downloadedBytes = downloadResult.SizeInBytes;
                 }
                 else
                 {

--- a/src/AppInstallerSharedLib/DateTime.cpp
+++ b/src/AppInstallerSharedLib/DateTime.cpp
@@ -149,6 +149,11 @@ namespace AppInstaller::Utility
         return winrt::clock::to_sys(winrt::clock::from_FILETIME(fileTime));
     }
 
+    FILETIME ConvertSystemClockToFileTime(const std::chrono::system_clock::time_point& time)
+    {
+        return winrt::clock::to_FILETIME(winrt::clock::from_sys(time));
+    }
+
     std::chrono::system_clock::time_point GetTimePointFromVersion(const UInt64Version& version)
     {
         // Our custom format for converting UTC into a version is:

--- a/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
+++ b/src/AppInstallerSharedLib/Public/AppInstallerDateTime.h
@@ -60,6 +60,9 @@ namespace AppInstaller::Utility
     // Converts the given file time to a system_clock::time_point.
     std::chrono::system_clock::time_point ConvertFiletimeToSystemClock(const FILETIME& fileTime);
 
+    // Converts the given system_clock::time_point to a FILETIME.
+    FILETIME ConvertSystemClockToFileTime(const std::chrono::system_clock::time_point& time);
+
     // Converts the given package version into a time_point using our custom format.
     // Ensure that the package is expected to use this format, or you may get strange times.
     // If the version is not convertable, the minimum time is returned.


### PR DESCRIPTION
## Change
Adds a telemetry event to collect data on index update frequency.  This data will be used to help us optimize default update check interval and for a potential future feature of delta index updates.  It is designed with that feature in mind, including some fields that will only be set differently when/if it is implemented.

The collected data is:
| Field | Type | Nullable | Description |
|-------|------|----------|-------------|
| `SourceId` | string | No | Identifier of the source being updated (for per-source stratification) |
| `PreviousIndexPublishedAt` | datetime | Yes | Timestamp embedded in the previously-held index. Null for net-new clients (no prior index). |
| `NewIndexPublishedAt` | datetime | No | Timestamp embedded in the newly-downloaded index. |
| `IndexStalenessDays` | float | Yes | `(NewIndexPublishedAt − PreviousIndexPublishedAt).TotalDays`. Pre-computed for pipeline convenience. Null when `PreviousIndexPublishedAt` is null. |
| `IsNewClient` | bool | No | True when `PreviousIndexPublishedAt` is null. Pre-computed; simplifies pipeline filtering for net-new client cohort. |
| `UsedDeltaDownload` | bool | No | True if the client downloaded a delta file rather than a full index. False for non-delta-capable clients or when no delta was available. |
| `PreviousBaselinePublishedAt` | datetime | Yes | Timestamp of the baseline the client held before this update. Null if client had no baseline (non-delta, or net-new delta client). |
| `NewBaselinePublishedAt` | datetime | Yes | Timestamp of the baseline in use after this update. Null if `UsedDeltaDownload` is false. |
| `BaselineStalenessDays` | float | Yes | `(NewBaselinePublishedAt − PreviousBaselinePublishedAt).TotalDays`. Pre-computed. Null when either baseline timestamp is null. |
| `BaselineUpdated` | bool | No | True if the client downloaded a new baseline as part of this update cycle. Pre-computed; avoids requiring consumers to diff baseline timestamps. |
| `DownloadedBytes` | long | No | Total bytes transferred for this update (baseline + delta, or full index). Actual bytes on the wire. |
| `IsManualUpdate` | bool | No | True if the update was directly user initiated; false if it was done automatically. |
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6175)