### PR TITLE
Bubble up child process errors in IndexCreationTool

### DIFF
--- a/src/AppInstallerCLIE2ETests/TestData/localsource.json
+++ b/src/AppInstallerCLIE2ETests/TestData/localsource.json
@@ -34,7 +34,8 @@
       "Type": "font",
       "Name": "AppInstallerTestFont/AppInstallerTestFont.ttf",
       "Input": "%BUILD_SOURCESDIRECTORY%/src/AppInstallerCLIE2ETests/TestData/AppInstallerTestFont.ttf",
-      "HashToken": "<FONTHASH>"
+      "HashToken": "<FONTHASH>",
+      "SkipSignature": true
     }
   ],
   "DynamicInstallers": [

--- a/src/WinGetSourceCreator/Helpers.cs
+++ b/src/WinGetSourceCreator/Helpers.cs
@@ -86,12 +86,7 @@ namespace Microsoft.WinGetSourceCreator
             string pathToSDK = SDKDetector.Instance.LatestSDKBinPath;
             string makeappxExecutable = Path.Combine(pathToSDK, "makeappx.exe");
             string args = $"unpack /nv /p \"{package}\" /d \"{outDir}\"";
-            Process p = new Process
-            {
-                StartInfo = new ProcessStartInfo(makeappxExecutable, args)
-            };
-            p.Start();
-            p.WaitForExit();
+            RunCommand(makeappxExecutable, args);
         }
 
         public static void PackWithMappingFile(string outputPackage, string mappingFile)
@@ -138,6 +133,11 @@ namespace Microsoft.WinGetSourceCreator
             }
             p.Start();
             p.WaitForExit();
+
+            if (p.ExitCode != 0)
+            {
+                throw new Exception($"Command failed with exit code {p.ExitCode}: {command} {args}");
+            }
         }
 
         // If in the future we edit more elements, this should be a nice wrapper class.

--- a/src/WinGetSourceCreator/Helpers.cs
+++ b/src/WinGetSourceCreator/Helpers.cs
@@ -136,7 +136,7 @@ namespace Microsoft.WinGetSourceCreator
 
             if (p.ExitCode != 0)
             {
-                throw new Exception($"Command failed with exit code {p.ExitCode}: {command} {args}");
+                throw new Exception($"Command failed with exit code {p.ExitCode}: {command}");
             }
         }
 


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
IndexCreationTool can run several child processes. If any of them fails, index creation has partially failed and I expect an exception, but IndexCreationTool exits 0. This PR throws an exception with the exit code and command/args to assist with debugging. I also updated `makeappx unpack` to use the shared `RunCommand` function.

I suspect IndexCreationTool isn't a stable/supported dependency, but thought this was worth submitting anyway.

## 🔗 References
Example SignTool error: https://github.com/pl4nty/winget-extras/actions/runs/26671649037/job/78615909376

## 🔍 Validation
I don't have a VS toolchain on hand, so I'd love if someone can run the ADO tests on this PR. Then I'll validate in my CI from the built IndexCreationTool.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6261)