### PR TITLE
Honor DSCv3 package installMode for silent and interactive

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -150,6 +150,7 @@ Dns
 Dobbeleer
 DONOT
 dsc
+dupenv
 dustojnikhummer
 dvinns
 dwgs

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -86,3 +86,4 @@ Added a user setting (`logging.fileNameStrategy`) for controlling the default na
 * DSC export now correctly exports WinGet Admin Settings
 * `winget validate` now performs case-insensitive comparison for file extensions where applicable
 * `winget source reset` now properly resets default sources instead of removing them
+* DSC v3 `Microsoft.WinGet/Package` resource now honors the `installMode` property to use silent or interactive installer switches as specified

--- a/src/AppInstallerCLICore/Commands/DscPackageResource.cpp
+++ b/src/AppInstallerCLICore/Commands/DscPackageResource.cpp
@@ -89,6 +89,20 @@ namespace AppInstaller::CLI
                     SubContext->Args.AddArg(Execution::Args::Type::AcceptSourceAgreements);
                     SubContext->Args.AddArg(Execution::Args::Type::AcceptPackageAgreements);
                 }
+
+                std::string installMode = Utility::ToLower(Input.InstallMode().value_or("default"));
+                if (installMode == "silent")
+                {
+                    SubContext->Args.AddArg(Execution::Args::Type::Silent);
+                }
+                else if (installMode == "interactive")
+                {
+                    SubContext->Args.AddArg(Execution::Args::Type::Interactive);
+                }
+                else if (installMode != "default")
+                {
+                    THROW_HR(E_INVALIDARG);
+                }
             }
 
             void PrepareSubContextInputs()

--- a/src/AppInstallerCLIE2ETests/DSCv3PackageResourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3PackageResourceCommand.cs
@@ -23,6 +23,7 @@ namespace AppInstallerCLIE2ETests
         private const string DefaultPackageLowVersion = "1.0.0.0";
         private const string DefaultPackageMidVersion = "1.1.0.0";
         private const string DefaultPackageHighVersion = "2.0.0.0";
+        private const string DefaultPackageInstallLocationEnvironmentVariableName = "WINGET_TEST_EXE_INSTALL_LOCATION";
         private const string PackageResource = "package";
         private const string VersionPropertyName = "version";
         private const string UseLatestPropertyName = "useLatest";
@@ -311,13 +312,15 @@ namespace AppInstallerCLIE2ETests
         public void Package_Set_SilentInstallMode_UsesSilentAndCustomSwitches()
         {
             string installDir = Path.GetTempPath();
+            var environmentVariables = new Dictionary<string, string>();
+            environmentVariables[DefaultPackageInstallLocationEnvironmentVariableName] = installDir;
             PackageResourceData packageResourceData = new PackageResourceData()
             {
                 Identifier = DefaultPackageIdentifier,
                 InstallMode = "silent",
             };
 
-            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData);
+            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData, environmentVariables: environmentVariables);
             AssertSuccessfulResourceRun(ref result);
 
             Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/execustom"));
@@ -332,13 +335,15 @@ namespace AppInstallerCLIE2ETests
         public void Package_Set_InteractiveInstallMode_UsesInteractiveAndCustomSwitches()
         {
             string installDir = Path.GetTempPath();
+            var environmentVariables = new Dictionary<string, string>();
+            environmentVariables[DefaultPackageInstallLocationEnvironmentVariableName] = installDir;
             PackageResourceData packageResourceData = new PackageResourceData()
             {
                 Identifier = DefaultPackageIdentifier,
                 InstallMode = "interactive",
             };
 
-            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData);
+            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData, environmentVariables: environmentVariables);
             AssertSuccessfulResourceRun(ref result);
 
             Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/execustom"));

