### PR TITLE
Promote source priority to a feature

### DIFF
--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 ## New Features
 
+### Source priority
+
+Source priority is now available without enabling an experimental feature. Use `winget source add --priority <value>` or `winget source edit --name <source> --priority <value>` to configure it. Higher values take precedence; sources with equal priority still require disambiguation when multiple matches remain.
+
 ### Output locale override
 
 Added a persistent `output.locale` setting to override winget interface language using a BCP47 tag.

--- a/doc/Settings.md
+++ b/doc/Settings.md
@@ -450,15 +450,3 @@ This feature enables support for fonts via `winget settings`. The `winget font l
         "fonts": true
   },
 ```
-
-### sourcePriority
-
-This feature enables sources to have a priority value assigned. Sources with a higher priority will appear earlier in search results and will be selected for installing new packages when multiple sources have a matching package.
-
-Note that search result ordering is dependent on several factors, and source priority is the lowest field in that currently (match quality and field are more important).
-
-```json
-  "experimentalFeatures": {
-        "sourcePriority": true
-  },
-```

--- a/doc/windows/package-manager/winget/source.md
+++ b/doc/windows/package-manager/winget/source.md
@@ -53,7 +53,7 @@ The **source** command supports the following options.
 |  **-n, --name** | The name to identify the source by. |
 |  **-a, --arg** | The URL or UNC of the source. |
 |  **-t, --type** | The type of source. |
-| **--priority** | Sets the source priority for **add** or **edit**. Higher values take precedence; the default is `0`. |
+| **-p, --priority** | Sets the source priority for **add** or **edit**. Higher values take precedence; new sources default to `0`. |
 | **-?, --help** |  Gets additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting. |
 | **--logs, --open-logs** | Open the default logs location. |

--- a/doc/windows/package-manager/winget/source.md
+++ b/doc/windows/package-manager/winget/source.md
@@ -77,21 +77,13 @@ The **add** sub-command also supports the optional **type** parameter. The **typ
 
 ## Source priority
 
-Source priority is available without enabling an experimental feature. Set it when adding a source with `--priority`, or update an existing source from an elevated terminal:
+To prefer a source when installing packages, set its priority from an elevated terminal:
 
 ```powershell
 winget source edit --name winget --priority 1
 ```
 
-Priorities are signed 32-bit integers, and all sources default to `0`. Higher-priority sources appear first in the source list. For search results, match quality and the matched field take precedence over source priority.
-
-When a command targeting available packages, such as `install`, finds multiple matches, WinGet keeps the matches from the highest-priority sources that returned results. If exactly one match remains, WinGet selects it and displays a warning. If multiple matches remain at that priority, the command still requires disambiguation. Source priority does not resolve multiple installed-package matches for `upgrade`, `uninstall`, `repair`, or `export`.
-
-Use `winget source list --name winget` to view a source's priority. To restore its default priority:
-
-```powershell
-winget source edit --name winget --priority 0
-```
+If multiple matches remain at the highest priority, refine the search or specify `--source`.
 
 ## list
 

--- a/doc/windows/package-manager/winget/source.md
+++ b/doc/windows/package-manager/winget/source.md
@@ -35,6 +35,7 @@ Source supports the following sub-commands for manipulating the sources.
 | Sub-command  | Description |
 |--------------|-------------|
 |  **add** |  Adds a new source. |
+|  **edit** | Edits an existing source. |
 |  **list** | Enumerates the list of enabled sources. |
 |  **update** | Updates a source. |
 |  **remove** | Removes a source. |
@@ -52,6 +53,7 @@ The **source** command supports the following options.
 |  **-n, --name** | The name to identify the source by. |
 |  **-a, --arg** | The URL or UNC of the source. |
 |  **-t, --type** | The type of source. |
+| **--priority** | Sets the source priority for **add** or **edit**. Higher values take precedence; the default is `0`. |
 | **-?, --help** |  Gets additional help on this command. |
 | **--wait** | Prompts the user to press any key before exiting. |
 | **--logs, --open-logs** | Open the default logs location. |
