### PR TITLE
Change symlink verification to avoid redirection guard policy

### DIFF
--- a/src/AppInstallerCLITests/Filesystem.cpp
+++ b/src/AppInstallerCLITests/Filesystem.cpp
@@ -49,6 +49,10 @@ TEST_CASE("VerifySymlink", "[filesystem]")
     REQUIRE(VerifySymlink(symlinkPath, testFilePath));
     REQUIRE_FALSE(VerifySymlink(symlinkPath, "badPath"));
 
+    // Verify case-insensitive comparison works (Windows paths are case-insensitive).
+    std::filesystem::path testFilePathUpperCase = basePath / "TESTFILE.TXT";
+    REQUIRE(VerifySymlink(symlinkPath, testFilePathUpperCase));
+
     std::filesystem::remove(testFilePath);
 
     // Ensure that symlink existence does not check the target

--- a/src/AppInstallerCLITests/main.cpp
+++ b/src/AppInstallerCLITests/main.cpp
@@ -67,6 +67,14 @@ int main(int argc, char** argv)
 {
     init_apartment();
 
+    // Enable ProcessRedirectionTrustPolicy to match the MSIX packaged process context in which
+    // WinGet runs in production. This policy causes Windows to block traversal of user-created
+    // symlinks (e.g. via weakly_canonical), so enabling it here surfaces bugs that would only
+    // manifest in the real product environment. The policy is one-way; it cannot be reversed.
+    PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY redirectionPolicy{};
+    redirectionPolicy.EnforceRedirectionTrust = 1;
+    SetProcessMitigationPolicy(ProcessRedirectionTrustPolicy, &redirectionPolicy, sizeof(redirectionPolicy));
+
     bool hasSetTestDataBasePath = false;
     bool waitBeforeReturn = false;
     bool keepSQLLogging = false;

--- a/src/AppInstallerSharedLib/Filesystem.cpp
+++ b/src/AppInstallerSharedLib/Filesystem.cpp
@@ -477,8 +477,21 @@ namespace AppInstaller::Filesystem
 
     bool VerifySymlink(const std::filesystem::path& symlink, const std::filesystem::path& target)
     {
-        const std::filesystem::path& symlinkTargetPath = std::filesystem::weakly_canonical(symlink);
-        return symlinkTargetPath == std::filesystem::weakly_canonical(target);
+        // Use read_symlink to get the symlink's recorded target without traversing the filesystem
+        // chain. weakly_canonical would follow the symlink, which is blocked by
+        // ProcessRedirectionTrustPolicy (inherited from the MSIX packaged process context on
+        // newer Windows builds) when the symlink was created by a non-elevated process.
+        const std::filesystem::path symlinkTarget = std::filesystem::read_symlink(symlink);
+
+        // If the recorded target is relative, resolve it against the symlink's parent directory.
+        const std::filesystem::path resolvedTarget = symlinkTarget.is_absolute() ?
+            symlinkTarget : (symlink.parent_path() / symlinkTarget);
+
+        // Windows paths are case-insensitive. Use lexically_normal to resolve . and .. without
+        // filesystem access, then compare case-insensitively.
+        return Utility::ICUCaseInsensitiveEquals(
+            resolvedTarget.lexically_normal().u8string(),
+            std::filesystem::path(target).lexically_normal().u8string());
     }
 
     void AppendExtension(std::filesystem::path& target, const std::string& value)

--- a/src/AppInstallerSharedLib/Filesystem.cpp
+++ b/src/AppInstallerSharedLib/Filesystem.cpp
@@ -491,7 +491,7 @@ namespace AppInstaller::Filesystem
         // filesystem access, then compare case-insensitively.
         return Utility::ICUCaseInsensitiveEquals(
             resolvedTarget.lexically_normal().u8string(),
-            std::filesystem::path(target).lexically_normal().u8string());
+            target.lexically_normal().u8string());
     }
 
     void AppendExtension(std::filesystem::path& target, const std::string& value)


### PR DESCRIPTION
## 📖 Description
Rather than comparing the symlink and desired target through `weakly_canonical`, this change checks that the symlink is pointing to the target via string comparison.  This avoids "resolving" the symlink and the redirection guard policy.

## 🔗 References
Fixes #6211

## 🔍 Validation
Enabled the redirection guard for the unit test process; test started failing as expected.
Product fix resolved test failure; added additional validations to test.

## 📋 Issue Type
- [X] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6239)