### PR TITLE
In-proc certificate pinning validation override

### DIFF
--- a/samples/ConnectionValidationSample/ConnectionValidationSample.csproj
+++ b/samples/ConnectionValidationSample/ConnectionValidationSample.csproj
@@ -38,10 +38,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.Management.Deployment.dll</Link>
     </Content>
-    <Content Include="$(WinGetSrcBinRoot)\Microsoft.Management.Deployment.InProc\Microsoft.Management.Deployment.InProc.pdb">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Microsoft.Management.Deployment.InProc.pdb</Link>
-    </Content>
     <Content Include="$(WinGetSrcBinRoot)\WindowsPackageManager\WindowsPackageManager.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>WindowsPackageManager.dll</Link>

--- a/samples/ConnectionValidationSample/ConnectionValidationSample.csproj
+++ b/samples/ConnectionValidationSample/ConnectionValidationSample.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Platforms>x64;x86;arm64</Platforms>
+    <!-- Override these to match the platform/configuration you built the solution with. -->
+    <WinGetBuildPlatform Condition="'$(WinGetBuildPlatform)' == ''">x64</WinGetBuildPlatform>
+    <WinGetBuildConfiguration Condition="'$(WinGetBuildConfiguration)' == ''">Debug</WinGetBuildConfiguration>
+    <!-- Platform-specific build output root. -->
+    <WinGetSrcBinRoot>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\..\src\$(WinGetBuildPlatform)\$(WinGetBuildConfiguration)'))</WinGetSrcBinRoot>
+  </PropertyGroup>
+
+  <!--
+    Generates a CsWinRT projection from the built winmd so this sample needs no published NuGet package.
+    Build the solution first (src\AppInstallerCLI.sln), then pass a catalog name as the argument.
+    Override the defaults if needed: -p:WinGetBuildPlatform=x64 -p:WinGetBuildConfiguration=Release
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
+    <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CsWinRTInputs Include="$(WinGetSrcBinRoot)\Microsoft.Management.Deployment\Microsoft.Management.Deployment.winmd" />
+  </ItemGroup>
+
+  <!-- Copy the native in-proc COM DLL next to the sample so CsWinRT can activate it. -->
+  <ItemGroup>
+    <Content Include="$(WinGetSrcBinRoot)\Microsoft.Management.Deployment.InProc\Microsoft.Management.Deployment.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Microsoft.Management.Deployment.dll</Link>
+    </Content>
+    <Content Include="$(WinGetSrcBinRoot)\Microsoft.Management.Deployment.InProc\Microsoft.Management.Deployment.InProc.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Microsoft.Management.Deployment.InProc.pdb</Link>
+    </Content>
+    <Content Include="$(WinGetSrcBinRoot)\WindowsPackageManager\WindowsPackageManager.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>WindowsPackageManager.dll</Link>
+    </Content>
+    <Content Include="$(WinGetSrcBinRoot)\WindowsPackageManager\WindowsPackageManager.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>WindowsPackageManager.pdb</Link>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/samples/ConnectionValidationSample/Program.cs
+++ b/samples/ConnectionValidationSample/Program.cs
@@ -48,6 +48,9 @@ catalogRef.ConnectionValidationHandler = (PackageCatalogConnectionValidationEven
     Certificate cert = validationArgs.ServerCertificate;
 
     Console.WriteLine();
+    Console.WriteLine("Catalog connection validation for: " + catalogRef.Info.Name);
+    Console.WriteLine("  at: " + catalogRef.Info.Argument);
+    Console.WriteLine();
     Console.WriteLine("=== Server Certificate ===");
     Console.WriteLine($"  Subject:    {cert.Subject}");
     Console.WriteLine($"  Issuer:     {cert.Issuer}");

--- a/samples/ConnectionValidationSample/Program.cs
+++ b/samples/ConnectionValidationSample/Program.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Sample demonstrating the ConnectionValidationHandler on PackageCatalogReference.
+//
+// This sample retrieves a named package catalog, installs a connection validation
+// callback that shows certificate information, prompts the user to accept or reject
+// the certificate, then reports the Connect() result.
+//
+// Usage: ConnectionValidationSample <CatalogName>
+// Example: ConnectionValidationSample winget
+//
+// Requirements:
+//   - Must run in-process (the ConnectionValidationHandler setter rejects out-of-proc callers).
+//   - The Microsoft.Management.Deployment COM server must be registered (deploy the dev package
+//     or install WinGet from the Microsoft Store).
+
+using Microsoft.Management.Deployment;
+using Windows.Security.Cryptography.Certificates;
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("Usage: ConnectionValidationSample <CatalogName>");
+    Console.Error.WriteLine("Example: ConnectionValidationSample winget");
+    return 1;
+}
+
+string catalogName = args[0];
+
+// Use in-proc activation so that ConnectionValidationHandler can be set.
+// CsWinRT activates PackageManager in-proc via DllGetActivationFactory from
+// Microsoft.Management.Deployment.dll placed alongside this executable.
+var packageManager = new PackageManager();
+
+var catalogRef = packageManager.GetPackageCatalogByName(catalogName);
+if (catalogRef is null)
+{
+    Console.Error.WriteLine($"No catalog named '{catalogName}' found.");
+    Console.Error.WriteLine("Use 'winget source list' to see available catalogs.");
+    return 1;
+}
+
+Console.WriteLine($"Catalog: {catalogRef.Info.Name}  ({catalogRef.Info.Argument})");
+Console.WriteLine("Setting connection validation handler...");
+
+catalogRef.ConnectionValidationHandler = (PackageCatalogConnectionValidationEventArgs validationArgs) =>
+{
+    Certificate cert = validationArgs.ServerCertificate;
+
+    Console.WriteLine();
+    Console.WriteLine("=== Server Certificate ===");
+    Console.WriteLine($"  Subject:    {cert.Subject}");
+    Console.WriteLine($"  Issuer:     {cert.Issuer}");
+    Console.WriteLine($"  Valid from: {cert.ValidFrom}");
+    Console.WriteLine($"  Valid to:   {cert.ValidTo}");
+    Console.WriteLine($"  Serial:     {cert.SerialNumber}");
+    Console.WriteLine("==========================");
+    Console.WriteLine();
+    Console.Write("Accept this certificate? [Y/N]: ");
+
+    while (true)
+    {
+        string? input = Console.ReadLine()?.Trim().ToUpperInvariant();
+        if (input == "Y")
+        {
+            Console.WriteLine("Certificate accepted.");
+            return PackageCatalogConnectionValidationResult.Ok;
+        }
+        else if (input == "N")
+        {
+            Console.WriteLine("Certificate rejected.");
+            return PackageCatalogConnectionValidationResult.CertificateRejected;
+        }
+        else
+        {
+            Console.Write("Please enter Y or N: ");
+        }
+    }
+};
+
+Console.WriteLine("Connecting...");
+ConnectResult result = catalogRef.Connect();
+
+Console.WriteLine();
+Console.WriteLine($"Connect result: {result.Status}");
+
+if (result.Status == ConnectResultStatus.Ok)
+{
+    Console.WriteLine($"Successfully connected to '{catalogName}'.");
+
+    // Run a simple search to force a live network call, since Connect() may serve a cached response.
+    Console.WriteLine("Searching to verify live connection...");
+    var findOptions = new FindPackagesOptions();
+    findOptions.Selectors.Add(new PackageMatchFilter
+    {
+        Field = PackageMatchField.Id,
+        Option = PackageFieldMatchOption.StartsWithCaseInsensitive,
+        Value = "Microsoft.",
+    });
+    var searchResult = result.PackageCatalog.FindPackages(findOptions);
+    Console.WriteLine($"Search result: {searchResult.Status} ({searchResult.Matches.Count} match(es))");
+
+    return 0;
+}
+else
+{
+    Console.Error.WriteLine($"Failed to connect to '{catalogName}'.");
+    if (result.ExtendedErrorCode is not null)
+    {
+        Console.Error.WriteLine($"  Error code: 0x{result.ExtendedErrorCode.HResult:X8}");
+    }
+    return 1;
+}

--- a/src/AppInstallerCLICore/Commands/RootCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/RootCommand.cpp
@@ -102,20 +102,20 @@ namespace AppInstaller::CLI
                 if (groupPolicies.GetState(Settings::TogglePolicy::Policy::AdditionalSources) == Settings::PolicyState::Enabled)
                 {
                     info << std::endl;
-                    auto sources = groupPolicies.GetValueRef<Settings::ValuePolicy::AdditionalSources>();
-                    if (sources.has_value() && !sources->get().empty())
+                    auto sources = groupPolicies.GetValue<Settings::ValuePolicy::AdditionalSources>();
+                    if (sources.has_value() && !sources->empty())
                     {
-                        OutputGroupPolicySourceList(context, sources->get(), Resource::String::SourceListAdditionalSource);
+                        OutputGroupPolicySourceList(context, sources.value(), Resource::String::SourceListAdditionalSource);
                     }
                 }
 
                 if (groupPolicies.GetState(Settings::TogglePolicy::Policy::AllowedSources) == Settings::PolicyState::Enabled)
                 {
                     info << std::endl;
-                    auto sources = groupPolicies.GetValueRef<Settings::ValuePolicy::AllowedSources>();
-                    if (sources.has_value() && !sources->get().empty())
+                    auto sources = groupPolicies.GetValue<Settings::ValuePolicy::AllowedSources>();
+                    if (sources.has_value() && !sources->empty())
                     {
-                        OutputGroupPolicySourceList(context, sources->get(), Resource::String::SourceListAllowedSource);
+                        OutputGroupPolicySourceList(context, sources.value(), Resource::String::SourceListAllowedSource);
                     }
                 }
                 info << std::endl;

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\AppInstallerCLIE2ETests\</OutDir>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86</Platforms>

--- a/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
+++ b/src/AppInstallerCLIE2ETests/AppInstallerCLIE2ETests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\AppInstallerCLIE2ETests\</OutDir>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86</Platforms>

--- a/src/AppInstallerCLIE2ETests/Constants.cs
+++ b/src/AppInstallerCLIE2ETests/Constants.cs
@@ -47,6 +47,9 @@ namespace AppInstallerCLIE2ETests
         public const string TestSourceUrl = @"https://localhost:5001/TestKit";
         public const string TestSourceType = "Microsoft.PreIndexed.Package";
         public const string TestSourceIdentifier = @"WingetE2E.Tests_8wekyb3d8bbwe";
+        public const string RestTestSourceName = @"TestRestSource";
+        public const string RestTestSourceUrl = @"https://localhost:5001/TestKit/TestData/TestRestSource";
+        public const string RestTestSourceType = "Microsoft.Rest";
 
         public const string AICLIPackageFamilyName = "WinGetDevCLI_8wekyb3d8bbwe";
         public const string AICLIPackageName = "WinGetDevCLI";

--- a/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
@@ -10,6 +10,7 @@ namespace AppInstallerCLIE2ETests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Xml.Linq;
     using AppInstallerCLIE2ETests.Helpers;
     using Microsoft.Win32;
@@ -236,6 +237,8 @@ namespace AppInstallerCLIE2ETests
             {
                 key.SetValue(this.ValueName, enabledValue);
             }
+
+            ReloadGroupPolicyIfAvailable();
         }
 
         /// <summary>
@@ -254,6 +257,8 @@ namespace AppInstallerCLIE2ETests
             {
                 key.SetValue(this.ValueName, disabledValue);
             }
+
+            ReloadGroupPolicyIfAvailable();
         }
 
         /// <summary>
@@ -288,6 +293,8 @@ namespace AppInstallerCLIE2ETests
                     }
                 }
             }
+
+            ReloadGroupPolicyIfAvailable();
         }
 
         /// <summary>
