### PR TITLE
Add JSON validation output and interop presentation model

### DIFF
--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -633,7 +633,7 @@ namespace AppInstaller::Manifest
         return m_manifestErrorMessage;
     }
 
-    std::string ManifestException::GetManifestErrorJSON() const noexcept
+    std::string ManifestException::GetManifestErrorJson() const noexcept
     {
         try
         {

--- a/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp
@@ -28,6 +28,9 @@ namespace AppInstaller::Manifest
 
         const auto& GetErrorIdToMessageMap()
         {
+            // Each entry here must have a corresponding WINGET_DEFINE_RESOURCE_STRINGID in
+            // ManifestValidation.h (ManifestError namespace) and a value in the
+            // ManifestErrorId enum in src/WinGetUtilInterop/Common/ManifestErrorId.cs.
             static std::map<AppInstaller::StringResource::StringId, std::string_view> ErrorIdToMessageMap = {
                 { AppInstaller::Manifest::ManifestError::InvalidRootNode, "Encountered unexpected root node."sv },
                 { AppInstaller::Manifest::ManifestError::FieldUnknown, "Unknown field."sv },
@@ -579,5 +582,88 @@ namespace AppInstaller::Manifest
         }
         
         return Utility::ConvertToUTF8(Message);
+    }
+
+    const std::string& ManifestException::GetManifestErrorMessage() const noexcept
+    {
+        if (m_manifestErrorMessage.empty())
+        {
+            if (m_errors.empty())
+            {
+                // Syntax error, yaml parser error is stored in FailureInfo
+                if (GetFailureInfo().pszMessage)
+                {
+                    m_manifestErrorMessage = Utility::ConvertToUTF8(GetFailureInfo().pszMessage);
+                }
+            }
+            else
+            {
+                for (auto const& error : m_errors)
+                {
+                    if (error.ErrorLevel == ValidationError::Level::Error)
+                    {
+                        m_manifestErrorMessage += ManifestError::ErrorMessagePrefix;
+                    }
+                    else if (error.ErrorLevel == ValidationError::Level::Warning)
+                    {
+                        m_manifestErrorMessage += ManifestError::WarningMessagePrefix;
+                    }
+                    m_manifestErrorMessage += error.GetErrorMessage();
+
+                    if (!error.Context.empty())
+                    {
+                        m_manifestErrorMessage += " [" + error.Context + "]";
+                    }
+                    if (!error.Value.empty())
+                    {
+                        m_manifestErrorMessage += " Value: " + error.Value;
+                    }
+                    if (error.Line > 0 && error.Column > 0)
+                    {
+                        m_manifestErrorMessage += " Line: " + std::to_string(error.Line) + ", Column: " + std::to_string(error.Column);
+                    }
+                    if (!error.FileName.empty())
+                    {
+                        m_manifestErrorMessage += " File: " + error.FileName;
+                    }
+                    m_manifestErrorMessage += '\n';
+                }
+            }
+        }
+        return m_manifestErrorMessage;
+    }
+
+    std::string ManifestException::GetManifestErrorJSON() const noexcept
+    {
+        try
+        {
+            Json::Value root;
+            root["fullMessage"] = GetManifestErrorMessage();
+            root["isSyntaxError"] = m_errors.empty();
+
+            Json::Value errorsArray(Json::arrayValue);
+            for (auto const& error : m_errors)
+            {
+                Json::Value entry;
+                entry["errorId"] = Utility::ConvertToUTF8(error.Message);
+                entry["message"] = error.GetErrorMessage();
+                entry["context"] = error.Context;
+                entry["value"] = error.Value;
+                entry["line"] = static_cast<Json::UInt64>(error.Line);
+                entry["column"] = static_cast<Json::UInt64>(error.Column);
+                entry["level"] = (error.ErrorLevel == ValidationError::Level::Error) ? "Error" : "Warning";
+                entry["file"] = error.FileName;
+                errorsArray.append(std::move(entry));
+            }
+            root["errors"] = std::move(errorsArray);
+
+            Json::StreamWriterBuilder writer;
+            writer["indentation"] = "";
+            return Json::writeString(writer, root);
+        }
+        catch (...)
+        {
+            return {};
+        }
     }
 }

--- a/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
@@ -19,6 +19,9 @@ namespace AppInstaller::Manifest
         const char* const ErrorMessagePrefix = "Manifest Error: ";
         const char* const WarningMessagePrefix = "Manifest Warning: ";
 
+        // Each StringId below must have a corresponding entry in:
+        //   - ErrorIdToMessageMap in ManifestValidation.cpp  (the human-readable message)
+        //   - ManifestErrorId enum in src/WinGetUtilInterop/Common/ManifestErrorId.cs  (the C# interop enum)
         WINGET_DEFINE_RESOURCE_STRINGID(ApproximateVersionNotAllowed);
         WINGET_DEFINE_RESOURCE_STRINGID(ArpValidationError);
         WINGET_DEFINE_RESOURCE_STRINGID(ArpVersionOverlapWithIndex);
@@ -179,54 +182,7 @@ namespace AppInstaller::Manifest
         ManifestException(HRESULT hr) : ManifestException({}, hr) {}
 
         // Error message without wil diagnostic info
-        const std::string& GetManifestErrorMessage() const noexcept
-        {
-            if (m_manifestErrorMessage.empty())
-            {
-                if (m_errors.empty())
-                {
-                    // Syntax error, yaml parser error is stored in FailureInfo
-                    if (GetFailureInfo().pszMessage)
-                    {
-                        m_manifestErrorMessage = Utility::ConvertToUTF8(GetFailureInfo().pszMessage);
-                    }
-                }
-                else
-                {
-                    for (auto const& error : m_errors)
-                    {
-                        if (error.ErrorLevel == ValidationError::Level::Error)
-                        {
-                            m_manifestErrorMessage += ManifestError::ErrorMessagePrefix;
-                        }
-                        else if (error.ErrorLevel == ValidationError::Level::Warning)
-                        {
-                            m_manifestErrorMessage += ManifestError::WarningMessagePrefix;
-                        }
-                        m_manifestErrorMessage += error.GetErrorMessage();
-
-                        if (!error.Context.empty())
-                        {
-                            m_manifestErrorMessage += " [" + error.Context + "]";
-                        }
-                        if (!error.Value.empty())
-                        {
-                            m_manifestErrorMessage += " Value: " + error.Value;
-                        }
-                        if (error.Line > 0 && error.Column > 0)
-                        {
-                            m_manifestErrorMessage += " Line: " + std::to_string(error.Line) + ", Column: " + std::to_string(error.Column);
-                        }
-                        if (!error.FileName.empty())
-                        {
-                            m_manifestErrorMessage += " File: " + error.FileName;
-                        }
-                        m_manifestErrorMessage += '\n';
-                    }
-                }
-            }
-            return m_manifestErrorMessage;
-        }
+        const std::string& GetManifestErrorMessage() const noexcept;
 
         bool IsWarningOnly() const noexcept
         {
@@ -248,6 +204,12 @@ namespace AppInstaller::Manifest
         }
 
         const std::vector<ValidationError>& Errors() const { return m_errors; }
+
+        // Error information as a JSON string. The JSON object contains:
+        //   "fullMessage": the same string as GetManifestErrorMessage()
+        //   "isSyntaxError": true if this is a YAML syntax error (no structured ValidationErrors)
+        //   "errors": array of objects with fields: errorId, message, context, value, line, column, level, file
+        std::string GetManifestErrorJSON() const noexcept;
 
     private:
         std::vector<ValidationError> m_errors;

--- a/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
+++ b/src/AppInstallerCommonCore/Public/winget/ManifestValidation.h
@@ -209,7 +209,7 @@ namespace AppInstaller::Manifest
         //   "fullMessage": the same string as GetManifestErrorMessage()
         //   "isSyntaxError": true if this is a YAML syntax error (no structured ValidationErrors)
         //   "errors": array of objects with fields: errorId, message, context, value, line, column, level, file
-        std::string GetManifestErrorJSON() const noexcept;
+        std::string GetManifestErrorJson() const noexcept;
 
     private:
         std::vector<ValidationError> m_errors;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,6 +32,7 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/WinGetUtil/Exports.cpp
+++ b/src/WinGetUtil/Exports.cpp
@@ -378,9 +378,9 @@ extern "C"
             }
             if (message)
             {
-                if (WI_IsFlagSet(option, WinGetCreateManifestOption::ReturnResponseAsJSON))
+                if (WI_IsFlagSet(option, WinGetCreateManifestOption::ReturnResponseAsJson))
                 {
-                    *message = ::SysAllocString(ConvertToUTF16(e.GetManifestErrorJSON()).c_str());
+                    *message = ::SysAllocString(ConvertToUTF16(e.GetManifestErrorJson()).c_str());
                 }
                 else
                 {

--- a/src/WinGetUtil/Exports.cpp
+++ b/src/WinGetUtil/Exports.cpp
@@ -378,7 +378,14 @@ extern "C"
             }
             if (message)
             {
-                *message = ::SysAllocString(ConvertToUTF16(e.GetManifestErrorMessage()).c_str());
+                if (WI_IsFlagSet(option, WinGetCreateManifestOption::ReturnResponseAsJSON))
+                {
+                    *message = ::SysAllocString(ConvertToUTF16(e.GetManifestErrorJSON()).c_str());
+                }
+                else
+                {
+                    *message = ::SysAllocString(ConvertToUTF16(e.GetManifestErrorMessage()).c_str());
+                }
             }
         }
 

