### PR TITLE
Fix triage label getting removed

### DIFF
--- a/.github/policies/labelManagement.triageLabels.yml
+++ b/.github/policies/labelManagement.triageLabels.yml
@@ -67,12 +67,6 @@ configuration:
               - labelAdded:
                   label: Interactive-Only-Installer
               - labelAdded:
-                  label: Issue-Bug
-              - labelAdded:
-                  label: Issue-Docs
-              - labelAdded:
-                  label: Issue-Feature
-              - labelAdded:
                   label: msstore
               - labelAdded:
                   label: Needs-Attention


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Although these three labels get applied when the issue is opened, it is technically a separate event that happens *after* the the issue is opened. This means that the policy service is catching this event and removing issues from triage before they are actually triaged. This is a faulty implementation from #6202 

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->
See recently opened issue https://github.com/microsoft/winget-cli/issues/6245

## 🔍 Validation
None
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6254)