### PR TITLE
[Settings, ListCommand] Add sort types, settings infrastructure, and CLI arguments for output ordering

### DIFF
--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -340,6 +340,35 @@
           "default": false
         }
       }
+    },
+    "Output": {
+      "description": "Output display settings",
+      "type": "object",
+      "properties": {
+        "sortOrder": {
+          "description": "Fields to sort output by, in priority order. Use an empty array to disable sorting.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "name",
+              "id",
+              "version",
+              "source",
+              "available"
+            ]
+          }
+        },
+        "sortDirection": {
+          "description": "Sort direction for output ordering",
+          "type": "string",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "default": "ascending"
+        }
+      }
     }
   },
   "allOf": [
@@ -406,6 +435,12 @@
     {
       "properties": {
         "interactivity": { "$ref": "#/definitions/Interactivity" }
+      },
+      "additionalItems": true
+    },
+    {
+      "properties": {
+        "output": { "$ref": "#/definitions/Output" }
       },
       "additionalItems": true
     },

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -346,7 +346,7 @@
       "type": "object",
       "properties": {
         "sortOrder": {
-          "description": "Fields to sort output by, in priority order. Use an empty array to disable sorting.",
+          "description": "Fields to sort output by, in priority order. An empty array results in default sorting.",
           "type": "array",
           "items": {
             "type": "string",

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -351,6 +351,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "relevance",
               "name",
               "id",
               "version",

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -189,6 +189,12 @@ namespace AppInstaller::CLI
             return { type, "upgrade-available"_liv};
         case Execution::Args::Type::ListDetails:
             return { type, "details"_liv };
+        case Execution::Args::Type::Sort:
+            return { type, "sort"_liv };
+        case Execution::Args::Type::SortAscending:
+            return { type, "ascending"_liv, "asc"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::SortDirection };
+        case Execution::Args::Type::SortDescending:
+            return { type, "descending"_liv, "desc"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::SortDirection };
 
         // Pin command
         case Execution::Args::Type::GatedVersion:

--- a/src/AppInstallerCLICore/Argument.h
+++ b/src/AppInstallerCLICore/Argument.h
@@ -92,6 +92,7 @@ namespace AppInstaller::CLI
         ConfigurationSetChoice = 0x80,
         DscResourceFunction = 0x100,
         DependenciesConflict = 0x200,
+        SortDirection = 0x400,
 
         // This must always be at the end
         Max

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -32,6 +32,9 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::IncludeUnknown, Resource::String::IncludeUnknownInListArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::IncludePinned, Resource::String::IncludePinnedInListArgumentDescription, ArgumentType::Flag},
             Argument::ForType(Execution::Args::Type::ListDetails),
+            Argument{ Execution::Args::Type::Sort, Resource::String::SortArgumentDescription, ArgumentType::Standard },
+            Argument{ Execution::Args::Type::SortAscending, Resource::String::SortAscendingArgumentDescription, ArgumentType::Flag },
+            Argument{ Execution::Args::Type::SortDescending, Resource::String::SortDescendingArgumentDescription, ArgumentType::Flag },
         };
     }
 

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -114,6 +114,9 @@ namespace AppInstaller::CLI::Execution
             // List Command
             Upgrade, // Used in List command to only show versions with upgrades
             ListDetails,
+            Sort, // Sort output by field (repeatable: --sort name --sort id)
+            SortAscending, // Sort output in ascending order
+            SortDescending, // Sort output in descending order
 
             // Pin command
             GatedVersion, // Differs from Version in that this supports wildcards

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -685,6 +685,9 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(ShowVersion);
         WINGET_DEFINE_RESOURCE_STRINGID(SilentArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SingleCharAfterDashError);
+        WINGET_DEFINE_RESOURCE_STRINGID(SortArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(SortAscendingArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(SortDescendingArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(SkipDependenciesArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesOnlyArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(DependenciesOnlyMessage);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -525,8 +525,8 @@ They can be configured through the settings file 'winget settings'.</value>
     <comment>{Locked="{0}"} Error message displayed when the user provides more than a single character command line alias argument after an alias argument specifier '-'. {0} is a placeholder replaced by the user's argument input.</comment>
   </data>
   <data name="SortArgumentDescription" xml:space="preserve">
-    <value>Sort results by a specified field (can be repeated for multi-field sort)</value>
-    <comment>Description for the --sort argument used to sort output by field name. Valid values are: name, id, version, source, available.</comment>
+    <value>Sort results by a property (can be repeated)</value>
+    <comment>Description for the --sort argument used to sort output by field name.</comment>
   </data>
   <data name="SortAscendingArgumentDescription" xml:space="preserve">
     <value>Sort results in ascending order</value>

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -524,6 +524,18 @@ They can be configured through the settings file 'winget settings'.</value>
     <value>Only the single character alias can occur after a single -: '{0}'</value>
     <comment>{Locked="{0}"} Error message displayed when the user provides more than a single character command line alias argument after an alias argument specifier '-'. {0} is a placeholder replaced by the user's argument input.</comment>
   </data>
+  <data name="SortArgumentDescription" xml:space="preserve">
+    <value>Sort results by a specified field (can be repeated for multi-field sort)</value>
+    <comment>Description for the --sort argument used to sort output by field name. Valid values are: name, id, version, source, available.</comment>
+  </data>
+  <data name="SortAscendingArgumentDescription" xml:space="preserve">
+    <value>Sort results in ascending order</value>
+    <comment>Description for the --ascending (--asc) flag that sets ascending sort direction for output.</comment>
+  </data>
+  <data name="SortDescendingArgumentDescription" xml:space="preserve">
+    <value>Sort results in descending order</value>
+    <comment>Description for the --descending (--desc) flag that sets descending sort direction for output.</comment>
+  </data>
   <data name="SourceAddAlreadyExistsDifferentArg" xml:space="preserve">
     <value>A source with the given name already exists and refers to a different location:</value>
   </data>

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -665,13 +665,12 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
 {
     auto again = DeleteUserSettingsFiles();
 
-    SECTION("Default value")
+    SECTION("Default value - empty vector sentinel for context-aware defaults")
     {
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Single field")
@@ -683,6 +682,17 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
         REQUIRE(sortOrder.size() == 1);
         REQUIRE(sortOrder[0] == SortField::Id);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Relevance field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["relevance"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Relevance);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Multiple fields")
@@ -699,17 +709,18 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
     }
     SECTION("All valid fields")
     {
-        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "version", "source", "available"] } })";
+        std::string_view json = R"({ "output": { "sortOrder": ["relevance", "name", "id", "version", "source", "available"] } })";
         SetSetting(Stream::PrimaryUserSettings, json);
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 5);
-        REQUIRE(sortOrder[0] == SortField::Name);
-        REQUIRE(sortOrder[1] == SortField::Id);
-        REQUIRE(sortOrder[2] == SortField::Version);
-        REQUIRE(sortOrder[3] == SortField::Source);
-        REQUIRE(sortOrder[4] == SortField::Available);
+        REQUIRE(sortOrder.size() == 6);
+        REQUIRE(sortOrder[0] == SortField::Relevance);
+        REQUIRE(sortOrder[1] == SortField::Name);
+        REQUIRE(sortOrder[2] == SortField::Id);
+        REQUIRE(sortOrder[3] == SortField::Version);
+        REQUIRE(sortOrder[4] == SortField::Source);
+        REQUIRE(sortOrder[5] == SortField::Available);
         REQUIRE(userSettingTest.GetWarnings().size() == 0);
     }
     SECTION("Case insensitive")
@@ -742,8 +753,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Mixed valid and invalid field")
@@ -753,8 +763,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Duplicate values - case-insensitive")
@@ -777,8 +786,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
     SECTION("Wrong type - number in array")
@@ -788,8 +796,7 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         UserSettingsTest userSettingTest;
 
         auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
-        REQUIRE(sortOrder.size() == 1);
-        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder.empty());
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
 }

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -858,3 +858,45 @@ TEST_CASE("SettingOutputSortDirection", "[settings]")
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
 }