--- a/src/WinGetUtil/WinGetUtil.h
+++ b/src/WinGetUtil/WinGetUtil.h
@@ -49,6 +49,10 @@ extern "C"
 
         // Return error if a network address is present in installer switches.
         ReturnErrorOnNetworkAddressInSwitches = 0x2000,
+
+        // Return the failure or warning message as a JSON string containing both the full message
+        // and a structured list of individual errors/warnings.
+        ReturnResponseAsJSON = 0x4000,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(WinGetCreateManifestOption);

--- a/src/WinGetUtil/WinGetUtil.h
+++ b/src/WinGetUtil/WinGetUtil.h
@@ -52,7 +52,7 @@ extern "C"
 
         // Return the failure or warning message as a JSON string containing both the full message
         // and a structured list of individual errors/warnings.
-        ReturnResponseAsJSON = 0x4000,
+        ReturnResponseAsJson = 0x4000,
     };
 
     DEFINE_ENUM_FLAG_OPERATORS(WinGetCreateManifestOption);

--- a/src/WinGetUtilInterop.UnitTests/APIUnitTests/ManifestUnitTests.cs
+++ b/src/WinGetUtilInterop.UnitTests/APIUnitTests/ManifestUnitTests.cs
@@ -185,7 +185,7 @@ namespace WinGetUtilInterop.UnitTests.APIUnitTests
                 mergedManifestPath,
                 WinGetCreateManifestOption.SchemaAndSemanticValidation
                     | WinGetCreateManifestOption.AllowShadowManifest
