### PR TITLE
Clarify some manifest values and add examples

### DIFF
--- a/schemas/JSON/manifests/latest/manifest.installer.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.installer.latest.json
@@ -546,9 +546,8 @@
       "properties": {
         "DefaultInstallLocation": {
           "type": [ "string", "null" ],
-          "minLength": 2,
+          "minLength": 1,
           "maxLength": 2048,
-          "pattern": "^[%\\]",
           "examples": ["%ProgramFiles%\\ContosoApp"],
           "description": "Represents the default installed package location. Used for deeper installation detection."
         },

--- a/schemas/JSON/manifests/latest/manifest.installer.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.installer.latest.json
@@ -313,7 +313,7 @@
           },
           "maxItems": 16,
           "uniqueItems": true,
-          "examples": ["ntvdm", "DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
+          "examples": ["DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
@@ -368,7 +368,7 @@
       "type": [ "string", "null" ],
       "minLength": 1,
       "maxLength": 255,
-      "examples": ["{MSI-GUID}", "ContosoApp", "Fabrikam.FantastikApp"],
+      "examples": ["{MSI-GUID}", "ContosoApp"],
       "description": "The name of the ARP registry key, could be used for correlation of packages across sources"
     },
     "UpgradeCode": {

--- a/schemas/JSON/manifests/latest/manifest.installer.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.installer.latest.json
@@ -152,7 +152,7 @@
           "type": [ "string", "null" ],
           "minLength": 1,
           "maxLength": 512,
-          "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
+          "description": "Silent is the value that should be passed to the installer when user chooses a silent install"
         },
         "SilentWithProgress": {
           "type": [ "string", "null" ],
@@ -313,6 +313,7 @@
           },
           "maxItems": 16,
           "uniqueItems": true,
+          "examples": ["ntvdm", "DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
@@ -367,7 +368,17 @@
       "type": [ "string", "null" ],
       "minLength": 1,
       "maxLength": 255,
-      "description": "ProductCode could be used for correlation of packages across sources"
+      "examples": ["{MSI-GUID}", "ContosoApp", "Fabrikam.FantastikApp"],
+      "description": "The name of the ARP registry key, could be used for correlation of packages across sources"
+    },
+    "UpgradeCode": {
+      "type": [ "string", "null" ],
+      "pattern": "^{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}$",
+      "minLength": 38,
+      "maxLength": 38,
+      "examples": ["{MSI-GUID}"],
+      "description": "Represents a related set of products, could be used for correlation of packages across sources",
+      "$comment": "https://learn.microsoft.com/en-us/windows/win32/msi/using-an-upgradecode"
     },
     "Capabilities": {
       "type": [ "array", "null" ],
@@ -378,6 +389,7 @@
       },
       "maxItems": 1000,
       "uniqueItems": true,
+      "examples": ["contacts", "internetClient", "globalMediaControl"],
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
@@ -389,6 +401,7 @@
       },
       "maxItems": 1000,
       "uniqueItems": true,