@@ -342,6 +349,25 @@ namespace AppInstallerCLIE2ETests
         public void SetEnabledList(IEnumerable<GroupPolicySource> values)
         {
             this.SetEnabledList(values.Select(source => JsonConvert.SerializeObject(source)));
+        }
+
+        [DllImport("WindowsPackageManager.dll", CallingConvention = CallingConvention.StdCall)]
+        private static extern int WindowsPackageManagerTestHook_ReloadGroupPolicy();
+
+        /// <summary>
+        /// Calls the in-process test hook to reload the GroupPolicy singleton from the current registry state.
+        /// Silently ignored if the DLL is not loaded in this process (e.g., out-of-process test scenarios).
+        /// </summary>
+        private static void ReloadGroupPolicyIfAvailable()
+        {
+            try
+            {
+                WindowsPackageManagerTestHook_ReloadGroupPolicy();
+            }
+            catch (Exception)
+            {
+                // The DLL is not loaded in this process (out-of-process scenario); nothing to do.
+            }
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
+++ b/src/AppInstallerCLIE2ETests/GroupPolicyHelper.cs
@@ -134,6 +134,11 @@ namespace AppInstallerCLIE2ETests
         public static GroupPolicyHelper EnableConfigurationProcessorPath { get; private set; } = new GroupPolicyHelper("EnableWindowsPackageManagerConfigurationProcessorPath");
 
         /// <summary>
+        /// Gets the Bypass certificate pinning for Microsoft Store policy.
+        /// </summary>
+        public static GroupPolicyHelper BypassCertificatePinningForMicrosoftStore { get; private set; } = new GroupPolicyHelper("EnableBypassCertificatePinningForMicrosoftStore");
+
+        /// <summary>
         /// Gets the Enable auto update interval policy.
         /// </summary>
         public static GroupPolicyHelper SourceAutoUpdateInterval { get; private set; } = new GroupPolicyHelper("SourceAutoUpdateInterval", "SourceAutoUpdateInterval");

--- a/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
@@ -40,6 +40,7 @@ namespace AppInstallerCLIE2ETests.Interop
         [SetUp]
         public void Setup()
         {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.SetNotConfigured();
             TestCommon.RunAICLICommand("source remove", Constants.RestTestSourceName);
             this.packageManager = this.TestFactory.CreatePackageManager();
         }
@@ -50,6 +51,7 @@ namespace AppInstallerCLIE2ETests.Interop
         [TearDown]
         public void TearDown()
         {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.SetNotConfigured();
             TestCommon.RunAICLICommand("source remove", Constants.RestTestSourceName);
         }
 
@@ -58,6 +60,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// that returning Ok allows the connection to succeed, and that the received certificate matches
         /// the known test server certificate.
         /// </summary>
+        /// <returns>The task.</returns>
         [Test]
         public async Task ConnectionValidationCallback_AllowsConnection_ConnectSucceeds()
         {
@@ -93,6 +96,7 @@ namespace AppInstallerCLIE2ETests.Interop
         /// Verifies that the connection validation callback is invoked and that returning CertificateRejected
         /// causes the connection to fail.
         /// </summary>
+        /// <returns>The task.</returns>
         [Test]
         public async Task ConnectionValidationCallback_RejectsConnection_ConnectFails()
         {
@@ -110,6 +114,71 @@ namespace AppInstallerCLIE2ETests.Interop
             Assert.IsNotNull(connectResult);
             Assert.AreEqual(ConnectResultStatus.CatalogError, connectResult.Status, "Connect should fail when handler rejects the certificate.");
             Assert.IsTrue(handlerCalled, "Handler should have been called.");
+        }
+
+        /// <summary>
+        /// Verifies that setting ConnectionValidationHandler on the Microsoft Store catalog is blocked
+        /// when the BypassCertificatePinningForMicrosoftStore policy is enabled.
+        /// </summary>
+        [Test]
+        public void ConnectionValidationHandler_MicrosoftStore_PolicyEnabled_ThrowsBlockedByPolicy()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Enable();
+
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
+            Assert.IsNotNull(catalogRef);
+
+            var ex = Assert.Throws<Exception>(() =>
+            {
+                catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
+            });
+
+            Assert.AreEqual(
+                Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY,
+                ex.HResult,
+                "Setting ConnectionValidationHandler on MicrosoftStore with policy enabled should return ERROR_BLOCKED_BY_POLICY.");
+        }
+
+        /// <summary>
+        /// Verifies that setting ConnectionValidationHandler on the Microsoft Store catalog is blocked
+        /// when the BypassCertificatePinningForMicrosoftStore policy is disabled.
+        /// </summary>
+        [Test]
+        public void ConnectionValidationHandler_MicrosoftStore_PolicyDisabled_ThrowsBlockedByPolicy()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Disable();
+
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
+            Assert.IsNotNull(catalogRef);
+
+            var ex = Assert.Throws<Exception>(() =>
+            {
+                catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
+            });
+
+            Assert.AreEqual(
+                Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY,
+                ex.HResult,
+                "Setting ConnectionValidationHandler on MicrosoftStore with policy disabled should return ERROR_BLOCKED_BY_POLICY.");
+        }
+
+        /// <summary>
+        /// Verifies that setting ConnectionValidationHandler on a non-Store catalog is allowed
+        /// even when the BypassCertificatePinningForMicrosoftStore policy is configured.
+        /// </summary>
+        /// <returns>The task.</returns>
+        [Test]
+        public async Task ConnectionValidationHandler_NonStoreCatalog_PolicyEnabled_Allowed()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Enable();
+
+            var catalogRef = await this.AddRestCatalogAsync();
+
+            // This should not throw — the policy only applies to the MicrosoftStore catalog.
+            Assert.DoesNotThrow(() =>
+            {
+                catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
+            });
         }
 
         private static byte[] GetCertificateDerBytes(Certificate certificate)
@@ -143,6 +212,8 @@ namespace AppInstallerCLIE2ETests.Interop
             return catalogRef;
         }
     }
+
+#pragma warning disable SA1402 // File may only contain a single type
 
     /// <summary>
     /// Verifies that the ConnectionValidationHandler setter is restricted to in-proc callers.