@@ -72,6 +74,24 @@ The **add** sub-command also supports the optional **type** parameter. The **typ
 |--------------|-------------|
 | **Microsoft.PreIndexed.Package** | The type of source \<default>. |
 | **Microsoft.Rest** | A Microsoft REST API source. |
+
+## Source priority
+
+Source priority is available without enabling an experimental feature. Set it when adding a source with `--priority`, or update an existing source from an elevated terminal:
+
+```powershell
+winget source edit --name winget --priority 1
+```
+
+Priorities are signed 32-bit integers, and all sources default to `0`. Higher-priority sources appear first in the source list. For search results, match quality and the matched field take precedence over source priority.
+
+When a command targeting available packages, such as `install`, finds multiple matches, WinGet keeps the matches from the highest-priority sources that returned results. If exactly one match remains, WinGet selects it and displays a warning. If multiple matches remain at that priority, the command still requires disambiguation. Source priority does not resolve multiple installed-package matches for `upgrade`, `uninstall`, `repair`, or `export`.
+
+Use `winget source list --name winget` to view a source's priority. To restore its default priority:
+
+```powershell
+winget source edit --name winget --priority 0
+```
 
 ## list
 

--- a/schemas/JSON/settings/settings.schema.0.2.json
+++ b/schemas/JSON/settings/settings.schema.0.2.json
@@ -343,11 +343,6 @@
           "description": "Enable support for some commands to resume",
           "type": "boolean",
           "default": false
-        },
-        "sourcePriority": {
-          "description": "Enable source priority feature",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/src/AppInstallerCLICore/Argument.cpp
+++ b/src/AppInstallerCLICore/Argument.cpp
@@ -433,7 +433,7 @@ namespace AppInstaller::CLI
         case Args::Type::SourceEditExplicit:
             return Argument{ type, Resource::String::SourceEditExplicitArgumentDescription, ArgumentType::Standard };
         case Args::Type::SourcePriority:
-            return Argument{ type, Resource::String::SourcePriorityArgumentDescription, ArgumentType::Standard, ExperimentalFeature::Feature::SourcePriority };
+            return Argument{ type, Resource::String::SourcePriorityArgumentDescription, ArgumentType::Standard };
         case Args::Type::SourceTrustLevel:
             return Argument{ type, Resource::String::SourceTrustLevelArgumentDescription, ArgumentType::Standard, Argument::Visibility::Help };
         case Args::Type::ValidateManifest:

--- a/src/AppInstallerCLICore/Commands/DscSourceResource.cpp
+++ b/src/AppInstallerCLICore/Commands/DscSourceResource.cpp
@@ -6,7 +6,6 @@
 #include "Resources.h"
 #include "Workflows/SourceFlow.h"
 #include <winget/RepositorySource.h>
-#include <winget/ExperimentalFeature.h>
 
 using namespace AppInstaller::Utility::literals;
 using namespace AppInstaller::Repository;
@@ -111,10 +110,7 @@ namespace AppInstaller::CLI
                         Output.TrustLevel(TrustLevelStringFromFlags(source.TrustLevel));
                         Output.Explicit(source.Explicit);
 
-                        if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::SourcePriority))
-                        {
-                            Output.Priority(source.Priority);
-                        }
+                        Output.Priority(source.Priority);
 
                         std::vector<Repository::SourceDetails> sources;
                         sources.emplace_back(source);
@@ -158,7 +154,6 @@ namespace AppInstaller::CLI
                 std::string priorityString;
                 if (Input.Priority())
                 {
-                    THROW_HR_IF(APPINSTALLER_CLI_ERROR_EXPERIMENTAL_FEATURE_DISABLED, !Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::SourcePriority));
                     priorityString = std::to_string(Input.Priority().value());
                     SubContext->Args.AddArg(Execution::Args::Type::SourcePriority, priorityString);
                 }
@@ -202,7 +197,6 @@ namespace AppInstaller::CLI
                 std::string priorityString;
                 if (Input.Priority())
                 {
-                    THROW_HR_IF(APPINSTALLER_CLI_ERROR_EXPERIMENTAL_FEATURE_DISABLED, !Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::SourcePriority));
                     priorityString = std::to_string(Input.Priority().value());
                     SubContext->Args.AddArg(Execution::Args::Type::SourcePriority, priorityString);
                 }
