### PR TITLE
Report DSC execution diagnostics on a timer

### DIFF
--- a/src/AppInstallerCLICore/Commands/DebugCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/DebugCommand.cpp
@@ -4,6 +4,8 @@
 
 #if _DEBUG
 #include "DebugCommand.h"
+#include "Public/ConfigurationSetProcessorFactoryRemoting.h"
+#include <AppInstallerRuntime.h>
 #include <winrt/Microsoft.Management.Configuration.h>
 #include <winrt/Microsoft.Management.Configuration.SetProcessorFactory.h>
 #include "AppInstallerDownloader.h"
@@ -62,6 +64,7 @@ namespace AppInstaller::CLI
             std::make_unique<DumpErrorResourceCommand>(FullName()),
             std::make_unique<ShowSixelCommand>(FullName()),
             std::make_unique<ProgressCommand>(FullName()),
+            std::make_unique<DebugDscResourceCommand>(FullName()),
         });
     }
 
@@ -363,6 +366,191 @@ namespace AppInstaller::CLI
         if (context.Args.Contains(WINGET_DEBUG_PROGRESS_POST))
         {
             context.Reporter.Info() << context.Args.GetArg(WINGET_DEBUG_PROGRESS_POST) << std::endl;
+        }
+    }
+
+#define WINGET_DEBUG_DSC_RESOURCE_RESOURCE  Args::Type::SourceName
+#define WINGET_DEBUG_DSC_RESOURCE_EXPORT    Args::Type::AllVersions
+
+    std::vector<Argument> DebugDscResourceCommand::GetArguments() const
+    {
+        return {
+            Argument{ "resource", 'r', WINGET_DEBUG_DSC_RESOURCE_RESOURCE, Resource::String::SourceListUpdatedNever, ArgumentType::Positional },
+            Argument{ "export", 'e', WINGET_DEBUG_DSC_RESOURCE_EXPORT, Resource::String::SourceListUpdatedNever, ArgumentType::Flag },
+            Argument::ForType(Args::Type::ConfigurationProcessorPath),
+        };
+    }
+
+    Resource::LocString DebugDscResourceCommand::ShortDescription() const
+    {
+        return Utility::LocIndString("Run DSCv3 resource actions"sv);
+    }
+
+    Resource::LocString DebugDscResourceCommand::LongDescription() const
+    {
+        return Utility::LocIndString("Directly invokes DSCv3 resource functions through WinGet's infrastructure, without requiring a full configuration document."sv);
+    }
+
+    void DebugDscResourceCommand::ExecuteInternal(Execution::Context& context) const
+    {
+        using namespace winrt::Microsoft::Management::Configuration;
+        using namespace winrt::Windows::Foundation::Collections;
+
+        if (!context.Args.Contains(WINGET_DEBUG_DSC_RESOURCE_EXPORT))
+        {
+            OutputHelp(context.Reporter);
+            return;
+        }
+
+        std::string resourceName{ context.Args.GetArg(WINGET_DEBUG_DSC_RESOURCE_RESOURCE) };
+
+        context.Reporter.Info() << "Creating OOP DSCv3 processor factory..." << std::endl;
+
+        IConfigurationSetProcessorFactory factory;
+        if (Runtime::IsRunningWithLimitedToken())
+        {
+            factory = ConfigurationRemoting::CreateDynamicRuntimeFactory(ConfigurationRemoting::ProcessorEngine::DSCv3);
+        }
+        else
+        {
+            factory = ConfigurationRemoting::CreateOutOfProcessFactory(ConfigurationRemoting::ProcessorEngine::DSCv3);
+        }
+
+        auto factoryMap = factory.as<IMap<winrt::hstring, winrt::hstring>>();
+
+        if (context.Args.Contains(Args::Type::ConfigurationProcessorPath))
+        {
+            factoryMap.Insert(ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::DscExecutablePath), Utility::ConvertToUTF16(context.Args.GetArg(Args::Type::ConfigurationProcessorPath)));
+        }
+        else
+        {
+            // Run the state machine to locate dsc.exe.
+            for (;;)
+            {
+                winrt::hstring nextTransition = factoryMap.Lookup(ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::FindDscStateMachine));
+                AICLI_LOG(CLI, Info, << "FindDscStateMachine: " << Utility::ConvertToUTF8(nextTransition));
+
+                if (nextTransition == L"Found")
+                {
+                    break;
+                }
+                else if (nextTransition == L"NotFound")
+                {
+                    context.Reporter.Error() << Resource::String::ConfigurationInstallDscPackageFailed << std::endl;
+                    AICLI_TERMINATE_CONTEXT(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
+                }
+                else
+                {
+                    // InstallStable/InstallPreview etc. are not supported in debug mode; install DSCv3 manually.
+                    context.Reporter.Error() << "DSCv3 unavailable (" << Utility::ConvertToUTF8(nextTransition) << "); use --processor-path or install DSCv3." << std::endl;
+                    AICLI_TERMINATE_CONTEXT(E_NOTIMPL);
+                }
+            }
+        }
+
+        if (Logging::Log().IsEnabled(Logging::Channel::Config, Logging::Level::Verbose))
+        {
+            factoryMap.Insert(ConfigurationRemoting::ToHString(ConfigurationRemoting::PropertyName::DiagnosticTraceEnabled), L"True");
+        }
+
+        // Build and configure the processor.
+        ConfigurationProcessor processor{ factory };
+        processor.Caller(L"winget-debug");
+
+        if (Logging::Log().IsEnabled(Logging::Channel::Config, Logging::Level::Verbose))
+        {
+            processor.MinimumLevel(DiagnosticLevel::Verbose);
+        }
+
+        processor.Diagnostics([&context](const winrt::Windows::Foundation::IInspectable&, const IDiagnosticInformation& diag)
+            {
+                Logging::Level level = Logging::Level::Info;
+                switch (diag.Level())
+                {
+                case DiagnosticLevel::Verbose: level = Logging::Level::Verbose; break;
+                case DiagnosticLevel::Informational: level = Logging::Level::Info; break;
+                case DiagnosticLevel::Warning: level = Logging::Level::Warning; break;
+                case DiagnosticLevel::Error: level = Logging::Level::Error; break;
+                case DiagnosticLevel::Critical: level = Logging::Level::Crit; break;
+                }
+                context.GetThreadGlobals().GetDiagnosticLogger().Write(Logging::Channel::Config, level, Utility::ConvertToUTF8(diag.Message()));
+            });
+
+        // Construct a minimal ConfigurationUnit for the named resource.
+        ConfigurationUnit unit;
+        unit.Type(Utility::ConvertToUTF16(resourceName));
+        unit.Identifier(L"debug-item");
+        unit.Intent(ConfigurationUnitIntent::Inform);
+
+        context.Reporter.Info() << "Exporting resource: " << resourceName << std::endl;
+
+        auto progressScope = context.Reporter.BeginAsyncProgress(true);
+        progressScope->Callback().SetProgressMessage(Resource::String::ConfigurationExportingUnit());
+
+        GetAllConfigurationUnitsResult exportResult = nullptr;
+        {
+            auto exportAction = processor.GetAllUnitsAsync(unit);
+            auto cancellationScope = progressScope->Callback().SetCancellationFunction([&]() { exportAction.Cancel(); });
+            exportResult = exportAction.get();
+        }
+
+        progressScope.reset();
+
+        HRESULT hr = exportResult.ResultInformation().ResultCode();
+        if (FAILED(hr))
+        {
+            auto description = exportResult.ResultInformation().Description();
+            context.Reporter.Error() << "Export failed (0x" << Logging::SetHRFormat << hr << "): ";
+            if (!description.empty())
+            {
+                context.Reporter.Error() << Utility::ConvertToUTF8(description);
+            }
+            context.Reporter.Error() << std::endl;
+            AICLI_TERMINATE_CONTEXT(hr);
+        }
+
+        auto units = exportResult.Units();
+        context.Reporter.Info() << "Exported " << units.Size() << " instance(s):" << std::endl;
+
+        for (const auto& resultUnit : units)
+        {
+            context.Reporter.Info() << "  Type:       " << Utility::ConvertToUTF8(resultUnit.Type()) << std::endl;
+            context.Reporter.Info() << "  Identifier: " << Utility::ConvertToUTF8(resultUnit.Identifier()) << std::endl;
+
+            auto settings = resultUnit.Settings();
+            if (settings && settings.Size() > 0)
+            {
+                context.Reporter.Info() << "  Settings:" << std::endl;
+                for (const auto& [key, value] : settings)
+                {
+                    auto prop = value.try_as<winrt::Windows::Foundation::IPropertyValue>();
+                    if (prop)
+                    {
+                        std::string valueStr;
+                        switch (prop.Type())
+                        {
+                        case winrt::Windows::Foundation::PropertyType::String:
+                            valueStr = Utility::ConvertToUTF8(prop.GetString());
+                            break;
+                        case winrt::Windows::Foundation::PropertyType::Boolean:
+                            valueStr = prop.GetBoolean() ? "true" : "false";
+                            break;
+                        case winrt::Windows::Foundation::PropertyType::Int32:
+                            valueStr = std::to_string(prop.GetInt32());
+                            break;
+                        case winrt::Windows::Foundation::PropertyType::Int64:
+                            valueStr = std::to_string(prop.GetInt64());
+                            break;
+                        default:
+                            valueStr = "(unsupported type)";
+                            break;
+                        }
+                        context.Reporter.Info() << "    " << Utility::ConvertToUTF8(key) << ": " << valueStr << std::endl;
+                    }
+                }
+            }
+
+            context.Reporter.Info() << std::endl;
         }
     }
 }

