### PR TITLE
Port scope targeted token check to 1.29

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
+++ b/src/AppInstallerCLICore/Workflows/ShellExecuteInstallerHandler.cpp
@@ -377,7 +377,7 @@ namespace AppInstaller::CLI::Workflow
 
         // When running as admin, block attempt to repair user scope installed package. 
         // [NOTE:] This check is to address the security concern related to above scenario.
-        if (Runtime::IsRunningAsAdmin())
+        if (Runtime::IsRunningWithNonDefaultFullToken())
         {
             auto installedPackageVersion = context.Get<Execution::Data::InstalledPackageVersion>();
             const std::string installedScopeString = installedPackageVersion->GetMetadata()[PackageVersionMetadata::InstalledScope];

--- a/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/UninstallFlow.cpp
@@ -233,7 +233,7 @@ namespace AppInstaller::CLI::Workflow
         auto installedType = ConvertToInstallerTypeEnum(packageMetadata[PackageVersionMetadata::InstalledType]);
 
         // When running as admin, block attempt to uninstall user scope package to prevent EOP paths.
-        if (AdminExecutionShouldBlockUserScopePackages(installedType) && Runtime::IsRunningAsAdmin())
+        if (AdminExecutionShouldBlockUserScopePackages(installedType) && Runtime::IsRunningWithNonDefaultFullToken())
         {
             auto scopeEnum = ConvertToScopeEnum(packageMetadata[PackageVersionMetadata::InstalledScope]);
             if (scopeEnum == ScopeEnum::User)

--- a/src/AppInstallerSharedLib/Public/winget/Runtime.h
+++ b/src/AppInstallerSharedLib/Public/winget/Runtime.h
@@ -51,6 +51,14 @@ namespace AppInstaller::Runtime
     //  3. the token is not already elevated
     bool IsRunningWithLimitedToken();
 
+    // Determines whether the current token is elevated.
+    // This only returns true for tokens that are TokenElevationTypeFull.
+    // Thus, it will only be true if:
+    //  1. UAC is enabled
+    //  2. the user is in the Administrators group
+    //  3. the token is elevated
+    bool IsRunningWithNonDefaultFullToken();
+
     // Determines if the given amount of stack bytes are available.
     // If the answer cannot be determined properly, the return value will be `false`.
     DECLSPEC_NOINLINE bool IsStackAvailable(size_t bytes);

--- a/src/AppInstallerSharedLib/Runtime.cpp
+++ b/src/AppInstallerSharedLib/Runtime.cpp
@@ -219,6 +219,26 @@ namespace AppInstaller::Runtime
         return wil::get_token_information<TOKEN_ELEVATION_TYPE>() == TokenElevationTypeLimited;
     }
 
+#ifndef AICLI_DISABLE_TEST_HOOKS
+    static bool* s_IsRunningWithNonDefaultFullToken_TestHook_Override = nullptr;
+
+    void TestHook_SetIsRunningWithNonDefaultFullToken_Override(bool* value)
+    {
+        s_IsRunningWithNonDefaultFullToken_TestHook_Override = value;
+    }
+#endif
+
+    bool IsRunningWithNonDefaultFullToken()
+    {
+#ifndef AICLI_DISABLE_TEST_HOOKS
+        if (s_IsRunningWithNonDefaultFullToken_TestHook_Override)
+        {
+            return *s_IsRunningWithNonDefaultFullToken_TestHook_Override;
+        }
+#endif
+        return wil::get_token_information<TOKEN_ELEVATION_TYPE>() == TokenElevationTypeFull;
+    }
+
     DECLSPEC_NOINLINE bool IsStackAvailable(size_t bytes)
     {
         // https://devblogs.microsoft.com/oldnewthing/20200610-00/?p=103855


### PR DESCRIPTION
## 📖 Description
Brings in the token type check over admin group for the uninstall and repair scope based security protections.

## 🔗 References
Fixes #6363 for UAC disabled adminstrators.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6386)