### PR TITLE
Format WinINet HRESULT messages

### DIFF
--- a/src/AppInstallerCLITests/Errors.cpp
+++ b/src/AppInstallerCLITests/Errors.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "TestCommon.h"
 #include <AppInstallerErrors.h>
+#include <system_error>
 
 using namespace AppInstaller;
 using namespace AppInstaller::Utility;
@@ -16,4 +17,19 @@ TEST_CASE("EnsureSortedErrorList", "[errors]")
         INFO(errors[i - 1]->Symbol() << " then " << errors[i]->Symbol());
         REQUIRE(errors[i]->Value() > errors[i - 1]->Value());
     }
+}
+
+TEST_CASE("Win32HResultMessageUsesWin32Code", "[errors]")
+{
+    constexpr HRESULT internetCannotConnect = HRESULT_FROM_WIN32(ERROR_INTERNET_CANNOT_CONNECT);
+    const std::string message = GetUserPresentableMessage(internetCannotConnect);
+    const std::string expectedSystemMessage = std::system_category().message(ERROR_INTERNET_CANNOT_CONNECT);
+    const std::string hresultSystemMessage = std::system_category().message(internetCannotConnect);
+
+    INFO(message);
+    INFO(expectedSystemMessage);
+    INFO(hresultSystemMessage);
+    REQUIRE(message.find("0x80072efd") != std::string::npos);
+    REQUIRE(message.find(expectedSystemMessage) != std::string::npos);
+    REQUIRE(message.find(hresultSystemMessage) == std::string::npos);
 }

--- a/src/AppInstallerCLITests/Errors.cpp
+++ b/src/AppInstallerCLITests/Errors.cpp
@@ -19,17 +19,21 @@ TEST_CASE("EnsureSortedErrorList", "[errors]")
     }
 }
 
-TEST_CASE("Win32HResultMessageUsesWin32Code", "[errors]")
+TEST_CASE("WinInetHResultMessageUsesWinInetMessage", "[errors]")
 {
     constexpr HRESULT internetCannotConnect = HRESULT_FROM_WIN32(ERROR_INTERNET_CANNOT_CONNECT);
     const std::string message = GetUserPresentableMessage(internetCannotConnect);
-    const std::string expectedSystemMessage = std::system_category().message(ERROR_INTERNET_CANNOT_CONNECT);
-    const std::string hresultSystemMessage = std::system_category().message(internetCannotConnect);
+    const std::string fallbackSystemMessage = std::system_category().message(internetCannotConnect);
 
     INFO(message);
-    INFO(expectedSystemMessage);
-    INFO(hresultSystemMessage);
+    INFO(fallbackSystemMessage);
     REQUIRE(message.find("0x80072efd") != std::string::npos);
-    REQUIRE(message.find(expectedSystemMessage) != std::string::npos);
-    REQUIRE(message.find(hresultSystemMessage) == std::string::npos);
+    REQUIRE(message.find(fallbackSystemMessage) == std::string::npos);
+
+    auto hresultInfo = Errors::HResultInformation::Find(internetCannotConnect);
+    REQUIRE(hresultInfo);
+
+    const auto description = hresultInfo->GetDescription();
+    INFO(description);
+    REQUIRE(description.get().find(fallbackSystemMessage) == std::string::npos);
 }

--- a/src/AppInstallerSharedLib/Errors.cpp
+++ b/src/AppInstallerSharedLib/Errors.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
+#include <wininet.h>
 #include "Public/AppInstallerErrors.h"
 #include "Public/AppInstallerLogging.h"
 #include "Public/AppInstallerStrings.h"
@@ -343,6 +344,55 @@ namespace AppInstaller
                 UnknownHResultInformation(hr).GetDescription();
         }
 
+        int GetSystemErrorCode(HRESULT hr)
+        {
+            return static_cast<int>(HRESULT_FACILITY(hr) == FACILITY_WIN32 ? HRESULT_CODE(hr) : hr);
+        }
+
+        // WinINet errors are not present in the system message table.
+        std::optional<std::string> GetWinInetErrorMessage(int errorCode)
+        {
+            if (errorCode < ERROR_INTERNET_OUT_OF_HANDLES || errorCode > INTERNET_ERROR_LAST)
+            {
+                return std::nullopt;
+            }
+
+            wil::unique_hmodule module{ LoadLibraryExW(L"wininet.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32) };
+            if (!module)
+            {
+                return std::nullopt;
+            }
+
+            LPWSTR buffer = nullptr;
+            const DWORD messageLength = FormatMessageW(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_IGNORE_INSERTS,
+                module.get(), errorCode, 0, reinterpret_cast<LPWSTR>(&buffer), 0, nullptr);
+            if (!messageLength)
+            {
+                return std::nullopt;
+            }
+
+            auto freeBuffer = wil::scope_exit([&]() { LocalFree(buffer); });
+            std::string message = Utility::ConvertToUTF8(std::wstring_view{ buffer, messageLength });
+            Utility::Trim(message);
+            return message.empty() ? std::nullopt : std::optional<std::string>{ std::move(message) };
+        }
+
+        std::string GetSystemErrorMessage(HRESULT hr)
+        {
+            const int errorCode = GetSystemErrorCode(hr);
+            if (HRESULT_FACILITY(hr) == FACILITY_WIN32)
+            {
+                auto winInetMessage = GetWinInetErrorMessage(errorCode);
+                if (winInetMessage)
+                {
+                    return std::move(winInetMessage).value();
+                }
+            }
+
+            return std::system_category().message(errorCode);
+        }
+
         void GetUserPresentableMessageForHR(std::ostringstream& strstr, HRESULT hr)
         {
             strstr << "0x" << Logging::SetHRFormat << hr << " : ";
@@ -361,8 +411,7 @@ namespace AppInstaller
                 }
                 else
                 {
-                    strstr << std::system_category().message(
-                        HRESULT_FACILITY(hr) == FACILITY_WIN32 ? HRESULT_CODE(hr) : hr);
+                    strstr << GetSystemErrorMessage(hr);
                 }
             }
         }