@@ -373,7 +367,6 @@ namespace AppInstaller::CLI
             {
                 if (Input.Priority())
                 {
-                    THROW_HR_IF(APPINSTALLER_CLI_ERROR_EXPERIMENTAL_FEATURE_DISABLED, !Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::SourcePriority));
                     if (Output.Priority())
                     {
                         return Input.Priority().value() == Output.Priority().value();
@@ -499,10 +492,7 @@ namespace AppInstaller::CLI
             output.TrustLevel(TrustLevelStringFromFlags(source.TrustLevel));
             output.Explicit(source.Explicit);
 
-            if (Settings::ExperimentalFeature::IsEnabled(Settings::ExperimentalFeature::Feature::SourcePriority))
-            {
-                output.Priority(source.Priority);
-            }
+            output.Priority(source.Priority);
 
             WriteJsonOutputLine(context, output.ToJson());
         }

--- a/src/AppInstallerCLICore/Workflows/SourceFlow.cpp
+++ b/src/AppInstallerCLICore/Workflows/SourceFlow.cpp
@@ -189,10 +189,7 @@ namespace AppInstaller::CLI::Workflow
             table.OutputLine({ Resource::LocString(Resource::String::SourceListIdentifier), source.Identifier });
             table.OutputLine({ Resource::LocString(Resource::String::SourceListTrustLevel), Repository::GetSourceTrustLevelForDisplay(source.TrustLevel)});
             table.OutputLine({ Resource::LocString(Resource::String::SourceListExplicit), std::string{ Utility::ConvertBoolToString(source.Explicit) } });
-            if (ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::SourcePriority))
-            {
-                table.OutputLine({ Resource::LocString(Resource::String::SourceListPriority), std::to_string(source.Priority) });
-            }
+            table.OutputLine({ Resource::LocString(Resource::String::SourceListPriority), std::to_string(source.Priority) });
 
             if (source.LastUpdateTime == Utility::ConvertUnixEpochToSystemClock(0))
             {
@@ -410,10 +407,7 @@ namespace AppInstaller::CLI::Workflow
                 s.TrustLevel = std::vector<std::string>(sourceTrustLevels.begin(), sourceTrustLevels.end());
                 s.Explicit = source.Explicit;
 
-                if (ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::SourcePriority))
-                {
-                    s.Priority = source.Priority;
-                }
+                s.Priority = source.Priority;
 
                 context.Reporter.Info() << s.ToJsonString() << std::endl;
             }

--- a/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
+++ b/src/AppInstallerCLICore/Workflows/WorkflowBase.cpp
@@ -1358,8 +1358,7 @@ namespace AppInstaller::CLI::Workflow
                 m_operationType == OperationType::Repair || m_operationType == OperationType::Export;
 
             // Try limiting results to highest priority sources
-            if (searchResult.Matches.size() > 1 && !operationTargetsInstalled &&
-                ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::SourcePriority))
+            if (searchResult.Matches.size() > 1 && !operationTargetsInstalled)
             {
                 // Find the set of matches that have the highest priority
                 std::vector<ResultMatch> highestPriorityMatches;

--- a/src/AppInstallerCLIE2ETests/DSCv3SourceResourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/DSCv3SourceResourceCommand.cs
@@ -78,7 +78,6 @@ namespace AppInstallerCLIE2ETests
         public void Setup()
         {
             RemoveTestSource();
-            WinGetSettingsHelper.ConfigureFeature("sourcePriority", true);
         }
 
         /// <summary>

--- a/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
+++ b/src/AppInstallerCLIE2ETests/Helpers/WinGetSettingsHelper.cs
@@ -245,7 +245,6 @@ namespace AppInstallerCLIE2ETests.Helpers
             ConfigureFeature(settingsJson, "resume", status);
             ConfigureFeature(settingsJson, "reboot", status);
             ConfigureFeature(settingsJson, "fonts", status);
-            ConfigureFeature(settingsJson, "sourcePriority", status);
 
             SetWingetSettings(settingsJson);
         }

