### PR TITLE
Add JSON format for list outputs

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,6 +1,6 @@
 ## New in v1.29
 
-Nothing yet.
+* Added `--format json` support for `winget list` and `winget upgrade` when listing available upgrades.
 
 ## Bug Fixes
 

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -195,6 +195,8 @@ namespace AppInstaller::CLI
             return { type, "ascending"_liv, "asc"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::SortDirection };
         case Execution::Args::Type::SortDescending:
             return { type, "descending"_liv, "desc"_liv, ArgTypeCategory::None, ArgTypeExclusiveSet::SortDirection };
+        case Execution::Args::Type::OutputFormat:
+            return { type, "format"_liv };
 
         // Pin command
         case Execution::Args::Type::GatedVersion:
@@ -508,6 +510,8 @@ namespace AppInstaller::CLI
             return Argument{ type, Resource::String::CorrelationArgumentDescription, ArgumentType::Standard, Argument::Visibility::Hidden };
         case Args::Type::ListDetails:
             return Argument{ type, Resource::String::ListDetailsArgumentDescription, ArgumentType::Flag, Argument::Visibility::Help };
+        case Args::Type::OutputFormat:
+            return Argument{ type, Resource::String::OutputFormatArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help };
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -819,6 +819,17 @@ namespace AppInstaller::CLI
             }
         }
 
+        if (execArgs.Contains(Execution::Args::Type::OutputFormat))
+        {
+            auto format = execArgs.GetArg(Execution::Args::Type::OutputFormat);
+            if (!Utility::CaseInsensitiveEquals(format, "table"sv) &&
+                !Utility::CaseInsensitiveEquals(format, "json"sv))
+            {
+                auto validOptions = Utility::Join(", "_liv, std::vector<Utility::LocIndString>{ "table"_lis, "json"_lis });
+                throw CommandException(Resource::String::InvalidArgumentValueError(ArgumentCommon::ForType(Execution::Args::Type::OutputFormat).Name, validOptions));
+            }
+        }
+
         Argument::ValidateExclusiveArguments(execArgs);
 
         ValidateArgumentsInternal(execArgs);