@@ -438,7 +487,7 @@ namespace AppInstaller
             }
             else
             {
-                return Utility::LocIndString{ std::system_category().message(m_value) };
+                return Utility::LocIndString{ GetSystemErrorMessage(m_value) };
             }
         }
 

--- a/src/AppInstallerSharedLib/Errors.cpp
+++ b/src/AppInstallerSharedLib/Errors.cpp
@@ -361,7 +361,8 @@ namespace AppInstaller
                 }
                 else
                 {
-                    strstr << std::system_category().message(hr);
+                    strstr << std::system_category().message(
+                        HRESULT_FACILITY(hr) == FACILITY_WIN32 ? HRESULT_CODE(hr) : hr);
                 }
             }
         }

--- a/src/AppInstallerSharedLib/Errors.cpp
+++ b/src/AppInstallerSharedLib/Errors.cpp
@@ -344,11 +344,6 @@ namespace AppInstaller
                 UnknownHResultInformation(hr).GetDescription();
         }
 
-        int GetSystemErrorCode(HRESULT hr)
-        {
-            return static_cast<int>(HRESULT_FACILITY(hr) == FACILITY_WIN32 ? HRESULT_CODE(hr) : hr);
-        }
-
         // WinINet errors are not present in the system message table.
         std::optional<std::string> GetWinInetErrorMessage(int errorCode)
         {
@@ -357,7 +352,8 @@ namespace AppInstaller
                 return std::nullopt;
             }
 
-            wil::unique_hmodule module{ LoadLibraryExW(L"wininet.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32) };
+            wil::unique_hmodule module{ LoadLibraryExW(
+                L"wininet.dll", nullptr, LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_SEARCH_SYSTEM32) };
             if (!module)
             {
                 return std::nullopt;
@@ -380,17 +376,16 @@ namespace AppInstaller
 
         std::string GetSystemErrorMessage(HRESULT hr)
         {
-            const int errorCode = GetSystemErrorCode(hr);
             if (HRESULT_FACILITY(hr) == FACILITY_WIN32)
             {
-                auto winInetMessage = GetWinInetErrorMessage(errorCode);
+                auto winInetMessage = GetWinInetErrorMessage(HRESULT_CODE(hr));
                 if (winInetMessage)
                 {
                     return std::move(winInetMessage).value();
                 }
             }
 
-            return std::system_category().message(errorCode);
+            return std::system_category().message(hr);
         }
 
         void GetUserPresentableMessageForHR(std::ostringstream& strstr, HRESULT hr)


### PR DESCRIPTION
## Summary

Fixes microsoft/winget-cli#6319.

`HRESULT_FROM_WIN32(ERROR_INTERNET_CANNOT_CONNECT)` is a WinINet error. On MSVC, `std::system_category().message(12029)` and `std::system_category().message(0x80072efd)` both return `unknown error`, so decoding the HRESULT alone cannot provide the useful WinINet diagnostic.

This change decodes `FACILITY_WIN32` HRESULTs and retrieves WinINet-range messages from `wininet.dll`, falling back to `std::system_category` for all other errors.

## Changes

- Centralize system error formatting for both user-facing HRESULT paths.
- Retrieve localized WinINet messages from the WinINet message table.
- Cover both `GetUserPresentableMessage` and `HResultInformation::Find(...)->GetDescription()`.

## Validation

- Evidence: an isolated MSVC probe showed that the system category returns unknown error for both 12029 and 0x80072efd, while the WinINet message table returns the localized connection-failure message.
- `git diff --check` passed.
- An isolated MSVC probe verified that the system category returns `unknown error` for both values while the WinINet message table returns the localized connection-failure message.
- I restored the NuGet packages locally, but could not run `AppInstallerCLITests` because the first-time vcpkg registry fetch was interrupted before the required historical port trees were available. The updated PR CI is queued for the x64 and x86 test validation.
