### PR TITLE
Add execution level to telemetry summary and logs

### DIFF
--- a/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
+++ b/src/AppInstallerCommonCore/AppInstallerTelemetry.cpp
@@ -237,6 +237,16 @@ namespace AppInstaller::Logging
             packageVersion = Runtime::GetPackageVersion();
         }
 
+        ExecutionLevel executionLevel = ExecutionLevel::User;
+        if (Runtime::IsRunningAsSystem())
+        {
+            executionLevel = ExecutionLevel::System;
+        }
+        else if (Runtime::IsRunningAsAdmin())
+        {
+            executionLevel = ExecutionLevel::Admin;
+        }
+
         if (IsTelemetryEnabled())
         {
             AICLI_TraceLoggingWriteActivity(
@@ -250,11 +260,12 @@ namespace AppInstaller::Logging
             if (m_useSummary)
             {
                 m_summary.IsCOMCall = isCOMCall;
+                m_summary.ExecutionLevel = executionLevel;
             }
         }
 
         AICLI_LOG(Core, Info, << "WinGet, version [" << version << "], activity [" << *GetActivityId() << ']');
-        AICLI_LOG(Core, Info, << "Process: " << Filesystem::GetExecutablePathForProcess(GetCurrentProcess()).filename() << "[" << GetCurrentProcessId() << "], Offset: " << &__ImageBase);
+        AICLI_LOG(Core, Info, << "Process: " << Filesystem::GetExecutablePathForProcess(GetCurrentProcess()).filename() << "[" << GetCurrentProcessId() << "], Level[" << executionLevel << "], Offset: " << &__ImageBase);
         AICLI_LOG(Core, Info, << "OS: " << Runtime::GetOSVersion());
         AICLI_LOG(Core, Info, << "Command line Args: " << Utility::ConvertToUTF8(GetCommandLineW()));
         if (Runtime::IsRunningInPackagedContext())
@@ -867,6 +878,7 @@ namespace AppInstaller::Logging
                     AICLI_TraceLoggingStringView(m_summary.FailureFile, "FailureFile"),
                     TraceLoggingUInt32(m_summary.FailureLine, "FailureLine"),
                     TraceLoggingBool(m_summary.IsCOMCall, "IsCOMCall"),
+                    TraceLoggingUInt32(static_cast<UINT32>(m_summary.ExecutionLevel), "ExecutionLevel"),
                     AICLI_TraceLoggingStringView(m_summary.Command, "Command"),
                     TraceLoggingBool(m_summary.CommandSuccess, "CommandSuccess"),
                     TraceLoggingBool(m_summary.IsManifestLocal, "IsManifestLocal"),

--- a/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
+++ b/src/AppInstallerCommonCore/Public/AppInstallerTelemetry.h
@@ -17,6 +17,13 @@ namespace AppInstaller::Settings
 
 namespace AppInstaller::Logging
 {
+    enum class ExecutionLevel : UINT32
+    {
+        User = 0,
+        Admin = 1,
+        System = 2,
+    };
+
     enum class FailureTypeEnum : UINT32
     {
         None = 0x0,
@@ -61,6 +68,7 @@ namespace AppInstaller::Logging
 
         // LogStartup
         bool IsCOMCall = false;
+        ExecutionLevel ExecutionLevel = ExecutionLevel::User;
 
         // LogCommand
         std::string Command;


### PR DESCRIPTION
## Change
Adds the execution level (user/admin/system) to the summary event and startup log lines.

## Validation
Manually confirmed presence in user/admin logs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6195)