--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -1072,7 +1072,10 @@ namespace AppInstaller::CLI
     {
         try
         {
-            Workflow::SetJsonOutputChannel(context);
+            if (!context.Args.Contains(Execution::Args::Type::Help))
+            {
+                Workflow::SetJsonOutputChannel(context);
+            }
 
             if (!Settings::User().GetWarnings().empty() &&
                 !WI_IsFlagSet(command->GetOutputFlags(), CommandOutputFlags::IgnoreSettingsWarnings))

--- a/src/AppInstallerCLICore/Command.cpp
+++ b/src/AppInstallerCLICore/Command.cpp
@@ -4,6 +4,7 @@
 #include "Command.h"
 #include "Resources.h"
 #include "Sixel.h"
+#include "Workflows/WorkflowBase.h"
 #include <winget/UserSettings.h>
 #include <AppInstallerRuntime.h>
 #include <winget/Locale.h>
@@ -1071,6 +1072,8 @@ namespace AppInstaller::CLI
     {
         try
         {
+            Workflow::SetJsonOutputChannel(context);
+
             if (!Settings::User().GetWarnings().empty() &&
                 !WI_IsFlagSet(command->GetOutputFlags(), CommandOutputFlags::IgnoreSettingsWarnings))
             {

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -9,6 +9,7 @@
 namespace AppInstaller::CLI
 {
     using namespace AppInstaller::CLI::Workflow;
+    using namespace AppInstaller::Utility::literals;
     using namespace std::string_view_literals;
 
     std::vector<Argument> ListCommand::GetArguments() const
@@ -100,8 +101,8 @@ namespace AppInstaller::CLI
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
 
         context <<
-            Workflow::OpenSource() <<
             Workflow::SetJsonOutputChannel <<
+            Workflow::OpenSource() <<
             Workflow::OpenCompositeSource(Workflow::DetermineInstalledSource(context)) <<
             Workflow::SearchSourceForMany <<
             Workflow::HandleSearchResultFailures <<

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -35,6 +35,7 @@ namespace AppInstaller::CLI
             Argument{ Execution::Args::Type::IncludeUnknown, Resource::String::IncludeUnknownInListArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::IncludePinned, Resource::String::IncludePinnedInListArgumentDescription, ArgumentType::Flag},
             Argument::ForType(Execution::Args::Type::ListDetails),
+            Argument::ForType(Execution::Args::Type::OutputFormat),
             Argument{ Execution::Args::Type::Sort, Resource::String::SortArgumentDescription, ArgumentType::Standard }.SetCountLimit(s_sortFieldCount),
             Argument{ Execution::Args::Type::SortAscending, Resource::String::SortAscendingArgumentDescription, ArgumentType::Flag },
             Argument{ Execution::Args::Type::SortDescending, Resource::String::SortDescendingArgumentDescription, ArgumentType::Flag },
@@ -90,6 +91,11 @@ namespace AppInstaller::CLI
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const
     {
+        if (Workflow::IsJsonOutputFormat(context.Args))
+        {
+            context.Reporter.SetChannel(Execution::Reporter::Channel::Json);
+        }
+
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
 
         context <<

--- a/src/AppInstallerCLICore/Commands/ListCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/ListCommand.cpp
@@ -87,19 +87,21 @@ namespace AppInstaller::CLI
     {
         Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludeUnknown, Execution::Args::Type::Upgrade);
         Argument::ValidateArgumentDependency(execArgs, Execution::Args::Type::IncludePinned, Execution::Args::Type::Upgrade);
+
+        if (Workflow::IsJsonOutputFormat(execArgs) && execArgs.Contains(Execution::Args::Type::ListDetails))
+        {
+            auto validOptions = Utility::Join(", "_liv, std::vector<Utility::LocIndString>{ "table"_lis });
+            throw CommandException(Resource::String::InvalidArgumentValueError(ArgumentCommon::ForType(Execution::Args::Type::OutputFormat).Name, validOptions));
+        }
     }
 
     void ListCommand::ExecuteInternal(Execution::Context& context) const
     {
-        if (Workflow::IsJsonOutputFormat(context.Args))
-        {
-            context.Reporter.SetChannel(Execution::Reporter::Channel::Json);
-        }
-
         context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
 
         context <<
             Workflow::OpenSource() <<
+            Workflow::SetJsonOutputChannel <<
             Workflow::OpenCompositeSource(Workflow::DetermineInstalledSource(context)) <<
             Workflow::SearchSourceForMany <<
             Workflow::HandleSearchResultFailures <<

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -161,11 +161,6 @@ namespace AppInstaller::CLI
         // We have to set it now to allow for source open failures to also just warn.
         if (ShouldListUpgrade(context.Args))
         {
-            if (Workflow::IsJsonOutputFormat(context.Args))
-            {
-                context.Reporter.SetChannel(Execution::Reporter::Channel::Json);
-            }
-
             context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
         }
 
@@ -173,6 +168,7 @@ namespace AppInstaller::CLI
             InitializeInstallerDownloadAuthenticatorsMap <<
             ReportExecutionStage(ExecutionStage::Discovery) <<
             OpenSource() <<
+            SetJsonOutputChannel <<
             OpenCompositeSource(DetermineInstalledSource(context));
 
         if (ShouldListUpgrade(context.Args))

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -167,8 +167,8 @@ namespace AppInstaller::CLI
         context <<
             InitializeInstallerDownloadAuthenticatorsMap <<
             ReportExecutionStage(ExecutionStage::Discovery) <<
-            OpenSource() <<
             SetJsonOutputChannel <<
+            OpenSource() <<
             OpenCompositeSource(DetermineInstalledSource(context));
 
         if (ShouldListUpgrade(context.Args))

--- a/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
+++ b/src/AppInstallerCLICore/Commands/UpgradeCommand.cpp
@@ -69,6 +69,7 @@ namespace AppInstaller::CLI
             Argument::ForType(Args::Type::CustomHeader),
             Argument::ForType(Args::Type::AuthenticationMode),
             Argument::ForType(Args::Type::AuthenticationAccount),
+            Argument::ForType(Args::Type::OutputFormat),
             Argument{ Args::Type::All, Resource::String::UpdateAllArgumentDescription, ArgumentType::Flag },
             Argument{ Args::Type::IncludeUnknown, Resource::String::IncludeUnknownArgumentDescription, ArgumentType::Flag },
             Argument{ Args::Type::IncludePinned, Resource::String::IncludePinnedArgumentDescription, ArgumentType::Flag},
@@ -138,6 +139,12 @@ namespace AppInstaller::CLI
     {
         const auto argCategories = Argument::GetCategoriesAndValidateCommonArguments(execArgs, /* requirePackageSelectionArg */ false);
 
+        if (Workflow::IsJsonOutputFormat(execArgs) && !ShouldListUpgrade(execArgs, argCategories))
+        {
+            auto validOptions = Utility::Join(", "_liv, std::vector<Utility::LocIndString>{ "table"_lis });
+            throw CommandException(Resource::String::InvalidArgumentValueError(ArgumentCommon::ForType(Execution::Args::Type::OutputFormat).Name, validOptions));
+        }
+
         if (!ShouldListUpgrade(execArgs, argCategories) &&
             WI_IsFlagClear(argCategories, ArgTypeCategory::PackageQuery) &&
             WI_IsFlagSet(argCategories, ArgTypeCategory::SingleInstallerBehavior))
@@ -154,6 +161,11 @@ namespace AppInstaller::CLI
         // We have to set it now to allow for source open failures to also just warn.
         if (ShouldListUpgrade(context.Args))
         {
+            if (Workflow::IsJsonOutputFormat(context.Args))
+            {
+                context.Reporter.SetChannel(Execution::Reporter::Channel::Json);
+            }
+
             context.SetFlags(Execution::ContextFlag::TreatSourceFailuresAsWarning);
         }
 

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -117,6 +117,7 @@ namespace AppInstaller::CLI::Execution
             Sort, // Sort output by field (repeatable: --sort name --sort id)
             SortAscending, // Sort output in ascending order
             SortDescending, // Sort output in descending order
+            OutputFormat, // Select the output format
 
             // Pin command
             GatedVersion, // Differs from Version in that this supports wildcards

--- a/src/AppInstallerCLICore/ExecutionArgs.h
+++ b/src/AppInstallerCLICore/ExecutionArgs.h
@@ -117,7 +117,6 @@ namespace AppInstaller::CLI::Execution
             Sort, // Sort output by field (repeatable: --sort name --sort id)
             SortAscending, // Sort output in ascending order
             SortDescending, // Sort output in descending order
-            OutputFormat, // Select the output format
 
             // Pin command
             GatedVersion, // Differs from Version in that this supports wildcards
@@ -196,6 +195,9 @@ namespace AppInstaller::CLI::Execution
 
             // Used for demonstration purposes
             ExperimentalArg,
+
+            // Output format selector. Keep new arguments appended to preserve serialized argument ordinals.
+            OutputFormat,
 
             // This should always be at the end
             Max

--- a/src/AppInstallerCLICore/ExecutionContextData.h
+++ b/src/AppInstallerCLICore/ExecutionContextData.h
@@ -69,6 +69,7 @@ namespace AppInstaller::CLI::Execution
         RepairString,
         MsixDigests,
         InstallerDownloadAuthenticators,
+        SourceOpenUpdateFailures,
         Max
     };
 
@@ -298,6 +299,12 @@ namespace AppInstaller::CLI::Execution
         {
             // The authenticator map shared with sub contexts
             using value_t = std::shared_ptr<std::map<Authentication::AuthenticationInfo, Authentication::Authenticator>>;
+        };
+
+        template<>
+        struct DataMapping<Data::SourceOpenUpdateFailures>
+        {
+            using value_t = std::vector<Repository::SourceDetails>;
         };
     }
 }

--- a/src/AppInstallerCLICore/Resources.h
+++ b/src/AppInstallerCLICore/Resources.h
@@ -521,6 +521,7 @@ namespace AppInstaller::CLI::Resource
         WINGET_DEFINE_RESOURCE_STRINGID(Options);
         WINGET_DEFINE_RESOURCE_STRINGID(OSVersionDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(OutputDirectoryArgumentDescription);
+        WINGET_DEFINE_RESOURCE_STRINGID(OutputFormatArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(OutputFileArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(OverrideArgumentDescription);
         WINGET_DEFINE_RESOURCE_STRINGID(OverwritingExistingFileAtMessage);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -391,6 +391,19 @@ namespace AppInstaller::CLI::Workflow
             return packages;
         }
 
+        Json::Value SourceFailuresToJson(const std::vector<SearchResult::Failure>& failures)
+        {
+            Json::Value result{ Json::ValueType::arrayValue };
+            for (const auto& failure : failures)
+            {
+                Json::Value sourceFailure{ Json::ValueType::objectValue };
+                sourceFailure["source"] = failure.SourceName;
+                result.append(std::move(sourceFailure));
+            }
+
+            return result;
+        }
+
         void OutputInstalledPackagesJson(
             Execution::Context& context,
             std::vector<InstalledPackagesTableLine>& lines,
@@ -409,6 +422,7 @@ namespace AppInstaller::CLI::Workflow
             Json::Value result{ Json::ValueType::objectValue };
             result["packages"] = InstalledPackageLinesToJson(lines);
             result["truncated"] = truncated;
+            result["sourceFailures"] = SourceFailuresToJson(context.Get<Execution::Data::SearchResult>().Failures);
 
             if (onlyShowUpgrades)
             {
@@ -648,6 +662,14 @@ namespace AppInstaller::CLI::Workflow
     {
         return args.Contains(Execution::Args::Type::OutputFormat) &&
             Utility::CaseInsensitiveEquals(args.GetArg(Execution::Args::Type::OutputFormat), "json"sv);
+    }
+
+    void SetJsonOutputChannel(Execution::Context& context)
+    {
+        if (IsJsonOutputFormat(context.Args))
+        {
+            context.Reporter.SetChannel(Execution::Reporter::Channel::Json);
+        }
     }
 
     HRESULT HandleException(Execution::Context* context, std::exception_ptr exception)

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -979,8 +979,25 @@ namespace AppInstaller::CLI::Workflow
             };
             context.Reporter.ExecuteWithProgress(openFunction, true);
         }
+        catch (const wil::ResultException& re)
+        {
+                if (IsJsonOutputFormat(context.Args))
+                {
+                    OutputInstalledPackagesJsonError(context, re.GetErrorCode(), Resource::String::SourceOpenPredefinedFailedSuggestion);
+                    AICLI_TERMINATE_CONTEXT(re.GetErrorCode());
+                }
+
+            context.Reporter.Error() << Resource::String::SourceOpenPredefinedFailedSuggestion << std::endl;
+            throw;
+        }
         catch (...)
         {
+                if (IsJsonOutputFormat(context.Args))
+                {
+                    OutputInstalledPackagesJsonError(context, E_FAIL, Resource::String::SourceOpenPredefinedFailedSuggestion);
+                    AICLI_TERMINATE_CONTEXT(E_FAIL);
+                }
+
             context.Reporter.Error() << Resource::String::SourceOpenPredefinedFailedSuggestion << std::endl;
             throw;
         }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1422,6 +1422,12 @@ namespace AppInstaller::CLI::Workflow
         if (searchResult.Matches.size() == 0)
         {
             Logging::Telemetry().LogNoAppMatch();
+
+            if (IsJsonOutputFormat(context.Args) && (m_operationType == OperationType::List || m_operationType == OperationType::Upgrade))
+            {
+                ReportListResult(m_operationType == OperationType::Upgrade)(context);
+                AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
+            }
             
             switch (m_operationType)
             {

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1037,6 +1037,10 @@ namespace AppInstaller::CLI::Workflow
 
         // Open the predefined source.
         context << OpenPredefinedSource(m_predefinedSource, m_forDependencies);
+        if (context.IsTerminated())
+        {
+            return;
+        }
 
         // Create the composite source from the two.
         Repository::Source source;

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -25,6 +25,7 @@
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
 using namespace std::string_literals;
+using namespace std::string_view_literals;
 using namespace AppInstaller::Utility::literals;
 using namespace AppInstaller::Pinning;
 using namespace AppInstaller::Repository;
@@ -813,7 +814,16 @@ namespace AppInstaller::CLI::Workflow
             {
                 auto policy = Settings::TogglePolicy::GetPolicy(e.Policy());
                 auto policyNameId = policy.PolicyName();
-                context->Reporter.Error() << Resource::String::DisabledByGroupPolicy(policyNameId) << std::endl;
+                auto message = Resource::String::DisabledByGroupPolicy(policyNameId);
+
+                if (IsJsonOutputFormat(context->Args))
+                {
+                    OutputInstalledPackagesJsonError(*context, APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY, message);
+                }
+                else
+                {
+                    context->Reporter.Error() << message << std::endl;
+                }
             }
             return APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY;
         }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -508,6 +508,19 @@ namespace AppInstaller::CLI::Workflow
             WriteJsonOutput(context, result);
         }
 
+        Resource::LocString GetUnexpectedErrorMessage(std::string_view message)
+        {
+            std::string result = Resource::LocString{ Resource::String::UnexpectedErrorExecutingCommand }.get();
+
+            if (!message.empty())
+            {
+                result += ' ';
+                result += message;
+            }
+
+            return Resource::LocString{ Utility::LocIndString{ std::move(result) } };
+        }
+
         void OutputInstalledPackagesJson(
             Execution::Context& context,
             std::vector<InstalledPackagesTableLine>& lines,
@@ -790,9 +803,17 @@ namespace AppInstaller::CLI::Workflow
             Logging::Telemetry().LogException(Logging::FailureTypeEnum::ResultException, re.what());
             if (context)
             {
-                context->Reporter.Error() <<
-                    Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
-                    GetUserPresentableMessage(re) << std::endl;
+                auto message = GetUserPresentableMessage(re);
+                if (IsJsonOutputFormat(context->Args))
+                {
+                    OutputInstalledPackagesJsonError(*context, re.GetErrorCode(), GetUnexpectedErrorMessage(message));
+                }
+                else
+                {
+                    context->Reporter.Error() <<
+                        Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
+                        message << std::endl;
+                }
             }
             return re.GetErrorCode();
         }
@@ -802,9 +823,16 @@ namespace AppInstaller::CLI::Workflow
             Logging::Telemetry().LogException(Logging::FailureTypeEnum::WinrtHResultError, message);
             if (context)
             {
-                context->Reporter.Error() <<
-                    Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
-                    message << std::endl;
+                if (IsJsonOutputFormat(context->Args))
+                {
+                    OutputInstalledPackagesJsonError(*context, hre.code(), GetUnexpectedErrorMessage(message));
+                }
+                else
+                {
+                    context->Reporter.Error() <<
+                        Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
+                        message << std::endl;
+                }
             }
             return hre.code();
         }
@@ -832,9 +860,17 @@ namespace AppInstaller::CLI::Workflow
             Logging::Telemetry().LogException(Logging::FailureTypeEnum::StdException, e.what());
             if (context)
             {
-                context->Reporter.Error() <<
-                    Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
-                    GetUserPresentableMessage(e) << std::endl;
+                auto message = GetUserPresentableMessage(e);
+                if (IsJsonOutputFormat(context->Args))
+                {
+                    OutputInstalledPackagesJsonError(*context, APPINSTALLER_CLI_ERROR_COMMAND_FAILED, GetUnexpectedErrorMessage(message));
+                }
+                else
+                {
+                    context->Reporter.Error() <<
+                        Resource::String::UnexpectedErrorExecutingCommand << ' ' << std::endl <<
+                        message << std::endl;
+                }
             }
             return APPINSTALLER_CLI_ERROR_COMMAND_FAILED;
         }
@@ -844,8 +880,15 @@ namespace AppInstaller::CLI::Workflow
             Logging::Telemetry().LogException(Logging::FailureTypeEnum::Unknown, {});
             if (context)
             {
-                context->Reporter.Error() <<
-                    Resource::String::UnexpectedErrorExecutingCommand << " ???"_liv << std::endl;
+                if (IsJsonOutputFormat(context->Args))
+                {
+                    OutputInstalledPackagesJsonError(*context, APPINSTALLER_CLI_ERROR_COMMAND_FAILED, GetUnexpectedErrorMessage("???"sv));
+                }
+                else
+                {
+                    context->Reporter.Error() <<
+                        Resource::String::UnexpectedErrorExecutingCommand << " ???"_liv << std::endl;
+                }
             }
             return APPINSTALLER_CLI_ERROR_COMMAND_FAILED;
         }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
+#include "Command.h"
 #include "WorkflowBase.h"
 #include "ExecutionContext.h"
 #include "PackageTableSortHelper.h"
@@ -182,6 +183,8 @@ namespace AppInstaller::CLI::Workflow
         }
         CATCH_LOG();
 
+        void OutputInstalledPackagesJsonError(Execution::Context& context, HRESULT resultCode, Resource::LocString message, Utility::LocIndView sourceName = {});
+
         Repository::Source OpenNamedSource(Execution::Context& context, Utility::LocIndView sourceName)
         {
             Repository::Source source;
@@ -197,11 +200,18 @@ namespace AppInstaller::CLI::Workflow
                     if (!sourceName.empty() && !sources.empty())
                     {
                         // A bad name was given, try to help.
-                        context.Reporter.Error() << Resource::String::OpenSourceFailedNoMatch(sourceName) << std::endl;
-                        context.Reporter.Info() << Resource::String::OpenSourceFailedNoMatchHelp << std::endl;
-                        for (const auto& details : sources)
+                        if (IsJsonOutputFormat(context.Args))
                         {
-                            context.Reporter.Info() << "  "_liv << details.Name << std::endl;
+                            OutputInstalledPackagesJsonError(context, APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST, Resource::String::OpenSourceFailedNoMatch(sourceName), sourceName);
+                        }
+                        else
+                        {
+                            context.Reporter.Error() << Resource::String::OpenSourceFailedNoMatch(sourceName) << std::endl;
+                            context.Reporter.Info() << Resource::String::OpenSourceFailedNoMatchHelp << std::endl;
+                            for (const auto& details : sources)
+                            {
+                                context.Reporter.Info() << "  "_liv << details.Name << std::endl;
+                            }
                         }
 
                         AICLI_TERMINATE_CONTEXT_RETURN(APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST, {});
@@ -209,7 +219,15 @@ namespace AppInstaller::CLI::Workflow
                     else
                     {
                         // Even if a name was given, there are no sources
-                        context.Reporter.Error() << Resource::String::OpenSourceFailedNoSourceDefined << std::endl;
+                        if (IsJsonOutputFormat(context.Args))
+                        {
+                            OutputInstalledPackagesJsonError(context, APPINSTALLER_CLI_ERROR_NO_SOURCES_DEFINED, Resource::String::OpenSourceFailedNoSourceDefined, sourceName);
+                        }
+                        else
+                        {
+                            context.Reporter.Error() << Resource::String::OpenSourceFailedNoSourceDefined << std::endl;
+                        }
+
                         AICLI_TERMINATE_CONTEXT_RETURN(APPINSTALLER_CLI_ERROR_NO_SOURCES_DEFINED, {});
                     }
                 }
@@ -404,6 +422,56 @@ namespace AppInstaller::CLI::Workflow
             return result;
         }
 
+        Json::Value EmptyInstalledPackagesJson(bool onlyShowUpgrades)
+        {
+            Json::Value result{ Json::ValueType::objectValue };
+            result["packages"] = Json::Value{ Json::ValueType::arrayValue };
+            result["truncated"] = false;
+            result["sourceFailures"] = Json::Value{ Json::ValueType::arrayValue };
+
+            if (onlyShowUpgrades)
+            {
+                result["availableUpgrades"] = 0;
+                result["packagesWithAvailableUpgradesForPins"] = Json::Value{ Json::ValueType::arrayValue };
+                result["packagesBlockedByPins"] = Json::Value{ Json::ValueType::arrayValue };
+                result["skippedUnknownVersions"] = 0;
+                result["skippedPinned"] = 0;
+            }
+
+            return result;
+        }
+
+        void WriteJsonOutput(Execution::Context& context, const Json::Value& result)
+        {
+            Json::StreamWriterBuilder writerBuilder;
+            writerBuilder.settings_["indentation"] = "";
+            writerBuilder.settings_["commentStyle"] = "None";
+            writerBuilder.settings_["emitUTF8"] = true;
+            context.Reporter.Json() << Json::writeString(writerBuilder, result) << std::endl;
+        }
+
+        void OutputInstalledPackagesJsonError(Execution::Context& context, HRESULT resultCode, Resource::LocString message, Utility::LocIndView sourceName)
+        {
+            Json::Value result = EmptyInstalledPackagesJson(context.GetExecutingCommand() && context.GetExecutingCommand()->Name() == "upgrade");
+
+            if (!sourceName.empty())
+            {
+                Json::Value sourceFailure{ Json::ValueType::objectValue };
+                sourceFailure["source"] = std::string{ sourceName };
+                result["sourceFailures"].append(std::move(sourceFailure));
+            }
+
+            std::ostringstream errorCode;
+            errorCode << WINGET_OSTREAM_FORMAT_HRESULT(resultCode);
+
+            Json::Value error{ Json::ValueType::objectValue };
+            error["code"] = errorCode.str();
+            error["message"] = message.get();
+            result["error"] = std::move(error);
+
+            WriteJsonOutput(context, result);
+        }
+
         void OutputInstalledPackagesJson(
             Execution::Context& context,
             std::vector<InstalledPackagesTableLine>& lines,
@@ -433,11 +501,7 @@ namespace AppInstaller::CLI::Workflow
                 result["skippedPinned"] = packagesWithUserPinsSkipped;
             }
 
-            Json::StreamWriterBuilder writerBuilder;
-            writerBuilder.settings_["indentation"] = "";
-            writerBuilder.settings_["commentStyle"] = "None";
-            writerBuilder.settings_["emitUTF8"] = true;
-            context.Reporter.Json() << Json::writeString(writerBuilder, result) << std::endl;
+            WriteJsonOutput(context, result);
         }
 
         void ShowMetadataField(

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -18,6 +18,7 @@
 #include <AppInstallerSHA256.h>
 #include <winget/Runtime.h>
 #include <winget/PackageVersionSelection.h>
+#include <json/json.h>
 #include <winget/IconExtraction.h>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
@@ -341,6 +342,8 @@ namespace AppInstaller::CLI::Workflow
             Utility::LocIndString Source;
         };
 
+        void SortInstalledPackagesTableLines(Execution::Context& context, std::vector<InstalledPackagesTableLine>& lines);
+
         void OutputInstalledPackagesTable(Execution::Context& context, std::vector<InstalledPackagesTableLine>& lines)
         {
             Execution::TableOutput<5> table(context.Reporter,
@@ -364,6 +367,63 @@ namespace AppInstaller::CLI::Workflow
             }
 
             table.Complete();
+        }
+
+        Json::Value InstalledPackageLineToJson(const InstalledPackagesTableLine& line)
+        {
+            Json::Value package{ Json::ValueType::objectValue };
+            package["name"] = line.Name.get();
+            package["id"] = line.Id.get();
+            package["installedVersion"] = line.InstalledVersion.get();
+            package["availableVersion"] = line.AvailableVersion.get();
+            package["source"] = line.Source.get();
+            return package;
+        }
+
+        Json::Value InstalledPackageLinesToJson(const std::vector<InstalledPackagesTableLine>& lines)
+        {
+            Json::Value packages{ Json::ValueType::arrayValue };
+            for (const auto& line : lines)
+            {
+                packages.append(InstalledPackageLineToJson(line));
+            }
+
+            return packages;
+        }
+
+        void OutputInstalledPackagesJson(
+            Execution::Context& context,
+            std::vector<InstalledPackagesTableLine>& lines,
+            std::vector<InstalledPackagesTableLine>& linesForExplicitUpgrade,
+            std::vector<InstalledPackagesTableLine>& linesForPins,
+            bool truncated,
+            bool onlyShowUpgrades,
+            int availableUpgradesCount,
+            int packagesWithUnknownVersionSkipped,
+            int packagesWithUserPinsSkipped)
+        {
+            SortInstalledPackagesTableLines(context, lines);
+            SortInstalledPackagesTableLines(context, linesForExplicitUpgrade);
+            SortInstalledPackagesTableLines(context, linesForPins);
+
+            Json::Value result{ Json::ValueType::objectValue };
+            result["packages"] = InstalledPackageLinesToJson(lines);
+            result["truncated"] = truncated;
+
+            if (onlyShowUpgrades)
+            {
+                result["availableUpgrades"] = availableUpgradesCount;
+                result["packagesWithAvailableUpgradesForPins"] = InstalledPackageLinesToJson(linesForExplicitUpgrade);
+                result["packagesBlockedByPins"] = InstalledPackageLinesToJson(linesForPins);
+                result["skippedUnknownVersions"] = packagesWithUnknownVersionSkipped;
+                result["skippedPinned"] = packagesWithUserPinsSkipped;
+            }
+
+            Json::StreamWriterBuilder writerBuilder;
+            writerBuilder.settings_["indentation"] = "";
+            writerBuilder.settings_["commentStyle"] = "None";
+            writerBuilder.settings_["emitUTF8"] = true;
+            context.Reporter.Json() << Json::writeString(writerBuilder, result) << std::endl;
         }
 
         void ShowMetadataField(
@@ -582,6 +642,12 @@ namespace AppInstaller::CLI::Workflow
         AICLI_LOG(CLI, Info, << "Created authentication arguments. Mode: " << Authentication::AuthenticationModeToString(authArgs.Mode) << ", Account: " << authArgs.AuthenticationAccount);
 
         return authArgs;
+    }
+
+    bool IsJsonOutputFormat(const Execution::Args& args)
+    {
+        return args.Contains(Execution::Args::Type::OutputFormat) &&
+            Utility::CaseInsensitiveEquals(args.GetArg(Execution::Args::Type::OutputFormat), "json"sv);
     }
 
     HRESULT HandleException(Execution::Context* context, std::exception_ptr exception)
@@ -1261,6 +1327,21 @@ namespace AppInstaller::CLI::Workflow
                     }
                 }
             }