+      "examples": ["deviceUnlock", "runFullTrust", "broadFileSystemAccess"],
       "description": "List of appx or msix installer restricted capabilities"
     },
     "Market": {
@@ -501,7 +514,7 @@
           "$ref": "#/definitions/ProductCode"
         },
         "UpgradeCode": {
-          "$ref": "#/definitions/ProductCode"
+          "$ref": "#/definitions/UpgradeCode"
         },
         "InstallerType": {
           "$ref": "#/definitions/InstallerType"
@@ -533,8 +546,10 @@
       "properties": {
         "DefaultInstallLocation": {
           "type": [ "string", "null" ],
-          "minLength": 1,
+          "minLength": 2,
           "maxLength": 2048,
+          "pattern": "^[%\\]",
+          "examples": ["%ProgramFiles%\\ContosoApp"],
           "description": "Represents the default installed package location. Used for deeper installation detection."
         },
         "Files": {

--- a/schemas/JSON/manifests/latest/manifest.singleton.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.singleton.latest.json
@@ -647,9 +647,8 @@
       "properties": {
         "DefaultInstallLocation": {
           "type": [ "string", "null" ],
-          "minLength": 2,
+          "minLength": 1,
           "maxLength": 2048,
-          "pattern": "^[%\\]",
           "examples": ["%ProgramFiles%\\ContosoApp"],
           "description": "Represents the default installed package location. Used for deeper installation detection."
         },

--- a/schemas/JSON/manifests/latest/manifest.singleton.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.singleton.latest.json
@@ -415,7 +415,7 @@
           },
           "maxItems": 16,
           "uniqueItems": true,
-          "examples": ["ntvdm", "DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
+          "examples": ["DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
@@ -469,7 +469,7 @@
       "type": [ "string", "null" ],
       "minLength": 1,
       "maxLength": 255,
-      "examples": ["{MSI-GUID}", "ContosoApp", "Fabrikam.FantastikApp"],
+      "examples": ["{MSI-GUID}", "ContosoApp"],
       "description": "The name of the ARP registry key, could be used for correlation of packages across sources"
     },
     "UpgradeCode": {

--- a/schemas/JSON/manifests/latest/manifest.singleton.latest.json
+++ b/schemas/JSON/manifests/latest/manifest.singleton.latest.json
@@ -254,7 +254,7 @@
           "type": [ "string", "null" ],
           "minLength": 1,
           "maxLength": 512,
-          "description": "Silent is the value that should be passed to the installer when user chooses a silent or quiet install"
+          "description": "Silent is the value that should be passed to the installer when user chooses a silent install"
         },
         "SilentWithProgress": {
           "type": [ "string", "null" ],
@@ -415,6 +415,7 @@
           },
           "maxItems": 16,
           "uniqueItems": true,
+          "examples": ["ntvdm", "DirectPlay", "Microsoft-Windows-Subsystem-Linux"],
           "description": "List of Windows feature dependencies"
         },
         "WindowsLibraries": {
@@ -468,7 +469,17 @@
       "type": [ "string", "null" ],
       "minLength": 1,
       "maxLength": 255,
-      "description": "ProductCode could be used for correlation of packages across sources"
+      "examples": ["{MSI-GUID}", "ContosoApp", "Fabrikam.FantastikApp"],
+      "description": "The name of the ARP registry key, could be used for correlation of packages across sources"
+    },
+    "UpgradeCode": {
+      "type": [ "string", "null" ],
+      "pattern": "^{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}$",
+      "minLength": 38,
+      "maxLength": 38,
+      "examples": ["{MSI-GUID}"],
+      "description": "Represents a related set of products, could be used for correlation of packages across sources",
+      "$comment": "https://learn.microsoft.com/en-us/windows/win32/msi/using-an-upgradecode"
     },
     "Capabilities": {
       "type": [ "array", "null" ],
@@ -479,6 +490,7 @@
       },
       "maxItems": 1000,
       "uniqueItems": true,
+      "examples": ["contacts", "internetClient", "globalMediaControl"],
       "description": "List of appx or msix installer capabilities"
     },
     "RestrictedCapabilities": {
@@ -490,6 +502,7 @@
       },
       "maxItems": 1000,
       "uniqueItems": true,
+      "examples": ["deviceUnlock", "runFullTrust", "broadFileSystemAccess"],
       "description": "List of appx or msix installer restricted capabilities"
     },
     "Market": {
@@ -602,7 +615,7 @@
           "$ref": "#/definitions/ProductCode"
         },
         "UpgradeCode": {
-          "$ref": "#/definitions/ProductCode"
+          "$ref": "#/definitions/UpgradeCode"
         },
         "InstallerType": {
           "$ref": "#/definitions/InstallerType"
@@ -634,8 +647,10 @@
       "properties": {
         "DefaultInstallLocation": {
           "type": [ "string", "null" ],
-          "minLength": 1,
+          "minLength": 2,
           "maxLength": 2048,
+          "pattern": "^[%\\]",
+          "examples": ["%ProgramFiles%\\ContosoApp"],
           "description": "Represents the default installed package location. Used for deeper installation detection."
         },
         "Files": {


### PR DESCRIPTION
## 📖 Description
 - Tries to clarify the description of some of the manifest values.
 - Adds value examples.
 - Adds the UpgradeCode definition.

#### Notes:
- `UpgradeCode` is restricted only to GUIDs because this is a MSI feature. I have verified that all existing manifests in the community repository only uses GUIDs here.
 - `DefaultInstallLocation` is restricted to strings starting with `%` or `\`. The thinking is that the only sane values are `%ProgramFiles%\MyApp`, `%LOCALAPPDATA%\Programs\MyApp` and `\AppInRootOfDrive`.

## 🔗 References
Fixes some of the issues reported in #6221 

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
None/YOLO

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6277)