-                    | WinGetCreateManifestOption.ReturnResponseAsJSON);
+                    | WinGetCreateManifestOption.ReturnResponseAsJson);
 
             Assert.True(result.IsValid);
             Assert.Null(result.Message);
@@ -208,7 +208,7 @@ namespace WinGetUtilInterop.UnitTests.APIUnitTests
             using var result = factory.CreateManifest(
                 input,
                 mergedManifestPath: null,
-                WinGetCreateManifestOption.SchemaAndSemanticValidation | WinGetCreateManifestOption.ReturnResponseAsJSON);
+                WinGetCreateManifestOption.SchemaAndSemanticValidation | WinGetCreateManifestOption.ReturnResponseAsJson);
 
             Assert.False(result.IsValid);
             Assert.NotNull(result.Message);

--- a/src/WinGetUtilInterop.UnitTests/APIUnitTests/ManifestUnitTests.cs
+++ b/src/WinGetUtilInterop.UnitTests/APIUnitTests/ManifestUnitTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="ManifestUnitTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -6,6 +6,7 @@
 
 namespace WinGetUtilInterop.UnitTests.APIUnitTests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -155,6 +156,85 @@ namespace WinGetUtilInterop.UnitTests.APIUnitTests
             var serialized = shadowManifest.Serialize();
             Assert.Equal(File.ReadAllText(Path.Combine(testCollateralDir, "ExpectedShadowManifest.yaml")), serialized);
             this.log.WriteLine(serialized);
+        }
+
+        /// <summary>
+        /// Accessing Diagnostics without ReturnResponseAsJSON throws InvalidOperationException.
+        /// </summary>
+        [Fact]
+        public void CreateManifestResult_DiagnosticsThrowsWithoutJsonFlag()
+        {
+            using var result = new CreateManifestResult(isValid: true, message: null, manifestHandle: null);
+            Assert.Throws<InvalidOperationException>(() => result.Diagnostics);
+        }
+
+        /// <summary>
+        /// CreateManifest with ReturnResponseAsJSON and a valid manifest returns empty Diagnostics.
+        /// </summary>
+        [Fact]
+        public void CreateManifest_WithJsonFlag_ValidManifest_ReturnsDiagnosticsEmpty()
+        {
+            var input = Path.Combine(testCollateralDir, "Shadow");
+            var mergedManifestPath = Path.GetTempFileName();
+            var logFile = Path.GetTempFileName();
+
+            var factory = new WinGetFactory();
+            using var log = factory.LoggingInit(logFile);
+            using var result = factory.CreateManifest(
+                input,
+                mergedManifestPath,
+                WinGetCreateManifestOption.SchemaAndSemanticValidation
+                    | WinGetCreateManifestOption.AllowShadowManifest
+                    | WinGetCreateManifestOption.ReturnResponseAsJSON);
+
+            Assert.True(result.IsValid);
+            Assert.Null(result.Message);
+            Assert.NotNull(result.Diagnostics);
+            Assert.Empty(result.Diagnostics);
+        }
+
+        /// <summary>
+        /// CreateManifest with ReturnResponseAsJSON and an invalid manifest returns structured Diagnostics.
+        /// </summary>
+        [Fact]
+        public void CreateManifest_WithJsonFlag_InvalidManifest_ReturnsDiagnosticsPopulated()
+        {
+            // V1ManifestInfoMissingRequiredPackageLocale.yaml is a locale-type manifest without PackageLocale.
+            var input = Path.Combine(testCollateralDir, "V1ManifestInfoMissingRequiredPackageLocale.yaml");
+            var logFile = Path.GetTempFileName();
+
+            var factory = new WinGetFactory();
+            using var log = factory.LoggingInit(logFile);
+            using var result = factory.CreateManifest(
+                input,
+                mergedManifestPath: null,
+                WinGetCreateManifestOption.SchemaAndSemanticValidation | WinGetCreateManifestOption.ReturnResponseAsJSON);
+
+            Assert.False(result.IsValid);
+            Assert.NotNull(result.Message);
+            Assert.NotEmpty(result.Message);
+
+            var diagnostics = result.Diagnostics;
+            Assert.NotNull(diagnostics);
+            Assert.NotEmpty(diagnostics);
+
+            // At least one diagnostic should be an error.
+            Assert.Contains(diagnostics, d => d.Level == ManifestDiagnosticLevel.Error);
+
+            // Every diagnostic must have a non-empty message and a known (non-Unknown) error ID.
+            Assert.All(diagnostics, d =>
+            {
+                Assert.NotEqual(ManifestErrorId.Unknown, d.ErrorId);
+                Assert.False(string.IsNullOrEmpty(d.Message));
+            });
+
+            // The Message property must equal the fullMessage from the JSON (same content as without the flag).
+            using var resultWithoutJson = factory.CreateManifest(
+                input,
+                mergedManifestPath: null,
+                WinGetCreateManifestOption.SchemaAndSemanticValidation);
+
+            Assert.Equal(resultWithoutJson.Message, result.Message);
         }
     }
 }

