### PR TITLE
Add .gitattributes and normalize line endings across repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Default: CRLF on checkout - primary tooling is Visual Studio / PowerShell on Windows.
+# Git always stores text as LF in the object store; eol= controls the working tree only.
+* text=auto eol=crlf
+
+# Cross-platform formats - no Windows tooling owns these, LF is safer for external consumers
+*.editorconfig  text eol=lf
+*.gitattributes text eol=lf
+*.gitignore     text eol=lf
+*.json          text eol=lf
+*.js            text eol=lf
+*.md            text eol=lf
+*.patch         text eol=lf
+*.txt           text eol=lf
+
+# Vendored external modules - preserve byte-for-byte as shipped upstream
+# (some files are UTF-16 LE; text=auto would misidentify or corrupt them)
+src/PowerShell/ExternalModules/** -text
+
+# Binary assets - suppress line-ending conversion and text diffs
+*.cer   binary
+*.crt   binary
+*.dll   binary
+*.exe   binary
+*.gif   binary
+*.ico   binary
+*.msi   binary
+*.msix  binary
+*.png   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,27 +2,6 @@
 # Git always stores text as LF in the object store; eol= controls the working tree only.
 * text=auto eol=crlf
 
-# Cross-platform formats - no Windows tooling owns these, LF is safer for external consumers
-*.editorconfig  text eol=lf
-*.gitattributes text eol=lf
-*.gitignore     text eol=lf
-*.json          text eol=lf
-*.js            text eol=lf
-*.md            text eol=lf
-*.patch         text eol=lf
-*.txt           text eol=lf
-
-# Vendored external modules - preserve byte-for-byte as shipped upstream
-# (some files are UTF-16 LE; text=auto would misidentify or corrupt them)
-src/PowerShell/ExternalModules/** -text
-
-# Binary assets - suppress line-ending conversion and text diffs
-*.cer   binary
-*.crt   binary
-*.dll   binary
-*.exe   binary
-*.gif   binary
-*.ico   binary
-*.msi   binary
-*.msix  binary
-*.png   binary
+# Patch files must stay LF - git apply matches content lines against the target source
+# tree, which vcpkg manages as LF internally
+*.patch text eol=lf


### PR DESCRIPTION
- set CRLF as the default checkout encoding for this Windows-native project; `text=auto` handles binary detection (including UTF-16 LE vendored files) without explicit overrides
- keep `*.patch` as LF -- vcpkg applies these against LF source trees via `git apply`
- the remaining 1,753 staged files are a one-time re-normalization of git's internal LF object storage; `git diff --ignore-all-space` shows only `.gitattributes` as a real change

Assisted-By: "claude my eyes right out"

(I'm more than happy to rebase, adjust, discuss, amend, etc)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6267)