--- a/src/AppInstallerCLIE2ETests/DSCv3PackageResourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3PackageResourceCommand.cs
@@ -7,6 +7,7 @@
 namespace AppInstallerCLIE2ETests
 {
     using System.Collections.Generic;
+    using System.IO;
     using System.Text.Json.Serialization;
     using AppInstallerCLIE2ETests.Helpers;
     using NUnit.Framework;
@@ -301,6 +302,48 @@ namespace AppInstallerCLIE2ETests
             AssertExistingPackageResourceData(output, DefaultPackageHighVersion);
 
             AssertDiffState(diff, []);
+        }
+
+        /// <summary>
+        /// Calls `set` on the `package` resource with `installMode` set to `silent`.
+        /// </summary>
+        [Test]
+        public void Package_Set_SilentInstallMode_UsesSilentAndCustomSwitches()
+        {
+            string installDir = Path.GetTempPath();
+            PackageResourceData packageResourceData = new PackageResourceData()
+            {
+                Identifier = DefaultPackageIdentifier,
+                InstallMode = "silent",
+            };
+
+            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData);
+            AssertSuccessfulResourceRun(ref result);
+
+            Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/execustom"));
+            Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/exesilent"));
+            TestCommon.BestEffortTestExeCleanup(installDir);
+        }
+
+        /// <summary>
+        /// Calls `set` on the `package` resource with `installMode` set to `interactive`.
+        /// </summary>
+        [Test]
+        public void Package_Set_InteractiveInstallMode_UsesInteractiveAndCustomSwitches()
+        {
+            string installDir = Path.GetTempPath();
+            PackageResourceData packageResourceData = new PackageResourceData()
+            {
+                Identifier = DefaultPackageIdentifier,
+                InstallMode = "interactive",
+            };
+
+            var result = RunDSCv3Command(PackageResource, SetFunction, packageResourceData);
+            AssertSuccessfulResourceRun(ref result);
+
+            Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/execustom"));
+            Assert.True(TestCommon.VerifyTestExeInstalled(installDir, "/exeinteractive"));
+            TestCommon.BestEffortTestExeCleanup(installDir);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/DSCv3ResourceTestBase.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3ResourceTestBase.cs
@@ -69,10 +69,17 @@ namespace AppInstallerCLIE2ETests
         /// <param name="input">Input for the function; supports null, direct string, or JSON serialization of complex objects.</param>
         /// <param name="timeOut">The maximum time to wait in milliseconds.</param>
         /// <param name="throwOnTimeout">Whether to throw on a timeout or simply return the incomplete result.</param>
+        /// <param name="environmentVariables">Environment variables to set.</param>
         /// <returns>A RunCommandResult containing the process exit code and output and error streams.</returns>
-        protected static TestCommon.RunCommandResult RunDSCv3Command(string resource, string function, object input, int timeOut = 60000, bool throwOnTimeout = true)
+        protected static TestCommon.RunCommandResult RunDSCv3Command(
+            string resource,
+            string function,
+            object input,
+            int timeOut = 60000,
+            bool throwOnTimeout = true,
+            Dictionary<string, string> environmentVariables = null)
         {
-            return TestCommon.RunAICLICommand($"dscv3 {resource}", $"--{function}", ConvertToJSON(input), timeOut, throwOnTimeout);
+            return TestCommon.RunAICLICommand($"dscv3 {resource}", $"--{function}", ConvertToJSON(input), timeOut, throwOnTimeout, environmentVariables);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/TestCommon.cs
@@ -7,6 +7,7 @@
 namespace AppInstallerCLIE2ETests.Helpers
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
@@ -112,8 +113,15 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="stdIn">Optional std in.</param>
         /// <param name="timeOut">Optional timeout.</param>
         /// <param name="throwOnTimeout">Throw on timeout.</param>
+        /// <param name="environmentVariables">Environment variables to set.</param>
         /// <returns>The result of the command.</returns>
-        public static RunCommandResult RunAICLICommand(string command, string parameters, string stdIn = null, int timeOut = 60000, bool throwOnTimeout = true)
+        public static RunCommandResult RunAICLICommand(
+            string command,
+            string parameters,
+            string stdIn = null,
+            int timeOut = 60000,
+            bool throwOnTimeout = true,
+            Dictionary<string, string> environmentVariables = null)
         {
             string correlationParameter = " --correlation " + Guid.NewGuid().ToString();
 
@@ -126,7 +134,7 @@ namespace AppInstallerCLIE2ETests.Helpers
                 }
             }
 
-            return RunAICLICommandViaDirectProcess(command, parameters + correlationParameter, stdIn, timeOut, throwOnTimeout);
+            return RunAICLICommandViaDirectProcess(command, parameters + correlationParameter, stdIn, timeOut, throwOnTimeout, environmentVariables);
         }
 
         /// <summary>
