### PR TITLE
Move pre-check errors to post-check

### DIFF
--- a/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/InstallFlow.cpp
@@ -211,16 +211,6 @@ namespace AppInstaller::CLI::Workflow
 
             bool isMachineScope = Manifest::ConvertToScopeEnum(context.Args.GetArg(Execution::Args::Type::InstallScope)) == Manifest::ScopeEnum::Machine;
 
-            // TODO: There was a bug in deployment api if provision api was called in packaged context.
-            // Remove this check when the OS bug is fixed and back ported.
-            if (isMachineScope && Runtime::IsRunningInPackagedContext())
-            {
-                context.Reporter.Error() << Resource::String::InstallFlowReturnCodeSystemNotSupported << std::endl;
-                context.Add<Execution::Data::OperationReturnCode>(static_cast<DWORD>(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED));
-                AICLI_LOG(CLI, Error, << "Device wide install for msix type is not supported in packaged context.");
-                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED);
-            }
-
             context.Reporter.Info() << Resource::String::InstallFlowStartingPackageInstall << std::endl;
 
             bool registrationDeferred = false;
@@ -241,6 +231,18 @@ namespace AppInstaller::CLI::Workflow
             }
             catch (const wil::ResultException& re)
             {
+                // There was a bug in the deployment provision API when called in a packaged context,
+                // fixed in 10.0.26100.0. On older OS versions, convert any failure under these conditions
+                // to the error that was previously always returned.
+                if (isMachineScope && Runtime::IsRunningInPackagedContext() &&
+                    !Runtime::IsCurrentOSVersionGreaterThanOrEqual(Utility::Version{ "10.0.26100.0" }))
+                {
+                    context.Reporter.Error() << Resource::String::InstallFlowReturnCodeSystemNotSupported << std::endl;
+                    context.Add<Execution::Data::OperationReturnCode>(static_cast<DWORD>(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED));
+                    AICLI_LOG(CLI, Error, << "Device wide install for msix type is not supported in packaged context on this OS version. Error: " << re.GetErrorCode());
+                    AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED);
+                }
+
                 context.Add<Execution::Data::OperationReturnCode>(re.GetErrorCode());
                 context << ReportInstallerResult("MSIX"sv, re.GetErrorCode(), /* isHResult */ true);
                 return;

--- a/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
@@ -366,16 +366,6 @@ namespace AppInstaller::CLI::Workflow
     {
         bool isMachineScope = Manifest::ConvertToScopeEnum(context.Args.GetArg(Execution::Args::Type::InstallScope)) == Manifest::ScopeEnum::Machine;
 
-        // TODO: There was a bug in deployment api if deprovision api was called in packaged context.
-        // Remove this check when the OS bug is fixed and back ported.
-        if (isMachineScope && Runtime::IsRunningInPackagedContext())
-        {
-            context.Reporter.Error() << Resource::String::InstallFlowReturnCodeSystemNotSupported << std::endl;
-            context.Add<Execution::Data::OperationReturnCode>(static_cast<DWORD>(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED));
-            AICLI_LOG(CLI, Error, << "Device wide uninstall for msix type is not supported in packaged context.");
-            AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED);
-        }
-
         const auto& packageFamilyNames = context.Get<Execution::Data::PackageFamilyNames>();
         context.Reporter.Info() << Resource::String::UninstallFlowStartingPackageUninstall << std::endl;
 
@@ -402,6 +392,18 @@ namespace AppInstaller::CLI::Workflow
             }
             catch (const wil::ResultException& re)
             {
+                // There was a bug in the deployment deprovision API when called in a packaged context,
+                // fixed in 10.0.26100.0. On older OS versions, convert any failure under these conditions
+                // to the error that was previously always returned.
+                if (isMachineScope && Runtime::IsRunningInPackagedContext() &&
+                    !Runtime::IsCurrentOSVersionGreaterThanOrEqual(Utility::Version{ "10.0.26100.0" }))
+                {
+                    context.Reporter.Error() << Resource::String::InstallFlowReturnCodeSystemNotSupported << std::endl;
+                    context.Add<Execution::Data::OperationReturnCode>(static_cast<DWORD>(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED));
+                    AICLI_LOG(CLI, Error, << "Device wide uninstall for msix type is not supported in packaged context on this OS version. Error: " << re.GetErrorCode());
+                    AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED);
+                }
+
                 context.Add<Execution::Data::OperationReturnCode>(re.GetErrorCode());
                 context << ReportUninstallerResult("MSIXUninstall"sv, re.GetErrorCode(), /* isHResult */ true);
                 return;

--- a/src/AppInstallerCommonCore/MSStore.cpp
+++ b/src/AppInstallerCommonCore/MSStore.cpp
@@ -401,15 +401,6 @@ namespace AppInstaller::MSStore
 
         if (m_scope == Manifest::ScopeEnum::Machine)
         {
-            // TODO: There was a bug in InstallService where admin user is incorrectly identified as not admin,
-            // causing false access denied on many OS versions.
-            // Remove this check when the OS bug is fixed and back ported.
-            if (!Runtime::IsRunningAsSystem())
-            {
-                AICLI_LOG(Core, Error, << "Device wide install for msstore type is not supported under admin context.");
-                return APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED;
-            }
-
             installOptions.InstallForAllUsers(true);
         }
 
@@ -437,6 +428,18 @@ namespace AppInstaller::MSStore
         }
 
         HRESULT hr = WaitForOperation(m_productId, m_isSilentMode, installItems, progress, monitor);
+
+        // There was a bug in InstallService where admin users were incorrectly identified as non-admin,
+        // causing false access denied errors; fixed in 10.0.26100.0. On older OS versions, convert any
+        // failure under these conditions to the error that was previously always returned.
+        if (FAILED(hr) &&
+            m_scope == Manifest::ScopeEnum::Machine &&
+            !Runtime::IsRunningAsSystem() &&
+            !Runtime::IsCurrentOSVersionGreaterThanOrEqual(Utility::Version{ "10.0.26100.0" }))
+        {
+            AICLI_LOG(Core, Error, << "Device wide install for msstore type is not supported under admin context on this OS version. Error: " << hr);
+            return APPINSTALLER_CLI_ERROR_INSTALL_SYSTEM_NOT_SUPPORTED;
+        }
 
         bool shouldProvision = m_scope == Manifest::ScopeEnum::Machine;
 #ifndef AICLI_DISABLE_TEST_HOOKS


### PR DESCRIPTION
## 📖 Description
We had some pre-check errors for various issues in the OS.  Move those to attempt the operation and convert any failures in the scenario on the older OS to the well-known HRESULT.

## 🔍 Validation
Existing regression tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6236)