### PR TITLE
Align .gitattributes and .editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 # Patch files must stay LF - git apply matches content lines against the target source
 # tree, which vcpkg manages as LF internally
 *.patch text eol=lf
+
+# Spelling action inputs must stay LF
+{allow.txt,excludes.txt,patterns.txt,expect.txt} text eol=lf


### PR DESCRIPTION
## 📖 Description
Follows on to #6267 as [my comment](https://github.com/microsoft/winget-cli/pull/6267#pullrequestreview-4440231044) was not addressed indicating that `.editorconfig` and `.gitattributes` should agree on the line endings.

The line endings of these files should be LF to ensure that the runner processes them correctly. 

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6285)