### PR TITLE
Make template string H6

### DIFF
--- a/.github/policies/labelAdded.noRecentActivity.yml
+++ b/.github/policies/labelAdded.noRecentActivity.yml
@@ -24,7 +24,7 @@ configuration:
                 This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
 
 
-                Template: msftbot/noRecentActivity
+                ###### Template: msftbot/noRecentActivity
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
       - description: >-
@@ -43,7 +43,7 @@ configuration:
                 This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
 
 
-                Template: msftbot/noRecentActivity
+                ###### Template: msftbot/noRecentActivity
         # The policy service should trigger even when the label was added by the policy service
         triggerOnOwnActions: true
 onFailure:

--- a/.github/policies/labelAdded.noRecentActivity.yml
+++ b/.github/policies/labelAdded.noRecentActivity.yml
@@ -18,7 +18,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
@@ -37,7 +37,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -44,7 +44,7 @@ configuration:
                 Instead of this PR, it would be helpful if you could [open an issue](https://github.com/microsoft/winget-cli/issues/new?template=Localization_Issue.yml) and it will be forwarded to the internal localization team for review. For more information, please see the [Development Guide](https://github.com/microsoft/winget-cli/blob/master/doc/Developing.md#localization).
 
 
-                Template: msftbot/PullRequests/LocalizationFileChange
+                ###### Template: msftbot/PullRequests/LocalizationFileChange
       - description: Add Needs-Triage to new issues
         if:
           - payloadType: Issues

--- a/.github/policies/labelManagement.needsFeedbackHub.yml
+++ b/.github/policies/labelManagement.needsFeedbackHub.yml
@@ -46,7 +46,7 @@ configuration:
                 The link on the bottom of the feedback report will provide the URL to paste in this Issue to share with us.
 
 
-                Template: msftbot/feedbackHub
+                ###### Template: msftbot/feedbackHub
           - assignTo:
               author: True
           - addLabel:

--- a/.github/policies/labelManagement.needsFeedbackHub.yml
+++ b/.github/policies/labelManagement.needsFeedbackHub.yml
@@ -35,7 +35,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                Hello @${issueAuthor},
+                Hello ${issueAuthor},
 
 
                 Please send us feedback with the Feedback Hub [Windows]+[f] with this issue and paste the link here so we can more easily find your crash information on the back end.

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -562,7 +562,7 @@ configuration:
                         We've identified this as a duplicate of another issue or PR that already exists. This specific instance is being closed in favor of the linked issue. Please add your 👍 to the other issue to raise its priority. Thanks for your contribution!
 
 
-                        Template: msftbot/duplicate/closed
+                        ###### Template: msftbot/duplicate/closed
                   - closeIssue
                   - removeLabel:
                       label: Needs-Triage

--- a/.github/policies/moderatorTriggers.yml
+++ b/.github/policies/moderatorTriggers.yml
@@ -556,7 +556,7 @@ configuration:
                 then:
                   - addReply:
                       reply: >-
-                        Hello @${issueAuthor},
+                        Hello ${issueAuthor},
 
 
                         We've identified this as a duplicate of another issue or PR that already exists. This specific instance is being closed in favor of the linked issue. Please add your 👍 to the other issue to raise its priority. Thanks for your contribution!


### PR DESCRIPTION
## 📖 Description
This PR makes the template string from bot comments H6 instead of normal text and removes some duplicate `@`

## 🔗 References
* https://github.com/microsoft/winget-cli/issues/6411#issuecomment-5122991555*

## 🔍 Validation
No valiation performed

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [x] Task

---

### Before

<img width="928" height="236" alt="image" src="https://github.com/user-attachments/assets/9344807b-468d-46f8-b2ed-f24774225168" />

### After

<img width="922" height="237" alt="image" src="https://github.com/user-attachments/assets/2945f001-ed0d-43d6-b738-6c5729cf85e3" />


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6413)