--- a/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
@@ -1,0 +1,196 @@
+// -----------------------------------------------------------------------------
+// <copyright file="ConnectionValidationInterop.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+namespace AppInstallerCLIE2ETests.Interop
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using AppInstallerCLIE2ETests.Helpers;
+    using Microsoft.Management.Deployment;
+    using Microsoft.Management.Deployment.Projection;
+    using NUnit.Framework;
+    using Windows.Security.Cryptography.Certificates;
+    using Windows.Storage.Streams;
+
+    /// <summary>
+    /// Tests for the in-proc connection validation callback on PackageCatalogReference.
+    /// These tests require an in-process COM server because ConnectionValidationHandler
+    /// can only be set by in-proc callers.
+    /// </summary>
+    [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.InProcess), Category = nameof(InstanceInitializersSource.InProcess))]
+    public class ConnectionValidationInterop : BaseInterop
+    {
+        private PackageManager packageManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionValidationInterop"/> class.
+        /// </summary>
+        /// <param name="initializer">initializer.</param>
+        public ConnectionValidationInterop(IInstanceInitializer initializer)
+            : base(initializer)
+        {
+        }
+
+        /// <summary>
+        /// Set up before each test: create a package manager and ensure the REST source is not present.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            TestCommon.RunAICLICommand("source remove", Constants.RestTestSourceName);
+            this.packageManager = this.TestFactory.CreatePackageManager();
+        }
+
+        /// <summary>
+        /// Tear down after each test: remove the REST source if it was added.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            TestCommon.RunAICLICommand("source remove", Constants.RestTestSourceName);
+        }
+
+        /// <summary>
+        /// Verifies that the connection validation callback is invoked with a non-null server certificate,
+        /// that returning Ok allows the connection to succeed, and that the received certificate matches
+        /// the known test server certificate.
+        /// </summary>
+        [Test]
+        public async Task ConnectionValidationCallback_AllowsConnection_ConnectSucceeds()
+        {
+            var catalogRef = await this.AddRestCatalogAsync();
+
+            byte[] receivedCertDer = null;
+            catalogRef.ConnectionValidationHandler = (args) =>
+            {
+                receivedCertDer = GetCertificateDerBytes(args.ServerCertificate);
+                return PackageCatalogConnectionValidationResult.Ok;
+            };
+
+            var connectResult = catalogRef.Connect();
+
+            Assert.IsNotNull(connectResult);
+            Assert.AreEqual(ConnectResultStatus.Ok, connectResult.Status, "Connect should succeed when handler returns Ok.");
+            Assert.IsNotNull(connectResult.PackageCatalog, "PackageCatalog should be non-null on success.");
+            Assert.IsNotNull(receivedCertDer, "Handler should have been called with a non-null certificate.");
+
+            // Verify the received certificate matches the test server's known certificate.
+            if (!string.IsNullOrEmpty(TestSetup.Parameters.LocalServerCertPath) &&
+                File.Exists(TestSetup.Parameters.LocalServerCertPath))
+            {
+                byte[] expectedCertDer = File.ReadAllBytes(TestSetup.Parameters.LocalServerCertPath);
+                Assert.AreEqual(
+                    expectedCertDer,
+                    receivedCertDer,
+                    "The certificate received in the callback should match the test server's certificate.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the connection validation callback is invoked and that returning CertificateRejected
+        /// causes the connection to fail.
+        /// </summary>
+        [Test]
+        public async Task ConnectionValidationCallback_RejectsConnection_ConnectFails()
+        {
+            var catalogRef = await this.AddRestCatalogAsync();
+
+            bool handlerCalled = false;
+            catalogRef.ConnectionValidationHandler = (args) =>
+            {
+                handlerCalled = true;
+                return PackageCatalogConnectionValidationResult.CertificateRejected;
+            };
+
+            var connectResult = catalogRef.Connect();
+
+            Assert.IsNotNull(connectResult);
+            Assert.AreEqual(ConnectResultStatus.CatalogError, connectResult.Status, "Connect should fail when handler rejects the certificate.");
+            Assert.IsTrue(handlerCalled, "Handler should have been called.");
+        }
+
+        private static byte[] GetCertificateDerBytes(Certificate certificate)
+        {
+            if (certificate is null)
+            {
+                return null;
+            }
+
+            var blob = certificate.GetCertificateBlob();
+            var bytes = new byte[blob.Length];
+            using var reader = DataReader.FromBuffer(blob);
+            reader.ReadBytes(bytes);
+            return bytes;
+        }
+
+        private async Task<PackageCatalogReference> AddRestCatalogAsync()
+        {
+            var options = this.TestFactory.CreateAddPackageCatalogOptions();
+            options.Name = Constants.RestTestSourceName;
+            options.SourceUri = Constants.RestTestSourceUrl;
+            options.Type = Constants.RestTestSourceType;
+            options.TrustLevel = PackageCatalogTrustLevel.Trusted;
+
+            var addResult = await this.packageManager.AddPackageCatalogAsync(options);
+            Assert.IsNotNull(addResult);
+            Assert.AreEqual(AddPackageCatalogStatus.Ok, addResult.Status, $"Failed to add REST test source. Error: {addResult.ExtendedErrorCode?.HResult:X}");
+
+            var catalogRef = this.packageManager.GetPackageCatalogByName(Constants.RestTestSourceName);
+            Assert.IsNotNull(catalogRef, "REST test source catalog reference should not be null after adding.");
+            return catalogRef;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the ConnectionValidationHandler setter is restricted to in-proc callers.
+    /// </summary>
+    [TestFixtureSource(typeof(InstanceInitializersSource), nameof(InstanceInitializersSource.OutOfProcess), Category = nameof(InstanceInitializersSource.OutOfProcess))]
+    public class ConnectionValidationHandlerOutOfProcessInterop : BaseInterop
+    {
+        private PackageManager packageManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionValidationHandlerOutOfProcessInterop"/> class.
+        /// </summary>
+        /// <param name="initializer">initializer.</param>
+        public ConnectionValidationHandlerOutOfProcessInterop(IInstanceInitializer initializer)
+            : base(initializer)
+        {
+        }
+
+        /// <summary>
+        /// Set up.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            this.packageManager = this.TestFactory.CreatePackageManager();
+        }
+
+        /// <summary>
+        /// Verifies that setting ConnectionValidationHandler from an out-of-process caller throws an access denied exception.
+        /// </summary>
+        [Test]
+        public void ConnectionValidationHandler_OutOfProcess_ThrowsAccessDenied()
+        {
+            // Use the default winget catalog -- we just need any catalog reference.
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.OpenWindowsCatalog);
+            Assert.IsNotNull(catalogRef);
+
+            // Setting the handler from out-of-proc should be rejected with E_ACCESSDENIED.
+            var ex = Assert.Throws<Exception>(() =>
+            {
+                catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
+            });
+
+            Assert.IsNotNull(ex);
+
+            // The exception should carry E_ACCESSDENIED (0x80070005).
+            const int E_ACCESSDENIED = unchecked((int)0x80070005);
+            Assert.AreEqual(E_ACCESSDENIED, ex.HResult, "Setting ConnectionValidationHandler out-of-proc should return E_ACCESSDENIED.");
+        }
+    }
+}

--- a/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
@@ -252,16 +252,10 @@ namespace AppInstallerCLIE2ETests.Interop
             Assert.IsNotNull(catalogRef);
 
             // Setting the handler from out-of-proc should be rejected with E_ACCESSDENIED.
-            var ex = Assert.Throws<Exception>(() =>
+            Assert.Throws<UnauthorizedAccessException>(() =>
             {
                 catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
             });
-
-            Assert.IsNotNull(ex);
-
-            // The exception should carry E_ACCESSDENIED (0x80070005).
-            const int E_ACCESSDENIED = unchecked((int)0x80070005);
-            Assert.AreEqual(E_ACCESSDENIED, ex.HResult, "Setting ConnectionValidationHandler out-of-proc should return E_ACCESSDENIED.");
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
@@ -117,26 +117,22 @@ namespace AppInstallerCLIE2ETests.Interop
         }
 
         /// <summary>
-        /// Verifies that setting ConnectionValidationHandler on the Microsoft Store catalog is blocked
+        /// Verifies that setting ConnectionValidationHandler on the Microsoft Store catalog is allowed
         /// when the BypassCertificatePinningForMicrosoftStore policy is enabled.
         /// </summary>
         [Test]
-        public void ConnectionValidationHandler_MicrosoftStore_PolicyEnabled_ThrowsBlockedByPolicy()
+        public void ConnectionValidationHandler_MicrosoftStore_PolicyEnabled_Allowed()
         {
             GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Enable();
 
             var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
             Assert.IsNotNull(catalogRef);
 
-            var ex = Assert.Throws<Exception>(() =>
+            // Policy enabled means the feature is allowed; setting the handler should not throw.
+            Assert.DoesNotThrow(() =>
             {
                 catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
             });
-
-            Assert.AreEqual(
-                Constants.ErrorCode.ERROR_BLOCKED_BY_POLICY,
-                ex.HResult,
-                "Setting ConnectionValidationHandler on MicrosoftStore with policy enabled should return ERROR_BLOCKED_BY_POLICY.");
         }
 
         /// <summary>
@@ -179,6 +175,80 @@ namespace AppInstallerCLIE2ETests.Interop
             {
                 catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
             });
+        }
+
+        /// <summary>
+        /// Verifies that setting ConnectionValidationHandler on a non-Store catalog is allowed
+        /// even when the BypassCertificatePinningForMicrosoftStore policy is disabled.
+        /// </summary>
+        /// <returns>The task.</returns>
+        [Test]
+        public async Task ConnectionValidationHandler_NonStoreCatalog_PolicyDisabled_Allowed()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Disable();
+
+            var catalogRef = await this.AddRestCatalogAsync();
+
+            // The policy only applies to the MicrosoftStore catalog.
+            Assert.DoesNotThrow(() =>
+            {
+                catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
+            });
+        }
+
+        /// <summary>
+        /// Verifies that IsConnectionValidationHandlerEnabled returns true for a non-Store catalog
+        /// regardless of policy state.
+        /// </summary>
+        /// <returns>The task.</returns>
+        [Test]
+        public async Task IsConnectionValidationHandlerEnabled_NonStoreCatalog_ReturnsTrue()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Disable();
+
+            var catalogRef = await this.AddRestCatalogAsync();
+            Assert.IsTrue(catalogRef.IsConnectionValidationHandlerEnabled, "Non-store catalog should always report handler enabled.");
+        }
+
+        /// <summary>
+        /// Verifies that IsConnectionValidationHandlerEnabled returns false for the MicrosoftStore
+        /// catalog when the policy is disabled.
+        /// </summary>
+        [Test]
+        public void IsConnectionValidationHandlerEnabled_MicrosoftStore_PolicyDisabled_ReturnsFalse()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Disable();
+
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
+            Assert.IsNotNull(catalogRef);
+            Assert.IsFalse(catalogRef.IsConnectionValidationHandlerEnabled, "MicrosoftStore catalog with policy disabled should report handler not enabled.");
+        }
+
+        /// <summary>
+        /// Verifies that IsConnectionValidationHandlerEnabled returns true for the MicrosoftStore
+        /// catalog when the policy is enabled.
+        /// </summary>
+        [Test]
+        public void IsConnectionValidationHandlerEnabled_MicrosoftStore_PolicyEnabled_ReturnsTrue()
+        {
+            GroupPolicyHelper.BypassCertificatePinningForMicrosoftStore.Enable();
+
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
+            Assert.IsNotNull(catalogRef);
+            Assert.IsTrue(catalogRef.IsConnectionValidationHandlerEnabled, "MicrosoftStore catalog with policy enabled should report handler enabled.");
+        }
+
+        /// <summary>
+        /// Verifies that IsConnectionValidationHandlerEnabled returns true for the MicrosoftStore
+        /// catalog when the policy is not configured.
+        /// </summary>
+        [Test]
+        public void IsConnectionValidationHandlerEnabled_MicrosoftStore_PolicyNotConfigured_ReturnsTrue()
+        {
+            // Policy is left at NotConfigured (set by SetUp).
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
+            Assert.IsNotNull(catalogRef);
+            Assert.IsTrue(catalogRef.IsConnectionValidationHandlerEnabled, "MicrosoftStore catalog with policy not configured should report handler enabled.");
         }
 
         private static byte[] GetCertificateDerBytes(Certificate certificate)
@@ -256,6 +326,17 @@ namespace AppInstallerCLIE2ETests.Interop
             {
                 catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
             });
+        }
+
+        /// <summary>
+        /// Verifies that IsConnectionValidationHandlerEnabled returns false for out-of-process callers.
+        /// </summary>
+        [Test]
+        public void IsConnectionValidationHandlerEnabled_OutOfProcess_ReturnsFalse()
+        {
+            var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.OpenWindowsCatalog);
+            Assert.IsNotNull(catalogRef);
+            Assert.IsFalse(catalogRef.IsConnectionValidationHandlerEnabled, "Out-of-process callers should always see IsConnectionValidationHandlerEnabled as false.");
         }
     }
 }

--- a/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
+++ b/src/AppInstallerCLIE2ETests/Interop/ConnectionValidationInterop.cs
@@ -7,6 +7,7 @@ namespace AppInstallerCLIE2ETests.Interop
 {
     using System;
     using System.IO;
+    using System.Runtime.InteropServices;
     using System.Threading.Tasks;
     using AppInstallerCLIE2ETests.Helpers;
     using Microsoft.Management.Deployment;
@@ -147,7 +148,7 @@ namespace AppInstallerCLIE2ETests.Interop
             var catalogRef = this.packageManager.GetPredefinedPackageCatalog(PredefinedPackageCatalog.MicrosoftStore);
             Assert.IsNotNull(catalogRef);
 
-            var ex = Assert.Throws<Exception>(() =>
+            var ex = Assert.Throws<COMException>(() =>
             {
                 catalogRef.ConnectionValidationHandler = (args) => PackageCatalogConnectionValidationResult.Ok;
             });

--- a/src/AppInstallerCLIE2ETests/TestData/TestRestSource/information
+++ b/src/AppInstallerCLIE2ETests/TestData/TestRestSource/information
@@ -1,0 +1,6 @@
+{
+  "Data": {
+    "SourceIdentifier": "TestRestSource",
+    "ServerSupportedVersions": ["1.0.0"]
+  }
+}

--- a/src/AppInstallerCommonCore/AdminSettings.cpp
+++ b/src/AppInstallerCommonCore/AdminSettings.cpp
@@ -277,12 +277,12 @@ namespace AppInstaller::Settings
             return GroupPolicies().GetState(policy);
         }
 
-        std::optional<std::reference_wrapper<const std::string>> GetPolicyStateForSetting(StringAdminSetting setting)
+        std::optional<std::string> GetPolicyStateForSetting(StringAdminSetting setting)
         {
             switch (setting)
             {
             case AppInstaller::Settings::StringAdminSetting::DefaultProxy:
-                return GroupPolicies().GetValueRef<ValuePolicy::DefaultProxy>();
+                return GroupPolicies().GetValue<ValuePolicy::DefaultProxy>();
             default:
                 return std::nullopt;
             }

--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include <AppInstallerDownloader.h>
 #include <AppInstallerRuntime.h>
+#include <winget/GroupPolicy.h>
 #include <winget/HttpClientHelper.h>
 #include <winget/NetworkSettings.h>
 #include <winhttp.h>
@@ -22,7 +23,7 @@ namespace AppInstaller::Http
             }
         }
 
-        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const Certificates::PinningConfiguration& pinningConfiguration, ThreadLocalStorage::ThreadGlobals* threadGlobals)
+        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const Certificates::PinningConfiguration& pinningConfiguration, const std::function<bool(PCCERT_CONTEXT)>& customValidation, ThreadLocalStorage::ThreadGlobals* threadGlobals)
         {
             decltype(threadGlobals->SetForCurrentThread()) previousThreadGlobals;
             if (threadGlobals)
@@ -38,6 +39,12 @@ namespace AppInstaller::Http
             THROW_IF_WIN32_BOOL_FALSE(WinHttpQueryOption(requestHandle, WINHTTP_OPTION_SERVER_CERT_CONTEXT, &certContext, &bufferSize));
 
             THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !pinningConfiguration.Validate(certContext.get()));
+
+            // Invoke the custom validation callback only when the certificate pinning group policy is not configured.
+            if (customValidation && AppInstaller::Settings::GroupPolicies().GetState(AppInstaller::Settings::TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) == AppInstaller::Settings::PolicyState::NotConfigured)
+            {
+                THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !customValidation(certContext.get()));
+            }
         }
 
         std::chrono::seconds GetRetryAfter(const web::http::http_headers& headers)
@@ -184,10 +191,15 @@ namespace AppInstaller::Http
 
     void HttpClientHelper::SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals)
     {
-        m_clientConfig.set_nativehandle_servercertificate_validation([pinConfig = configuration, globals = std::move(threadGlobals)](web::http::client::native_handle handle)
+        m_clientConfig.set_nativehandle_servercertificate_validation([pinConfig = configuration, customValidation = m_serverCertValidationCallback, globals = std::move(threadGlobals)](web::http::client::native_handle handle)
             {
-                NativeHandleServerCertificateValidation(handle, pinConfig, globals.get());
+                NativeHandleServerCertificateValidation(handle, pinConfig, customValidation, globals.get());
             });
+    }
+
+    void HttpClientHelper::SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback)
+    {
+        m_serverCertValidationCallback = std::move(callback);
     }
 
     web::http::client::http_client HttpClientHelper::GetClient(const utility::string_t& uri) const

