### PR TITLE
[Settings] Add sort field and direction types for output ordering

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -340,6 +340,35 @@
           "default": false
         }
       }
+    },
+    "Output": {
+      "description": "Output display settings",
+      "type": "object",
+      "properties": {
+        "sortOrder": {
+          "description": "Fields to sort output by, in priority order. Use an empty array to disable sorting.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "name",
+              "id",
+              "version",
+              "source",
+              "available"
+            ]
+          }
+        },
+        "sortDirection": {
+          "description": "Sort direction for output ordering",
+          "type": "string",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "default": "ascending"
+        }
+      }
     }
   },
   "allOf": [
@@ -406,6 +435,12 @@
     {
       "properties": {
         "interactivity": { "$ref": "#/definitions/Interactivity" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "output": { "$ref": "#/definitions/Output" }
       },
       "additionalItems": true
     },

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -351,6 +351,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "relevance",
               "name",
               "id",
               "version",

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -665,13 +665,12 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
 {
     auto again = DeleteUserSettingsFiles();
 
-    SECTION("Default value")
+    SECTION("Default value - empty vector sentinel for context-aware defaults")
     {
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Single field")
@@ -683,6 +682,17 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
         REQUIRE(sortOrder.size() == 1);
         REQUIRE(sortOrder[0] == SortField::Id);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Relevance field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["relevance"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Relevance);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Multiple fields")
@@ -699,17 +709,18 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
     }
     SECTION("All valid fields")
     {
-        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "version", "source", "available"] } })";
+        std::string_view json = R"({ "output": { "sortOrder": ["relevance", "name", "id", "version", "source", "available"] } })";
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 5);
-        REQUIRE(sortOrder[0] == SortField::Name);
-        REQUIRE(sortOrder[1] == SortField::Id);
-        REQUIRE(sortOrder[2] == SortField::Version);
-        REQUIRE(sortOrder[3] == SortField::Source);
-        REQUIRE(sortOrder[4] == SortField::Available);
+        REQUIRE(sortOrder.size() == 6);
+        REQUIRE(sortOrder[0] == SortField::Relevance);
+        REQUIRE(sortOrder[1] == SortField::Name);
+        REQUIRE(sortOrder[2] == SortField::Id);
+        REQUIRE(sortOrder[3] == SortField::Version);
+        REQUIRE(sortOrder[4] == SortField::Source);
+        REQUIRE(sortOrder[5] == SortField::Available);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Case insensitive")
@@ -742,8 +753,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Mixed valid and invalid field")
@@ -753,8 +763,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Duplicate values - case-insensitive")
@@ -777,8 +786,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Wrong type - number in array")
@@ -788,8 +796,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
 }

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -660,3 +660,181 @@ TEST_CASE("LoggingChannels", "[settings]")
         REQUIRE(userSettingTest.Get<Setting::LoggingChannelPreference>() == (Channel::CLI | Channel::SQL));
     }
 }
+
+TEST_CASE("SettingOutputSortOrder", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Default value")
+    {
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Single field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["id"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Id);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Multiple fields")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["available", "name"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 2);
+        REQUIRE(sortOrder[0] == SortField::Available);
+        REQUIRE(sortOrder[1] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("All valid fields")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "version", "source", "available"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 5);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Version);
+        REQUIRE(sortOrder[3] == SortField::Source);
+        REQUIRE(sortOrder[4] == SortField::Available);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Case insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["Name", "ID", "VERSION"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 3);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Version);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Empty array disables sorting")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": [] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 0);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Invalid field name")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["invalid"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Mixed valid and invalid field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "bogus"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - string instead of array")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": "name" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - number in array")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": [1] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}
+
+TEST_CASE("SettingOutputSortDirection", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Default value")
+    {
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Ascending")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "ascending" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Descending")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "descending" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Descending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Case insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "DESCENDING" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Descending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Invalid value")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "sideways" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - array instead of string")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": ["ascending"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -757,6 +757,19 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         REQUIRE(sortOrder[0] == SortField::Name);
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
+    SECTION("Duplicate values - case-insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "Name"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 3);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().empty());
+    }
     SECTION("Wrong type - string instead of array")
     {
         std::string_view json = R"({ "output": { "sortOrder": "name" } })";

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -50,7 +50,7 @@ namespace AppInstaller::Settings
     // Sort field for output ordering.
     enum class SortField
     {
-        Relevance,  // Internal: preserves current natural order (not valid in settings)
+        Relevance,  // Preserves current natural order (source-defined relevance ranking)
         Name,
         Id,
         Version,
@@ -230,7 +230,7 @@ namespace AppInstaller::Settings
         // Interactivity
         SETTINGMAPPING_SPECIALIZATION(Setting::InteractivityDisable, bool, bool, false, ".interactivity.disable"sv);
         // Output behavior
-        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{ SortField::Name }, ".output.sortOrder"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{}, ".output.sortOrder"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortDirection, std::string, SortDirection, SortDirection::Ascending, ".output.sortDirection"sv);
         
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -47,6 +47,24 @@ namespace AppInstaller::Settings
         Disabled,
     };
 