--- a/src/WinGetUtilInterop/Api/WinGetFactory.cs
+++ b/src/WinGetUtilInterop/Api/WinGetFactory.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="WinGetFactory.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -103,7 +103,7 @@ namespace Microsoft.WinGetUtil.Api
                         WinGetCreateManifestOption.NoValidation);
                 }
 
-                bool returnAsJson = option.HasFlag(WinGetCreateManifestOption.ReturnResponseAsJSON);
+                bool returnAsJson = option.HasFlag(WinGetCreateManifestOption.ReturnResponseAsJson);
                 if (returnAsJson && failureOrWarningMessage != null)
                 {
                     return ParseJsonManifestResult(succeeded, failureOrWarningMessage, succeeded ? new WinGetManifest(manifestHandle) : null);

--- a/src/WinGetUtilInterop/Api/WinGetFactory.cs
+++ b/src/WinGetUtilInterop/Api/WinGetFactory.cs
@@ -7,7 +7,9 @@
 namespace Microsoft.WinGetUtil.Api
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
+    using System.Text.Json;
     using Microsoft.WinGetUtil.Common;
     using Microsoft.WinGetUtil.Exceptions;
     using Microsoft.WinGetUtil.Interfaces;
@@ -101,6 +103,17 @@ namespace Microsoft.WinGetUtil.Api
                         WinGetCreateManifestOption.NoValidation);
                 }
 
+                bool returnAsJson = option.HasFlag(WinGetCreateManifestOption.ReturnResponseAsJSON);
+                if (returnAsJson && failureOrWarningMessage != null)
+                {
+                    return ParseJsonManifestResult(succeeded, failureOrWarningMessage, succeeded ? new WinGetManifest(manifestHandle) : null);
+                }
+                else if (returnAsJson)
+                {
+                    // No errors/warnings; return empty diagnostics list.
+                    return new CreateManifestResult(succeeded, null, succeeded ? new WinGetManifest(manifestHandle) : null, new List<ManifestDiagnostic>());
+                }
+
                 return new CreateManifestResult(succeeded, failureOrWarningMessage, succeeded ? new WinGetManifest(manifestHandle) : null);
             }
             catch (Exception e)