--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -23,7 +23,7 @@ namespace AppInstaller::Http
             }
         }
 
-        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const Certificates::PinningConfiguration& pinningConfiguration, const std::function<bool(PCCERT_CONTEXT)>& customValidation, ThreadLocalStorage::ThreadGlobals* threadGlobals)
+        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const std::function<bool(PCCERT_CONTEXT)>& validation, ThreadLocalStorage::ThreadGlobals* threadGlobals)
         {
             decltype(threadGlobals->SetForCurrentThread()) previousThreadGlobals;
             if (threadGlobals)
@@ -38,13 +38,7 @@ namespace AppInstaller::Http
             DWORD bufferSize = sizeof(&certContext);
             THROW_IF_WIN32_BOOL_FALSE(WinHttpQueryOption(requestHandle, WINHTTP_OPTION_SERVER_CERT_CONTEXT, &certContext, &bufferSize));
 
-            THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !pinningConfiguration.Validate(certContext.get()));
-
-            // Invoke the custom validation callback only when the certificate pinning group policy is not configured.
-            if (customValidation && AppInstaller::Settings::GroupPolicies().GetState(AppInstaller::Settings::TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) == AppInstaller::Settings::PolicyState::NotConfigured)
-            {
-                THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !customValidation(certContext.get()));
-            }
+            THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !validation(certContext.get()));
         }
 
         std::chrono::seconds GetRetryAfter(const web::http::http_headers& headers)
@@ -189,17 +183,24 @@ namespace AppInstaller::Http
         RethrowAsWilException(exception);
     }
 
-    void HttpClientHelper::SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals)
+    void HttpClientHelper::SetPinningConfiguration(
+        const Certificates::PinningConfiguration& configuration,
+        std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals,
+        std::function<bool(PCCERT_CONTEXT)> validationCallback)
     {
-        m_clientConfig.set_nativehandle_servercertificate_validation([pinConfig = configuration, customValidation = m_serverCertValidationCallback, globals = std::move(threadGlobals)](web::http::client::native_handle handle)
-            {
-                NativeHandleServerCertificateValidation(handle, pinConfig, customValidation, globals.get());
-            });
-    }
+        using namespace AppInstaller::Settings;
 
-    void HttpClientHelper::SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback)
-    {
-        m_serverCertValidationCallback = std::move(callback);
+        // Only allow the validation callback when the policy is not configured.
+        if (!validationCallback ||
+            GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured)
+        {
+            validationCallback = [pinConfig = configuration](PCCERT_CONTEXT context) { return pinConfig.Validate(context); };
+        }
+
+        m_clientConfig.set_nativehandle_servercertificate_validation([validation = std::move(validationCallback), globals = std::move(threadGlobals)](web::http::client::native_handle handle)
+            {
+                NativeHandleServerCertificateValidation(handle, validation, globals.get());
+            });
     }
 
     web::http::client::http_client HttpClientHelper::GetClient(const utility::string_t& uri) const

--- a/src/AppInstallerCommonCore/HttpClientHelper.cpp
+++ b/src/AppInstallerCommonCore/HttpClientHelper.cpp
@@ -3,7 +3,6 @@
 #include "pch.h"
 #include <AppInstallerDownloader.h>
 #include <AppInstallerRuntime.h>
-#include <winget/GroupPolicy.h>
 #include <winget/HttpClientHelper.h>
 #include <winget/NetworkSettings.h>
 #include <winhttp.h>
@@ -23,7 +22,7 @@ namespace AppInstaller::Http
             }
         }
 
-        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const std::function<bool(PCCERT_CONTEXT)>& validation, ThreadLocalStorage::ThreadGlobals* threadGlobals)
+        void NativeHandleServerCertificateValidation(web::http::client::native_handle handle, const Certificates::PinningConfiguration& pinningConfiguration, ThreadLocalStorage::ThreadGlobals* threadGlobals)
         {
             decltype(threadGlobals->SetForCurrentThread()) previousThreadGlobals;
             if (threadGlobals)
@@ -38,7 +37,7 @@ namespace AppInstaller::Http
             DWORD bufferSize = sizeof(&certContext);
             THROW_IF_WIN32_BOOL_FALSE(WinHttpQueryOption(requestHandle, WINHTTP_OPTION_SERVER_CERT_CONTEXT, &certContext, &bufferSize));
 
-            THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !validation(certContext.get()));
+            THROW_HR_IF(APPINSTALLER_CLI_ERROR_PINNED_CERTIFICATE_MISMATCH, !pinningConfiguration.Validate(certContext.get()));
         }
 
         std::chrono::seconds GetRetryAfter(const web::http::http_headers& headers)
@@ -183,23 +182,11 @@ namespace AppInstaller::Http
         RethrowAsWilException(exception);
     }
 
-    void HttpClientHelper::SetPinningConfiguration(
-        const Certificates::PinningConfiguration& configuration,
-        std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals,
-        std::function<bool(PCCERT_CONTEXT)> validationCallback)
+    void HttpClientHelper::SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals)
     {
-        using namespace AppInstaller::Settings;
-
-        // Only allow the validation callback when the policy is not configured.
-        if (!validationCallback ||
-            GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured)
-        {
-            validationCallback = [pinConfig = configuration](PCCERT_CONTEXT context) { return pinConfig.Validate(context); };
-        }
-
-        m_clientConfig.set_nativehandle_servercertificate_validation([validation = std::move(validationCallback), globals = std::move(threadGlobals)](web::http::client::native_handle handle)
+        m_clientConfig.set_nativehandle_servercertificate_validation([pinConfig = configuration, globals = std::move(threadGlobals)](web::http::client::native_handle handle)
             {
-                NativeHandleServerCertificateValidation(handle, validation, globals.get());
+                NativeHandleServerCertificateValidation(handle, pinConfig, globals.get());
             });
     }
 

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -38,6 +38,11 @@ namespace AppInstaller::Http
 
         void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {});
 
+        // Set a custom server certificate validation callback. Called after built-in pinning validation,
+        // only when the certificate pinning group policy is not configured.
+        // Return true to accept the connection, false to reject.
+        void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback);
+
     protected:
         std::optional<web::json::value> ValidateAndExtractResponse(const web::http::http_response& response) const;
 
@@ -51,5 +56,6 @@ namespace AppInstaller::Http
 
         std::shared_ptr<web::http::http_pipeline_stage> m_defaultRequestHandlerStage;
         web::http::client::http_client_config m_clientConfig;
+        std::function<bool(PCCERT_CONTEXT)> m_serverCertValidationCallback;
     };
 }

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -36,7 +36,7 @@ namespace AppInstaller::Http
 
         std::optional<web::json::value> HandleGet(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}, const HttpResponseHandler& customHandler = {}) const;
 
-        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {}, std::function<bool(PCCERT_CONTEXT)> validationCallback = {});
+        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {});
 
     protected:
         std::optional<web::json::value> ValidateAndExtractResponse(const web::http::http_response& response) const;

--- a/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
+++ b/src/AppInstallerCommonCore/Public/winget/HttpClientHelper.h
@@ -36,12 +36,7 @@ namespace AppInstaller::Http
 
         std::optional<web::json::value> HandleGet(const utility::string_t& uri, const HttpRequestHeaders& headers = {}, const HttpRequestHeaders& authHeaders = {}, const HttpResponseHandler& customHandler = {}) const;
 
-        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {});
-
-        // Set a custom server certificate validation callback. Called after built-in pinning validation,
-        // only when the certificate pinning group policy is not configured.
-        // Return true to accept the connection, false to reject.
-        void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback);
+        void SetPinningConfiguration(const Certificates::PinningConfiguration& configuration, std::shared_ptr<ThreadLocalStorage::ThreadGlobals> threadGlobals = {}, std::function<bool(PCCERT_CONTEXT)> validationCallback = {});
 
     protected:
         std::optional<web::json::value> ValidateAndExtractResponse(const web::http::http_response& response) const;
@@ -56,6 +51,5 @@ namespace AppInstaller::Http
 
         std::shared_ptr<web::http::http_pipeline_stage> m_defaultRequestHandlerStage;
         web::http::client::http_client_config m_clientConfig;
-        std::function<bool(PCCERT_CONTEXT)> m_serverCertValidationCallback;
     };
 }

--- a/src/AppInstallerRepositoryCore/ISource.h
+++ b/src/AppInstallerRepositoryCore/ISource.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "Public/winget/RepositorySource.h"
 #include <winget/SharedThreadGlobals.h>
+#include <functional>
 #include <memory>
 
 namespace AppInstaller::Repository
@@ -91,6 +92,10 @@ namespace AppInstaller::Repository
 
         // Set authentication arguments.
         virtual void SetAuthenticationArguments(Authentication::AuthenticationArguments) {}
+
+        // Set a custom server certificate validation callback.
+        // Return true from the callback to accept the connection, false to reject.
+        virtual void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)>) {}
 
         // Determine if the source needs to be updated before being opened.
         virtual bool ShouldUpdateBeforeOpen(const std::optional<TimeSpan>&) { return false; }

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -293,6 +293,11 @@ namespace AppInstaller::Repository
         // Set authentication arguments. Must be set before Open to have effect.
         void SetAuthenticationArguments(Authentication::AuthenticationArguments args);
 
+        // Set a custom server certificate validation callback. Must be set before Open to have effect.
+        // Return true from the callback to accept the connection, false to reject.
+        // Only invoked when the certificate pinning group policy is not configured.
+        void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback);
+
         // Set thread globals. Must be set before Open to have effect.
         void SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>& threadGlobals);
 

--- a/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
+++ b/src/AppInstallerRepositoryCore/Public/winget/RepositorySource.h
@@ -309,7 +309,7 @@ namespace AppInstaller::Repository
         void InstalledPackageInformationOnly(bool value);
 
         // Determines if this source refers to the given well known source.
-        bool IsWellKnownSource(WellKnownSource wellKnownSource);
+        bool IsWellKnownSource(WellKnownSource wellKnownSource) const;
 
         // Execute a search on the source.
         SearchResult Search(const SearchRequest& request) const;

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -713,7 +713,7 @@ namespace AppInstaller::Repository
         m_installedPackageInformationOnly = value;
     }
 
-    bool Source::IsWellKnownSource(WellKnownSource wellKnownSource)
+    bool Source::IsWellKnownSource(WellKnownSource wellKnownSource) const
     {
         SourceDetails details = GetDetails();
         auto wellKnown = CheckForWellKnownSourceMatch(details.Name, details.Arg, details.Type);

--- a/src/AppInstallerRepositoryCore/RepositorySource.cpp
+++ b/src/AppInstallerRepositoryCore/RepositorySource.cpp
@@ -687,6 +687,14 @@ namespace AppInstaller::Repository
         }
     }
 
+    void Source::SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback)
+    {
+        for (auto& sourceReference : m_sourceReferences)
+        {
+            sourceReference->SetServerCertificateValidationCallback(callback);
+        }
+    }
+
     void Source::SetThreadGlobals(const std::shared_ptr<ThreadLocalStorage::ThreadGlobals>& threadGlobals)
     {
         for (auto& sourceReference : m_sourceReferences)

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -49,7 +49,9 @@ namespace AppInstaller::Repository::Rest
 
             void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback) override
             {
-                m_serverCertValidationCallback = std::move(callback);
+                Certificates::PinningConfiguration config;
+                config.AddChain(std::make_shared<Certificates::CallbackPinningChainValidation>(std::move(callback)));
+                m_overridePinningConfiguration = std::move(config);
             }
 
             std::shared_ptr<ISource> Open(IProgressCallback&) override
