### PR TITLE
Use custom build pool with additional resources

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,9 @@ jobs:
   timeoutInMinutes: 120
   dependsOn: 'GetReleaseTag'
   condition: always()
+  # Use custom agent with additional resources.
+  pool:
+    name: 1es-pool-winget
 
   strategy:
     matrix:
@@ -134,7 +137,7 @@ jobs:
                     /p:AppxPackageDir="$(appxPackageDir)"
                     /p:AppxBundle=Always
                     /p:UapAppxPackageBuildMode=SideloadOnly
-                    /p:WingetCleanIntermediateFiles=true
+                    /p:PreferredToolArchitecture=x64
                     /p:WingetDisableIncrementalLinkTimeCodeGeneration=true'
       maximumCpuCount: true
 
@@ -680,6 +683,9 @@ jobs:
 - job: 'Fuzzing'
   timeoutInMinutes: 60
   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+  # Use custom agent with additional resources.
+  pool:
+    name: 1es-pool-winget
 
   strategy:
     matrix:


### PR DESCRIPTION
Created a custom pool for our build pipeline that has additional resources compared to the standard Microsoft-hosted agents. This should help with the recurring issues of running out of disk space. Only using the new pool for the build jobs, since they are the ones that need more resources and I ran into issues getting the tests working in the new pool.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-cli/pull/6521)