### PR TITLE
Fix crash with --disable-interactivity and EFResume

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -4,4 +4,4 @@ Nothing yet.
 
 ## Bug Fixes
 
-* None yet
+* Fixed a crash (`0x8000ffff`) when using `--disable-interactivity` with the Resume experimental feature enabled during install operations.

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -448,6 +448,8 @@ namespace AppInstaller::CLI
             return Argument{ type, Resource::String::NoProgressArgumentDescription, ArgumentType::Flag, Argument::Visibility::Hidden };
         case Args::Type::VerboseLogs:
             return Argument{ type, Resource::String::VerboseLogsArgumentDescription, ArgumentType::Flag };
+        case Args::Type::DisableInteractivity:
+            return Argument{ type, Resource::String::DisableInteractivityArgumentDescription, ArgumentType::Flag, false };
         case Args::Type::CustomHeader:
             return Argument{ type, Resource::String::HeaderArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help };
         case Args::Type::AcceptSourceAgreements:


### PR DESCRIPTION
## 📖 Description
When `winget install --disable-interactivity` is executed with the Resume experimental feature enabled, checkpoint creation saves all command-line arguments. On resume or during checkpoint validation, the code calls `Argument::ForType()` on every saved argument type to reconstruct the execution context. However, `Execution::Args::Type::DisableInteractivity` was missing from the `Argument::ForType()` switch statement, causing the default case to throw `E_UNEXPECTED (0x8000ffff)` instead of properly handling the flag.

## 🔗 References
* Resolves #4584

## 🔍 Validation
Manually tested - did not add unit tests as resume is still experimental

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6302)