### PR TITLE
Added a note about MSStoreProductIdentifier non-support to RestInterface_1_1.cpp.

### DIFF
--- a/src/AppInstallerCLITests/RestInterface_1_1.cpp
+++ b/src/AppInstallerCLITests/RestInterface_1_1.cpp
@@ -498,6 +498,7 @@ TEST_CASE("GetManifests_GoodRequest_OnlyMarketRequired", "[RestSource][Interface
     REQUIRE(manifest.Installers[0].Url == "https://installer.example.com/foobar.exe");
 }
 
+// Note that "MSStoreProductIdentifier" is not supported in regular manifests as of ManifestVersion 1.28.0.
 TEST_CASE("GetManifests_GoodResponse_MSStoreType", "[RestSource][Interface_1_1]")
 {
     utility::string_t msstoreInstallerResponse = _XPLATSTR(


### PR DESCRIPTION
## 📖 Description
The following section in https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerCLITests/RestInterface_1_1.cpp claims that the following would be able to get working in a manifest:
```
(...)
{
  "Architecture": "x64",
  "InstallerType": "msstore",
  "MSStoreProductIdentifier": "9nblggh4nns1"
}
(...)
```

It can't.

So this PR adds a note about that it can't.

## 🔗 References
* https://github.com/microsoft/winget-pkgs/pull/416200

## 🔍 Validation
Added a secondary installer to a manifest that used the syntaxing used for the `msstore` InstallerType in https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerCLITests/RestInterface_1_1.cpp

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6458)