### PR TITLE
Strengthen contributor guidance to support Help-Wanted contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 <!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->
 
 ## 🔍 Validation
-<!-- How did you test? List manual steps or note automated test coverage. -->
+<!-- How did you test? List manual steps or note automated test coverage. If applicable, include a screenshot or short recording demonstrating the change working. -->
 
 ## ✅ Checklist
 <!-- Place an "x" between the brackets to check an item. e.g: [x] -->
@@ -14,7 +14,13 @@
 - [ ] Linked to an issue
 - [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
 - [ ] Updated documentation (if applicable)
+- [ ] Added or updated tests (or noted why not applicable)
 - [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
+
+## 🤖 AI Assistance
+<!-- Check one -->
+- [ ] AI assistance was used and has been disclosed in this PR
+- [ ] No AI assistance was used
 
 ## 📋 Issue Type
 <!-- Select the type that best describes this PR -->

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -13,6 +13,7 @@ admx
 AFAIK
 aicli
 AICLIC
+Allman
 allusers
 alreadyinstalled
 AMap
@@ -148,6 +149,7 @@ DMC
 dnld
 Dns
 Dobbeleer
+Downcasting
 DONOT
 dsc
 dupenv
@@ -398,6 +400,7 @@ NOUPDATE
 nowarn
 npmjs
 nsis
+NRVO
 NTFS
 objbase
 objidl

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,16 +105,16 @@ void WorkflowTask(Execution::Context& context)
 {
     // Check if already terminated
     AICLI_RETURN_IF_TERMINATED(context);
-    
+
     // Access data
     auto& data = context.Get<Data::Installer>();
-    
+
     // Report to user
     context.Reporter.Info() << "Doing something";
-    
+
     // Store data for next workflow
     context.Add<Data::SomeResult>(result);
-    
+
     // Terminate on error
     if (failed)
     {
@@ -160,6 +160,13 @@ void WorkflowTask(Execution::Context& context)
 - Specs required for features (stored in `doc/specs/`); see `.github/instructions/specs.instructions.md` for detailed guidance
 - Follow existing code style (see `stylecop.json`)
 - CI runs on Azure Pipelines (`azure-pipelines.yml`)
+
+### Pull Request Expectations
+
+- PRs must follow the repository PR template and keep its sections and checklist intact
+- AI assistance is allowed, but contributors are fully accountable for AI-assisted output as if they wrote it themselves.
+	- Unless explicitly directed otherwise, confirm with the user that they have reviewed the submission.
+- When raising a PR, include a brief disclosure in the PR description and identify which parts were assisted.
 
 ## Useful Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ Therefore, if you do file issues, or create PRs, please keep an eye on your GitH
 
 **Please do not report security vulnerabilities through public GitHub issues.** Instead, please report them to the Microsoft Security Response Center (MSRC). See [SECURITY.md](./SECURITY.md) for more information.
 
+## AI-assisted contributions
+
+AI assistance is welcome, but contributors remain fully responsible for the submitted work. If AI contributes to a change, you are accountable for that content exactly as if you wrote it yourself: you must understand it, ensure it follows project conventions, and provide the same testing and validation evidence expected for any other contribution.
+
+When opening or updating a PR, disclose material AI-generated assistance and briefly describe which parts were assisted.
+
+Opening a PR requires real engineering review time. Please keep this in mind and submit contributions that are complete, reviewed, and ready for meaningful feedback. Low-effort, unreviewed, or unverifiable AI-generated submissions may be closed at maintainer discretion.
+
 ## Before you start, file an issue
 
 Please follow this simple rule to help us eliminate any unnecessary wasted effort & frustration, and ensure an efficient and effective use of everyone's time - yours, ours, and other community members':

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,11 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and you
 
 Testing is a key part of getting a change ready for review.
 
-If your contribution changes behavior or implementation, please add or update automated tests along with the code. For most fixes and features, that means updating unit tests in `AppInstallerCLITests`. If your change crosses command or workflow boundaries, you should also add or update end-to-end coverage in `AppInstallerCLIE2ETests`.
+If your contribution changes behavior or implementation, please plan to add or update automated tests alongside the code.
+
+As a quick rule of thumb: unit tests in `AppInstallerCLITests` focus on the code and logic, while end-to-end tests in `AppInstallerCLIE2ETests` focus on actual `winget` command behavior and the resulting system outcomes.
+
+For non-trivial code changes, the bar is high. Where practical, include both unit tests and end-to-end coverage. If you believe that tests aren't needed for your change, please call that out in your PR and explain why.
 
 Documentation-only updates and non-functional metadata changes generally do not require new tests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,10 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and you
 1. Work on your changes.
 1. Build and see if it works.
 
+### Coding Standards
+
+Before writing code, review [doc/Standards.md](./doc/Standards.md) for the conventions used in this codebase — naming, formatting, error handling, casts, `std::move()` usage, and resource strings. PRs that diverge from these conventions will be asked to bring their changes into line before review completes.
+
 ### Testing
 
 Testing is a key part of getting a change ready for review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,15 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and you
 
 ### Testing
 
-Testing is a key component in the development workflow.
+Testing is a key part of getting a change ready for review.
+
+If your contribution changes behavior or implementation, please add or update automated tests along with the code. For most fixes and features, that means updating unit tests in `AppInstallerCLITests`. If your change crosses command or workflow boundaries, you should also add or update end-to-end coverage in `AppInstallerCLIE2ETests`.
+
+Documentation-only updates and non-functional metadata changes generally do not require new tests.
+
+For build and test execution details, see [Running Unit Tests](./doc/Developing.md#running-unit-tests) and [Running End-to-End Tests](./doc/Developing.md#running-end-to-end-tests) in [doc/Developing.md](./doc/Developing.md).
+
+PRs without appropriate coverage may be asked to add tests before review completes.
 
 ### Code Review
 

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -47,6 +47,20 @@ The unit tests are located inside the `AppInstallerCLITests` project. When the s
 > [!TIP]
 > If you just want to run a particular test, you can specify the test name as an argument to the executable. For example, `AppInstallerCLITests.exe EnsureSortedErrorList`.
 
+> [!TIP]
+> For local debugging, you can increase test output detail and include timing information by running `AppInstallerCLITests.exe -d yes -v high`.
+
+## Running End-to-End Tests
+
+The end-to-end tests are located in the `AppInstallerCLIE2ETests` project and are executed with NUnit.
+
+For setup details (including `Test.runsettings`, local test source setup, and localhost web server usage), see [`src/AppInstallerCLIE2ETests/README.md`](../src/AppInstallerCLIE2ETests/README.md).
+
+A typical local workflow is:
+1. Build the solution.
+2. Configure `src/AppInstallerCLIE2ETests/Test.runsettings` for your environment.
+3. Run `AppInstallerCLIE2ETests` from Test Explorer, or run `dotnet test src\AppInstallerCLIE2ETests\AppInstallerCLIE2ETests.csproj --settings src\AppInstallerCLIE2ETests\Test.runsettings`.
+
 ## Localization
 
 The English resource strings are the source of truth and live in:

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -1,5 +1,9 @@
 # Developer guidance
 
+## Coding Standards
+
+For naming, formatting, error handling, casts, `std::move()` usage, and resource string requirements, see [doc/Standards.md](./Standards.md).
+
 ## Prerequisites
 
 * Windows 10 1809 (17763) or later

--- a/doc/Standards.md
+++ b/doc/Standards.md
@@ -1,0 +1,281 @@
+# Coding Standards
+
+This document describes the coding conventions used in the WinGet CLI codebase. It is a companion to:
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — workflow and process guidance
+- [`doc/Developing.md`](./Developing.md) — build, test, and localization instructions
+
+The codebase is primarily C++/WinRT. Brief notes for .NET (C#) components appear at the end.
+
+---
+
+## File Formatting
+
+All source files must conform to the rules in [`.editorconfig`](../.editorconfig):
+
+- **Line endings**: CRLF
+- **Encoding**: UTF-8
+- **Final newline**: required
+- **Trailing whitespace**: must be trimmed
+- **YAML files** (`.yml`/`.yaml`): 2-space indentation
+- **Markdown files** (`.md`): tab indentation
+
+Configure your editor to apply these settings on save, or run a check before committing.
+
+---
+
+## File Headers
+
+Every C++ source and header file must begin with:
+
+```cpp
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+```
+
+Every C# source file must begin with:
+
+```csharp
+// -----------------------------------------------------------------------------
+// <copyright file="FileName.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------------
+```
+
+---
+
+## Brace Style
+
+The codebase uses **Allman style** (also known as BSD style): the opening brace of every block goes on its **own new line**, at the same indentation level as the statement that introduced it.
+
+```cpp
+namespace AppInstaller::CLI::Workflow
+{
+    void SomeWorkflowTask(Execution::Context& context)
+    {
+        if (condition)
+        {
+            DoSomething();
+        }
+        else if (otherCondition)
+        {
+            DoSomethingElse();
+        }
+        else
+        {
+            Fallback();
+        }
+
+        for (const auto& item : items)
+        {
+            Process(item);
+        }
+
+        switch (value)
+        {
+        case SomeEnum::First:
+            HandleFirst();
+            break;
+        case SomeEnum::Second:
+            HandleSecond();
+            break;
+        default:
+            THROW_HR(E_UNEXPECTED);
+        }
+    }
+}
+```
+
+Key points:
+
+- `else` and `else if` go on their own line after the closing `}` — never on the same line as `}`.
+- `case` labels inside a `switch` are **not** indented relative to the `switch` keyword; they sit at the same level.
+- **Trivial single-expression bodies** (simple getters, forwarding constructors, one-liner lambdas) may be written inline:
+  ```cpp
+  bool IsTerminated() const { return m_isTerminated; }
+  SomeClass(std::string name) : m_name(std::move(name)) {}
+  ```
+  Use judgment: if the body is anything more than a single expression, use the full Allman form.
+
+---
+
+## Naming Conventions
+
+### C++
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Types (classes, structs, enums, type aliases) | `PascalCase` | `ExecutionContext`, `ContextFlag` |
+| Functions and methods | `PascalCase` | `GetErrorCode()`, `IsTerminated()` |
+| Local variables and parameters | `camelCase` | `installerType`, `packageId` |
+| Non-static member variables | `m_` prefix + `camelCase` | `m_name`, `m_flags` |
+| Static member variables | `s_` prefix + `camelCase` | `s_disabledReason` |
+| Namespaces | `PascalCase` | `AppInstaller::CLI::Workflow` |
+| Macros | `AICLI_` or `WINGET_` prefix, `ALL_CAPS` | `AICLI_TERMINATE_CONTEXT`, `WINGET_CATCH_STORE` |
+| Enum members | `PascalCase` | `ContextFlag::InstallerTrusted` |
+
+### C\#
+
+Follow standard .NET naming conventions (PascalCase for public members, camelCase for local variables and private fields). StyleCop is configured in `src/stylecop.json`.
+
+---
+
+## Error Handling
+
+### C++: WIL macros (preferred)
+
+The codebase uses the [Windows Implementation Library (WIL)](https://github.com/microsoft/wil) for HRESULT-based error handling. Prefer WIL macros over manual `if (FAILED(hr))` checks:
+
+```cpp
+// Throw on failure — use in code where exceptions are acceptable
+THROW_IF_FAILED(SomeWin32OrComApi());
+THROW_HR(E_UNEXPECTED);
+THROW_HR_IF(E_POINTER, ptr == nullptr);
+THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), "Stage %d is not valid here", stage);
+
+// Return the HRESULT on failure — use in COM methods or HRESULT-returning functions
+RETURN_IF_FAILED(SomeWin32OrComApi());
+
+// Log without propagating — use for non-fatal side effects
+LOG_IF_FAILED(CleanupTempFiles());
+```
+
+Prefer the most specific macro. For example, `THROW_HR_IF` is cleaner than `if (condition) { THROW_HR(...); }`.
+
+### C++: Workflow context termination
+
+Inside workflow functions (functions that take `Execution::Context& context`), use the `AICLI_*` family of macros rather than throwing:
+
+```cpp
+void WorkflowTask(Execution::Context& context)
+{
+    // Guard against an already-terminated context at the top of every task
+    AICLI_RETURN_IF_TERMINATED(context);
+
+    // Terminate the context and return from the current function
+    if (failed)
+    {
+        AICLI_TERMINATE_CONTEXT(HRESULT_VALUE);
+    }
+
+    // Terminate but return a specific value (useful in non-void helpers)
+    // AICLI_TERMINATE_CONTEXT_RETURN(HRESULT_VALUE, returnValue);
+}
+```
+
+`AICLI_TERMINATE_CONTEXT` records the file and line of the failure, sets the context's termination HRESULT, and returns from the current function. Do not throw exceptions out of workflow functions — use context termination instead.
+
+### C++: Unexpected cases must not be swallowed
+
+Every `switch` statement over an enum or integer must have an explicit `default` branch. That branch must either:
+
+1. **Terminate with `E_UNEXPECTED`** if reaching it indicates a programming error (an enum value was added but the switch was not updated, or the caller passed an invalid value):
+   ```cpp
+   switch (installerType)
+   {
+   case InstallerTypeEnum::Exe:     /* ... */ break;
+   case InstallerTypeEnum::Msi:     /* ... */ break;
+   default:
+       THROW_HR(E_UNEXPECTED);
+   }
+   ```
+
+2. **Have a clearly intentional and documented fallback** when a default behavior is genuinely correct:
+   ```cpp
+   switch (result)
+   {
+   case ConfigurationTestResult::Positive: return Resource::StringId::ConfigPositive;
+   case ConfigurationTestResult::Negative: return Resource::StringId::ConfigNegative;
+   default: return Resource::StringId::Empty(); // Unknown/not yet tested
+   }
+   ```
+
+The same principle applies outside of switches: use `THROW_HR_IF(E_UNEXPECTED, condition)` to assert runtime invariants that should never be violated:
+
+```cpp
+THROW_HR_IF(E_UNEXPECTED, entries.size() != expectedCount);
+```
+
+**Do not leave an empty `default:` or an empty `else` branch** that silently discards an unexpected case. Silent failures are harder to debug than explicit ones.
+
+---
+
+## Casts
+
+**Never use C-style casts.** C-style casts (e.g., `(int)value`) bypass the type system silently. Use the named C++ cast operators instead:
+
+| Situation | Use |
+|-----------|-----|
+| Safe numeric or enum conversions | `static_cast<T>(value)` |
+| Reinterpreting pointer/integer bytes | `reinterpret_cast<T>(value)` |
+| Removing `const` (rare; justify in a comment) | `const_cast<T>(value)` |
+| Downcasting via virtual dispatch | `dynamic_cast<T>(value)` |
+| WinRT interface conversion | `.as<T>()` from C++/WinRT |
+| Converting `ToIntegral` for enums | Use the project helper `ToIntegral(enumValue)` where available |
+
+---
+
+## `std::move()`
+
+`std::move()` casts a value to an rvalue reference so its resources can be transferred rather than copied. Use it only where ownership transfer is clearly intended.
+
+### When to use
+
+- **Passing to a constructor or function that takes by value or `&&`** when you no longer need the source:
+  ```cpp
+  context.Add<Data::Manifest>(std::move(manifest));
+  m_items.push_back(std::move(item));
+  ```
+- **Initializing members from constructor parameters**:
+  ```cpp
+  MyClass(std::string name) : m_name(std::move(name)) {}
+  ```
+
+### When NOT to use
+
+- **On `return` statements.** Named Return Value Optimization (NRVO) can eliminate the copy/move entirely, but only if you return the variable directly. `std::move()` on a return statement suppresses NRVO and can result in an extra move that would not otherwise occur:
+
+  ```cpp
+  // ✗ Suppresses NRVO
+  std::string BuildResult() { return std::move(result); }
+
+  // ✓ Allows NRVO
+  std::string BuildResult() { return result; }
+  ```
+
+- **On trivially copyable types** (`int`, `HRESULT`, raw pointers, enums, etc.). Moving these is no cheaper than copying, and `std::move()` just adds noise.
+
+- **On `const` objects.** The move constructor cannot be selected for a `const` object; the call silently falls back to a copy.
+
+- **On an object you still need after the call.** After a move, the source is in a valid but unspecified state. Accessing it without re-assignment is undefined behavior.
+
+---
+
+## Resource Strings
+
+All user-visible strings must be added to the English resource file:
+
+```
+src/AppInstallerCLIPackage/Shared/Strings/en-us/winget.resw
+```
+
+**Do not edit** any file under `Localization/Resources/<locale>/`; those files are owned by Microsoft's localization pipeline and will be overwritten automatically.
+
+Every new or modified string entry must include a `<comment>` element that gives translators enough context. This is especially important for:
+
+- Short or single-word values (column headers, status labels) where the word has multiple meanings
+- Technical jargon that may have a different colloquial meaning in other languages
+- Strings with placeholders — document what each `{0}`, `{1}`, etc. represents
+
+See [Localization in `doc/Developing.md`](./Developing.md#localization) for an example.
+
+---
+
+## .NET (C#) Components
+
+The PowerShell modules (`src/PowerShell`) and configuration tests are written in C#. In addition to the file header and naming guidance above:
+
+- StyleCop Analyzers are configured in `src/stylecop.json`. Build warnings from StyleCop must not be suppressed without justification.
+- Follow standard .NET exception handling — avoid swallowing exceptions silently.
+- Match the namespace structure of the surrounding project (e.g., `Microsoft.WinGet.Client.Engine.Commands`).


### PR DESCRIPTION
## 📖 Description

Strengthens contributor guidance to better support `Help-Wanted` contributions. Addresses the four sub-issues tracked under #6393:

- Adds an explicit testing policy to `CONTRIBUTING.md` specifying when unit and E2E tests are expected, when they may be omitted, and how to run them.
- Adds `doc/Standards.md`, a new coding conventions reference covering file formatting, brace style, naming (C++ and C#), error handling (`WIL`/`AICLI_*` macros), casts, `std::move()` usage, and resource string requirements.
- Adds an AI-assisted contributions policy to `CONTRIBUTING.md` clarifying that contributors are fully accountable for AI-generated code and must disclose material AI use in their PR.
- Updates `.github/PULL_REQUEST_TEMPLATE.md` to add an evidence prompt in the Validation section, a tests checkbox, and an AI Assistance disclosure section.
- Updates `doc/Developing.md` to cross-reference `doc/Standards.md` and add a dedicated "Running End-to-End Tests" section.
- Updates `.github/copilot-instructions.md` to document PR expectations for AI-assisted work and normalize trailing whitespace.

cc @denelon

## 🔗 References

- Relates to #6393
- Resolves #6394
- Resolves #6395
- Resolves #6396
- Resolves #6397

## 🔍 Validation

Documentation-only changes. All cross-references and Markdown anchor links verified. No functional code changed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [x] Updated documentation (if applicable)
- [x] Added or updated tests (or noted why not applicable — documentation-only change)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 🤖 AI Assistance

- [x] AI assistance was used and has been disclosed in this PR

GitHub Copilot assisted in authoring all documentation additions in this PR: the new `doc/Standards.md` file, the AI-assisted contributions policy, the expanded testing guidance in `CONTRIBUTING.md`, the "Running End-to-End Tests" section in `doc/Developing.md`, and the PR template updates. I have reviewed and revised the submitted content.

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6402)