--- a/src/AppInstallerCLIE2ETests/InstallCommand.cs
+++ b/src/AppInstallerCLIE2ETests/InstallCommand.cs
@@ -17,15 +17,6 @@ namespace AppInstallerCLIE2ETests
     public class InstallCommand : BaseCommand
     {
         /// <summary>
-        /// One time set up.
-        /// </summary>
-        [OneTimeSetUp]
-        public void OneTimeSetup()
-        {
-            WinGetSettingsHelper.ConfigureFeature("sourcePriority", true);
-        }
-
-        /// <summary>
         /// Set up.
         /// </summary>
         [SetUp]

--- a/src/AppInstallerCLIE2ETests/README.md
+++ b/src/AppInstallerCLIE2ETests/README.md
@@ -50,7 +50,7 @@ Assuming you clone winget-cli in c:\dev, the localhost web server is running in 
             <Parameter name="LocalServerCertPath" value="C:\dev\Temp\servercert.cer" />
             <Parameter name="InprocTestbedPath" value="c:\dev\winget-cli\src\x64\Debug\ComInprocTestbed\ComInprocTestbed.exe" />
             <Parameter name="InprocTestbedUseTestPackage" value="false" />
-            <Parameter name="ForcedExperimentalFeatures" value="directMSI|resume|fonts|sourcePriority" />
+            <Parameter name="ForcedExperimentalFeatures" value="directMSI|resume|fonts" />
             <Parameter name="SkipTestSource" value="false" />
         </TestRunParameters>
     </RunSettings>

--- a/src/AppInstallerCLIE2ETests/SourceCommand.cs
+++ b/src/AppInstallerCLIE2ETests/SourceCommand.cs
@@ -15,15 +15,6 @@ namespace AppInstallerCLIE2ETests
     public class SourceCommand : BaseCommand
     {
         /// <summary>
-        /// One time set up.
-        /// </summary>
-        [OneTimeSetUp]
-        public void OneTimeSetup()
-        {
-            WinGetSettingsHelper.ConfigureFeature("sourcePriority", true);
-        }
-
-        /// <summary>
         /// Test set up.
         /// </summary>
         [SetUp]

--- a/src/AppInstallerCLITests/SourceFlow.cpp
+++ b/src/AppInstallerCLITests/SourceFlow.cpp
@@ -4,6 +4,8 @@
 #include "WorkflowCommon.h"
 #include "TestHooks.h"
 #include "TestSettings.h"
+#include <winget/ManifestYamlParser.h>
+#include <Commands/DscSourceResource.h>
 #include <Commands/SourceCommand.h>
 #include <Workflows/PromptFlow.h>
 #include <Workflows/SourceFlow.h>
@@ -13,6 +15,208 @@ using namespace AppInstaller::CLI;
 using namespace AppInstaller::CLI::Workflow;
 using namespace AppInstaller::Repository;
 using namespace AppInstaller::Settings;
+
+TEST_CASE("SourcePriority_Arguments", "[SourcePriority][workflow]")
+{
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::ExperimentalFeatures, GENERATE(PolicyState::NotConfigured, PolicyState::Disabled));
+    auto priority = GENERATE("-2147483648"sv, "0"sv, "42"sv, "2147483647"sv);
+
+    Execution::Args addArgs;
+    addArgs.AddArg(Execution::Args::Type::SourceName, "TestSource"sv);
+    addArgs.AddArg(Execution::Args::Type::SourceArg, "https://test"sv);
+    addArgs.AddArg(Execution::Args::Type::SourcePriority, priority);
+    SourceAddCommand sourceAdd({});
+    REQUIRE_NOTHROW(sourceAdd.ValidateArguments(addArgs));
+
+    Execution::Args editArgs;
+    editArgs.AddArg(Execution::Args::Type::SourceName, "TestSource"sv);
+    editArgs.AddArg(Execution::Args::Type::SourcePriority, priority);
+    SourceEditCommand sourceEdit({});
+    REQUIRE_NOTHROW(sourceEdit.ValidateArguments(editArgs));
+
+    REQUIRE(Argument::ForType(Execution::Args::Type::SourcePriority).GetVisibility() != Argument::Visibility::Hidden);
+}
+
+TEST_CASE("SourcePriority_SearchResult", "[SourcePriority][workflow]")
+{
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::ExperimentalFeatures, GENERATE(PolicyState::NotConfigured, PolicyState::Disabled));
+    auto operationType = GENERATE(OperationType::Install, OperationType::Upgrade, OperationType::Uninstall, OperationType::Repair, OperationType::Export);
+
+    std::vector<int32_t> priorities;
+    size_t expectedMatches = 1;
+
+    SECTION("Unique highest priority")
+    {
+        priorities = { 0, 2, 1 };
+    }
+    SECTION("Default priorities")
+    {
+        priorities = { 0, 0, 0 };
+        expectedMatches = 3;
+    }
+    SECTION("Tied highest priority")
+    {
+        priorities = { 0, 2, 2 };
+        expectedMatches = 2;
+    }
+    SECTION("Negative priorities")
+    {
+        priorities = { -3, -1, -2 };
+    }
+
+    auto manifest = AppInstaller::Manifest::YamlParser::CreateFromPath(TestDataFile("InstallFlowTest_Exe.yaml"));
+    std::vector<AppInstaller::Manifest::Manifest> versions{ manifest };
+    std::vector<std::shared_ptr<TestSource>> sources;
+    SearchResult searchResult;
+
+    for (int32_t priority : priorities)
+    {
+        auto source = std::make_shared<TestSource>();
+        source->Details.Priority = priority;
+        auto package = TestCompositePackage::Make(versions, source);
+        if (operationType != OperationType::Install)
+        {
+            package->Installed = TestPackage::Make(manifest, TestPackage::MetadataMap{}, source);
+        }
+
+        searchResult.Matches.emplace_back(package, PackageMatchFilter{ PackageMatchField::Id, MatchType::Exact, manifest.Id });
+        sources.emplace_back(std::move(source));
+    }
+
+    auto expectedPackage = searchResult.Matches[1].Package;
+    if (operationType != OperationType::Install)
+    {
+        expectedMatches = priorities.size();
+    }
+
+    std::ostringstream output;
+    TestContext context{ output, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Add<Execution::Data::SearchResult>(std::move(searchResult));
+    context << EnsureOneMatchFromSearchResult(operationType);
+
+    INFO(output.str());
+    REQUIRE(context.Get<Execution::Data::SearchResult>().Matches.size() == expectedMatches);
+    REQUIRE(context.GetTerminationHR() == (expectedMatches == 1 ? S_OK : APPINSTALLER_CLI_ERROR_MULTIPLE_APPLICATIONS_FOUND));
+    REQUIRE((output.str().find(Resource::LocString(Resource::String::MultiplePackagesFoundFilteredBySourcePriority).get()) != std::string::npos) ==
+        (expectedMatches < priorities.size()));
+
+    if (expectedMatches == 1)
+    {
+        REQUIRE(context.Get<Execution::Data::Package>() == expectedPackage);
+    }
+}
+
+TEST_CASE("SourcePriority_SourceOutput", "[SourcePriority][workflow]")
+{
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::ExperimentalFeatures, GENERATE(PolicyState::NotConfigured, PolicyState::Disabled));
+
+    SourceDetails source;
+    source.Name = "PriorityTestSource";
+    source.Priority = GENERATE(-1, 0, 42);
+
+    std::ostringstream output;
+    TestContext context{ output, std::cin };
+    auto previousThreadGlobals = context.SetForCurrentThread();
+    context.Add<Execution::Data::SourceList>(std::vector<SourceDetails>{ source });
+
+    SECTION("List")
+    {
+        context.Args.AddArg(Execution::Args::Type::SourceName, source.Name);
+        context << ListSources;
+        REQUIRE(output.str().find(Resource::LocString(Resource::String::SourceListPriority).get()) != std::string::npos);
+        REQUIRE(output.str().find(std::to_string(source.Priority)) != std::string::npos);
+    }
+    SECTION("Export")
+    {
+        context << ExportSourceList;
+        auto json = ConvertToJson(output.str());
+        REQUIRE(json["Priority"].isInt());
+        REQUIRE(json["Priority"].asInt() == source.Priority);
+    }
+
+    REQUIRE(context.GetTerminationHR() == S_OK);
+}
+
+TEST_CASE("SourcePriority_DscSource", "[SourcePriority][workflow]")
+{
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::ExperimentalFeatures, GENERATE(PolicyState::NotConfigured, PolicyState::Disabled));
+    SetSetting(Stream::UserSources, "Sources:"sv);
+    RemoveSetting(Stream::SourcesMetadata);
+    TestHook_ClearSourceFactoryOverrides();
+
+    TestSourceFactory factory{ [](const SourceDetails& details) { return std::make_shared<TestSource>(details); } };
+    auto clearFactoryOverrides = wil::scope_exit([]() { TestHook_ClearSourceFactoryOverrides(); });
+    TestHook_SetSourceFactoryOverride("Microsoft.Test", factory);
+
+    Json::Value input{ Json::ValueType::objectValue };
+    input["name"] = "PriorityTestSource";
+    input["argument"] = "priority-test";
+    input["type"] = "Microsoft.Test";
+    input["priority"] = GENERATE(-1, 0, 42);
+
+    auto invoke = [&](Execution::Args::Type function, bool modifiesSource = false)
+    {
+        std::istringstream inputStream{ Json::writeString(Json::StreamWriterBuilder{}, input) };
+        std::ostringstream output;
+        TestContext context{ output, inputStream };
+        auto previousThreadGlobals = context.SetForCurrentThread();
+        context.Args.AddArg(function);
+        if (modifiesSource)
+        {
+            context.Override({ EnsureRunningAsAdmin, [](TestContext& subContext)
+            {
+                subContext.Reporter.SetChannel(Execution::Reporter::Channel::Json);
+            } });
+        }
+
+        DscSourceResource command({});
+        command.Execute(context);
+        INFO(output.str());
+        REQUIRE(context.GetTerminationHR() == S_OK);
+
+        std::vector<Json::Value> result;
+        std::istringstream outputStream{ output.str() };
+        for (std::string line; std::getline(outputStream, line);)
+        {
+            result.emplace_back(ConvertToJson(line));
+        }
+        REQUIRE_FALSE(result.empty());
+        return result;
+    };
+
+    auto result = invoke(Execution::Args::Type::DscResourceFunctionSet, true);
+    REQUIRE(result[0]["priority"] == input["priority"]);
+
+    result = invoke(Execution::Args::Type::DscResourceFunctionGet);
+    REQUIRE(result[0]["priority"] == input["priority"]);
+
+    result = invoke(Execution::Args::Type::DscResourceFunctionTest);
+    REQUIRE(result[0]["_inDesiredState"].asBool());
+
+    input["priority"] = input["priority"].asInt() + 1;
+    result = invoke(Execution::Args::Type::DscResourceFunctionTest);
+    REQUIRE_FALSE(result[0]["_inDesiredState"].asBool());
+
+    result = invoke(Execution::Args::Type::DscResourceFunctionSet, true);
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[0]["priority"] == input["priority"]);
+    REQUIRE(result[1].size() == 1);
+    REQUIRE(result[1][0].asString() == "priority");
+
+    result = invoke(Execution::Args::Type::DscResourceFunctionSet);
+    REQUIRE(result.size() == 2);
+    REQUIRE(result[1].empty());
+
+    result = invoke(Execution::Args::Type::DscResourceFunctionExport);
+    auto source = std::find_if(result.begin(), result.end(), [&](const Json::Value& value) { return value["name"] == input["name"]; });
+    REQUIRE(source != result.end());
+    REQUIRE((*source)["priority"] == input["priority"]);
+}
 
 void OverrideForSourceAddWithAgreements(TestContext& context, bool isAddExpected = true)
 {

--- a/src/AppInstallerCLITests/Sources.cpp
+++ b/src/AppInstallerCLITests/Sources.cpp
@@ -406,24 +406,14 @@ TEST_CASE("RepoSources_SingleSource_AllProperties", "[sources]")
 
 TEST_CASE("RepoSources_ThreeSources", "[sources]")
 {
+    GroupPolicyTestOverride policies;
+    policies.SetState(TogglePolicy::Policy::ExperimentalFeatures, GENERATE(PolicyState::NotConfigured, PolicyState::Disabled));
+
     SetSetting(Stream::UserSources, s_ThreeSources);
     SetSetting(Stream::SourcesMetadata, s_ThreeSourcesMetadata);
 
     const char* suffixStrings[3] = { "", "2", "3" };
-    size_t suffixUnsorted[3] = { 0, 1, 2 };
-    size_t suffixPrioritySorted[3] = { 1, 2, 0 };
-    size_t* suffix = nullptr;
-    std::unique_ptr<TestHook::SetSingleExperimentalFeature_Override> override;
-
-    SECTION("Unsorted")
-    {
-        suffix = suffixUnsorted;
-    }
-    SECTION("Priority Sorted")
-    {
-        override = std::make_unique<TestHook::SetSingleExperimentalFeature_Override>(ExperimentalFeature::Feature::SourcePriority);
-        suffix = suffixPrioritySorted;
-    }
+    size_t suffix[3] = { 1, 2, 0 };
 
     std::vector<SourceDetails> sources = GetSources();
     REQUIRE(sources.size() == 3);

--- a/src/AppInstallerCommonCore/ExperimentalFeature.cpp
+++ b/src/AppInstallerCommonCore/ExperimentalFeature.cpp
@@ -65,8 +65,6 @@ namespace AppInstaller::Settings
                 return userSettings.Get<Setting::EFResume>();
             case ExperimentalFeature::Feature::Font:
                 return userSettings.Get<Setting::EFFonts>();
-            case ExperimentalFeature::Feature::SourcePriority:
-                return userSettings.Get<Setting::EFSourcePriority>();
             default:
                 THROW_HR(E_UNEXPECTED);
             }
@@ -100,8 +98,6 @@ namespace AppInstaller::Settings
             return ExperimentalFeature{ "Resume", "resume", "https://aka.ms/winget-settings", Feature::Resume };
         case Feature::Font:
             return ExperimentalFeature{ "Font", "fonts", "https://aka.ms/winget-settings", Feature::Font };
-        case Feature::SourcePriority:
-            return ExperimentalFeature{ "Source Priority", "sourcePriority", "https://aka.ms/winget-settings", Feature::SourcePriority };
         default:
             THROW_HR(E_UNEXPECTED);
         }