@@ -1159,15 +1167,25 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="stdIn">Optional std in.</param>
         /// <param name="timeOut">Optional timeout.</param>
         /// <param name="throwOnTimeout">Throw on timeout.</param>
+        /// <param name="environmentVariables">Environment variables to set.</param>
         /// <returns>The result of the command.</returns>
-        public static RunCommandResult RunProcess(string executablePath, string command, string parameters, string stdIn, int timeOut, bool throwOnTimeout)
+        public static RunCommandResult RunProcess(
+            string executablePath,
+            string command,
+            string parameters,
+            string stdIn,
+            int timeOut,
+            bool throwOnTimeout,
+            Dictionary<string, string> environmentVariables)
         {
             string inputMsg =
                     "Exe path: " + executablePath +
                     " Command: " + command +
                     " Parameters: " + parameters +
                     (string.IsNullOrEmpty(stdIn) ? string.Empty : " StdIn: " + stdIn) +
-                    " Timeout: " + timeOut;
+                    " Timeout: " + timeOut +
+                    (environmentVariables == null ? string.Empty :
+                        " Env: " + string.Join(", ", environmentVariables.Select(item => $"{item.Key}={item.Value}")));
 
             TestContext.Out.WriteLine($"Starting command run. {inputMsg}");
 
@@ -1201,6 +1219,14 @@ namespace AppInstallerCLIE2ETests.Helpers
             if (!string.IsNullOrEmpty(stdIn))
             {
                 p.StartInfo.RedirectStandardInput = true;
+            }
+
+            if (environmentVariables != null)
+            {
+                foreach (var item in environmentVariables)
+                {
+                    p.StartInfo.EnvironmentVariables[item.Key] = item.Value;
+                }
             }
 
             p.Start();
@@ -1251,10 +1277,17 @@ namespace AppInstallerCLIE2ETests.Helpers
         /// <param name="stdIn">Optional std in.</param>
         /// <param name="timeOut">Optional timeout.</param>
         /// <param name="throwOnTimeout">Throw on timeout.</param>
+        /// <param name="environmentVariables">Environment variables to set.</param>
         /// <returns>The result of the command.</returns>
-        private static RunCommandResult RunAICLICommandViaDirectProcess(string command, string parameters, string stdIn, int timeOut, bool throwOnTimeout)
+        private static RunCommandResult RunAICLICommandViaDirectProcess(
+            string command,
+            string parameters,
+            string stdIn,
+            int timeOut,
+            bool throwOnTimeout,
+            Dictionary<string, string> environmentVariables)
         {
-            return RunProcess(TestSetup.Parameters.AICLIPath, command, parameters, stdIn, timeOut, throwOnTimeout);
+            return RunProcess(TestSetup.Parameters.AICLIPath, command, parameters, stdIn, timeOut, throwOnTimeout, environmentVariables);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/InprocTestbedTests.cs
+++ b/src/AppInstallerCLIE2ETests/InprocTestbedTests.cs
@@ -212,7 +212,7 @@ namespace AppInstallerCLIE2ETests
                 builtParameters += $"-no-term ";
             }
 
-            var result = TestCommon.RunProcess(this.InprocTestbedPath, this.TargetPackageInformation, builtParameters, null, timeout, true);
+            var result = TestCommon.RunProcess(this.InprocTestbedPath, this.TargetPackageInformation, builtParameters, null, timeout, true, null);
             Assert.AreEqual(0, result.ExitCode);
         }
 

--- a/src/AppInstallerTestExeInstaller/main.cpp
+++ b/src/AppInstallerTestExeInstaller/main.cpp
@@ -619,14 +619,21 @@ int wmain(int argc, const wchar_t** argv)
 
     if (!installDirectory)
     {
-        auto value = std::getenv(InstallLocationEnvironmentVariableName);
-        if (value)
+        char* value = nullptr;
+        size_t valueLength = 0;
+        errno_t result = _dupenv_s(&value, &valueLength, InstallLocationEnvironmentVariableName);
+        if (result == 0 && value)
         {
             installDirectory = value;
         }
         else
         {
             installDirectory = temp_directory_path();
+        }
+
+        if (value)
+        {
+            free(value);
         }
     }
 

--- a/src/AppInstallerTestExeInstaller/main.cpp
+++ b/src/AppInstallerTestExeInstaller/main.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <fstream>
 #include <filesystem>
