### PR TITLE
Update troubleshooting README to remove old Insider info

### DIFF
--- a/doc/troubleshooting/README.md
+++ b/doc/troubleshooting/README.md
@@ -24,8 +24,6 @@ Customers may install the [latest stable release](https://github.com/microsoft/w
 
 >Note: There is a known problem restoring the client to the latest stable App Installer release. We will be distributing the latest stable builds and providing instructions once they are made available.
 
-During the initial Windows Package Manager Preview period, releases were distributed to all Windows Insider channels. Customers who [sign up](http://aka.ms/winget-InsiderProgram) to become members of the Windows Package Manager Insider program also receive pre-release builds. The final process for inclusion into the program requires manual steps, so the App Installer update may not be available for a few days **after** receiving their e-mail notification.
-
 Customers may install any [release](https://github.com/microsoft/winget-cli/releases/) including pre-release builds directly from the GitHub repository. These packages are signed, and customers will receive automatic updates if IT Policy does not block the Microsoft Store.
 
 >Note: Insiders will receive updates to the latest build (stable or pre-release) if IT Policy does not block the Microsoft Store. Other customers will receive updates to the latest stable build once a newer stable version is published if IT Policy does not block the Microsoft Store.


### PR DESCRIPTION
Removed outdated information regarding Windows Package Manager Insider program and pre-release builds.

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Removes old Windows Insider details, including a dead link to a Microsoft Form.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->
Fixes [#6494](https://github.com/microsoft/winget-cli/issues/6494), where a no longer valid Microsoft Insider sign-up link is listed (http://aka.ms/winget-InsiderProgram).

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
The releases page (which includes insider releases (pre-releases) is already listed in the documentation.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6495)