+    // Sort field for output ordering.
+    enum class SortField
+    {
+        Relevance,  // Internal: preserves current natural order (not valid in settings)
+        Name,
+        Id,
+        Version,
+        Source,
+        Available,
+    };
+
+    // Sort direction for output ordering.
+    enum class SortDirection
+    {
+        Ascending,
+        Descending,
+    };
+
     // The download code to use for *installers*.
     enum class InstallerDownloader
     {
@@ -114,6 +132,9 @@ namespace AppInstaller::Settings
         ConfigureDefaultModuleRoot,
         // Interactivity
         InteractivityDisable,
+        // Output behavior
+        OutputSortOrder,
+        OutputSortDirection,
 #ifndef AICLI_DISABLE_TEST_HOOKS
         // Debug
         EnableSelfInitiatedMinidump,
@@ -208,6 +229,9 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::LoggingFileCountLimit, uint32_t, uint32_t, 0, ".logging.file.countLimit"sv);
         // Interactivity
         SETTINGMAPPING_SPECIALIZATION(Setting::InteractivityDisable, bool, bool, false, ".interactivity.disable"sv);
+        // Output behavior
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{ SortField::Name }, ".output.sortOrder"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortDirection, std::string, SortDirection, SortDirection::Ascending, ".output.sortDirection"sv);
         
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.
         template <size_t... I>

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -482,6 +482,53 @@ namespace AppInstaller::Settings
         {
             return value * 24h;
         }
+
+        WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
+        {
+            std::vector<SortField> fields;
+            for (auto const& entry : value)
+            {
+                if (Utility::CaseInsensitiveEquals(entry, "name"))
+                {
+                    fields.emplace_back(SortField::Name);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "id"))
+                {
+                    fields.emplace_back(SortField::Id);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "version"))
+                {
+                    fields.emplace_back(SortField::Version);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "source"))
+                {
+                    fields.emplace_back(SortField::Source);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "available"))
+                {
+                    fields.emplace_back(SortField::Available);
+                }
+                else
+                {
+                    return {};
+                }
+            }
+            return fields;
+        }
+
+        WINGET_VALIDATE_SIGNATURE(OutputSortDirection)
+        {
+            if (Utility::CaseInsensitiveEquals(value, "ascending"))
+            {
+                return SortDirection::Ascending;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, "descending"))
+            {
+                return SortDirection::Descending;
+            }
+
+            return {};
+        }
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -485,6 +485,7 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
         {
+            static constexpr std::string_view s_sortField_relevance = "relevance";
             static constexpr std::string_view s_sortField_name = "name";
             static constexpr std::string_view s_sortField_id = "id";
             static constexpr std::string_view s_sortField_version = "version";
@@ -494,23 +495,29 @@ namespace AppInstaller::Settings
             std::vector<SortField> fields;
             for (auto const& entry : value)
             {
-                if (Utility::CaseInsensitiveEquals(entry, s_sortField_name))
+                std::string lowered = Utility::ToLower(entry);
+
+                if (lowered == s_sortField_relevance)
+                {
+                    fields.emplace_back(SortField::Relevance);
+                }
+                else if (lowered == s_sortField_name)
                 {
                     fields.emplace_back(SortField::Name);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_id))
+                else if (lowered == s_sortField_id)
                 {
                     fields.emplace_back(SortField::Id);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_version))