+
+TEST_CASE("ConvertToSortField", "[settings]")
+{
+    SECTION("Valid values - lowercase")
+    {
+        REQUIRE(ConvertToSortField("relevance") == SortField::Relevance);
+        REQUIRE(ConvertToSortField("name") == SortField::Name);
+        REQUIRE(ConvertToSortField("id") == SortField::Id);
+        REQUIRE(ConvertToSortField("version") == SortField::Version);
+        REQUIRE(ConvertToSortField("source") == SortField::Source);
+        REQUIRE(ConvertToSortField("available") == SortField::Available);
+    }
+    SECTION("Case-insensitive")
+    {
+        REQUIRE(ConvertToSortField("RELEVANCE") == SortField::Relevance);
+        REQUIRE(ConvertToSortField("NAME") == SortField::Name);
+        REQUIRE(ConvertToSortField("Id") == SortField::Id);
+        REQUIRE(ConvertToSortField("VERSION") == SortField::Version);
+        REQUIRE(ConvertToSortField("Source") == SortField::Source);
+        REQUIRE(ConvertToSortField("AVAILABLE") == SortField::Available);
+    }
+    SECTION("Invalid values return nullopt")
+    {
+        REQUIRE_FALSE(ConvertToSortField("").has_value());
+        REQUIRE_FALSE(ConvertToSortField("foo").has_value());
+        REQUIRE_FALSE(ConvertToSortField("names").has_value());
+        REQUIRE_FALSE(ConvertToSortField("nam").has_value());
+    }
+    SECTION("Settings round-trip with ConvertToSortField")
+    {
+        auto again = DeleteUserSettingsFiles();
+
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "id"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto fields = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(fields.size() == 2);
+        REQUIRE(fields[0] == SortField::Name);
+        REQUIRE(fields[1] == SortField::Id);
+    }
+}

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -660,3 +660,181 @@ TEST_CASE("LoggingChannels", "[settings]")
         REQUIRE(userSettingTest.Get<Setting::LoggingChannelPreference>() == (Channel::CLI | Channel::SQL));
     }
 }
