### PR TITLE
Fix: Quote install location in Nullsoft /D= switch to support paths with spaces

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -9,3 +9,4 @@ Added a new `--ignore-unavailable` flag to the `install` command. When installin
 * Fixed an issue where `winget search --id <msstoreId>` could fail to return a Microsoft Store package unless `--exact` was also provided.
 * Updated NUnit to v4
 * Fixed a crash (`0x8000ffff`) when using `--disable-interactivity` with the Resume experimental feature enabled during install operations.
+* Location parameter is now passed in quotes for Nullsoft Installers by default

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj
@@ -474,6 +474,9 @@
     <CopyFileToFolders Include="TestData\InstallerArgTest_Inno_NoSwitches.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallerArgTest_Nullsoft_NoSwitches.yaml">
+      <DeploymentContent>true</DeploymentContent>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\InstallerArgTest_Inno_WithSwitches.yaml">
       <DeploymentContent>true</DeploymentContent>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
+++ b/src/AppInstallerCLITests/AppInstallerCLITests.vcxproj.filters
@@ -795,6 +795,9 @@
     <CopyFileToFolders Include="TestData\InstallerArgTest_Inno_NoSwitches.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="TestData\InstallerArgTest_Nullsoft_NoSwitches.yaml">
+      <Filter>TestData</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="TestData\UpdateFlowTest_Exe.yaml">
       <Filter>TestData</Filter>
     </CopyFileToFolders>

--- a/src/AppInstallerCLITests/InstallFlow.cpp
+++ b/src/AppInstallerCLITests/InstallFlow.cpp
@@ -960,6 +960,21 @@ TEST_CASE("ShellExecuteHandlerInstallerArgs", "[InstallFlow][workflow]")
         std::ostringstream installOutput;
         TestContext context{ installOutput, std::cin };
         auto previousThreadGlobals = context.SetForCurrentThread();
+        // Nullsoft type with --location containing spaces; verify value is quoted in /D= switch
+        auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Nullsoft_NoSwitches.yaml"));
+        context.Args.AddArg(Execution::Args::Type::Silent);
+        context.Args.AddArg(Execution::Args::Type::InstallLocation, R"(C:\Program Files\CustomInstallDir)"sv);
+        context.Add<Data::Manifest>(manifest);
+        context.Add<Data::Installer>(manifest.Installers.at(0));
+        context << GetInstallerArgs;
+        std::string installerArgs = context.Get<Data::InstallerArgs>();
+        REQUIRE(installerArgs.find(R"(/D="C:\Program Files\CustomInstallDir")") != std::string::npos);
+    }
+
+    {
+        std::ostringstream installOutput;
+        TestContext context{ installOutput, std::cin };
+        auto previousThreadGlobals = context.SetForCurrentThread();
         // Override switch specified. The whole arg passed to installer is overridden.
         auto manifest = YamlParser::CreateFromPath(TestDataFile("InstallerArgTest_Inno_WithSwitches.yaml"));
         context.Args.AddArg(Execution::Args::Type::Silent);

--- a/src/AppInstallerCLITests/TestData/InstallerArgTest_Nullsoft_NoSwitches.yaml
+++ b/src/AppInstallerCLITests/TestData/InstallerArgTest_Nullsoft_NoSwitches.yaml
@@ -1,0 +1,12 @@
+Id: AppInstallerCliTest.TestInstaller
+Version: 1.0.0.0
+Name: AppInstaller Test Installer
+Publisher: Microsoft Corporation
+AppMoniker: AICLITest
+License: Test
+Installers: 
+    - Arch: x64
+      Url: https://ThisIsNotUsed
+      InstallerType: nullsoft
+      Sha256: 65DB2F2AC2686C7F2FD69D4A4C6683B888DC55BFA20A0E32CA9F838B51689A3B
+ManifestVersion: 0.1.0

--- a/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
+++ b/src/AppInstallerCommonCore/Manifest/ManifestCommon.cpp
@@ -1049,7 +1049,7 @@ namespace AppInstaller::Manifest
             {
                 {InstallerSwitchType::Silent, ManifestInstaller::string_t("/S")},
                 {InstallerSwitchType::SilentWithProgress, ManifestInstaller::string_t("/S")},
-                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("/D=" + std::string(ARG_TOKEN_INSTALLPATH))}
+                {InstallerSwitchType::InstallLocation, ManifestInstaller::string_t("/D=\"" + std::string(ARG_TOKEN_INSTALLPATH) + "\"")}
             };
         case InstallerTypeEnum::Inno:
             return


### PR DESCRIPTION
## 📖 Description

Nullsoft (NSIS) installers use a non-standard `/D=<path>` switch to specify the install directory. Unlike standard command-line switches, `/D=` does not support quoted paths — NSIS parses it literally and treats everything after `=` as the path. This means a path containing spaces (e.g. `C:\Program Files\MyApp`) would be split at the first space, causing the installer to target the wrong directory (e.g. `C:\Program` instead of `C:\Program Files\MyApp`).

This fix wraps the install location token in double quotes within the default switch template (`/D="<installpath>"`), so paths with spaces are passed correctly.

> [!NOTE]
> This issue was reported against a Joplin install in microsoft/winget-pkgs#413775.

## 🔗 References

Resolves microsoft/winget-pkgs#413775

## 🔍 Validation

- Added a unit test in `ShellExecuteHandlerInstallerArgs` that passes `C:\Program Files\CustomInstallDir` as `--location` for a Nullsoft installer and asserts the resulting args contain `/D="C:\Program Files\CustomInstallDir"`.
- Existing Msi and Inno tests continue to pass.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---
> This pull request was prepared with assistance from GitHub Copilot.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6444)