@@ -137,6 +150,50 @@ namespace Microsoft.WinGetUtil.Api
             catch (Exception e)
             {
                 throw new WinGetInstallerMetadataException(e);
+            }
+        }
+
+        private static CreateManifestResult ParseJsonManifestResult(bool succeeded, string json, IWinGetManifest manifestHandle)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                string fullMessage = root.TryGetProperty("fullMessage", out var fullMsgProp) ? fullMsgProp.GetString() : json;
+
+                var diagnostics = new List<ManifestDiagnostic>();
+                if (root.TryGetProperty("errors", out var errorsArray) && errorsArray.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var entry in errorsArray.EnumerateArray())
+                    {
+                        string errorId = entry.TryGetProperty("errorId", out var p) ? p.GetString() : string.Empty;
+                        string message = entry.TryGetProperty("message", out p) ? p.GetString() : string.Empty;
+                        string context = entry.TryGetProperty("context", out p) ? p.GetString() : string.Empty;
+                        string value = entry.TryGetProperty("value", out p) ? p.GetString() : string.Empty;
+                        long line = entry.TryGetProperty("line", out p) ? p.GetInt64() : 0;
+                        long column = entry.TryGetProperty("column", out p) ? p.GetInt64() : 0;
+                        string levelStr = entry.TryGetProperty("level", out p) ? p.GetString() : "Error";
+                        string file = entry.TryGetProperty("file", out p) ? p.GetString() : string.Empty;
+
+                        var level = string.Equals(levelStr, "Warning", StringComparison.OrdinalIgnoreCase)
+                            ? ManifestDiagnosticLevel.Warning
+                            : ManifestDiagnosticLevel.Error;
+
+                        ManifestErrorId parsedErrorId = Enum.TryParse<ManifestErrorId>(errorId, out var knownId)
+                            ? knownId
+                            : ManifestErrorId.Unknown;
+
+                        diagnostics.Add(new ManifestDiagnostic(parsedErrorId, message, context, value, line, column, level, file));
+                    }
+                }
+
+                return new CreateManifestResult(succeeded, fullMessage, manifestHandle, diagnostics);
+            }
+            catch
+            {
+                // Fallback: JSON parsing failed; return raw string with no structured diagnostics.
+                return new CreateManifestResult(succeeded, json, manifestHandle, new List<ManifestDiagnostic>());
             }
         }
 

--- a/src/WinGetUtilInterop/Common/CreateManifestResult.cs
+++ b/src/WinGetUtilInterop/Common/CreateManifestResult.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 // <copyright file="CreateManifestResult.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -7,6 +7,7 @@
 namespace Microsoft.WinGetUtil.Common
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.WinGetUtil.Interfaces;
 
     /// <summary>
@@ -14,6 +15,9 @@ namespace Microsoft.WinGetUtil.Common
     /// </summary>
     public class CreateManifestResult : IDisposable
     {
+        private readonly IReadOnlyList<ManifestDiagnostic> diagnostics;
+        private readonly bool hasDiagnostics;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateManifestResult"/> class.
         /// </summary>
@@ -25,6 +29,24 @@ namespace Microsoft.WinGetUtil.Common
             this.IsValid = isValid;
             this.Message = message;
             this.ManifestHandle = manifestHandle;
+            this.diagnostics = null;
+            this.hasDiagnostics = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateManifestResult"/> class with structured diagnostics.
+        /// </summary>
+        /// <param name="isValid">Is manifest valid.</param>
+        /// <param name="message">Warning or failure validation message (the full concatenated string).</param>
+        /// <param name="manifestHandle">Created manifest handle if succeeded.</param>
+        /// <param name="diagnostics">Structured list of individual errors and warnings.</param>
+        public CreateManifestResult(bool isValid, string message, IWinGetManifest manifestHandle, IReadOnlyList<ManifestDiagnostic> diagnostics)
+        {
+            this.IsValid = isValid;
+            this.Message = message;
+            this.ManifestHandle = manifestHandle;
+            this.diagnostics = diagnostics;
+            this.hasDiagnostics = true;
         }
 
         /// <summary>
@@ -41,6 +63,29 @@ namespace Microsoft.WinGetUtil.Common
         /// Gets created manifest handle if succeeded.
         /// </summary>
         public IWinGetManifest ManifestHandle { get; } = null;
+
+        /// <summary>
+        /// Gets the structured list of individual manifest errors and warnings.
+        /// Only available when <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/> was passed
+        /// to <see cref="Microsoft.WinGetUtil.Api.WinGetFactory.CreateManifest"/>. Accessing this
+        /// property without that flag throws <see cref="InvalidOperationException"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/> was not set.
+        /// </exception>
+        public IReadOnlyList<ManifestDiagnostic> Diagnostics
+        {
+            get
+            {
+                if (!this.hasDiagnostics)
+                {
+                    throw new InvalidOperationException(
+                        $"Structured diagnostics are not available. Pass {nameof(WinGetCreateManifestOption)}.{nameof(WinGetCreateManifestOption.ReturnResponseAsJSON)} to CreateManifest to enable them.");
+                }
+
+                return this.diagnostics;
+            }
+        }
 
         /// <summary>
         /// Dispose method.

--- a/src/WinGetUtilInterop/Common/CreateManifestResult.cs
+++ b/src/WinGetUtilInterop/Common/CreateManifestResult.cs
@@ -66,12 +66,12 @@ namespace Microsoft.WinGetUtil.Common
 
         /// <summary>
         /// Gets the structured list of individual manifest errors and warnings.
-        /// Only available when <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/> was passed
+        /// Only available when <see cref="WinGetCreateManifestOption.ReturnResponseAsJson"/> was passed
         /// to <see cref="Microsoft.WinGetUtil.Api.WinGetFactory.CreateManifest"/>. Accessing this
         /// property without that flag throws <see cref="InvalidOperationException"/>.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/> was not set.
+        /// Thrown when <see cref="WinGetCreateManifestOption.ReturnResponseAsJson"/> was not set.
         /// </exception>
         public IReadOnlyList<ManifestDiagnostic> Diagnostics
         {
@@ -80,7 +80,7 @@ namespace Microsoft.WinGetUtil.Common
                 if (!this.hasDiagnostics)
                 {
                     throw new InvalidOperationException(
-                        $"Structured diagnostics are not available. Pass {nameof(WinGetCreateManifestOption)}.{nameof(WinGetCreateManifestOption.ReturnResponseAsJSON)} to CreateManifest to enable them.");
+                        $"Structured diagnostics are not available. Pass {nameof(WinGetCreateManifestOption)}.{nameof(WinGetCreateManifestOption.ReturnResponseAsJson)} to CreateManifest to enable them.");
                 }
 
                 return this.diagnostics;

--- a/src/WinGetUtilInterop/Common/Enums.cs
+++ b/src/WinGetUtilInterop/Common/Enums.cs
@@ -47,6 +47,13 @@ namespace Microsoft.WinGetUtil.Common
         /// Return error if a network address is present in installer switches.
         /// </summary>
         ReturnErrorOnNetworkAddressInSwitches = 0x2000,
+
+        /// <summary>
+        /// Return the failure or warning message as a JSON string containing both the full message
+        /// and a structured list of individual errors/warnings. When set, <see cref="Common.CreateManifestResult.Diagnostics"/>
+        /// will be populated with the structured data.
+        /// </summary>
+        ReturnResponseAsJSON = 0x4000,
     }
 
     /// <summary>