--- a/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
+++ b/src/AppInstallerCommonCore/Public/winget/ExperimentalFeature.h
@@ -25,7 +25,6 @@ namespace AppInstaller::Settings
             DirectMSI = 0x1,
             Resume = 0x2,
             Font = 0x4,
-            SourcePriority = 0x8,
             Max, // This MUST always be after all experimental features
 
             // Features listed after Max will not be shown with the features command

--- a/src/AppInstallerCommonCore/Public/winget/UserSettings.h
+++ b/src/AppInstallerCommonCore/Public/winget/UserSettings.h
@@ -102,7 +102,6 @@ namespace AppInstaller::Settings
         EFDirectMSI,
         EFResume,
         EFFonts,
-        EFSourcePriority,
         // Telemetry
         TelemetryDisable,
         // Install behavior
@@ -195,7 +194,6 @@ namespace AppInstaller::Settings
         SETTINGMAPPING_SPECIALIZATION(Setting::EFDirectMSI, bool, bool, false, ".experimentalFeatures.directMSI"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFResume, bool, bool, false, ".experimentalFeatures.resume"sv);
         SETTINGMAPPING_SPECIALIZATION(Setting::EFFonts, bool, bool, false, ".experimentalFeatures.fonts"sv);
-        SETTINGMAPPING_SPECIALIZATION(Setting::EFSourcePriority, bool, bool, false, ".experimentalFeatures.sourcePriority"sv);
         // Telemetry
         SETTINGMAPPING_SPECIALIZATION(Setting::TelemetryDisable, bool, bool, false, ".telemetry.disable"sv);
         // Install behavior