+        }
+
+        if (IsJsonOutputFormat(context.Args))
+        {
+            OutputInstalledPackagesJson(
+                context,
+                lines,
+                linesForExplicitUpgrade,
+                linesForPins,
+                searchResult.Truncated,
+                m_onlyShowUpgrades,
+                availableUpgradesCount,
+                packagesWithUnknownVersionSkipped,
+                packagesWithUserPinsSkipped);
+            return;
         }
 
         OutputInstalledPackages(context, lines);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -256,6 +256,17 @@ namespace AppInstaller::CLI::Workflow
                     context.Reporter.Warn() << Resource::String::SourceOpenWithFailedUpdate(Utility::LocIndView{ s.Name }) << std::endl;
                 }
 
+                if (!updateFailures.empty())
+                {
+                    if (!context.Contains(Execution::Data::SourceOpenUpdateFailures))
+                    {
+                        context.Add<Execution::Data::SourceOpenUpdateFailures>({});
+                    }
+
+                    auto& sourceOpenUpdateFailures = context.Get<Execution::Data::SourceOpenUpdateFailures>();
+                    std::move(updateFailures.begin(), updateFailures.end(), std::back_inserter(sourceOpenUpdateFailures));
+                }
+
                 // Report sources that may need authentication
                 if (source.IsComposite())
                 {
@@ -274,6 +285,12 @@ namespace AppInstaller::CLI::Workflow
             }
             catch (const wil::ResultException& re)
             {
+                if (IsJsonOutputFormat(context.Args))
+                {
+                    OutputInstalledPackagesJsonError(context, re.GetErrorCode(), Resource::String::SourceOpenFailedSuggestion, sourceName);
+                    AICLI_TERMINATE_CONTEXT_RETURN(re.GetErrorCode(), {});
+                }
+
                 context.Reporter.Error() << Resource::String::SourceOpenFailedSuggestion << std::endl;
                 if (re.GetErrorCode() == APPINSTALLER_CLI_ERROR_FAILED_TO_OPEN_ALL_SOURCES)
                 {
@@ -288,6 +305,12 @@ namespace AppInstaller::CLI::Workflow
             }
             catch (...)
             {
+                if (IsJsonOutputFormat(context.Args))
+                {
+                    OutputInstalledPackagesJsonError(context, E_FAIL, Resource::String::SourceOpenFailedSuggestion, sourceName);
+                    AICLI_TERMINATE_CONTEXT_RETURN(E_FAIL, {});
+                }
+
                 context.Reporter.Error() << Resource::String::SourceOpenFailedSuggestion << std::endl;
                 throw;
             }
@@ -422,6 +445,16 @@ namespace AppInstaller::CLI::Workflow
             return result;
         }
 