+
+TEST_CASE("SettingOutputSortOrder", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Default value")
+    {
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Single field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["id"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Id);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Multiple fields")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["available", "name"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 2);
+        REQUIRE(sortOrder[0] == SortField::Available);
+        REQUIRE(sortOrder[1] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("All valid fields")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "version", "source", "available"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 5);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Version);
+        REQUIRE(sortOrder[3] == SortField::Source);
+        REQUIRE(sortOrder[4] == SortField::Available);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Case insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["Name", "ID", "VERSION"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 3);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Version);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Empty array disables sorting")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": [] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 0);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Invalid field name")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["invalid"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Mixed valid and invalid field")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "bogus"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - string instead of array")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": "name" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - number in array")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": [1] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 1);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}
+
+TEST_CASE("SettingOutputSortDirection", "[settings]")
+{
+    auto again = DeleteUserSettingsFiles();
+
+    SECTION("Default value")
+    {
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Ascending")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "ascending" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Descending")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "descending" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Descending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Case insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "DESCENDING" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Descending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 0);
+    }
+    SECTION("Invalid value")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": "sideways" } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+    SECTION("Wrong type - array instead of string")
+    {
+        std::string_view json = R"({ "output": { "sortDirection": ["ascending"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        REQUIRE(userSettingTest.Get<Setting::OutputSortDirection>() == SortDirection::Ascending);
+        REQUIRE(userSettingTest.GetWarnings().size() == 1);
+    }
+}

--- a/src/AppInstallerCLITests/UserSettings.cpp
+++ b/src/AppInstallerCLITests/UserSettings.cpp
@@ -757,6 +757,19 @@ TEST_CASE("SettingOutputSortOrder", "[settings]")
         REQUIRE(sortOrder[0] == SortField::Name);
         REQUIRE(userSettingTest.GetWarnings().size() == 1);
     }
