### PR TITLE
Sort and deduplicate exported packages

### DIFF
--- a/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/ImportExportFlow.cpp
@@ -170,6 +170,23 @@ namespace AppInstaller::CLI::Workflow
             sourceItr->Packages.emplace_back(std::move(exportPackage));
         }
 
+        for (auto& source : exportedSources)
+        {
+            auto& packages = source.Packages;
+            std::stable_sort(packages.begin(), packages.end(), [](const auto& left, const auto& right)
+                {
+                    return left.Id < right.Id;
+                });
+
+            if (!includeVersions)
+            {
+                packages.erase(std::unique(packages.begin(), packages.end(), [](const auto& left, const auto& right)
+                    {
+                        return left.Id.get() == right.Id.get();
+                    }), packages.end());
+            }
+        }
+
         context.Add<Execution::Data::PackageCollection>(std::move(exportedPackages));
     }
 

--- a/src/AppInstallerCLITests/ExportFlow.cpp
+++ b/src/AppInstallerCLITests/ExportFlow.cpp
@@ -20,12 +20,13 @@ TEST_CASE("ExportFlow_ExportAll", "[ExportFlow][workflow]")
     TestContext context{ exportOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
     OverrideForCompositeInstalledSource(context, CreateTestSource({
-        TSR::TestInstaller_Exe,
-        TSR::TestInstaller_Exe_UnknownVersion,
-        TSR::TestInstaller_Msix,
-        TSR::TestInstaller_MSStore,
-        TSR::TestInstaller_Portable,
         TSR::TestInstaller_Zip,
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_Exe,
         }));
     context.Args.AddArg(Execution::Args::Type::OutputFile, exportResultPath);
 
@@ -40,6 +41,12 @@ TEST_CASE("ExportFlow_ExportAll", "[ExportFlow][workflow]")
 
     const auto& exportedPackages = exportedCollection.Sources[0].Packages;
     REQUIRE(exportedPackages.size() == 6);
+    REQUIRE(exportedPackages[0].Id == "AppInstallerCliTest.TestExeInstaller");
+    REQUIRE(exportedPackages[1].Id == "AppInstallerCliTest.TestExeUnknownVersion");
+    REQUIRE(exportedPackages[2].Id == "AppInstallerCliTest.TestMSStoreInstaller");
+    REQUIRE(exportedPackages[3].Id == "AppInstallerCliTest.TestMsixInstaller");
+    REQUIRE(exportedPackages[4].Id == "AppInstallerCliTest.TestPortableInstaller");
+    REQUIRE(exportedPackages[5].Id == "AppInstallerCliTest.TestZipInstaller");
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestExeInstaller" && p.VersionAndChannel.GetVersion().ToString().empty();
@@ -74,12 +81,13 @@ TEST_CASE("ExportFlow_ExportAll_WithVersions", "[ExportFlow][workflow]")
     TestContext context{ exportOutput, std::cin };
     auto previousThreadGlobals = context.SetForCurrentThread();
     OverrideForCompositeInstalledSource(context, CreateTestSource({
-        TSR::TestInstaller_Exe,
-        TSR::TestInstaller_Exe_UnknownVersion,
-        TSR::TestInstaller_Msix,
-        TSR::TestInstaller_MSStore,
-        TSR::TestInstaller_Portable,
         TSR::TestInstaller_Zip,
+        TSR::TestInstaller_Exe,
+        TSR::TestInstaller_Portable,
+        TSR::TestInstaller_Exe_UnknownVersion,
+        TSR::TestInstaller_MSStore,
+        TSR::TestInstaller_Msix,
+        TSR::TestInstaller_Exe,
         }));
     context.Args.AddArg(Execution::Args::Type::OutputFile, exportResultPath);
     context.Args.AddArg(Execution::Args::Type::IncludeVersions);
@@ -94,7 +102,14 @@ TEST_CASE("ExportFlow_ExportAll_WithVersions", "[ExportFlow][workflow]")
     REQUIRE(exportedCollection.Sources[0].Details.Identifier == "*TestSource");
 
     const auto& exportedPackages = exportedCollection.Sources[0].Packages;
-    REQUIRE(exportedPackages.size() == 6);
+    REQUIRE(exportedPackages.size() == 7);
+    REQUIRE(exportedPackages[0].Id == "AppInstallerCliTest.TestExeInstaller");
+    REQUIRE(exportedPackages[1].Id == "AppInstallerCliTest.TestExeInstaller");
+    REQUIRE(exportedPackages[2].Id == "AppInstallerCliTest.TestExeUnknownVersion");
+    REQUIRE(exportedPackages[3].Id == "AppInstallerCliTest.TestMSStoreInstaller");
+    REQUIRE(exportedPackages[4].Id == "AppInstallerCliTest.TestMsixInstaller");
+    REQUIRE(exportedPackages[5].Id == "AppInstallerCliTest.TestPortableInstaller");
+    REQUIRE(exportedPackages[6].Id == "AppInstallerCliTest.TestZipInstaller");
     REQUIRE(exportedPackages.end() != std::find_if(exportedPackages.begin(), exportedPackages.end(), [](const auto& p)
         {
             return p.Id == "AppInstallerCliTest.TestExeInstaller" && p.VersionAndChannel.GetVersion().ToString() == "1.0.0.0";


### PR DESCRIPTION
## 📖 Description

Sort each exported source's package list by package identifier. For the default
export mode, remove repeated identifiers after sorting. Keep repeated entries
when `--include-versions` is present so distinct version records are retained.

The workflow tests now start from an intentionally unsorted source and include
a duplicate package, then assert ordering and the mode-specific duplicate
behavior.

AI assistance: OpenAI Codex helped draft the implementation and tests. I
reviewed the complete diff and validation evidence and take responsibility for
the contribution.

## 🔗 References

Resolves #1058

## 🔍 Validation

- `AppInstallerCLITests.exe 'ExportFlow*' --reporter compact`: 38 assertions in 3 test cases passed
- relevant AppInstaller CLI test target built successfully
- `git diff --check`

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com) — pending the automated PR check
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) — not applicable to this focused change
- [ ] Updated documentation — not applicable; export behavior and tests are self-contained
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) — not applicable; no build, architecture, or convention change

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6438)