+        void AppendSourceFailures(Json::Value& sourceFailures, const std::vector<SourceDetails>& failures)
+        {
+            for (const auto& failure : failures)
+            {
+                Json::Value sourceFailure{ Json::ValueType::objectValue };
+                sourceFailure["source"] = failure.Name;
+                sourceFailures.append(std::move(sourceFailure));
+            }
+        }
+
         Json::Value EmptyInstalledPackagesJson(bool onlyShowUpgrades)
         {
             Json::Value result{ Json::ValueType::objectValue };
@@ -452,7 +485,9 @@ namespace AppInstaller::CLI::Workflow
 
         void OutputInstalledPackagesJsonError(Execution::Context& context, HRESULT resultCode, Resource::LocString message, Utility::LocIndView sourceName)
         {
-            Json::Value result = EmptyInstalledPackagesJson(context.GetExecutingCommand() && context.GetExecutingCommand()->Name() == "upgrade");
+            Json::Value result = EmptyInstalledPackagesJson(
+                (context.GetExecutingCommand() && context.GetExecutingCommand()->Name() == "upgrade") ||
+                context.Args.Contains(Execution::Args::Type::Upgrade));
 
             if (!sourceName.empty())
             {
@@ -491,6 +526,11 @@ namespace AppInstaller::CLI::Workflow
             result["packages"] = InstalledPackageLinesToJson(lines);
             result["truncated"] = truncated;
             result["sourceFailures"] = SourceFailuresToJson(context.Get<Execution::Data::SearchResult>().Failures);
+
+            if (context.Contains(Execution::Data::SourceOpenUpdateFailures))
+            {
+                AppendSourceFailures(result["sourceFailures"], context.Get<Execution::Data::SourceOpenUpdateFailures>());
+            }
 
             if (onlyShowUpgrades)
             {
@@ -1489,7 +1529,7 @@ namespace AppInstaller::CLI::Workflow
 
             if (IsJsonOutputFormat(context.Args) && (m_operationType == OperationType::List || m_operationType == OperationType::Upgrade))
             {
-                ReportListResult(m_operationType == OperationType::Upgrade)(context);
+                ReportListResult(m_operationType == OperationType::Upgrade || context.Args.Contains(Execution::Args::Type::Upgrade))(context);
                 AICLI_TERMINATE_CONTEXT(APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
             }
             

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -85,6 +85,9 @@ namespace AppInstaller::CLI::Workflow
     // Helper to create authentication arguments from context input.
     Authentication::AuthenticationArguments GetAuthenticationArguments(const Execution::Context& context);
 
+    // Helper to determine whether the requested output format is JSON.
+    bool IsJsonOutputFormat(const Execution::Args& args);
+
     // Helper to report exceptions and return the HRESULT.
     // If context is null, no output will be attempted.
     HRESULT HandleException(Execution::Context* context, std::exception_ptr exception);

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.h
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.h
@@ -88,6 +88,9 @@ namespace AppInstaller::CLI::Workflow
     // Helper to determine whether the requested output format is JSON.
     bool IsJsonOutputFormat(const Execution::Args& args);
 
+    // Helper to set the reporter to JSON when requested.
+    void SetJsonOutputChannel(Execution::Context& context);
+
     // Helper to report exceptions and return the HRESULT.
     // If context is null, no output will be attempted.
     HRESULT HandleException(Execution::Context* context, std::exception_ptr exception);

--- a/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+++ b/src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
@@ -859,6 +859,10 @@ They can be configured through the settings file 'winget settings'.</value>
   <data name="OutputFileArgumentDescription" xml:space="preserve">
     <value>File where the result is to be written</value>
   </data>
+  <data name="OutputFormatArgumentDescription" xml:space="preserve">
+    <value>Output format</value>
+    <comment>Description for the --format argument used to select command output format.</comment>
+  </data>
   <data name="ImportFileArgumentDescription" xml:space="preserve">
     <value>File describing the packages to install</value>
   </data>

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -4,6 +4,7 @@
 #include "WorkflowCommon.h"
 #include "TestHooks.h"
 #include <Commands/InstallCommand.h>
+#include <Commands/ListCommand.h>
 #include <Commands/UninstallCommand.h>
 #include <Commands/UpgradeCommand.h>
 #include <winget/PathVariable.h>
@@ -304,6 +305,61 @@ TEST_CASE("UpdateFlow_NoArgs_UnknownVersion", "[UpdateFlow][workflow]")
 
     // Verify --include-unknown help text is displayed if update is executed with no args and an unknown version package is available for upgrade.
     REQUIRE(updateOutput.str().find(Resource::String::UpgradeUnknownVersionCount(1)) != std::string::npos);
+}
+
+TEST_CASE("ListFlow_JsonOutput", "[ListFlow][workflow]")
+{
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    list.Execute(context);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].size() == 1);
+    REQUIRE(json["packages"][0]["id"].asString() == "AppInstallerCliTest.TestExeInstaller");
+    REQUIRE(json["packages"][0]["installedVersion"].asString() == "1.0.0.0");
+    REQUIRE(json["truncated"].asBool() == false);
+}
+
+TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
+{
+    std::ostringstream updateOutput;
+    TestContext context{ updateOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    UpgradeCommand update({});
+    context.SetExecutingCommand(&update);
+    update.Execute(context);
+    INFO(updateOutput.str());
+
+    Json::Value json = ConvertToJson(updateOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].size() == 1);
+    REQUIRE(json["packages"][0]["id"].asString() == "AppInstallerCliTest.TestExeInstaller");
+    REQUIRE(json["packages"][0]["availableVersion"].asString() != "");
+    REQUIRE(json["availableUpgrades"].asInt() == 1);
+    REQUIRE(json["packagesBlockedByPins"].isArray());
+    REQUIRE(json["packagesWithAvailableUpgradesForPins"].isArray());
+}
+
+TEST_CASE("UpdateFlow_JsonOutputRequiresListMode", "[UpdateFlow][workflow]")
+{
+    Execution::Args args;
+    args.AddArg(Execution::Args::Type::All);
+    args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    UpgradeCommand update({});
+    REQUIRE_THROWS_AS(update.ValidateArguments(args), CommandException);
 }
 
 TEST_CASE("UpdateFlow_IncludeUnknown", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "WorkflowCommon.h"
 #include "TestHooks.h"
+#include "TestSettings.h"
 #include <Commands/InstallCommand.h>
 #include <Commands/ListCommand.h>
 #include <Commands/UninstallCommand.h>
@@ -352,6 +353,39 @@ TEST_CASE("ListFlow_JsonOutputNoMatches", "[ListFlow][workflow]")
     REQUIRE(json["sourceFailures"].isArray());
     REQUIRE(json["sourceFailures"].empty());
     REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
+}
+
+TEST_CASE("ListFlow_JsonOutputBadSource", "[ListFlow][workflow]")
+{
+    SetSetting(Stream::UserSources, R"(
+Sources:
+  - Name: TestSource
+    Type: Microsoft.Test
+    Arg: TestArg
+    Data: TestData
+    IsTombstone: false
+)"sv);
+
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Args.AddArg(Execution::Args::Type::Source, "MissingSource"sv);
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    list.Execute(context);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].size() == 1);
+    REQUIRE(json["sourceFailures"][0]["source"].asString() == "MissingSource");
+    REQUIRE(json["error"]["code"].asString() == "0x8a150012");
+    REQUIRE(json["error"]["message"].asString().empty() == false);
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST);
 }
 
 TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -435,6 +435,33 @@ Sources:
     REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_NAME_DOES_NOT_EXIST);
 }
 