--- a/src/WinGetUtilInterop/Common/Enums.cs
+++ b/src/WinGetUtilInterop/Common/Enums.cs
@@ -53,7 +53,7 @@ namespace Microsoft.WinGetUtil.Common
         /// and a structured list of individual errors/warnings. When set, <see cref="Common.CreateManifestResult.Diagnostics"/>
         /// will be populated with the structured data.
         /// </summary>
-        ReturnResponseAsJSON = 0x4000,
+        ReturnResponseAsJson = 0x4000,
     }
 
     /// <summary>

--- a/src/WinGetUtilInterop/Common/ManifestDiagnostic.cs
+++ b/src/WinGetUtilInterop/Common/ManifestDiagnostic.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------------
+// <copyright file="ManifestDiagnostic.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGetUtil.Common
+{
+    /// <summary>
+    /// Severity level of a manifest diagnostic.
+    /// </summary>
+    public enum ManifestDiagnosticLevel
+    {
+        /// <summary>
+        /// The diagnostic is a warning; the manifest may still be valid.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// The diagnostic is an error; the manifest is invalid.
+        /// </summary>
+        Error,
+    }
+
+    /// <summary>
+    /// Represents a single manifest error or warning returned by <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/>.
+    /// </summary>
+    public class ManifestDiagnostic
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManifestDiagnostic"/> class.
+        /// </summary>
+        /// <param name="errorId">The error identifier.</param>
+        /// <param name="message">The human-readable error message.</param>
+        /// <param name="context">The field or context associated with the error.</param>
+        /// <param name="value">The field value that caused the error, if any.</param>
+        /// <param name="line">The 1-based line number in the source file, or 0 if unknown.</param>
+        /// <param name="column">The 1-based column number in the source file, or 0 if unknown.</param>
+        /// <param name="level">The severity level of the diagnostic.</param>
+        /// <param name="file">The source file name, if applicable.</param>
+        public ManifestDiagnostic(
+            ManifestErrorId errorId,
+            string message,
+            string context,
+            string value,
+            long line,
+            long column,
+            ManifestDiagnosticLevel level,
+            string file)
+        {
+            this.ErrorId = errorId;
+            this.Message = message;
+            this.Context = context;
+            this.Value = value;
+            this.Line = line;
+            this.Column = column;
+            this.Level = level;
+            this.File = file;
+        }
+
+        /// <summary>
+        /// Gets the error identifier.
+        /// </summary>
+        public ManifestErrorId ErrorId { get; }
+
+        /// <summary>
+        /// Gets the human-readable error message.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets the field or context associated with the error.
+        /// </summary>
+        public string Context { get; }
+
+        /// <summary>
+        /// Gets the field value that caused the error, if any.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Gets the 1-based line number in the source file, or 0 if unknown.
+        /// </summary>
+        public long Line { get; }
+
+        /// <summary>
+        /// Gets the 1-based column number in the source file, or 0 if unknown.
+        /// </summary>
+        public long Column { get; }
+
+        /// <summary>
+        /// Gets the severity level of this diagnostic.
+        /// </summary>
+        public ManifestDiagnosticLevel Level { get; }
+
+        /// <summary>
+        /// Gets the source file name associated with this diagnostic, if applicable.
+        /// </summary>
+        public string File { get; }
+    }
+}