--- a/src/AppInstallerCommonCore/UserSettings.cpp
+++ b/src/AppInstallerCommonCore/UserSettings.cpp
@@ -317,7 +317,6 @@ namespace AppInstaller::Settings
         WINGET_VALIDATE_PASS_THROUGH(EFDirectMSI)
         WINGET_VALIDATE_PASS_THROUGH(EFResume)
         WINGET_VALIDATE_PASS_THROUGH(EFFonts)
-        WINGET_VALIDATE_PASS_THROUGH(EFSourcePriority)
         WINGET_VALIDATE_PASS_THROUGH(AnonymizePathForDisplay)
         WINGET_VALIDATE_PASS_THROUGH(TelemetryDisable)
         WINGET_VALIDATE_PASS_THROUGH(InteractivityDisable)

--- a/src/AppInstallerRepositoryCore/SourceList.cpp
+++ b/src/AppInstallerRepositoryCore/SourceList.cpp
@@ -759,10 +759,7 @@ namespace AppInstaller::Repository
             }
         }
 
-        if (ExperimentalFeature::IsEnabled(ExperimentalFeature::Feature::SourcePriority))
-        {
-            std::stable_sort(m_sourceList.begin(), m_sourceList.end());
-        }
+        std::stable_sort(m_sourceList.begin(), m_sourceList.end());
     }
 
     void SourceList::OverwriteMetadata()