+    SECTION("Duplicate values - case-insensitive")
+    {
+        std::string_view json = R"({ "output": { "sortOrder": ["name", "id", "Name"] } })";
+        SetSetting(Stream::PrimaryUserSettings, json);
+        UserSettingsTest userSettingTest;
+
+        auto sortOrder = userSettingTest.Get<Setting::OutputSortOrder>();
+        REQUIRE(sortOrder.size() == 3);
+        REQUIRE(sortOrder[0] == SortField::Name);
+        REQUIRE(sortOrder[1] == SortField::Id);
+        REQUIRE(sortOrder[2] == SortField::Name);
+        REQUIRE(userSettingTest.GetWarnings().empty());
+    }
     SECTION("Wrong type - string instead of array")
     {
         std::string_view json = R"({ "output": { "sortOrder": "name" } })";

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -50,7 +50,7 @@ namespace AppInstaller::Settings
     // Sort field for output ordering.
     enum class SortField
     {
-        Relevance,  // Internal: preserves current natural order (not valid in settings)
+        Relevance,  // Preserves current natural order (source-defined relevance ranking)
         Name,
         Id,
         Version,
@@ -230,7 +230,7 @@ namespace AppInstaller::Settings
         // Interactivity
         SETTINGMAPPING_SPECIALIZATION(Setting::InteractivityDisable, bool, bool, false, ".interactivity.disable"sv);
         // Output behavior
-        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{ SortField::Name }, ".output.sortOrder"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{}, ".output.sortOrder"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortDirection, std::string, SortDirection, SortDirection::Ascending, ".output.sortDirection"sv);
         
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -65,6 +65,9 @@ namespace AppInstaller::Settings
         Descending,
     };
 
+    // Converts a string to SortField. Returns std::nullopt for unrecognized values.
+    std::optional<SortField> ConvertToSortField(std::string_view value);
+
     // The download code to use for *installers*.
     enum class InstallerDownloader
     {

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -47,6 +47,24 @@ namespace AppInstaller::Settings
         Disabled,
     };
 
+    // Sort field for output ordering.
+    enum class SortField
+    {
+        Relevance,  // Internal: preserves current natural order (not valid in settings)
+        Name,
+        Id,
+        Version,
+        Source,
+        Available,
+    };
+
+    // Sort direction for output ordering.
+    enum class SortDirection
+    {
+        Ascending,
+        Descending,
+    };
+
     // The download code to use for *installers*.
     enum class InstallerDownloader
     {
@@ -114,6 +132,9 @@ namespace AppInstaller::Settings
         ConfigureDefaultModuleRoot,
         // Interactivity
         InteractivityDisable,
+        // Output behavior
+        OutputSortOrder,
+        OutputSortDirection,
 #ifndef AICLI_DISABLE_TEST_HOOKS
         // Debug
         EnableSelfInitiatedMinidump,
@@ -208,6 +229,9 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::LoggingFileCountLimit, uint32_t, uint32_t, 0, ".logging.file.countLimit"sv);
         // Interactivity
         SETTINGMAPPING_SPECIALIZATION(Setting::InteractivityDisable, bool, bool, false, ".interactivity.disable"sv);
+        // Output behavior
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortOrder, std::vector<std::string>, std::vector<SortField>, std::vector<SortField>{ SortField::Name }, ".output.sortOrder"sv);
+        SETTINGMAPPING_SPECIALIZATION(Setting::OutputSortDirection, std::string, SortDirection, SortDirection::Ascending, ".output.sortDirection"sv);
         
         // Used to deduce the SettingVariant type; making a variant that includes std::monostate and all SettingMapping types.
         template <size_t... I>

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -482,6 +482,53 @@ namespace AppInstaller::Settings
         {
             return value * 24h;
         }
+
+        WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
+        {
+            std::vector<SortField> fields;
+            for (auto const& entry : value)
+            {
+                if (Utility::CaseInsensitiveEquals(entry, "name"))
+                {
+                    fields.emplace_back(SortField::Name);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "id"))
+                {
+                    fields.emplace_back(SortField::Id);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "version"))
+                {
+                    fields.emplace_back(SortField::Version);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "source"))
+                {
+                    fields.emplace_back(SortField::Source);
+                }
+                else if (Utility::CaseInsensitiveEquals(entry, "available"))
+                {
+                    fields.emplace_back(SortField::Available);
+                }
+                else
+                {
+                    return {};
+                }
+            }
+            return fields;
+        }
+
+        WINGET_VALIDATE_SIGNATURE(OutputSortDirection)
+        {
+            if (Utility::CaseInsensitiveEquals(value, "ascending"))
+            {
+                return SortDirection::Ascending;
+            }
+            else if (Utility::CaseInsensitiveEquals(value, "descending"))
+            {
+                return SortDirection::Descending;
+            }
+
+            return {};
+        }
     }
 
 #ifndef AICLI_DISABLE_TEST_HOOKS

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -485,6 +485,7 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
         {
+            static constexpr std::string_view s_sortField_relevance = "relevance";
             static constexpr std::string_view s_sortField_name = "name";
             static constexpr std::string_view s_sortField_id = "id";
             static constexpr std::string_view s_sortField_version = "version";
@@ -494,23 +495,29 @@ namespace AppInstaller::Settings
             std::vector<SortField> fields;
             for (auto const& entry : value)
             {
-                if (Utility::CaseInsensitiveEquals(entry, s_sortField_name))
+                std::string lowered = Utility::ToLower(entry);
+
+                if (lowered == s_sortField_relevance)
+                {
+                    fields.emplace_back(SortField::Relevance);
+                }
+                else if (lowered == s_sortField_name)
                 {
                     fields.emplace_back(SortField::Name);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_id))
+                else if (lowered == s_sortField_id)
                 {
                     fields.emplace_back(SortField::Id);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_version))