--- a/src/AppInstallerCLICore/Commands/DebugCommand.h
+++ b/src/AppInstallerCLICore/Commands/DebugCommand.h
@@ -85,6 +85,20 @@ namespace AppInstaller::CLI
     protected:
         void ExecuteInternal(Execution::Context& context) const override;
     };
+
+    // Directly invokes a DSCv3 resource function through WinGet's infrastructure.
+    struct DebugDscResourceCommand final : public Command
+    {
+        DebugDscResourceCommand(std::string_view parent) : Command("dsc-resource", {}, parent) {}
+
+        std::vector<Argument> GetArguments() const override;
+
+        Resource::LocString ShortDescription() const override;
+        Resource::LocString LongDescription() const override;
+
+    protected:
+        void ExecuteInternal(Execution::Context& context) const override;
+    };
 }
 
 #endif

--- a/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
+++ b/src/AppInstallerCLIE2ETests/ConfigureExportCommand.cs
@@ -144,6 +144,7 @@ namespace AppInstallerCLIE2ETests
         /// Export all.
         /// </summary>
         [Test]
+        [Ignore("DSC 3.2 design changes ", Until = "2026-05-10")]
         public void ExportAll()
         {
             var exportDir = TestCommon.GetRandomTestDir();

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
     /// </summary>
     internal class ProcessExecution
     {
+        private static int nextExecutionNumber = 0;
+
         private List<string> outputLines = new List<string>();
         private List<string> errorLines = new List<string>();
 
@@ -26,6 +28,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// </summary>
         public ProcessExecution()
         {
+            this.ExecutionNumber = Interlocked.Increment(ref nextExecutionNumber);
         }
 
         /// <summary>
@@ -37,6 +40,11 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// An event that receives the error lines as they are delivered.
         /// </summary>
         public event EventHandler<string>? ErrorLineReceived;
+
+        /// <summary>
+        /// Gets the monotonically increasing number assigned to this process execution.
+        /// </summary>
+        public int ExecutionNumber { get; }
 
         /// <summary>
         /// Gets the executable path.
@@ -264,7 +272,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
 
             foreach (string line in lines)
             {
-                stringBuilder.AppendLine(line);
+                stringBuilder.Append(line).Append('\n');
             }
 
             return stringBuilder.ToString();

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessExecution.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// <summary>
         /// Gets the data to write to standard input of the process.
         /// </summary>
-        public string? Input { get; init; } = null;
+        public string? Input { get; init; } = string.Empty;
 
         /// <summary>
         /// Gets the list of custom environment variables to use for the process.

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessOutputBatcher.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessOutputBatcher.cs
@@ -1,0 +1,117 @@
+// -----------------------------------------------------------------------------
+// <copyright file="ProcessOutputBatcher.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
+{
+    using System;
+    using System.Text;
+    using System.Threading;
+
+    /// <summary>
+    /// Subscribes to a <see cref="ProcessExecution"/>'s output and error events,
+    /// accumulates lines in a thread-safe buffer, and forwards them to an
+    /// <see cref="IDiagnosticsSink"/> as a single batched message on a fixed interval.
+    /// This avoids one cross-process IPC call per output line while still delivering
+    /// output promptly even if the process never exits.
+    /// </summary>
+    internal sealed class ProcessOutputBatcher : IDisposable
+    {
+        private const string OutputPrefix = "[out] ";
+        private const string ErrorPrefix = "[err] ";
+        private const string BatchHeader = "--- Process Output ---";
+
+        private readonly IDiagnosticsSink? sink;
+        private readonly Timer flushTimer;
+        private readonly object bufferLock = new object();
+        private StringBuilder buffer = new StringBuilder();
+        private bool disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessOutputBatcher"/> class.
+        /// </summary>
+        /// <param name="sink">The diagnostics sink to forward batched output to. May be null.</param>
+        /// <param name="flushInterval">How often to flush accumulated output to the sink.</param>
+        public ProcessOutputBatcher(IDiagnosticsSink? sink, TimeSpan flushInterval)
+        {
+            this.sink = sink;
+            this.flushTimer = new Timer(this.OnTimerTick, null, flushInterval, flushInterval);
+        }
+
+        /// <summary>
+        /// Subscribes to the given <see cref="ProcessExecution"/>'s output and error events.
+        /// Must be called before <see cref="ProcessExecution.Start"/>.
+        /// </summary>
+        /// <param name="processExecution">The process execution to monitor.</param>
+        public void Subscribe(ProcessExecution processExecution)
+        {
+            processExecution.OutputLineReceived += this.OnOutputLineReceived;
+            processExecution.ErrorLineReceived += this.OnErrorLineReceived;
+        }
+
+        /// <summary>
+        /// Stops the timer, flushes any remaining buffered lines to the sink, and disposes resources.
+        /// Call this after <see cref="ProcessExecution.WaitForExit"/> returns to ensure all output is delivered.
+        /// </summary>
+        public void Flush()
+        {
+            this.flushTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            this.EmitBuffer();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                this.disposed = true;
+                this.flushTimer.Dispose();
+            }
+        }
+
+        private void OnOutputLineReceived(object? sender, string line)
+        {
+            lock (this.bufferLock)
+            {
+                this.buffer.AppendLine(OutputPrefix + line);
+            }
+        }
+
+        private void OnErrorLineReceived(object? sender, string line)
+        {
+            lock (this.bufferLock)
+            {
+                this.buffer.AppendLine(ErrorPrefix + line);
+            }
+        }
+
+        private void OnTimerTick(object? state)
+        {
+            this.EmitBuffer();
+        }
+
+        private void EmitBuffer()
+        {
+            if (this.sink == null)
+            {
+                return;
+            }
+
+            StringBuilder toEmit;
+            lock (this.bufferLock)
+            {
+                if (this.buffer.Length == 0)
+                {
+                    return;
+                }
+
+                toEmit = this.buffer;
+                this.buffer = new StringBuilder();
+            }
+
+            this.sink.OnDiagnostics(DiagnosticLevel.Verbose, BatchHeader + "\n" + toEmit);
+        }
+    }
+}

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessOutputBatcher.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Helpers/ProcessOutputBatcher.cs
@@ -19,14 +19,13 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
     /// </summary>
     internal sealed class ProcessOutputBatcher : IDisposable
     {
-        private const string OutputPrefix = "[out] ";
-        private const string ErrorPrefix = "[err] ";
-        private const string BatchHeader = "--- Process Output ---";
-
         private readonly IDiagnosticsSink? sink;
         private readonly Timer flushTimer;
         private readonly object bufferLock = new object();
         private StringBuilder buffer = new StringBuilder();
+        private string batchHeader = "--- Process Output ---";
+        private string outputPrefix = "[out] ";
+        private string errorPrefix = "[err] ";
         private bool disposed = false;
 
         /// <summary>
@@ -47,6 +46,10 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         /// <param name="processExecution">The process execution to monitor.</param>
         public void Subscribe(ProcessExecution processExecution)
         {
+            int number = processExecution.ExecutionNumber;
+            this.batchHeader = $"--- [{number}] Process Output ---";
+            this.outputPrefix = $"[{number}:out] ";
+            this.errorPrefix = $"[{number}:err] ";
             processExecution.OutputLineReceived += this.OnOutputLineReceived;
             processExecution.ErrorLineReceived += this.OnErrorLineReceived;
         }
@@ -75,7 +78,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         {
             lock (this.bufferLock)
             {
-                this.buffer.AppendLine(OutputPrefix + line);
+                this.buffer.Append('\n').Append(this.outputPrefix).Append(line);
             }
         }
 
@@ -83,7 +86,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
         {
             lock (this.bufferLock)
             {
-                this.buffer.AppendLine(ErrorPrefix + line);
+                this.buffer.Append('\n').Append(this.errorPrefix).Append(line);
             }
         }
 
@@ -111,7 +114,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Helpers
                 this.buffer = new StringBuilder();
             }
 
-            this.sink.OnDiagnostics(DiagnosticLevel.Verbose, BatchHeader + "\n" + toEmit);
+            this.sink.OnDiagnostics(DiagnosticLevel.Verbose, this.batchHeader + toEmit);
         }
     }
 }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Model/ResourceKind.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Model/ResourceKind.cs