@@ -70,7 +72,10 @@ namespace AppInstaller::Repository::Rest
                 std::call_once(m_initializeFlag,
                     [&]()
                     {
-                        m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration, m_threadGlobals, m_serverCertValidationCallback);
+                        const auto& pinConfig = m_overridePinningConfiguration.has_value()
+                            ? *m_overridePinningConfiguration
+                            : m_details.CertificatePinningConfiguration;
+                        m_httpClientHelper.SetPinningConfiguration(pinConfig, m_threadGlobals);
                         m_restClientInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
 
                         m_details.Identifier = m_restClientInformation.SourceIdentifier;
@@ -97,7 +102,7 @@ namespace AppInstaller::Repository::Rest
             std::optional<std::string> m_customHeader;
             std::string m_caller;
             Authentication::AuthenticationArguments m_authArgs;
-            std::function<bool(PCCERT_CONTEXT)> m_serverCertValidationCallback;
+            std::optional<Certificates::PinningConfiguration> m_overridePinningConfiguration;
             std::once_flag m_initializeFlag;
             std::shared_ptr<ThreadLocalStorage::ThreadGlobals> m_threadGlobals;
         };

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -47,6 +47,11 @@ namespace AppInstaller::Repository::Rest
                 m_authArgs = std::move(authArgs);
             }
 