+                else if (lowered == s_sortField_version)
                 {
                     fields.emplace_back(SortField::Version);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_source))
+                else if (lowered == s_sortField_source)
                 {
                     fields.emplace_back(SortField::Source);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_available))
+                else if (lowered == s_sortField_available)
                 {
                     fields.emplace_back(SortField::Available);
                 }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -485,26 +485,32 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
         {
+            static constexpr std::string_view s_sortField_name = "name";
+            static constexpr std::string_view s_sortField_id = "id";
+            static constexpr std::string_view s_sortField_version = "version";
+            static constexpr std::string_view s_sortField_source = "source";
+            static constexpr std::string_view s_sortField_available = "available";
+
             std::vector<SortField> fields;
             for (auto const& entry : value)
             {
-                if (Utility::CaseInsensitiveEquals(entry, "name"))
+                if (Utility::CaseInsensitiveEquals(entry, s_sortField_name))
                 {
                     fields.emplace_back(SortField::Name);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "id"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_id))
                 {
                     fields.emplace_back(SortField::Id);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "version"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_version))
                 {
                     fields.emplace_back(SortField::Version);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "source"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_source))
                 {
                     fields.emplace_back(SortField::Source);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "available"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_available))
                 {
                     fields.emplace_back(SortField::Available);
                 }
@@ -518,11 +524,14 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortDirection)
         {
-            if (Utility::CaseInsensitiveEquals(value, "ascending"))
+            static constexpr std::string_view s_sortDirection_ascending = "ascending";
+            static constexpr std::string_view s_sortDirection_descending = "descending";
+
+            if (Utility::CaseInsensitiveEquals(value, s_sortDirection_ascending))
             {
                 return SortDirection::Ascending;
             }
-            else if (Utility::CaseInsensitiveEquals(value, "descending"))
+            else if (Utility::CaseInsensitiveEquals(value, s_sortDirection_descending))
             {
                 return SortDirection::Descending;
             }


### PR DESCRIPTION
## Summary
Add settings infrastructure for configurable output sorting in `winget list`. This is
part 1 of a 3-part stack that lays the type system and settings foundation without
changing any runtime behavior.

Part of https://github.com/microsoft/winget-cli/issues/4238

## Changes
- **SortField and SortDirection enums**: Add `SortField` (Relevance, Name, Id, Version,
  Source, Available) and `SortDirection` (Ascending, Descending) to the settings type
  system. Relevance is internal-only and not exposed as a valid settings value.
- **Settings entries**: Register `OutputSortOrder` and `OutputSortDirection` with typed
  validation that maps JSON string values to enums using case-insensitive comparison.
  Default sort order is `[Name]` ascending. Invalid field names reject the entire
  setting and fall back to default.
- **JSON schema**: Extend `settings.schema.0.2.json` with an `output` section containing
  `sortOrder` (string array) and `sortDirection` (string enum with ascending default).
- **Static constexpr pattern**: String constants for field name and direction comparisons
  follow the established `static constexpr std::string_view` pattern used by
  `NetworkDownloader`, `LoggingLevelPreference`, and other existing validators.

## Impact
- No behavioral change — settings are defined but not yet consumed by any command or
  workflow. Existing `winget list` output remains unchanged.
- Users who edit `settings.json` to add `output.sortOrder` or `output.sortDirection`
  will have their values validated and stored, but the values will not take effect
  until the sort logic is wired in a follow-up PR.

## How Validated
- Unit tests added: 16 test sections across `SettingOutputSortOrder` and
  `SettingOutputSortDirection` test cases covering default values, single and multi-field
  configurations, case insensitivity, empty array, invalid fields, mixed valid/invalid,
  and wrong JSON types (62 assertions total).
- Compilation verified for AppInstallerCommonCore and AppInstallerCLITests.

## Follow-up
This PR is part 1 of a 3-PR stack:
- **PR1** (this): Settings types and schema
- **PR2**: CLI arguments (`--sort`, `--ascending`, `--descending`)
- **PR3**: Sort logic wiring, `ConvertToSortField` shared parser, and comprehensive tests

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6176)