+TEST_CASE("ListFlow_JsonOutputStopsCompositeAfterInstalledSourceFailure", "[ListFlow][workflow]")
+{
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+    Workflow::SetJsonOutputChannel(context);
+
+    auto availableSource = AppInstaller::Repository::Source{ CreateTestSource({ TSR::TestInstaller_Exe }) };
+    context.Add<Execution::Data::Source>(availableSource);
+    context.Override({ "OpenPredefinedSource", [](TestContext& context)
+    {
+        context.Reporter.Json() << R"({"packages":[],"truncated":false,"sourceFailures":[],"error":{"code":"0x8a15000e","message":"Failed to open source."}})" << std::endl;
+        context.SetTerminationHR(APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED);
+    } });
+
+    context << Workflow::OpenCompositeSource(AppInstaller::Repository::PredefinedSource::Installed);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["error"]["code"].asString() == "0x8a15000e");
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED);
+    REQUIRE_FALSE(context.Get<Execution::Data::Source>().IsComposite());
+}
+
 TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
 {
     std::ostringstream updateOutput;

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -355,6 +355,28 @@ TEST_CASE("ListFlow_JsonOutputNoMatches", "[ListFlow][workflow]")
     REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
 }
 
+TEST_CASE("ListFlow_JsonOutputWithSettingsWarnings", "[ListFlow][workflow]")
+{
+    auto settingsGuard = DeleteUserSettingsFiles();
+    SetSetting(Stream::PrimaryUserSettings, "{"sv);
+
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    OverrideForCompositeInstalledSource(context, CreateTestSource({ TSR::TestInstaller_Exe }));
+    context.Args.AddArg(Execution::Args::Type::Query, TSR::TestInstaller_Exe.Query);
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    ExecuteWithoutLoggingSuccess(context, &list);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].size() == 1);
+}
+
 TEST_CASE("ListFlow_JsonOutputBadSource", "[ListFlow][workflow]")
 {
     SetSetting(Stream::UserSources, R"(
@@ -411,6 +433,30 @@ TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
     REQUIRE(json["packagesWithAvailableUpgradesForPins"].isArray());
     REQUIRE(json["sourceFailures"].isArray());
     REQUIRE(json["sourceFailures"].empty());
+}
+
+TEST_CASE("UpdateFlow_ListJsonOutputNoMatches", "[UpdateFlow][workflow]")
+{
+    std::ostringstream updateOutput;
+    TestContext context{ updateOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    OverrideForCompositeInstalledSource(context, CreateTestSource({}));
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    UpgradeCommand update({});
+    context.SetExecutingCommand(&update);
+    update.Execute(context);
+    INFO(updateOutput.str());
+
+    Json::Value json = ConvertToJson(updateOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["availableUpgrades"].asInt() == 0);
+    REQUIRE(json["packagesBlockedByPins"].isArray());
+    REQUIRE(json["packagesWithAvailableUpgradesForPins"].isArray());
+    REQUIRE(json["skippedUnknownVersions"].asInt() == 0);
+    REQUIRE(json["skippedPinned"].asInt() == 0);
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
 }
 
 TEST_CASE("UpdateFlow_JsonOutputRequiresListMode", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -377,6 +377,23 @@ TEST_CASE("ListFlow_JsonOutputWithSettingsWarnings", "[ListFlow][workflow]")
     REQUIRE(json["packages"].size() == 1);
 }
 
+TEST_CASE("ListFlow_JsonOutputHelpUsesTextOutput", "[ListFlow][workflow]")
+{
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Args.AddArg(Execution::Args::Type::Help);
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    ExecuteWithoutLoggingSuccess(context, &list);
+    INFO(listOutput.str());
+
+    REQUIRE(listOutput.str().find(Resource::String::Usage("winget"_liv, "list"_liv).get()) != std::string::npos);
+    REQUIRE_FALSE(context.IsTerminated());
+}
+
 TEST_CASE("ListFlow_JsonOutputWinGetPolicyDisabled", "[ListFlow][workflow]")
 {
     GroupPolicyTestOverride policies;
@@ -400,6 +417,32 @@ TEST_CASE("ListFlow_JsonOutputWinGetPolicyDisabled", "[ListFlow][workflow]")
     REQUIRE(json["error"]["code"].asString() == "0x8a15003a");
     REQUIRE(json["error"]["message"].asString().empty() == false);
     REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY);
+}
+
+TEST_CASE("ListFlow_JsonOutputGenericExecutionFailure", "[ListFlow][workflow]")
+{
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+    context.Override({ "OpenSource", [](TestContext&)
+    {
+        THROW_HR(APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED);
+    } });
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    ExecuteWithoutLoggingSuccess(context, &list);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].empty());
+    REQUIRE(json["error"]["code"].asString() == "0x8a150045");
+    REQUIRE(json["error"]["message"].asString().empty() == false);
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_SOURCE_OPEN_FAILED);
 }
 
 TEST_CASE("ListFlow_JsonOutputBadSource", "[ListFlow][workflow]")

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -377,6 +377,31 @@ TEST_CASE("ListFlow_JsonOutputWithSettingsWarnings", "[ListFlow][workflow]")
     REQUIRE(json["packages"].size() == 1);
 }
 
