### PR TITLE
Disable incremental link on pipeline

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -265,6 +265,8 @@ insufficientmemory
 Intelli
 INTRESOURCE
 invalidparameter
+iobj
+ipdb
 ishelp
 ISQ
 ISVs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,12 @@ jobs:
     appxPackageDir: $(Build.ArtifactStagingDirectory)\$(buildPlatform)\AppxPackages
 
   steps:
+  - task: PowerShell@2
+    displayName: Report Initial Disk Space
+    inputs:
+      targetType: 'inline'
+      script: 'Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Name="UsedGB";Expression={[math]::Round($_.Used/1GB,2)}}, @{Name="FreeGB";Expression={[math]::Round($_.Free/1GB,2)}}'
+
   - task: NuGetToolInstaller@1
     displayName: Install Nuget
 
@@ -119,8 +125,16 @@ jobs:
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=SideloadOnly
-                    /p:WingetCleanIntermediateFiles=true'
+                    /p:WingetCleanIntermediateFiles=true
+                    /p:WingetDisableIncrementalLinkTimeCodeGeneration=true'
       maximumCpuCount: true
+
+  - task: PowerShell@2
+    displayName: Report Disk Space
+    condition: succeededOrFailed()
+    inputs:
+      targetType: 'inline'
+      script: 'Get-PSDrive -PSProvider FileSystem | Format-Table Name, @{Name="UsedGB";Expression={[math]::Round($_.Used/1GB,2)}}, @{Name="FreeGB";Expression={[math]::Round($_.Free/1GB,2)}}'
 
   - task: MSBuild@1
     displayName: Build MSIX Test Installer File

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Consume containing solution build targets if present. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" Condition="'' != $([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- Incremental link time code generation writes .iobj and .ipdb files that can be hundreds of megabytes
+       per binary. They only pay off across repeated local links, so they are pure disk cost on build agents.
+       This must be in Directory.Build.targets rather than Directory.Build.props, as WholeProgramOptimization
+       is not yet defined when Directory.Build.props is imported. -->
+  <ItemDefinitionGroup Condition="'$(WingetDisableIncrementalLinkTimeCodeGeneration)'=='true' and '$(WholeProgramOptimization)'=='true'">
+    <Link>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
## 📖 Description
Pipeline builds have been failing sporadically in the build step due to a space issue (yet again).  Disabling incremental linking there reduces the disk footprint.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6503)