+                else if (lowered == s_sortField_version)
                 {
                     fields.emplace_back(SortField::Version);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_source))
+                else if (lowered == s_sortField_source)
                 {
                     fields.emplace_back(SortField::Source);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_available))
+                else if (lowered == s_sortField_available)
                 {
                     fields.emplace_back(SortField::Available);
                 }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -485,26 +485,32 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
         {
+            static constexpr std::string_view s_sortField_name = "name";
+            static constexpr std::string_view s_sortField_id = "id";
+            static constexpr std::string_view s_sortField_version = "version";
+            static constexpr std::string_view s_sortField_source = "source";
+            static constexpr std::string_view s_sortField_available = "available";
+
             std::vector<SortField> fields;
             for (auto const& entry : value)
             {
-                if (Utility::CaseInsensitiveEquals(entry, "name"))
+                if (Utility::CaseInsensitiveEquals(entry, s_sortField_name))
                 {
                     fields.emplace_back(SortField::Name);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "id"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_id))
                 {
                     fields.emplace_back(SortField::Id);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "version"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_version))
                 {
                     fields.emplace_back(SortField::Version);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "source"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_source))
                 {
                     fields.emplace_back(SortField::Source);
                 }
-                else if (Utility::CaseInsensitiveEquals(entry, "available"))
+                else if (Utility::CaseInsensitiveEquals(entry, s_sortField_available))
                 {
                     fields.emplace_back(SortField::Available);
                 }
@@ -518,11 +524,14 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortDirection)
         {
-            if (Utility::CaseInsensitiveEquals(value, "ascending"))
+            static constexpr std::string_view s_sortDirection_ascending = "ascending";
+            static constexpr std::string_view s_sortDirection_descending = "descending";
+
+            if (Utility::CaseInsensitiveEquals(value, s_sortDirection_ascending))
             {
                 return SortDirection::Ascending;
             }
-            else if (Utility::CaseInsensitiveEquals(value, "descending"))
+            else if (Utility::CaseInsensitiveEquals(value, s_sortDirection_descending))
             {
                 return SortDirection::Descending;
             }

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -215,6 +215,26 @@ namespace AppInstaller::Settings
         }
     }
 