+            void SetServerCertificateValidationCallback(std::function<bool(PCCERT_CONTEXT)> callback) override
+            {
+                m_serverCertValidationCallback = std::move(callback);
+            }
+
             std::shared_ptr<ISource> Open(IProgressCallback&) override
             {
                 Initialize();
@@ -65,6 +70,10 @@ namespace AppInstaller::Repository::Rest
                 std::call_once(m_initializeFlag,
                     [&]()
                     {
+                        if (m_serverCertValidationCallback)
+                        {
+                            m_httpClientHelper.SetServerCertificateValidationCallback(m_serverCertValidationCallback);
+                        }
                         m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration, m_threadGlobals);
                         m_restClientInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
 
@@ -92,6 +101,7 @@ namespace AppInstaller::Repository::Rest
             std::optional<std::string> m_customHeader;
             std::string m_caller;
             Authentication::AuthenticationArguments m_authArgs;
+            std::function<bool(PCCERT_CONTEXT)> m_serverCertValidationCallback;
             std::once_flag m_initializeFlag;
             std::shared_ptr<ThreadLocalStorage::ThreadGlobals> m_threadGlobals;
         };

--- a/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
+++ b/src/AppInstallerRepositoryCore/Rest/RestSourceFactory.cpp
@@ -70,11 +70,7 @@ namespace AppInstaller::Repository::Rest
                 std::call_once(m_initializeFlag,
                     [&]()
                     {
-                        if (m_serverCertValidationCallback)
-                        {
-                            m_httpClientHelper.SetServerCertificateValidationCallback(m_serverCertValidationCallback);
-                        }
-                        m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration, m_threadGlobals);
+                        m_httpClientHelper.SetPinningConfiguration(m_details.CertificatePinningConfiguration, m_threadGlobals, m_serverCertValidationCallback);
                         m_restClientInformation = RestClient::GetInformation(m_details.Arg, m_customHeader, m_caller, m_httpClientHelper);
 
                         m_details.Identifier = m_restClientInformation.SourceIdentifier;

--- a/src/AppInstallerRepositoryCore/SourceList.cpp
+++ b/src/AppInstallerRepositoryCore/SourceList.cpp
@@ -852,10 +852,10 @@ namespace AppInstaller::Repository
             if (GroupPolicies().GetState(TogglePolicy::Policy::AdditionalSources) == PolicyState::Enabled)
             {
                 AICLI_LOG(Repo, Verbose, << "Additional sources GP is enabled...");
-                auto additionalSourcesOpt = GroupPolicies().GetValueRef<ValuePolicy::AdditionalSources>();
+                auto additionalSourcesOpt = GroupPolicies().GetValue<ValuePolicy::AdditionalSources>();
                 if (additionalSourcesOpt.has_value())
                 {
-                    const auto& additionalSources = additionalSourcesOpt->get();
+                    const auto& additionalSources = additionalSourcesOpt.value();
                     for (const auto& additionalSource : additionalSources)
                     {
                         AICLI_LOG(Repo, Verbose, << "... with configured source " << additionalSource.Name);

--- a/src/AppInstallerRepositoryCore/SourcePolicy.cpp
+++ b/src/AppInstallerRepositoryCore/SourcePolicy.cpp
@@ -40,13 +40,13 @@ namespace AppInstaller::Repository
         template<ValuePolicy P>
         std::optional<SourceFromPolicy> FindSourceInPolicy(std::string_view name, std::string_view type, std::string_view arg)
         {
-            auto sourcesOpt = GroupPolicies().GetValueRef<P>();
+            auto sourcesOpt = GroupPolicies().GetValue<P>();
             if (!sourcesOpt.has_value())
             {
                 return std::nullopt;
             }
 
-            const auto& sources = sourcesOpt->get();
+            const auto& sources = sourcesOpt.value();
             auto source = std::find_if(
                 sources.begin(),
                 sources.end(),

--- a/src/AppInstallerSharedLib/Certificates.cpp
+++ b/src/AppInstallerSharedLib/Certificates.cpp
@@ -3,8 +3,10 @@
 #include "pch.h"
 #include "winget/Certificates.h"
 #include "AppInstallerDateTime.h"
+#include "AppInstallerErrors.h"
 #include "AppInstallerLogging.h"
 #include "AppInstallerStrings.h"
+#include "winget/GroupPolicy.h"
 #include "winget/JsonUtil.h"
 #include "winget/Resources.h"
 
@@ -593,6 +595,28 @@ namespace AppInstaller::Certificates
         return result;
     }
 
+    CallbackPinningChainValidation::CallbackPinningChainValidation(std::function<bool(PCCERT_CONTEXT)> callback)
+        : m_callback(std::move(callback))
+    {
+        using namespace AppInstaller::Settings;
+        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
+    }
+
+    bool CallbackPinningChainValidation::Validate(PCCERT_CHAIN_CONTEXT chainContext) const
+    {
+        THROW_HR_IF(E_INVALIDARG, !chainContext || chainContext->cChain == 0);
+        PCCERT_SIMPLE_CHAIN simpleChain = chainContext->rgpChain[0];
+        THROW_HR_IF(E_INVALIDARG, !simpleChain || simpleChain->cElement == 0);
+        PCCERT_CHAIN_ELEMENT leafElement = simpleChain->rgpElement[0];
+        THROW_HR_IF(E_INVALIDARG, !leafElement || !leafElement->pCertContext);
+        return m_callback(leafElement->pCertContext);
+    }
+
+    std::string CallbackPinningChainValidation::GetDescription() const
+    {
+        return "<callback validation>";
+    }
+
     PinningConfiguration::PinningConfiguration(std::string identifier) : m_identifier(identifier)
     {
         if (m_identifier.empty())
@@ -607,7 +631,12 @@ namespace AppInstaller::Certificates
 
     void PinningConfiguration::AddChain(PinningChain chain)
     {
-        AICLI_LOG(Core, Verbose, << "Adding chain to pinning configuration [" << m_identifier << "]:\n" << chain.GetDescription());
+        AddChain(std::make_shared<PinningChain>(std::move(chain)));
+    }
+
+    void PinningConfiguration::AddChain(std::shared_ptr<IPinningChainValidation> chain)
+    {
+        AICLI_LOG(Core, Verbose, << "Adding chain to pinning configuration [" << m_identifier << "]:\n" << chain->GetDescription());
         m_configuration.emplace_back(std::move(chain));
     }
 
@@ -648,9 +677,9 @@ namespace AppInstaller::Certificates
 
         for (const auto& chain : m_configuration)
         {
-            if (chain.Validate(chainContext.get()))
+            if (chain->Validate(chainContext.get()))
             {
-                AICLI_LOG(Core, Verbose, << "Certificate `" << GetSimpleDisplayName(certContext) << "` accepted by pinning configuration:\n" << chain.GetDescription());
+                AICLI_LOG(Core, Verbose, << "Certificate `" << GetSimpleDisplayName(certContext) << "` accepted by pinning configuration:\n" << chain->GetDescription());
                 result = true;
                 break;
             }
@@ -658,7 +687,7 @@ namespace AppInstaller::Certificates
 
         if (result)
         {
-            // Only cache a successful validation
+            // Only cache a successful validation.
             m_cachedCertificate.assign(encodedBegin, encodedEnd);
         }
         else
@@ -731,7 +760,7 @@ namespace AppInstaller::Certificates
 
         for (const auto& chain : m_configuration)
         {
-            result = std::max(result, chain.GetRemainingLifetimePercentage());
+            result = std::max(result, chain->GetRemainingLifetimePercentage());
         }
 
         return result;

--- a/src/AppInstallerSharedLib/Certificates.cpp
+++ b/src/AppInstallerSharedLib/Certificates.cpp
@@ -3,10 +3,8 @@
 #include "pch.h"
 #include "winget/Certificates.h"
 #include "AppInstallerDateTime.h"
-#include "AppInstallerErrors.h"
 #include "AppInstallerLogging.h"
 #include "AppInstallerStrings.h"
-#include "winget/GroupPolicy.h"
 #include "winget/JsonUtil.h"
 #include "winget/Resources.h"
 
@@ -598,8 +596,6 @@ namespace AppInstaller::Certificates
     CallbackPinningChainValidation::CallbackPinningChainValidation(std::function<bool(PCCERT_CONTEXT)> callback)
         : m_callback(std::move(callback))
     {
-        using namespace AppInstaller::Settings;
-        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
     }
 
     bool CallbackPinningChainValidation::Validate(PCCERT_CHAIN_CONTEXT chainContext) const

--- a/src/AppInstallerSharedLib/GroupPolicy.cpp
+++ b/src/AppInstallerSharedLib/GroupPolicy.cpp
@@ -10,9 +10,9 @@ namespace AppInstaller::Settings
 {
     namespace
     {
-        const GroupPolicy& InstanceInternal(std::optional<GroupPolicy*> overridePolicy = {})
+        GroupPolicy& InstanceInternal(std::optional<GroupPolicy*> overridePolicy = {})
         {
-            const static GroupPolicy s_groupPolicy{ Registry::Key::OpenIfExists(HKEY_LOCAL_MACHINE, "Software\\Policies\\Microsoft\\Windows\\AppInstaller") };
+            static GroupPolicy s_groupPolicy{ Registry::Key::OpenIfExists(HKEY_LOCAL_MACHINE, "Software\\Policies\\Microsoft\\Windows\\AppInstaller") };
             static GroupPolicy* s_override = nullptr;
 
             if (overridePolicy.has_value())
@@ -385,19 +385,31 @@ namespace AppInstaller::Settings
         return Json::writeString(writerBuilder, json);
     }
 
-    GroupPolicy::GroupPolicy(const Registry::Key& key)
+    GroupPolicy::GroupPolicy(Registry::Key key) : m_key(std::move(key))
     {
-        ValidateAllValuePolicies(key, m_values, std::make_index_sequence<static_cast<size_t>(ValuePolicy::Max)>());
+        Reload();
+    }
+
+    void GroupPolicy::Reload()
+    {
+        std::map<TogglePolicy::Policy, PolicyState> toggles;
+        ValuePoliciesMap values;
+
+        ValidateAllValuePolicies(m_key, values, std::make_index_sequence<static_cast<size_t>(ValuePolicy::Max)>());
 
         using Toggle_t = std::underlying_type_t<TogglePolicy::Policy>;
         for (Toggle_t i = static_cast<Toggle_t>(TogglePolicy::Policy::None); i < static_cast<Toggle_t>(TogglePolicy::Policy::Max); ++i)
         {
             auto policy = static_cast<TogglePolicy::Policy>(i);
-            m_toggles[policy] = GetStateInternal(key, policy);
+            toggles[policy] = GetStateInternal(m_key, policy);
         }
+
+        auto lock = m_lock.lock_exclusive();
+        m_toggles = std::move(toggles);
+        m_values = std::move(values);
     }
 
-    PolicyState GroupPolicy::GetState(TogglePolicy::Policy policy) const
+    PolicyState GroupPolicy::GetStateNoLock(TogglePolicy::Policy policy) const
     {
         auto itr = m_toggles.find(policy);
         if (itr == m_toggles.end())
@@ -408,6 +420,12 @@ namespace AppInstaller::Settings
         return itr->second;
     }
 
+    PolicyState GroupPolicy::GetState(TogglePolicy::Policy policy) const
+    {
+        auto lock = m_lock.lock_shared();
+        return GetStateNoLock(policy);
+    }
+
     bool GroupPolicy::IsEnabled(TogglePolicy::Policy policy) const
     {
         if (policy == TogglePolicy::Policy::None)
@@ -415,7 +433,8 @@ namespace AppInstaller::Settings
             return true;
         }
 
-        PolicyState state = GetState(policy);
+        auto lock = m_lock.lock_shared();
+        PolicyState state = GetStateNoLock(policy);
         if (state == PolicyState::NotConfigured)
         {
             return TogglePolicy::GetPolicy(policy).DefaultIsEnabled();
@@ -424,7 +443,7 @@ namespace AppInstaller::Settings
         return state == PolicyState::Enabled;
     }
 
-    GroupPolicy const& GroupPolicy::Instance()
+    GroupPolicy& GroupPolicy::Instance()
     {
         return InstanceInternal();
     }

--- a/src/AppInstallerSharedLib/Public/winget/Certificates.h
+++ b/src/AppInstallerSharedLib/Public/winget/Certificates.h
@@ -191,8 +191,6 @@ namespace AppInstaller::Certificates
     };
 
     // A chain validation that delegates to a caller-supplied callback.
-    // Construction enforces that the BypassCertificatePinningForMicrosoftStore group policy is not configured;
-    // throws APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY if it is.
     struct CallbackPinningChainValidation : public IPinningChainValidation
     {
         // callback receives the leaf (end-entity) certificate and returns true to accept, false to reject.

--- a/src/AppInstallerSharedLib/Public/winget/Certificates.h
+++ b/src/AppInstallerSharedLib/Public/winget/Certificates.h
@@ -7,7 +7,9 @@
 #include <wil/resource.h>
 
 #include <functional>
+#include <memory>
 #include <ostream>
+#include <string>
 #include <vector>
 
 
@@ -107,8 +109,25 @@ namespace AppInstaller::Certificates
         PinningVerificationType m_pinning = PinningVerificationType::None;
     };
 
+    // Interface for a single chain validation strategy within a PinningConfiguration.
+    // For a certificate to be accepted by PinningConfiguration, it must be accepted by at least one chain.
+    struct IPinningChainValidation
+    {
+        virtual ~IPinningChainValidation() = default;
+
+        // Returns true if the certificate chain is accepted.
+        virtual bool Validate(PCCERT_CHAIN_CONTEXT chainContext) const = 0;
+
+        // Returns a human-readable description of this validation for logging.
+        virtual std::string GetDescription() const = 0;
+
+        // Returns the remaining lifetime percentage of the pinned material (0.0 = expired, 1.0 = full life remaining).
+        // Implementations without a fixed lifetime should return 1.0.
+        virtual double GetRemainingLifetimePercentage() const = 0;
+    };
+
     // Contains the full chain of pinning details.
-    struct PinningChain
+    struct PinningChain : public IPinningChainValidation
     {
         PinningChain() = default;
 
@@ -155,20 +174,36 @@ namespace AppInstaller::Certificates
         // Validates the given certificate chain against the configuration.
         // Returns true to indicate that the chain meets the pinning configuration criteria.
         // Returns false to indicate the it does not.
-        bool Validate(PCCERT_CHAIN_CONTEXT chainContext) const;
+        bool Validate(PCCERT_CHAIN_CONTEXT chainContext) const override;
 
         // Gets a description of the pinning chain.
-        std::string GetDescription() const;
+        std::string GetDescription() const override;
 
         // Loads the pinning chain from the given JSON.
         [[nodiscard]] bool LoadFrom(const Json::Value& configuration);
 
         // Determines how far the certificate chain is through its lifespan (the minimum of all of its certificates).
-        double GetRemainingLifetimePercentage() const;
+        double GetRemainingLifetimePercentage() const override;
 
     private:
         std::vector<PinningDetails> m_chain;
         bool m_partial = false;
+    };
+
+    // A chain validation that delegates to a caller-supplied callback.
+    // Construction enforces that the BypassCertificatePinningForMicrosoftStore group policy is not configured;
+    // throws APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY if it is.
+    struct CallbackPinningChainValidation : public IPinningChainValidation
+    {
+        // callback receives the leaf (end-entity) certificate and returns true to accept, false to reject.
+        explicit CallbackPinningChainValidation(std::function<bool(PCCERT_CONTEXT)> callback);
+
+        bool Validate(PCCERT_CHAIN_CONTEXT chainContext) const override;
+        std::string GetDescription() const override;
+        double GetRemainingLifetimePercentage() const override { return 1.0; }
+
+    private:
+        std::function<bool(PCCERT_CONTEXT)> m_callback;
     };
 
     // Holds the details about how a certificate chain is to be validated (aka "pinned").
@@ -185,6 +220,7 @@ namespace AppInstaller::Certificates
         // Adds a possible chain to the configuration.
         // For a certificate to be valid, it must match only one of the configured chains.
         void AddChain(PinningChain chain);
+        void AddChain(std::shared_ptr<IPinningChainValidation> chain);
 
         // Validates the given leaf certificate against the configuration.
         // Returns true to indicate that the certificate meets the pinning configuration criteria.
@@ -205,7 +241,7 @@ namespace AppInstaller::Certificates
         std::string m_identifier;
 
         // The configured chains.
-        std::vector<PinningChain> m_configuration;
+        std::vector<std::shared_ptr<IPinningChainValidation>> m_configuration;
 
         // We store the last certificate that was successfully validated to speed up subsequent checks.
         // Only cache a single certificate under the assumption that most of the time there will

--- a/src/AppInstallerSharedLib/Public/winget/GroupPolicy.h
+++ b/src/AppInstallerSharedLib/Public/winget/GroupPolicy.h
@@ -5,6 +5,7 @@
 #include <winget/Certificates.h>
 #include <winget/Registry.h>
 #include <winget/Resources.h>
+#include <wil/resource.h>
 
 #include <string_view>
 
@@ -124,7 +125,6 @@ namespace AppInstaller::Settings
         {
             using value_t = std::monostate;
             using opt_value_t = std::nullopt_t;
-            using opt_ref_value_t = std::nullopt_t;
             static std::nullopt_t ReadAndValidate(const Registry::Key& policiesKey);
         };
 
@@ -134,7 +134,6 @@ namespace AppInstaller::Settings
         { \
             using value_t = _type_; \
             using opt_value_t = std::optional<value_t>; \
-            using opt_ref_value_t = std::optional<std::reference_wrapper<const value_t>>; \
             static std::optional<value_t> ReadAndValidate(const Registry::Key& policiesKey); \
             _extra_ \
         }
@@ -165,9 +164,9 @@ namespace AppInstaller::Settings
     {
         using ValuePoliciesMap = EnumBasedVariantMap<ValuePolicy, details::ValuePolicyMapping>;
 
-        static GroupPolicy const& Instance();
+        static GroupPolicy& Instance();
 
-        GroupPolicy(const Registry::Key& key);
+        GroupPolicy(Registry::Key key);
         ~GroupPolicy() = default;
 
         GroupPolicy() = delete;
@@ -185,22 +184,10 @@ namespace AppInstaller::Settings
         template<ValuePolicy P>
         typename details::ValuePolicyMapping<P>::opt_value_t GetValue() const
         {
+            auto lock = m_lock.lock_shared();
             if (m_values.Contains(P))
             {
                 return m_values.Get<P>();
-            }
-            else
-            {
-                return std::nullopt;
-            }
-        }
-
-        template<ValuePolicy P>
-        typename details::ValuePolicyMapping<P>::opt_ref_value_t GetValueRef() const
-        {
-            if (m_values.Contains(P))
-            {
-                return std::cref(m_values.Get<P>());
             }
             else
             {
@@ -214,17 +201,14 @@ namespace AppInstaller::Settings
             return std::nullopt;
         }
 
-        template<>
-        std::nullopt_t GetValueRef<ValuePolicy::None>() const
-        {
-            return std::nullopt;
-        }
-
         PolicyState GetState(TogglePolicy::Policy policy) const;
 
         // Checks whether a policy is enabled, using an appropriate default when not configured.
         // Should not be used when not configured means something different than enabled/disabled.
         bool IsEnabled(TogglePolicy::Policy policy) const;
+
+        // Re-reads all policy values from the registry.
+        void Reload();
 
 #ifndef AICLI_DISABLE_TEST_HOOKS
     protected:
@@ -233,8 +217,13 @@ namespace AppInstaller::Settings
 #else
     private:
 #endif
+        Registry::Key m_key;
+        mutable wil::srwlock m_lock;
         std::map<TogglePolicy::Policy, PolicyState> m_toggles;
         ValuePoliciesMap m_values;
+
+    private:
+        PolicyState GetStateNoLock(TogglePolicy::Policy policy) const;
     };
 
     inline const GroupPolicy& GroupPolicies()

--- a/src/LocalhostWebServer/Startup.cs
+++ b/src/LocalhostWebServer/Startup.cs
@@ -74,10 +74,12 @@ namespace LocalhostWebServer
                 DefaultContentType = "application/octet-stream",
                 OnPrepareResponse = ctx =>
                 {
-                    // Prevent caching of REST source information files so that each Connect() call
-                    // gets a fresh response and triggers certificate validation.
+                    // REST source information files are extensionless JSON; set the correct content type
+                    // and prevent caching so that each Connect() call gets a fresh response and
+                    // triggers certificate validation.
                     if (ctx.File.Name == "information")
                     {
+                        ctx.Context.Response.ContentType = "application/json";
                         ctx.Context.Response.Headers.CacheControl = "no-store";
                     }
                 },

--- a/src/LocalhostWebServer/Startup.cs
+++ b/src/LocalhostWebServer/Startup.cs
@@ -71,7 +71,16 @@ namespace LocalhostWebServer
                 RequestPath = StaticFileRequestPath,
                 ContentTypeProvider = provider,
                 ServeUnknownFileTypes = true,
-                DefaultContentType = "application/octet-stream"
+                DefaultContentType = "application/octet-stream",
+                OnPrepareResponse = ctx =>
+                {
+                    // Prevent caching of REST source information files so that each Connect() call
+                    // gets a fresh response and triggers certificate validation.
+                    if (ctx.File.Name == "information")
+                    {
+                        ctx.Context.Response.Headers.CacheControl = "no-store";
+                    }
+                },
             });
 
             app.UseDirectoryBrowser(new DirectoryBrowserOptions

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\Microsoft.Management.Deployment.Projection\</OutDir>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86;arm64</Platforms>
@@ -16,8 +16,30 @@
   <!-- CsWinRT properties -->
   <PropertyGroup>
     <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
-    <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
-    <CsWinRTExcludes>Windows.Foundation.Diagnostics;Windows.Security.Cryptography.Certificates;Windows.Storage.Streams;Windows.System</CsWinRTExcludes>
+    <CsWinRTIncludes>
+      Microsoft.Management.Deployment;
+      Windows.Data.Text.TextSegmen;
+      Windows.Devices.Geolocation;
+      Windows.Foundation;
+      Windows.Globalization.DayOfWee;
+      Windows.Networking.Connectivity;
+      Windows.Networking.IDomainNameType;
+      Windows.Networking.DomainNameType;
+      Windows.Networking.IEndpointPair;
+      Windows.Networking.EndpointPair;
+      Windows.Networking.IHostName;
+      Windows.Networking.HostName;
+      Windows.Security.Cryptography.Certificates;
+      Windows.Storage;
+      Windows.Storage.Provider.FileUpdateStatu;
+      Windows.System.ProcessorArchitecture;
+      Windows.System.IUser;
+      Windows.System.User;
+    </CsWinRTIncludes>
+    <CsWinRTExcludes>
+      Windows.Foundation.Diagnostics;
+      Windows.Storage.Provider;
+    </CsWinRTExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -18,7 +18,7 @@
     <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
     <CsWinRTIncludes>
       Microsoft.Management.Deployment;
-      Windows.Data.Text.TextSegmen;
+      Windows.Data.Text.TextSegment;
       Windows.Devices.Geolocation;
       Windows.Foundation;
       Windows.Globalization.DayOfWee;
@@ -31,7 +31,7 @@
       Windows.Networking.HostName;
       Windows.Security.Cryptography.Certificates;
       Windows.Storage;
-      Windows.Storage.Provider.FileUpdateStatu;
+      Windows.Storage.Provider.FileUpdateStatus;
       Windows.System.ProcessorArchitecture;
       Windows.System.IUser;
       Windows.System.User;

--- a/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
+++ b/src/Microsoft.Management.Deployment.Projection/Microsoft.Management.Deployment.Projection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\Microsoft.Management.Deployment.Projection\</OutDir>
     <IsPackable>false</IsPackable>
     <Platforms>x64;x86;arm64</Platforms>
@@ -16,8 +16,8 @@
   <!-- CsWinRT properties -->
   <PropertyGroup>
     <CsWinRTWindowsMetadata>10.0.26100.0</CsWinRTWindowsMetadata>
-    <CsWinRTIncludes>Microsoft.Management.Deployment;Windows.Foundation;Windows.System.ProcessorArchitecture</CsWinRTIncludes>
-    <CsWinRTExcludes>Windows.Foundation.Diagnostics</CsWinRTExcludes>
+    <CsWinRTIncludes>Microsoft.Management.Deployment</CsWinRTIncludes>
+    <CsWinRTExcludes>Windows.Foundation.Diagnostics;Windows.Security.Cryptography.Certificates;Windows.Storage.Streams;Windows.System</CsWinRTExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Management.Deployment/Helpers.cpp
+++ b/src/Microsoft.Management.Deployment/Helpers.cpp
@@ -59,6 +59,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         }
     }
 
+    bool IsInProcCaller()
+    {
+        auto [hr, callerProcessId] = GetCallerProcessId();
+        return SUCCEEDED(hr) && callerProcessId == GetCurrentProcessId();
+    }
+
     std::wstring_view GetStringForCapability(Capability capability)
     {
         switch (capability)

--- a/src/Microsoft.Management.Deployment/Helpers.h
+++ b/src/Microsoft.Management.Deployment/Helpers.h
@@ -17,6 +17,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
     HRESULT EnsureProcessHasCapability(Capability requiredCapability, DWORD callerProcessId);
     HRESULT EnsureComCallerHasCapability(Capability requiredCapability);
     std::pair<HRESULT, DWORD> GetCallerProcessId();
+    bool IsInProcCaller();
     std::wstring TryGetCallerProcessInfo(DWORD callerProcessId);
     std::string GetCallerName();
     bool IsBackgroundProcessForPolicy();

--- a/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
+++ b/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="MicrosoftEntraIdAuthenticationInfo.h" />
     <ClInclude Include="PackageAgreement.h" />
     <ClInclude Include="PackageCatalog.h" />
+    <ClInclude Include="PackageCatalogConnectionValidationEventArgs.h" />
     <ClInclude Include="PackageCatalogInfo.h" />
     <ClInclude Include="PackageCatalogProgress.h" />
     <ClInclude Include="PackageCatalogReference.h" />
@@ -234,6 +235,7 @@
     <ClCompile Include="MicrosoftEntraIdAuthenticationInfo.cpp" />
     <ClCompile Include="PackageAgreement.cpp" />
     <ClCompile Include="PackageCatalog.cpp" />
+    <ClCompile Include="PackageCatalogConnectionValidationEventArgs.cpp" />
     <ClCompile Include="PackageCatalogInfo.cpp" />
     <ClCompile Include="PackageCatalogProgress.cpp" />
     <ClCompile Include="PackageCatalogReference.cpp" />

--- a/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj.filters
+++ b/src/Microsoft.Management.Deployment/Microsoft.Management.Deployment.vcxproj.filters
@@ -20,6 +20,7 @@
     <ClCompile Include="MatchResult.cpp" />
     <ClCompile Include="PackageAgreement.cpp" />
     <ClCompile Include="PackageCatalog.cpp" />
+    <ClCompile Include="PackageCatalogConnectionValidationEventArgs.cpp" />
     <ClCompile Include="PackageCatalogInfo.cpp" />
     <ClCompile Include="PackageCatalogReference.cpp" />
     <ClCompile Include="CatalogPackageMetadata.cpp" />
@@ -70,6 +71,7 @@
     <ClInclude Include="MatchResult.h" />
     <ClInclude Include="PackageAgreement.h" />
     <ClInclude Include="PackageCatalog.h" />
+    <ClInclude Include="PackageCatalogConnectionValidationEventArgs.h" />
     <ClInclude Include="PackageCatalogInfo.h" />
     <ClInclude Include="PackageCatalogReference.h" />
     <ClInclude Include="PackageInstallerInfo.h" />

--- a/src/Microsoft.Management.Deployment/PackageCatalogConnectionValidationEventArgs.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogConnectionValidationEventArgs.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "PackageCatalogConnectionValidationEventArgs.h"
+#include "PackageCatalogConnectionValidationEventArgs.g.cpp"
+
+namespace winrt::Microsoft::Management::Deployment::implementation
+{
+    void PackageCatalogConnectionValidationEventArgs::Initialize(winrt::Windows::Security::Cryptography::Certificates::Certificate serverCertificate)
+    {
+        m_serverCertificate = serverCertificate;
+    }
+
+    winrt::Windows::Security::Cryptography::Certificates::Certificate PackageCatalogConnectionValidationEventArgs::ServerCertificate()
+    {
+        return m_serverCertificate;
+    }
+}

--- a/src/Microsoft.Management.Deployment/PackageCatalogConnectionValidationEventArgs.h
+++ b/src/Microsoft.Management.Deployment/PackageCatalogConnectionValidationEventArgs.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include "PackageCatalogConnectionValidationEventArgs.g.h"
+
+namespace winrt::Microsoft::Management::Deployment::implementation
+{
+    struct PackageCatalogConnectionValidationEventArgs : PackageCatalogConnectionValidationEventArgsT<PackageCatalogConnectionValidationEventArgs>
+    {
+        PackageCatalogConnectionValidationEventArgs() = default;
+
+#if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
+        void Initialize(winrt::Windows::Security::Cryptography::Certificates::Certificate serverCertificate);
+#endif
+
+        winrt::Windows::Security::Cryptography::Certificates::Certificate ServerCertificate();
+
+#if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
+    private:
+        winrt::Windows::Security::Cryptography::Certificates::Certificate m_serverCertificate{ nullptr };
+#endif
+    };
+}

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -188,14 +188,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             source.SetCaller(callerName);
             source.SetBackgroundUpdateInterval(PackageCatalogBackgroundUpdateInterval());
             source.InstalledPackageInformationOnly(m_installedPackageInformationOnly);
-            if (AuthenticationInfo().AuthenticationType() != winrt::Microsoft::Management::Deployment::AuthenticationType::None)
-            {
-                source.SetAuthenticationArguments(GetAuthenticationArguments(m_authenticationArguments));
-            }
             auto validationCallback = MakeServerCertificateValidationCallback(m_connectionValidationHandler);
             if (validationCallback)
             {
                 source.SetServerCertificateValidationCallback(std::move(validationCallback));
+            }
+            if (AuthenticationInfo().AuthenticationType() != winrt::Microsoft::Management::Deployment::AuthenticationType::None)
+            {
+                source.SetAuthenticationArguments(GetAuthenticationArguments(m_authenticationArguments));
             }
             source.Open(progress);
         }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -367,9 +367,15 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
     void PackageCatalogReference::ConnectionValidationHandler(winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& value)
     {
+        using namespace AppInstaller::Settings;
+
         auto [hr, callerProcessId] = GetCallerProcessId();
         THROW_IF_FAILED(hr);
         THROW_HR_IF(E_ACCESSDENIED, callerProcessId != GetCurrentProcessId());
+
+        // Inform the caller that the handler is not allowed when the policy is configured (in either direction).
+        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
+
         m_connectionValidationHandler = value;
     }
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -138,14 +138,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 copy.SetCaller(callerName);
                 copy.SetBackgroundUpdateInterval(catalog.PackageCatalogBackgroundUpdateInterval());
                 copy.InstalledPackageInformationOnly(catalog.InstalledPackageInformationOnly());
-                if (catalog.AuthenticationInfo().AuthenticationType() != winrt::Microsoft::Management::Deployment::AuthenticationType::None)
-                {
-                    copy.SetAuthenticationArguments(GetAuthenticationArguments(catalog.AuthenticationArguments()));
-                }
                 auto validationCallback = MakeServerCertificateValidationCallback(catalogImpl->m_connectionValidationHandler);
                 if (validationCallback)
                 {
                     copy.SetServerCertificateValidationCallback(std::move(validationCallback));
+                }
+                if (catalog.AuthenticationInfo().AuthenticationType() != winrt::Microsoft::Management::Deployment::AuthenticationType::None)
+                {
+                    copy.SetAuthenticationArguments(GetAuthenticationArguments(catalog.AuthenticationArguments()));
                 }
                 copy.Open(progress);
                 remoteSources.emplace_back(std::move(copy));

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -35,6 +35,20 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             return *updateResult;
         }
 
+        // Returns true if the ConnectionValidationHandler may be set for the given source.
+        // Returns false if the BypassCertificatePinningForMicrosoftStore policy is explicitly
+        // disabled and the source is the well-known MicrosoftStore catalog.
+        bool IsConnectionValidationHandlerEnabledForSource(const ::AppInstaller::Repository::Source& source)
+        {
+            using namespace AppInstaller::Settings;
+            if (source.IsWellKnownSource(::AppInstaller::Repository::WellKnownSource::MicrosoftStore))
+            {
+                return GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::Disabled;
+            }
+
+            return true;
+        }
+
         std::function<bool(PCCERT_CONTEXT)> MakeServerCertificateValidationCallback(
             winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& handler)
         {
@@ -369,19 +383,14 @@ namespace winrt::Microsoft::Management::Deployment::implementation
 
     void PackageCatalogReference::ConnectionValidationHandler(winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& value)
     {
-        using namespace AppInstaller::Settings;
-
-        auto [hr, callerProcessId] = GetCallerProcessId();
-        THROW_IF_FAILED(hr);
-        THROW_HR_IF(E_ACCESSDENIED, callerProcessId != GetCurrentProcessId());
-
-        // For the well-known Microsoft Store source, the callback is not allowed when the
-        // certificate pinning bypass policy is configured (in either direction).
-        if (m_sourceReference.IsWellKnownSource(::AppInstaller::Repository::WellKnownSource::MicrosoftStore))
-        {
-            THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
-        }
+        THROW_HR_IF(E_ACCESSDENIED, !IsInProcCaller());
+        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, !IsConnectionValidationHandlerEnabledForSource(m_sourceReference));
 
         m_connectionValidationHandler = value;
+    }
+
+    bool PackageCatalogReference::IsConnectionValidationHandlerEnabled()
+    {
+        return IsInProcCaller() && IsConnectionValidationHandlerEnabledForSource(m_sourceReference);
     }
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -6,6 +6,7 @@
 #include "PackageCatalogReference.g.cpp"
 #include "PackageCatalogInfo.h"
 #include "PackageCatalog.h"
+#include "PackageCatalogConnectionValidationEventArgs.h"
 #include "SourceAgreement.h"
 #include "ConnectResult.h"
 #include "AuthenticationInfo.h"
@@ -32,6 +33,24 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             auto updateResult = winrt::make_self<wil::details::module_count_wrapper<winrt::Microsoft::Management::Deployment::implementation::RefreshPackageCatalogResult>>();
             updateResult->Initialize(status, terminationStatus);
             return *updateResult;
+        }
+
+        std::function<bool(PCCERT_CONTEXT)> MakeServerCertificateValidationCallback(
+            winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& handler)
+        {
+            if (!handler)
+            {
+                return {};
+            }
+            return [handler](PCCERT_CONTEXT certContext) -> bool
+            {
+                auto certBytes = winrt::array_view<uint8_t const>{ certContext->pbCertEncoded, certContext->pbCertEncoded + certContext->cbCertEncoded };
+                auto buffer = winrt::Windows::Security::Cryptography::CryptographicBuffer::CreateFromByteArray(certBytes);
+                winrt::Windows::Security::Cryptography::Certificates::Certificate cert{ buffer };
+                auto args = winrt::make_self<wil::details::module_count_wrapper<PackageCatalogConnectionValidationEventArgs>>();
+                args->Initialize(cert);
+                return handler(*args) == winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationResult::Ok;
+            };
         }
     }
 
@@ -121,6 +140,11 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 {
                     copy.SetAuthenticationArguments(GetAuthenticationArguments(catalog.AuthenticationArguments()));
                 }
+                auto validationCallback = MakeServerCertificateValidationCallback(catalogImpl->m_connectionValidationHandler);
+                if (validationCallback)
+                {
+                    copy.SetServerCertificateValidationCallback(std::move(validationCallback));
+                }
                 copy.Open(progress);
                 remoteSources.emplace_back(std::move(copy));
             }
@@ -167,6 +191,11 @@ namespace winrt::Microsoft::Management::Deployment::implementation
             if (AuthenticationInfo().AuthenticationType() != winrt::Microsoft::Management::Deployment::AuthenticationType::None)
             {
                 source.SetAuthenticationArguments(GetAuthenticationArguments(m_authenticationArguments));
+            }
+            auto validationCallback = MakeServerCertificateValidationCallback(m_connectionValidationHandler);
+            if (validationCallback)
+            {
+                source.SetServerCertificateValidationCallback(std::move(validationCallback));
             }
             source.Open(progress);
         }
@@ -329,5 +358,18 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         }
 
         co_return GetRefreshPackageCatalogResult(terminationHR);
+    }
+
+    winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler PackageCatalogReference::ConnectionValidationHandler()
+    {
+        return m_connectionValidationHandler;
+    }
+
+    void PackageCatalogReference::ConnectionValidationHandler(winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& value)
+    {
+        auto [hr, callerProcessId] = GetCallerProcessId();
+        THROW_IF_FAILED(hr);
+        THROW_HR_IF(E_ACCESSDENIED, callerProcessId != GetCurrentProcessId());
+        m_connectionValidationHandler = value;
     }
 }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -49,7 +49,9 @@ namespace winrt::Microsoft::Management::Deployment::implementation
                 winrt::Windows::Security::Cryptography::Certificates::Certificate cert{ buffer };
                 auto args = winrt::make_self<wil::details::module_count_wrapper<PackageCatalogConnectionValidationEventArgs>>();
                 args->Initialize(cert);
