### PR TITLE
Handle empty package enumeration during COM manual activation

### DIFF
--- a/src/WinGetServer/WinGetServerManualActivation_Client.cpp
+++ b/src/WinGetServer/WinGetServerManualActivation_Client.cpp
@@ -113,7 +113,7 @@ private:
         std::unique_ptr<UINT32[]> properties;
 
         LONG result = FindPackagesByPackageFamily(pfn.c_str(), PACKAGE_FILTER_HEAD, &count, nullptr, &bufferLength, nullptr, nullptr);
-        THROW_WIN32_IF(result, result != ERROR_INSUFFICIENT_BUFFER);
+        THROW_WIN32_IF(result, result != ERROR_INSUFFICIENT_BUFFER && result != ERROR_SUCCESS);
 
         for (size_t i = 0; i < 10 && result == ERROR_INSUFFICIENT_BUFFER; ++i)
         {


### PR DESCRIPTION
## 📖 Description

The initial sizing call to `FindPackagesByPackageFamily` returns `ERROR_INSUFFICIENT_BUFFER` when matching packages exist, but can validly return `ERROR_SUCCESS` with a count of zero when no package is registered for the current identity.

The current code passes that success result to a failure-only WIL macro, causing the calling process to CRASH through FAIL_FAST instead of receiving a normal HRESULT. This change accepts the valid empty result and lets the existing control flow return `ERROR_PACKAGE_NOT_REGISTERED_FOR_USER` instead.

The registered-package path and propagation of other Win32 errors remain unchanged. This is consistent with the handling established in #2922.

For the SYSTEM scenario in #4944, this prevents the direct CRASH caused by FAIL_FAST, but does not add OutOfProc COM support, enumerate packages registered to other users, or use staged packages.

## 🔗 References

- Related to #4944; addresses the FAIL_FAST CRASH only.
- Similar empty-result handling was introduced in #2922.
- [`FindPackagesByPackageFamily` documentation](https://learn.microsoft.com/windows/win32/api/appmodel/nf-appmodel-findpackagesbypackagefamily)

## 🔍 Validation

- Reproduced the existing SYSTEM CRASH with `0xC0000409` (`FAIL_FAST`).
- Confirmed that the API returns `ERROR_SUCCESS` with a package count of zero under SYSTEM.
- Built `Microsoft.Management.Deployment.OutOfProc` for x64 Debug with the production package family and CLSIDs.
- Verified the modified DLL as a normal user: exit code 0 and 237 packages enumerated.
- Verified the modified DLL under SYSTEM: caught `COMException` with HRESULT `0x80073D35`; exit code 0 with no process crash.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (not applicable)
- [x] Updated documentation (not applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (not applicable)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6496)