+#include <optional>
 #include <sstream>
 
 using namespace std::filesystem;
@@ -17,6 +18,7 @@ std::wstring_view DefaultProductID = L"{A499DD5E-8DC5-4AD2-911A-BCD0263295E9}";
 std::wstring_view DefaultDisplayName = L"AppInstallerTestExeInstaller";
 std::wstring_view DefaultDisplayVersion = L"1.0.0.0";
 std::wstring_view DscSubDirectoryName = L"SubDirectory";
+auto InstallLocationEnvironmentVariableName = "WINGET_TEST_EXE_INSTALL_LOCATION";
 
 void WriteModifyRepairScript(std::wofstream& script, const path& repairCompletedTextFilePath, bool isModifyScript) {
     std::wstring scriptName = isModifyScript ? L"Modify" : L"Uninstaller";
@@ -447,7 +449,7 @@ void HandleInstallationOperation(
 // The installer prints all args to an output file and writes to the Uninstall registry key
 int wmain(int argc, const wchar_t** argv)
 {
-    path installDirectory = temp_directory_path();
+    std::optional<path> installDirectory;
     std::wstringstream outContent;
     std::wstring productCode;
     std::wstring displayName;
@@ -476,7 +478,6 @@ int wmain(int argc, const wchar_t** argv)
             if (++i < argc)
             {
                 installDirectory = argv[i];
-                std::filesystem::create_directories(installDirectory);
                 outContent << argv[i] << ' ';
             }
         }
@@ -616,6 +617,21 @@ int wmain(int argc, const wchar_t** argv)
         }
     }
 
+    if (!installDirectory)
+    {
+        auto value = std::getenv(InstallLocationEnvironmentVariableName);
+        if (value)
+        {
+            installDirectory = value;
+        }
+        else
+        {
+            installDirectory = temp_directory_path();
+        }
+    }
+
+    std::filesystem::create_directories(installDirectory.value());
+
     if (noOperation)
     {
         return exitCode;
@@ -650,8 +666,6 @@ int wmain(int argc, const wchar_t** argv)
         displayVersion = DefaultDisplayVersion;
     }
 
-    path outFilePath = installDirectory;
-
     if (isRepair)
     {
         outContent << L"\nInstaller Repair operation for AppInstallerTestExeInstaller.exe completed successfully.";
@@ -659,7 +673,7 @@ int wmain(int argc, const wchar_t** argv)
     }
     else
     {
-        HandleInstallationOperation(*out, installDirectory, outContent, productCode, useHKLM, displayName, displayVersion, noRepair, noModify, generateDscResourceFiles);
+        HandleInstallationOperation(*out, installDirectory.value(), outContent, productCode, useHKLM, displayName, displayVersion, noRepair, noModify, generateDscResourceFiles);
     }
 
     return exitCode;


### PR DESCRIPTION
## 📖 Description
When using DSCv3 Microsoft.WinGet/Package resource with installMode: silent specified, WinGet was not honoring the requested mode and instead defaulting to SilentWithProgress. This resulted in progress UI being shown and manifest custom switches being omitted from installer arguments.

This PR maps the installMode property (declared in DscPackageResource) to execution context args (--silent or --interactive) before install/update/reinstall workflows execute, ensuring:
- installMode: silent selects Silent installer switches
- installMode: interactive selects Interactive installer switches  
- installMode: default preserves existing behavior (no mode arg added)
- Manifest custom switches continue to be appended to installer arguments

## 🔗 References
Resolves #6248

## 🔍 Validation
Added DSCv3 E2E regression tests in DSCv3PackageResourceCommand.cs:
- Package_Set_SilentInstallMode_UsesSilentAndCustomSwitches: Validates silent mode uses /exesilent and includes /execustom
- Package_Set_InteractiveInstallMode_UsesInteractiveAndCustomSwitches: Validates interactive mode uses /exeinteractive and includes /execustom

Environment note: Targeted test execution was attempted but blocked by missing Visual C++ MSBuild targets (MSB4278). Tests require Visual Studio build environment.

## ✅ Checklist
- [x] Linked to an issue (#6248)
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [x] Bug fix
- [ ] Feature
- [ ] Task

---
Copilot assisted with this PR.