-                return handler(*args) == winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationResult::Ok;
+                auto handlerResult = handler(*args);
+                AICLI_LOG(Repo, Info, << "PackageCatalogConnectionValidationHandler returned: " << handlerResult);
+                return handlerResult == winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationResult::Ok;
             };
         }
     }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.cpp
@@ -375,8 +375,12 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         THROW_IF_FAILED(hr);
         THROW_HR_IF(E_ACCESSDENIED, callerProcessId != GetCurrentProcessId());
 
-        // Inform the caller that the handler is not allowed when the policy is configured (in either direction).
-        THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
+        // For the well-known Microsoft Store source, the callback is not allowed when the
+        // certificate pinning bypass policy is configured (in either direction).
+        if (m_sourceReference.IsWellKnownSource(::AppInstaller::Repository::WellKnownSource::MicrosoftStore))
+        {
+            THROW_HR_IF(APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, GroupPolicies().GetState(TogglePolicy::Policy::BypassCertificatePinningForMicrosoftStore) != PolicyState::NotConfigured);
+        }
 
         m_connectionValidationHandler = value;
     }

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.h
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.h
@@ -38,6 +38,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         // Contract 29
         winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler ConnectionValidationHandler();
         void ConnectionValidationHandler(winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& value);
+        bool IsConnectionValidationHandlerEnabled();
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:

