### PR TITLE
Use NUnit key constraints in DSCv3 settings tests

### DIFF
--- a/src/AppInstallerCLIE2ETests/DSCv3AdminSettingsResourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3AdminSettingsResourceCommand.cs
@@ -79,9 +79,9 @@ namespace AppInstallerCLIE2ETests
             AdminSettingsResourceData output = GetSingleOutputLineAs<AdminSettingsResourceData>(result.StdOut);
             Assert.That(output, Is.Not.Null);
             Assert.That(output.Settings, Is.Not.Null);
-            Assert.That(output.Settings.ContainsKey(LocalManifestFiles), Is.True);
-            Assert.That(output.Settings.ContainsKey(DefaultProxy), Is.False);
-            Assert.That(output.Settings.ContainsKey(NotAnAdminSettingName), Is.False);
+            Assert.That(output.Settings, Contains.Key(LocalManifestFiles));
+            Assert.That(output.Settings, Does.Not.ContainKey(DefaultProxy));
+            Assert.That(output.Settings, Does.Not.ContainKey(NotAnAdminSettingName));
         }
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace AppInstallerCLIE2ETests
             Assert.That(output, Is.Not.Null);
             Assert.That(output.InDesiredState, Is.EqualTo(inDesiredState));
             Assert.That(output.Settings, Is.Not.Null);
-            Assert.That(output.Settings.ContainsKey(settingName), Is.True);
+            Assert.That(output.Settings, Contains.Key(settingName));
             Assert.That(output.Settings[settingName].AsValue().GetValueKind(), Is.EqualTo(expectedState ? JsonValueKind.True : JsonValueKind.False));
 
             AssertDiffState(diff, inDesiredState ? [] : [ SettingsPropertyName ]);
@@ -308,7 +308,7 @@ namespace AppInstallerCLIE2ETests
             (AdminSettingsResourceData output, List<string> diff) = GetSingleOutputLineAndDiffAs<AdminSettingsResourceData>(result.StdOut);
             Assert.That(output, Is.Not.Null);
             Assert.That(output.Settings, Is.Not.Null);
-            Assert.That(output.Settings.ContainsKey(settingName), Is.True);
+            Assert.That(output.Settings, Contains.Key(settingName));
             Assert.That(output.Settings[settingName].AsValue().GetValueKind(), Is.EqualTo(desiredState ? JsonValueKind.True : JsonValueKind.False));
 
             AssertDiffState(diff, inDesiredState ? [] : [ SettingsPropertyName ]);
@@ -326,12 +326,12 @@ namespace AppInstallerCLIE2ETests
             Assert.That(output.Settings, Is.Not.Null);
             if (expectedState != null)
             {
-                Assert.That(output.Settings.ContainsKey(settingName), Is.True);
+                Assert.That(output.Settings, Contains.Key(settingName));
                 Assert.That(output.Settings[settingName].AsValue().GetValue<string>(), Is.EqualTo(expectedState));
             }
             else
             {
-                Assert.That(output.Settings.ContainsKey(settingName), Is.False);
+                Assert.That(output.Settings, Does.Not.ContainKey(settingName));
             }
 
             AssertDiffState(diff, inDesiredState ? [] : [SettingsPropertyName]);
@@ -348,12 +348,12 @@ namespace AppInstallerCLIE2ETests
             Assert.That(output.Settings, Is.Not.Null);
             if (desiredState != null)
             {
-                Assert.That(output.Settings.ContainsKey(settingName), Is.True);
+                Assert.That(output.Settings, Contains.Key(settingName));
                 Assert.That(output.Settings[settingName].AsValue().GetValue<string>(), Is.EqualTo(desiredState));
             }
             else
             {
-                Assert.That(output.Settings.ContainsKey(settingName), Is.False);
+                Assert.That(output.Settings, Does.Not.ContainKey(settingName));
             }
 
             AssertDiffState(diff, inDesiredState ? [] : [SettingsPropertyName]);

--- a/src/AppInstallerCLIE2ETests/DSCv3UserSettingsFileResourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3UserSettingsFileResourceCommand.cs
@@ -325,10 +325,10 @@ public class DSCv3UserSettingsFileResourceCommand : DSCv3ResourceTestBase
     private static void AssertMockProperties(JsonObject settings, string value)
     {
         Assert.That(settings, Is.Not.Null);
-        Assert.That(settings.ContainsKey(SettingsMock), Is.True);
+        Assert.That(settings, Contains.Key(SettingsMock));
         Assert.That(value, Is.EqualTo(settings[SettingsMock].ToString()));
-        Assert.That(settings.ContainsKey(SettingsMockObject), Is.True);
-        Assert.That(settings[SettingsMockObject].AsObject().ContainsKey(SettingsMockNested), Is.True);
+        Assert.That(settings, Contains.Key(SettingsMockObject));
+        Assert.That(settings[SettingsMockObject].AsObject(), Contains.Key(SettingsMockNested));
         Assert.That(value, Is.EqualTo(settings[SettingsMockObject][SettingsMockNested].ToString()));
     }
 


### PR DESCRIPTION
## 📖 Description
This PR updates Settings E2E tests to use NUnit built-in key constraints instead of boolean `ContainsKey(...)` checks.

Changed files:
- `src/AppInstallerCLIE2ETests/DSCv3AdminSettingsResourceCommand.cs`
- `src/AppInstallerCLIE2ETests/DSCv3UserSettingsFileResourceCommand.cs`

This was prepared with assistance from GitHub Copilot.

## 🔗 References
Resolves microsoft/winget-cli#6369

## 🔍 Validation
Not run in this session (user runs builds/tests).

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6371)