@@ -36,5 +36,10 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Model
         /// An importer resource.
         /// </summary>
         Importer,
+
+        /// <summary>
+        /// An exporter resource.
+        /// </summary>
+        Exporter,
     }
 }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/DSCv3.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/DSCv3.cs
@@ -273,15 +273,19 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Schema_2024_04
         /// <returns>True if the exit code was not 0.</returns>
         private bool RunSynchronously(ProcessExecution processExecution)
         {
-            this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"Starting process: {processExecution.CommandLine}{(processExecution.Input == null ? string.Empty : $"\n--- Input Stream ---\n{processExecution.Input}")}");
+            this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"[{processExecution.ExecutionNumber}] Starting process: {processExecution.CommandLine}{(processExecution.Input == null ? string.Empty : $"\n--- Input Stream ---\n{processExecution.Input}")}");
 
             using (var batcher = new ProcessOutputBatcher(this.processorSettings.DiagnosticsSink, TimeSpan.FromMilliseconds(500)))
             {
-                batcher.Subscribe(processExecution);
-
-                processExecution.Start().WaitForExit();
-
-                batcher.Flush();
+                try
+                {
+                    batcher.Subscribe(processExecution);
+                    processExecution.Start().WaitForExit();
+                }
+                finally
+                {
+                    batcher.Flush();
+                }
             }
 
             this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"Process exited with code: {processExecution.ExitCode}");

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/DSCv3.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/DSCv3.cs
@@ -275,9 +275,16 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Schema_2024_04
         {
             this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"Starting process: {processExecution.CommandLine}{(processExecution.Input == null ? string.Empty : $"\n--- Input Stream ---\n{processExecution.Input}")}");
 