+TEST_CASE("ListFlow_JsonOutputWinGetPolicyDisabled", "[ListFlow][workflow]")
+{
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::WinGet, PolicyState::Disabled);
+
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    ExecuteWithoutLoggingSuccess(context, &list);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].empty());
+    REQUIRE(json["error"]["code"].asString() == "0x8a15003a");
+    REQUIRE(json["error"]["message"].asString().empty() == false);
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_BLOCKED_BY_POLICY);
+}
+
 TEST_CASE("ListFlow_JsonOutputBadSource", "[ListFlow][workflow]")
 {
     SetSetting(Stream::UserSources, R"(

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -327,6 +327,8 @@ TEST_CASE("ListFlow_JsonOutput", "[ListFlow][workflow]")
     REQUIRE(json["packages"][0]["id"].asString() == "AppInstallerCliTest.TestExeInstaller");
     REQUIRE(json["packages"][0]["installedVersion"].asString() == "1.0.0.0");
     REQUIRE(json["truncated"].asBool() == false);
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].empty());
 }
 
 TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
@@ -350,6 +352,8 @@ TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
     REQUIRE(json["availableUpgrades"].asInt() == 1);
     REQUIRE(json["packagesBlockedByPins"].isArray());
     REQUIRE(json["packagesWithAvailableUpgradesForPins"].isArray());
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].empty());
 }
 
 TEST_CASE("UpdateFlow_JsonOutputRequiresListMode", "[UpdateFlow][workflow]")