--- a/src/WinGetUtilInterop/Common/ManifestDiagnostic.cs
+++ b/src/WinGetUtilInterop/Common/ManifestDiagnostic.cs
@@ -23,7 +23,7 @@ namespace Microsoft.WinGetUtil.Common
     }
 
     /// <summary>
-    /// Represents a single manifest error or warning returned by <see cref="WinGetCreateManifestOption.ReturnResponseAsJSON"/>.
+    /// Represents a single manifest error or warning returned by <see cref="WinGetCreateManifestOption.ReturnResponseAsJson"/>.
     /// </summary>
     public class ManifestDiagnostic
     {

--- a/src/WinGetUtilInterop/Common/ManifestErrorId.cs
+++ b/src/WinGetUtilInterop/Common/ManifestErrorId.cs
@@ -1,0 +1,207 @@
+// -----------------------------------------------------------------------------
+// <copyright file="ManifestErrorId.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.WinGetUtil.Common
+{
+    /// <summary>
+    /// Identifies a specific manifest validation error or warning.
+    /// Each value corresponds to a <c>WINGET_DEFINE_RESOURCE_STRINGID</c> entry in
+    /// <c>src/AppInstallerCommonCore/Public/winget/ManifestValidation.h</c> (ManifestError namespace)
+    /// and an entry in the <c>ErrorIdToMessageMap</c> in
+    /// <c>src/AppInstallerCommonCore/Manifest/ManifestValidation.cpp</c>.
+    /// When adding, removing, or renaming an error ID, all three locations must be updated.
+    /// </summary>
+    public enum ManifestErrorId
+    {
+        /// <summary>
+        /// The error ID was not recognized (e.g. defined in a newer native version).
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>Approximate version not allowed.</summary>
+        ApproximateVersionNotAllowed,
+
+        /// <summary>Arp Validation Error.</summary>
+        ArpValidationError,
+
+        /// <summary>DisplayVersion declared in the manifest has overlap with existing DisplayVersion range in the index. Existing DisplayVersion range in index: </summary>
+        ArpVersionOverlapWithIndex,
+
+        /// <summary>Internal error while validating DisplayVersion against index.</summary>
+        ArpVersionValidationInternalError,
+
+        /// <summary>Contains a blocked MSI property.</summary>
+        BlockedMsiProperty,
+
+        /// <summary>Both AllowedMarkets and ExcludedMarkets defined.</summary>
+        BothAllowedAndExcludedMarketsDefined,
+
+        /// <summary>Installer switch contains network address.</summary>
+        ContainsNetworkAddress,
+
+        /// <summary>Duplicate portable command alias found.</summary>
+        DuplicatePortableCommandAlias,
+
+        /// <summary>Duplicate relative file path found.</summary>
+        DuplicateRelativeFilePath,
+
+        /// <summary>The multi file manifest contains duplicate PackageLocale.</summary>
+        DuplicateMultiFileManifestLocale,
+
+        /// <summary>The multi file manifest should contain only one file with the particular ManifestType.</summary>
+        DuplicateMultiFileManifestType,
+
+        /// <summary>Duplicate installer entry found.</summary>
+        DuplicateInstallerEntry,
+
+        /// <summary>Multiple Installer URLs found with the same InstallerSha256. Please ensure the accuracy of the URLs.</summary>
+        DuplicateInstallerHash,
+
+        /// <summary>Duplicate installer return code found.</summary>
+        DuplicateReturnCodeEntry,
+
+        /// <summary>Only zero or one entry for Apps and Features may be specified for InstallerType portable.</summary>
+        ExceededAppsAndFeaturesEntryLimit,
+
+        /// <summary>Only zero or one value for Commands may be specified for InstallerType portable.</summary>
+        ExceededCommandsLimit,
+
+        /// <summary>Only one entry for NestedInstallerFiles can be specified for non-portable InstallerTypes.</summary>
+        ExceededNestedInstallerFilesLimit,
+
+        /// <summary>Silent and SilentWithProgress switches are not specified for InstallerType exe. Please make sure the installer can run unattended.</summary>
+        ExeInstallerMissingSilentSwitches,
+
+        /// <summary>Duplicate field found in the manifest.</summary>
+        FieldDuplicate,
+
+        /// <summary>Failed to process field.</summary>
+        FieldFailedToProcess,
+
+        /// <summary>All field names should be PascalCased.</summary>
+        FieldIsNotPascalCase,
+
+        /// <summary>Field is not supported.</summary>
+        FieldNotSupported,
+
+        /// <summary>Field usage requires verified publishers.</summary>
+        FieldRequireVerifiedPublisher,
+
+        /// <summary>Unknown field.</summary>
+        FieldUnknown,
+
+        /// <summary>Field value is not supported.</summary>
+        FieldValueNotSupported,
+
+        /// <summary>Loop found.</summary>
+        FoundDependencyLoop,
+
+        /// <summary>The multi file manifest is incomplete. A multi file manifest must contain at least version, installer and defaultLocale manifest.</summary>
+        IncompleteMultiFileManifest,
+
+        /// <summary>The values of InstallerSha256 do not match for all instances of the same InstallerUrl.</summary>
+        InconsistentInstallerHash,
+
+        /// <summary>DefaultLocale value in version manifest does not match PackageLocale value in defaultLocale manifest.</summary>
+        InconsistentMultiFileManifestDefaultLocale,
+
+        /// <summary>The multi file manifest has inconsistent field values.</summary>
+        InconsistentMultiFileManifestFieldValue,
+
+        /// <summary>Failed to process installer.</summary>
+        InstallerFailedToProcess,
+
+        /// <summary>Inconsistent value in the manifest.</summary>
+        InstallerMsixInconsistencies,
+
+        /// <summary>The specified installer type does not support PackageFamilyName.</summary>
+        InstallerTypeDoesNotSupportPackageFamilyName,
+
+        /// <summary>The specified installer type does not support ProductCode.</summary>
+        InstallerTypeDoesNotSupportProductCode,
+
+        /// <summary>The specified installer type does not write to Apps and Features entry.</summary>
+        InstallerTypeDoesNotWriteAppsAndFeaturesEntry,
+
+        /// <summary>The locale value is not a well formed bcp47 language tag.</summary>
+        InvalidBcp47Value,
+
+        /// <summary>Invalid field value.</summary>
+        InvalidFieldValue,
+
+        /// <summary>Contains invalid MSI switches.</summary>
+        InvalidMsiSwitches,
+
+        /// <summary>Encountered unexpected root node.</summary>
+        InvalidRootNode,
+
+        /// <summary>The provided value is not a valid Windows feature name.</summary>
+        InvalidWindowsFeatureName,
+
+        /// <summary>Dependency not found: </summary>
+        MissingManifestDependenciesNode,
+
+        /// <summary>Failed to calculate MSIX signature hash. Please verify that the input file is a valid, signed MSIX.</summary>
+        MsixSignatureHashFailed,
+
+        /// <summary>Deleting the manifest will break the following dependencies.</summary>
+        MultiManifestPackageHasDependencies,
+
+        /// <summary>No Suitable Minimum Version: </summary>
+        NoSuitableMinVersionDependency,
+
+        /// <summary>No supported platforms.</summary>
+        NoSupportedPlatforms,
+
+        /// <summary>Optional field missing.</summary>
+        OptionalFieldMissing,
+
+        /// <summary>Relative file path must not point to a location outside of archive directory.</summary>
+        RelativeFilePathEscapesDirectory,
+
+        /// <summary>Required field with empty value.</summary>
+        RequiredFieldEmpty,
+
+        /// <summary>Required field missing.</summary>
+        RequiredFieldMissing,
+
+        /// <summary>Schema Error.</summary>
+        SchemaError,
+
+        /// <summary>Scope is not supported for InstallerType portable.</summary>
+        ScopeNotSupported,
+
+        /// <summary>Shadow manifest is not allowed.</summary>
+        ShadowManifestNotAllowed,
+
+        /// <summary>Package has a single manifest and is a dependency of other manifests.</summary>
+        SingleManifestPackageHasDependencies,
+
+        /// <summary>The multi file manifest should not contain file with the particular ManifestType.</summary>
+        UnsupportedMultiFileManifestType,
+
+        /// <summary>Schema header not found.</summary>
+        SchemaHeaderNotFound,
+
+        /// <summary>The schema header is invalid. Please verify that the schema header is present and formatted correctly.</summary>
+        InvalidSchemaHeader,
+
+        /// <summary>The manifest type in the schema header does not match the ManifestType property value in the manifest.</summary>
+        SchemaHeaderManifestTypeMismatch,
+
+        /// <summary>The manifest version in the schema header does not match the ManifestVersion property value in the manifest.</summary>
+        SchemaHeaderManifestVersionMismatch,
+
+        /// <summary>The schema header URL does not match the expected pattern.</summary>
+        SchemaHeaderUrlPatternMismatch,
+
+        /// <summary>The file type of the referenced file is not allowed.</summary>
+        InvalidPortableFiletype,
+
+        /// <summary>The file type of the referenced file is not a supported font file type.</summary>
+        InvalidFontFiletype,
+    }
+}

--- a/src/WinGetUtilInterop/WinGetUtilInterop.csproj
+++ b/src/WinGetUtilInterop/WinGetUtilInterop.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Change
Adds a new flag to request JSON from manifest creation/validation pass.  Doing so enables the interop layer to provide the validation warnings/errors as an object model.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6183)