-            processExecution.Start().WaitForExit();
+            using (var batcher = new ProcessOutputBatcher(this.processorSettings.DiagnosticsSink, TimeSpan.FromMilliseconds(500)))
+            {
+                batcher.Subscribe(processExecution);
 
-            this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"Process exited with code: {processExecution.ExitCode}\n--- Output Stream ---\n{processExecution.GetAllOutputLines()}\n--- Error Stream ---\n{processExecution.GetAllErrorLines()}");
+                processExecution.Start().WaitForExit();
+
+                batcher.Flush();
+            }
+
+            this.processorSettings.DiagnosticsSink?.OnDiagnostics(DiagnosticLevel.Verbose, $"Process exited with code: {processExecution.ExitCode}");
 
             return processExecution.ExitCode != 0;
         }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/Definitions/ResourceKind.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/Definitions/ResourceKind.cs
@@ -43,5 +43,10 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Schema_2024_04.Defi
         /// The name used by the code.
         /// </summary>
         Importer = Import,
+
+        /// <summary>
+        /// An exporter resource.
+        /// </summary>
+        Exporter,
     }
 }

--- a/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/Outputs/ResourceListItem.cs
+++ b/src/Microsoft.Management.Configuration.Processor/DSCv3/Schema_2024_04/Outputs/ResourceListItem.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Management.Configuration.Processor.DSCv3.Schema_2024_04.Outp
             Definitions.ResourceKind.Adapter => Model.ResourceKind.Adapter,
             Definitions.ResourceKind.Group => Model.ResourceKind.Group,
             Definitions.ResourceKind.Import => Model.ResourceKind.Importer,
+            Definitions.ResourceKind.Exporter => Model.ResourceKind.Exporter,
             _ => throw new System.IO.InvalidDataException($"Unknown ResourceKind: {this.Kind}")
         };
 


### PR DESCRIPTION
## Change
To investigate why dsc appears to start hanging with 3.2.0, output dsc lines in batches on a timer rather than after the process has exited.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6196)