+    std::optional<SortField> ConvertToSortField(std::string_view value)
+    {
+        static constexpr std::string_view s_sortField_relevance = "relevance";
+        static constexpr std::string_view s_sortField_name = "name";
+        static constexpr std::string_view s_sortField_id = "id";
+        static constexpr std::string_view s_sortField_version = "version";
+        static constexpr std::string_view s_sortField_source = "source";
+        static constexpr std::string_view s_sortField_available = "available";
+
+        std::string lowered = Utility::ToLower(value);
+
+        if (lowered == s_sortField_relevance) return SortField::Relevance;
+        if (lowered == s_sortField_name) return SortField::Name;
+        if (lowered == s_sortField_id) return SortField::Id;
+        if (lowered == s_sortField_version) return SortField::Version;
+        if (lowered == s_sortField_source) return SortField::Source;
+        if (lowered == s_sortField_available) return SortField::Available;
+        return std::nullopt;
+    }
+
     namespace details
     {
 #define WINGET_VALIDATE_SIGNATURE(_setting_) \

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -505,46 +505,15 @@ namespace AppInstaller::Settings
 
         WINGET_VALIDATE_SIGNATURE(OutputSortOrder)
         {
-            static constexpr std::string_view s_sortField_relevance = "relevance";
-            static constexpr std::string_view s_sortField_name = "name";
-            static constexpr std::string_view s_sortField_id = "id";
-            static constexpr std::string_view s_sortField_version = "version";
-            static constexpr std::string_view s_sortField_source = "source";
-            static constexpr std::string_view s_sortField_available = "available";
-
             std::vector<SortField> fields;
             for (auto const& entry : value)
             {
-                std::string lowered = Utility::ToLower(entry);
-
-                if (lowered == s_sortField_relevance)
-                {
-                    fields.emplace_back(SortField::Relevance);
-                }
-                else if (lowered == s_sortField_name)
-                {
-                    fields.emplace_back(SortField::Name);
-                }
-                else if (lowered == s_sortField_id)
-                {
-                    fields.emplace_back(SortField::Id);
-                }
-                else if (lowered == s_sortField_version)
-                {
-                    fields.emplace_back(SortField::Version);
-                }
-                else if (lowered == s_sortField_source)
-                {
-                    fields.emplace_back(SortField::Source);
-                }
-                else if (lowered == s_sortField_available)
-                {
-                    fields.emplace_back(SortField::Available);
-                }
-                else
+                auto field = ConvertToSortField(entry);
+                if (!field)
                 {
                     return {};
                 }
+                fields.emplace_back(field.value());
             }
             return fields;
         }


### PR DESCRIPTION
## Summary

Add settings infrastructure and CLI arguments for configurable output sorting in
`winget list`. This lays the full type system, settings plumbing, and argument
registration without changing any runtime behavior — sort logic is wired in a
follow-up PR.

Part of https://github.com/microsoft/winget-cli/issues/4238

## Changes

### Settings types and schema
- **SortField and SortDirection enums**: Add `SortField` (Relevance, Name, Id, Version,
  Source, Available) and `SortDirection` (Ascending, Descending) to the settings type
  system. Relevance preserves the current natural ordering and is publicly configurable
  (users can set `["relevance"]` to explicitly opt out of sorting).
- **Settings entries**: Register `OutputSortOrder` and `OutputSortDirection` with typed
  validation using lowercase-once comparison (`Utility::ToLower` + `==`). Default sort
  order is empty (`{}`) — an empty vector acts as a sentinel meaning "use context-aware
  defaults" (the follow-up PR's sort logic decides: relevance for queries, Name for
  no-query).
- **JSON schema**: Extend `settings.schema.0.2.json` with an `output` section containing
  `sortOrder` (string array with relevance, name, id, version, source, available) and
  `sortDirection` (string enum with ascending default).
- **Static constexpr pattern**: String constants for field name and direction comparisons
  follow the established `static constexpr std::string_view` pattern used by existing
  validators.

### CLI arguments
- **Execution args**: Add `Sort`, `SortAscending`, and `SortDescending` arg types to
  `ExecutionArgs.h`.
- **Argument registration**: Define `--sort` (multi-use, max 7 values), `--ascending`/`--asc`,
  and `--descending`/`--desc` in `Argument.cpp` with resource string descriptions.
  `--ascending` and `--descending` are mutually exclusive via `ExclusiveOf`.
- **ListCommand**: Add the three new arguments to `ListCommand::GetArguments()`.
- **Resource strings**: Add localized descriptions for all three arguments in
  `winget.resw` and resource IDs in `Resources.h`.

## Impact

- No behavioral change — settings and arguments are defined but not yet consumed by
  any workflow. Existing `winget list` output remains unchanged.
- `winget list --sort name` is accepted without error but output remains unsorted until
  the sort logic PR lands.
- `--ascending` and `--descending` are mutually exclusive — passing both produces an error.

## How Validated

- Unit tests: 17 test sections across `SettingOutputSortOrder` and `SettingOutputSortDirection`
  covering default values (empty fallback), single/multi-field, case insensitivity, empty
  array, relevance field, duplicate fields, invalid fields, mixed valid/invalid, and wrong
  JSON types (68 assertions total).
- Manual verification: `wingetdev list --sort name` accepted, `wingetdev list --help`
  shows new arguments.

## Follow-up

- Sort logic wiring, query-aware defaults, and
  comprehensive sort tests will be in a follow-up PR.
