### PR TITLE
Allow Dependabot cooldown spelling

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -43,6 +43,7 @@ COMMONDATA
 comparand
 conemu
 contoso
+cooldown
 COSTDEFERRED
 cotaskmem
 cpprest


### PR DESCRIPTION
## 📖 Description

Adds the valid Dependabot configuration key `cooldown` to the spelling allow-list so the Check Spelling workflow accepts the configuration introduced by https://github.com/microsoft/winget-cli/pull/6471.

Authored with GitHub Copilot assistance.

## 🔗 References

Closes https://github.com/microsoft/winget-cli/issues/6477

Unblocks https://github.com/microsoft/winget-cli/pull/6471

## 🔍 Validation

- Confirmed `.github/actions/spelling/allow.txt` remains alphabetically sorted.
- Confirmed `cooldown` appears exactly once and matches the allow-list format.
- Ran `git diff --check`.
- Confirmed the commit changes only `.github/actions/spelling/allow.txt`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (not applicable)
- [x] Updated documentation (not applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (not applicable; no build, architecture, or convention changes)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6478)