@@ -360,6 +364,16 @@ TEST_CASE("UpdateFlow_JsonOutputRequiresListMode", "[UpdateFlow][workflow]")
 
     UpgradeCommand update({});
     REQUIRE_THROWS_AS(update.ValidateArguments(args), CommandException);
+}
+
+TEST_CASE("ListFlow_JsonOutputRejectsDetails", "[ListFlow][workflow]")
+{
+    Execution::Args args;
+    args.AddArg(Execution::Args::Type::ListDetails);
+    args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    REQUIRE_THROWS_AS(list.ValidateArguments(args), CommandException);
 }
 
 TEST_CASE("UpdateFlow_IncludeUnknown", "[UpdateFlow][workflow]")

--- a/src/AppInstallerCLITests/UpdateFlow.cpp
+++ b/src/AppInstallerCLITests/UpdateFlow.cpp
@@ -331,6 +331,29 @@ TEST_CASE("ListFlow_JsonOutput", "[ListFlow][workflow]")
     REQUIRE(json["sourceFailures"].empty());
 }
 
+TEST_CASE("ListFlow_JsonOutputNoMatches", "[ListFlow][workflow]")
+{
+    std::ostringstream listOutput;
+    TestContext context{ listOutput, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    OverrideForCompositeInstalledSource(context, CreateTestSource({}));
+    context.Args.AddArg(Execution::Args::Type::Query, "NoSuchPackage"sv);
+    context.Args.AddArg(Execution::Args::Type::OutputFormat, "json"sv);
+
+    ListCommand list({});
+    context.SetExecutingCommand(&list);
+    list.Execute(context);
+    INFO(listOutput.str());
+
+    Json::Value json = ConvertToJson(listOutput.str());
+    REQUIRE(json["packages"].isArray());
+    REQUIRE(json["packages"].empty());
+    REQUIRE(json["truncated"].asBool() == false);
+    REQUIRE(json["sourceFailures"].isArray());
+    REQUIRE(json["sourceFailures"].empty());
+    REQUIRE(context.GetTerminationHR() == APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND);
+}
+
 TEST_CASE("UpdateFlow_ListJsonOutput", "[UpdateFlow][workflow]")
 {
     std::ostringstream updateOutput;


### PR DESCRIPTION
## 📖 Description

Adds `--format json` support for package listing output.

This enables machine-readable output for:

- `winget list --format json`
- `winget upgrade --format json` when used in list-only mode

The default table output is unchanged.

The JSON output includes installed package fields that match the existing list and upgrade table data, including package name, id, installed version, available version, and source. It also keeps JSON parseable for empty results and common error paths such as source-open failures, WinGet policy blocks, and generic execution failures.

`winget upgrade --format json` is intentionally limited to non-mutating upgrade listing. Commands such as `winget upgrade --all --format json` are rejected so package installation progress is not mixed with structured output.

## 🔗 References

Related to #1753.

## 🔍 Validation

Added focused test coverage for:

- JSON list output
- JSON upgrade-list output
- empty result output
- settings warnings before JSON output
- source-open failures
- WinGet policy blocks
- generic execution failures
- preserving help output for `--format json --help`
- rejecting JSON output for unsupported upgrade execution modes
- rejecting `--details` with JSON list output

Ran the focused `AppInstallerCLITests` scenarios for the JSON list and upgrade flows locally.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6346)