### PR TITLE
Mitigate stack overflow issue

### DIFF
--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -267,6 +267,20 @@ namespace AppInstaller::Http
             toThrow = HRESULT_FROM_WIN32(errorValue);
         }
 
-        THROW_HR_MSG(toThrow, "%hs", exception.what());
+        // Ensure that sufficient stack space remains to include the message.
+        // We have seen rare crashes due to running out of stack space in this path
+        // so we will only include the message if there is enough space.
+        // PrintLoggingMessage usage in WIL always creates a 4K stack buffer (2K of wchar_t),
+        // so we leave some on top of that as well as the buffer is kept alive into further calls.
+        static constexpr size_t s_msgMinimum = 5 * 1024;
+
+        if (Runtime::IsStackAvailable(s_msgMinimum))
+        {
+            THROW_HR_MSG(toThrow, "%hs", exception.what());
+        }
+        else
+        {
+            THROW_HR(toThrow);
+        }
     }
 }

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -272,7 +272,7 @@ namespace AppInstaller::Repository
         std::string GetIdentifier() const;
 
         // Get the source's configuration details from settings.
-        SourceDetails GetDetails() const;
+        const SourceDetails& GetDetails() const;
 
         // Get the source's information.
         SourceInformation GetInformation() const;

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -621,7 +621,7 @@ namespace AppInstaller::Repository
         }
     }
 
-    SourceDetails Source::GetDetails() const
+    const SourceDetails& Source::GetDetails() const
     {
         if (m_source)
         {

--- a/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestClient.cpp
@@ -142,36 +142,34 @@ namespace AppInstaller::Repository::Rest
 
         // Check the cache for a valid information entry
         RestInformationCache informationCache;
-        std::optional<Schema::IRestClient::Information> cachedInformation = informationCache.Get(endpoint, customHeader, caller);
+        std::optional<Schema::IRestClient::Information> result = informationCache.Get(endpoint, customHeader, caller);
 
-        if (cachedInformation)
+        if (!result)
         {
-            return std::move(cachedInformation).value();
+            // Not in cache, make REST call to retrieve it
+            auto headers = GetHeaders(customHeader, caller);
+            CacheControlPolicy cacheControl;
+
+            std::optional<web::json::value> response = helper.HandleGet(
+                endpoint,
+                headers,
+                {},
+                [&](const web::http::http_response& httpResponse)
+                {
+                    cacheControl = CacheControlPolicy{ httpResponse.headers().cache_control() };
+                    return Http::HttpClientHelper::HttpResponseHandlerResult{ std::nullopt, true };
+                });
+
+            THROW_HR_IF(APPINSTALLER_CLI_ERROR_UNSUPPORTED_RESTSOURCE, !response);
+
+            InformationResponseDeserializer responseDeserializer;
+            result = responseDeserializer.Deserialize(response.value());
+
+            // Cache the information value as requested
+            informationCache.Cache(endpoint, customHeader, caller, cacheControl, std::move(response).value());
         }
 
-        // Not in cache, make REST call to retrieve it
-        auto headers = GetHeaders(customHeader, caller);
-        CacheControlPolicy cacheControl;
-
-        std::optional<web::json::value> response = helper.HandleGet(
-            endpoint,
-            headers,
-            {},
-            [&](const web::http::http_response& httpResponse)
-            {
-                cacheControl = CacheControlPolicy{ httpResponse.headers().cache_control() };
-                return Http::HttpClientHelper::HttpResponseHandlerResult{ std::nullopt, true };
-            });
-
-        THROW_HR_IF(APPINSTALLER_CLI_ERROR_UNSUPPORTED_RESTSOURCE, !response);
-
-        InformationResponseDeserializer responseDeserializer;
-        auto result = responseDeserializer.Deserialize(response.value());
-
-        // Cache the information value as requested
-        informationCache.Cache(endpoint, customHeader, caller, cacheControl, std::move(response).value());
-
-        return result;
+        return std::move(result).value();
     }
 
     std::unique_ptr<Schema::IRestClient> RestClient::GetSupportedInterface(

--- a/src/AppInstallerSharedLib/Public/winget/Runtime.h
+++ b/src/AppInstallerSharedLib/Public/winget/Runtime.h
@@ -51,6 +51,10 @@ namespace AppInstaller::Runtime
     //  3. the token is not already elevated
     bool IsRunningWithLimitedToken();
 
+    // Determines if the given amount of stack bytes are available.
+    // If the answer cannot be determined properly, the return value will be `false`.
+    DECLSPEC_NOINLINE bool IsStackAvailable(size_t bytes);
+
     // Returns true if this is a release build; false if not.
     inline constexpr bool IsReleaseBuild()
     {

--- a/src/AppInstallerSharedLib/Runtime.cpp
+++ b/src/AppInstallerSharedLib/Runtime.cpp
@@ -218,4 +218,19 @@ namespace AppInstaller::Runtime
     {
         return wil::get_token_information<TOKEN_ELEVATION_TYPE>() == TokenElevationTypeLimited;
     }
+
+    DECLSPEC_NOINLINE bool IsStackAvailable(size_t bytes)
+    {
+        // https://devblogs.microsoft.com/oldnewthing/20200610-00/?p=103855
+        ULONG_PTR low, high;
+        GetCurrentThreadStackLimits(&low, &high);
+        auto remaining = reinterpret_cast<ULONG_PTR>(&low) - low;
+        if (remaining > high - low) {
+            // Choosing to return false instead of failing
+            return false;
+        }
+        ULONG guarantee = 0;
+        SetThreadStackGuarantee(&guarantee);
+        return remaining >= bytes + guarantee;
+    }
 }

--- a/src/AppInstallerSharedLib/Runtime.cpp
+++ b/src/AppInstallerSharedLib/Runtime.cpp
@@ -225,10 +225,12 @@ namespace AppInstaller::Runtime
         ULONG_PTR low, high;
         GetCurrentThreadStackLimits(&low, &high);
         auto remaining = reinterpret_cast<ULONG_PTR>(&low) - low;
-        if (remaining > high - low) {
+        if (remaining > high - low)
+        {
             // Choosing to return false instead of failing
             return false;
         }
+
         ULONG guarantee = 0;
         SetThreadStackGuarantee(&guarantee);
         return remaining >= bytes + guarantee;


### PR DESCRIPTION
## 📖 Description
We see some very rare crashes where the stack is too small to support the WIL message formatting of `THROW_HR_MSG`.  This change attempts to mitigate that through a few targeted reductions in stack usage (doesn't get a lot but these were the only high ROI locations found) and by probing the remaining stack to decide whether to include the exception message or not on the throw.

## 🔗 References
None.

## 🔍 Validation
Manual run with forced error still includes the exception message.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6224)