--- a/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.Client.Tests.ps1
@@ -188,9 +188,6 @@ Describe 'Reset-WinGetSource' {
 Describe 'Get|Add|Reset-WinGetSource' {
 
     BeforeAll {
-        $ogSettings = @{ experimentalFeatures= @{sourcePriority=$true}}
-        SetWinGetSettingsHelper $ogSettings
-
         Add-WinGetSource -Name 'TestSource' -Arg 'https://localhost:5001/TestKit/' -TrustLevel 'Trusted' -Explicit -Priority 42
     }
 
@@ -217,7 +214,6 @@ Describe 'Get|Add|Reset-WinGetSource' {
 
     AfterAll {
         RemoveTestSource
-        RestoreWinGetSettings
     }
 }
 
@@ -512,9 +508,6 @@ Describe 'Install-WinGetPackage Source Priority' {
     }
 
     It 'Install higher Priority' {
-        $ogSettings = @{ experimentalFeatures= @{sourcePriority=$true}}
-        SetWinGetSettingsHelper $ogSettings
-
         RemoveTestSource
         Add-WinGetSource -Name 'TestSource' -Arg 'https://localhost:5001/TestKit/' -Priority 1
         Add-WinGetSource -Name 'dummyPackageSource' -Type 'Microsoft.Test.Configurable' -Arg '{"ContainsPackage":true}'
@@ -542,7 +535,6 @@ Describe 'Install-WinGetPackage Source Priority' {
 
         Remove-WinGetSource  -Name 'dummyPackageSource'
         RemoveTestSource
-        RestoreWinGetSettings
     }
 }
 

--- a/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
+++ b/src/PowerShell/tests/Microsoft.WinGet.DSC.Tests.ps1
@@ -130,8 +130,6 @@ Describe 'WinGetUserSettings' {
 
 Describe 'WinGetSource' {
     BeforeAll {
-        InvokeWinGetDSC -Name WinGetUserSettings -Method Set -Property @{ Settings = @{ experimentalFeatures = @{ sourcePriority = $true } } }
-
         $testSourceName = 'TestSource'
         $testSourceArg = 'https://localhost:5001/TestKit/'
         $testSourceType = 'Microsoft.PreIndexed.Package'


### PR DESCRIPTION
## 📖 Description

Promotes source priority to a regular feature by removing experimental gating from CLI and DSC workflows and retiring the `experimentalFeatures.sourcePriority` setting.

Uses the existing commands and options. Default priorities, selection rules, and tie handling are unchanged. Updates documentation, release notes, and regression coverage.

REST filtering, interactive resolution, and heuristic deduplication remain out of scope for this PR.

## 🔗 References

- Related to #5345 — source-priority workstream only.
- Builds on #6029.

## 🔍 Validation

- Built the CLI, native tests, and E2E test project.
- Passed **43 native test cases with 792 assertions**, covering priority ordering, ties, negative values, argument boundaries, disabled experimental-feature policy, source output, and DSC source operations.
- Passed CLI smoke checks for `source add --help`, `source edit --help`, `features`, and `dscv3 source --schema`.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated [Release Notes](../doc/ReleaseNotes.md) (if applicable)
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed) — not applicable

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6509)