--- a/src/Microsoft.Management.Deployment/PackageCatalogReference.h
+++ b/src/Microsoft.Management.Deployment/PackageCatalogReference.h
@@ -35,6 +35,9 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Microsoft::Management::Deployment::AuthenticationInfo AuthenticationInfo();
         // Contract 12.0
         winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Microsoft::Management::Deployment::RefreshPackageCatalogResult, double> RefreshPackageCatalogAsync();
+        // Contract 29
+        winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler ConnectionValidationHandler();
+        void ConnectionValidationHandler(winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler const& value);
 
 #if !defined(INCLUDE_ONLY_INTERFACE_METHODS)
     private:
@@ -50,6 +53,7 @@ namespace winrt::Microsoft::Management::Deployment::implementation
         winrt::Microsoft::Management::Deployment::AuthenticationArguments m_authenticationArguments{ nullptr };
         std::once_flag m_authenticationInfoOnceFlag;
         winrt::Microsoft::Management::Deployment::AuthenticationInfo m_authenticationInfo{ nullptr };
+        winrt::Microsoft::Management::Deployment::PackageCatalogConnectionValidationHandler m_connectionValidationHandler{ nullptr };
 #endif
     };
 }

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -995,6 +995,8 @@ namespace Microsoft.Management.Deployment
         {
             /// A callback invoked to validate the server certificate during Connect or ConnectAsync.
             /// Only available to in-process callers; out-of-process callers will receive E_ACCESSDENIED on set.
+            /// If the BypassCertificatePinningForMicrosoftStore group policy is configured, this cannot be set for the MicrosoftStore catalog.
+            /// Attempting to set it in that case produces an APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY error.
             PackageCatalogConnectionValidationHandler ConnectionValidationHandler;
         }
     }

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -995,9 +995,14 @@ namespace Microsoft.Management.Deployment
         {
             /// A callback invoked to validate the server certificate during Connect or ConnectAsync.
             /// Only available to in-process callers; out-of-process callers will receive E_ACCESSDENIED on set.
-            /// If the BypassCertificatePinningForMicrosoftStore group policy is configured, this cannot be set for the MicrosoftStore catalog.
-            /// Attempting to set it in that case produces an APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY error.
+            /// If the BypassCertificatePinningForMicrosoftStore group policy is disabled, this cannot be set
+            /// for the MicrosoftStore catalog; attempting to do so produces APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY.
             PackageCatalogConnectionValidationHandler ConnectionValidationHandler;
+
+            /// Indicates whether the ConnectionValidationHandler can be set for this catalog reference.
+            /// Returns false if setting the handler would be blocked by policy (e.g., the
+            /// BypassCertificatePinningForMicrosoftStore group policy is disabled for the MicrosoftStore catalog).
+            Boolean IsConnectionValidationHandlerEnabled { get; };
         }
     }
 

--- a/src/Microsoft.Management.Deployment/PackageManager.idl
+++ b/src/Microsoft.Management.Deployment/PackageManager.idl
@@ -859,6 +859,29 @@ namespace Microsoft.Management.Deployment
         MicrosoftEntraIdAuthenticationInfo MicrosoftEntraIdAuthenticationInfo { get; };
     }
 
+    /// Result of a connection validation callback.
+    [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 29)]
+    enum PackageCatalogConnectionValidationResult
+    {
+        /// The connection was accepted.
+        Ok,
+        /// The connection was rejected because the certificate was not accepted.
+        CertificateRejected,
+    };
+
+    /// Arguments provided to a connection validation callback.
+    [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 29)]
+    runtimeclass PackageCatalogConnectionValidationEventArgs
+    {
+        /// The server certificate presented during the connection.
+        Windows.Security.Cryptography.Certificates.Certificate ServerCertificate { get; };
+    }
+
+    /// Callback invoked to validate a catalog connection.
+    /// Return Ok to accept the connection or another value to reject it for that reason.
+    [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 29)]
+    delegate PackageCatalogConnectionValidationResult PackageCatalogConnectionValidationHandler(PackageCatalogConnectionValidationEventArgs args);
+
     /// Status of the Connect call
     [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 1)]
     enum ConnectResultStatus
@@ -966,6 +989,13 @@ namespace Microsoft.Management.Deployment
             /// The progress value, represented as a double, indicates the percentage of update package catalog operation completion.
             /// The progress range is from 0 to 100.
             Windows.Foundation.IAsyncOperationWithProgress<RefreshPackageCatalogResult, Double> RefreshPackageCatalogAsync();
+        }
+
+        [contract(Microsoft.Management.Deployment.WindowsPackageManagerContract, 29)]
+        {
+            /// A callback invoked to validate the server certificate during Connect or ConnectAsync.
+            /// Only available to in-process callers; out-of-process callers will receive E_ACCESSDENIED on set.
+            PackageCatalogConnectionValidationHandler ConnectionValidationHandler;
         }
     }
 

--- a/src/Microsoft.Management.Deployment/pch.h
+++ b/src/Microsoft.Management.Deployment/pch.h
@@ -5,6 +5,8 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.Metadata.h>
+#include <winrt/Windows.Security.Cryptography.h>
+#include <winrt/Windows.Security.Cryptography.Certificates.h>
 #include <winrt/Windows.Web.Http.h>
 
 #include <ostream>

--- a/src/WindowsPackageManager/main.cpp
+++ b/src/WindowsPackageManager/main.cpp
@@ -148,4 +148,13 @@ extern "C"
         return S_OK;
     }
     CATCH_RETURN();
+
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    __declspec(dllexport) WINDOWS_PACKAGE_MANAGER_API WindowsPackageManagerTestHook_ReloadGroupPolicy() try
+    {
+        AppInstaller::Settings::GroupPolicy::Instance().Reload();
+        return S_OK;
+    }
+    CATCH_RETURN();
+#endif
 }


### PR DESCRIPTION
## 📖 Description
Adds the ability to override the certificate pinning validation with their own handler for in-proc COM callers.  In-proc callers can provide a handler delegate on their `PackageCatalogReference` object(s) before calling `Connect` and will receive a callback when winget would execute a certificate pinning validation.  If they accept the server connection, the certificate will be cached as it is with the internal check and automatically approved for any future connections.

Note that `Connect` may not actually trigger the callback if the `/information` for the catalog is already cached, but you must set the callback before the `Connect` call for it to be attached to the connected catalog for future use.

The callback can only be set for the MS Store catalog when the group policy `BypassCertificatePinningForMicrosoftStore` is not configured.

## 🔍 Validation
Added a sample CLI caller that provides the user with a prompt to accept or reject the connection.  Manual validation of logs and caching behavior.
Added E2E tests for the callback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6233)